### PR TITLE
field limiting

### DIFF
--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from usaspending_api.awards.models import *
 from usaspending_api.accounts.serializers import AppropriationAccountBalancesSerializer
 from usaspending_api.references.serializers import *
+from usaspending_api.common.serializers import LimitableSerializer
 
 
 class FinancialAccountsByAwardsSerializer(serializers.ModelSerializer):
@@ -36,7 +37,7 @@ class FinancialAssistanceAwardSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class AwardSerializer(serializers.ModelSerializer):
+class AwardSerializer(LimitableSerializer):
 
     recipient = LegalEntitySerializer(read_only=True)
     awarding_agency = AgencySerializer(read_only=True)

--- a/usaspending_api/awards/views.py
+++ b/usaspending_api/awards/views.py
@@ -69,7 +69,10 @@ class AwardListSummary(APIView):
 
         paged_data = ResponsePaginator.get_paged_data(awards, request_parameters=body)
 
-        serializer = AwardSerializer(paged_data, many=True)
+        fields = body.get('fields', None)
+        exclude = body.get('exclude', None)
+
+        serializer = AwardSerializer(paged_data, fields=fields, exclude=exclude, many=True)
         response_object = {
             "total_metadata": {
                 "count": awards.count(),

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+
+
+# Extends model serializer to support limiting fields via kwargs
+class LimitableSerializer(serializers.ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        override_fields = kwargs.pop('fields', None)
+        exclude_fields = kwargs.pop('exclude', None)
+        super(LimitableSerializer, self).__init__(*args, **kwargs)
+
+        # We must exclude before include to avoid conflicts from user error
+        if exclude_fields:
+            for field_name in exclude_fields:
+                self.fields.pop(field_name)
+
+        if override_fields:
+            allowed = set(override_fields)
+            existing = set(self.fields.keys())
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)

--- a/using_the_api.md
+++ b/using_the_api.md
@@ -66,6 +66,8 @@ The structure of the post request allows for a flexible and complex query with b
 {
     "page": 1,
     "limit": 1000,
+    "fields": ["fain", "total_obligation"]
+    "exclude": ["recipient"]
     "filters": [
       {
         "field": "fain",
@@ -84,8 +86,10 @@ The structure of the post request allows for a flexible and complex query with b
 
 * `page` - If your request requires pagination, this parameter specifies the page of results to return. Default: 1
 * `limit` - The maximum length of a page in the response. Default: 100
+* `fields` - What fields to return. Must be a list. Omitting this will return all fields.
+* `exclude` - What fields to exclude from the return. Must be a list.
 * `filters` - An array of objects specifying how to filter the dataset. When multiple filters are specified in the root list, they will be joined via _and_
-  * `field` - A string specifying the field to compare the value to. This supports Django's foreign key relationship traversal; therefore, `funding_agency__fpds_code` will filter on the field `fpds_code` for the referenced object stored in `funding_agency`. Some fields have special handling functions, see the section _Special Fields_ for more information.
+  * `field` - A string specifying the field to compare the value to. This supports Django's foreign key relationship traversal; therefore, `funding_agency__fpds_code` will filter on the field `fpds_code` for the referenced object stored in `funding_agency`.
   * `operation` - The operation to use to compare the field to the value. Some operations place requirements upon the data type in the values parameter, noted below. The options for this field are:
     * `equals` - Evaluates the equality of the value with that stored in the field
       ```


### PR DESCRIPTION
Allowing for the limiting of fields

* Added ‘fields’ option to post requests
* Added ‘exclude’ option to post requests
* Added docs for ‘fields’ and ‘exclude’
* Probably want to refactor the code from ‘views.py’ somewhere abstract for future use, but this can wait until next post method implementation