### PR TITLE
Add django-extensions to the code base

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dj-database-url==0.4.1
 Django==1.10.1
 django-cors-headers==1.2.2
 -e git://github.com/jazzband/django-debug-toolbar.git#egg=django-debug-toolbar
+django-extensions==1.7.5
 django-filter==0.14.0
 djangorestframework==3.4.6
 Markdown==2.6.6

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.postgres',
 
+    'django_extensions',
     'rest_framework',
     'corsheaders',
     'usaspending_api.common',


### PR DESCRIPTION
This PR adds django-extensions to our code base. Specifically,
I'm adding it to make use of the show_urls command to debug
some urlpatterns. More generally, django extensions includes
a large collection of helpful things, which you can
read about in the docs.