### PR TITLE
Add Django extensions to INSTALLED_APPS

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.postgres',
 
+    'django_extensions',
     'rest_framework',
     'corsheaders',
     'usaspending_api.common',


### PR DESCRIPTION
Django extensions was already installed by virtue of its
inclusion in requirements.txt. This commit turns it on
by adding it the list of installed apps in settings.py.

Adding this b/c I needed to debug urlpatterns. Django
extensions lets you do:
```python
python manage.py show_urls
```

And gives you helpful info like:
```python
/api-auth/login/	django.contrib.auth.views.login	rest_framework:login	
/api-auth/logout/	django.contrib.auth.views.logout	rest_framework:logout	
/api/v1/accounts/	usaspending_api.accounts.views.TreasuryAppropriationAccountBalancesViewSet	accounts-list	
/api/v1/accounts/<pk>/	usaspending_api.accounts.views.TreasuryAppropriationAccountBalancesViewSet	accounts-detail	
/api/v1/awards/	usaspending_api.awards.views.AwardList		
/api/v1/awards/fain/<fain>	usaspending_api.awards.views.AwardList		
/api/v1/awards/piid/<piid>	usaspending_api.awards.views.AwardList		
/api/v1/awards/summary/	usaspending_api.awards.views.AwardListSummaryViewSet	
/api/v1/awards/summary/autocomplete/	usaspending_api.awards.views.AwardListSummaryAutocomplete		
/api/v1/awards/total/	usaspending_api.awards.views.AwardListAggregate		
/api/v1/awards/uri/<uri>	usaspending_api.awards.views.AwardList		
/api/v1/financial_activities/	usaspending_api.financial_activities.views.FinancialAccountsByProgramActivityObjectClassList		
/api/v1/references/locations/	usaspending_api.references.views.LocationEndpoint		
/api/v1/references/locations/geocomplete	usaspending_api.references.views.LocationEndpoint		
/api/v1/submissions/	usaspending_api.submissions.views.SubmissionAttributesList		
/status/	usaspending_api.views.StatusView
```