### PR TITLE
Enable Django debug toolbar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ coverage==4.2
 dj-database-url==0.4.1
 Django==1.10.1
 django-cors-headers==1.2.2
-django-debug-toolbar==1.5
+-e git://github.com/jazzband/django-debug-toolbar.git#egg=django-debug-toolbar
 django-filter==0.14.0
 djangorestframework==3.4.6
 Markdown==2.6.6

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.postgres',
 
+    'debug_toolbar',
     'rest_framework',
     'corsheaders',
     'usaspending_api.references',
@@ -50,8 +51,12 @@ INSTALLED_APPS = [
     'usaspending_api.financial_activities'
 ]
 
+# IPs allowed to see django-debug-toolbar output.
+INTERNAL_IPS = ('127.0.0.1',)
+
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/usaspending_api/urls.py
+++ b/usaspending_api/urls.py
@@ -13,8 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.conf.urls import url, include
-from django.contrib import admin
 from usaspending_api import views as views
 
 
@@ -26,3 +26,9 @@ urlpatterns = [
     url(r'^api/v1/financial_activities/', include('usaspending_api.financial_activities.urls')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]


### PR DESCRIPTION
This commit enables the Django debug toolbar. Note that the toolbar
is only visible when the app is in DEBUG mode and when you're
coming from IP 127.0.0.1. One other thing worth noting is that
the changeset updates requirements.txt to install the debug
toolbar directly from git, because that version is compatible
with new-style Django MIDDLEWARE.