### PR TITLE
Write some unittests for functions related to contract loading

### DIFF
--- a/usaspending_api/awards/management/commands/loadcontracts.py
+++ b/usaspending_api/awards/management/commands/loadcontracts.py
@@ -255,7 +255,7 @@ def get_or_create_location(row):
             location_foreign_city_name=row["city"],
         )
 
-    recipient_location = Location.objects.filter(Q(**location_dict)).first()
+    recipient_location = Location.objects.filter(**location_dict).first()
     if not recipient_location:
         recipient_location = Location.objects.create(**location_dict)
     return recipient_location

--- a/usaspending_api/awards/management/commands/loadcontracts.py
+++ b/usaspending_api/awards/management/commands/loadcontracts.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             "multiple_or_single_award_idv": lambda row: row['multipleorsingleawardidc'].split(' ')[0].split(':')[0],
             "cost_or_pricing_data": lambda row: row['costorpricingdata'].split(' ')[0].split(':')[0],
             "type_of_contract_pricing": lambda row: row['typeofcontractpricing'].split(' ')[0].split(':')[0],
-            "contract_award_type": self.evaluate_contract_award_type,
+            "contract_award_type": evaluate_contract_award_type,
             "naics": lambda row: row['nationalinterestactioncode'].split(' ')[0].split(':')[0],
             "multiple_or_single_award_idv": lambda row: row['multipleorsingleawardidc'].split(' ')[0].split(':')[0],
             "dod_claimant_program_code": lambda row: row['claimantprogramcode'].split(' ')[0].split(':')[0],
@@ -93,24 +93,6 @@ class Command(BaseCommand):
 
         loader = ThreadedDataLoader(Procurement, field_map=field_map, value_map=value_map)
         loader.load_from_file(options['file'][0])
-
-    def evaluate_contract_award_type(self, row):
-        first_element = row['contractactiontype'].split(' ')[0].split(':')[0]
-        if len(first_element) == 1:
-            return first_element
-        else:
-            cat = row['contractactiontype'].lower()
-            # Not using DAIMS enumeration . . .
-            if 'bpa' in cat:
-                return 'A'
-            if 'purchase' in cat:
-                return 'B'
-            elif 'delivery' in cat:
-                return 'C'
-            elif 'definitive' in cat:
-                return 'D'
-            else:
-                return None
 
     def get_agency(self, row):
         agency = Agency.objects.filter(subtier_code=self.get_agency_code(row['maj_agency_cat'])).first()
@@ -251,3 +233,22 @@ class Command(BaseCommand):
         award.recipient = self.create_or_get_recipient(row)
         award.save()
         return award
+
+
+def evaluate_contract_award_type(row):
+    first_element = row['contractactiontype'].split(' ')[0].split(':')[0]
+    if len(first_element) == 1:
+        return first_element
+    else:
+        cat = row['contractactiontype'].lower()
+        # Not using DAIMS enumeration . . .
+        if 'bpa' in cat:
+            return 'A'
+        if 'purchase' in cat:
+            return 'B'
+        elif 'delivery' in cat:
+            return 'C'
+        elif 'definitive' in cat:
+            return 'D'
+        else:
+            return None

--- a/usaspending_api/awards/test_contracts_load.py
+++ b/usaspending_api/awards/test_contracts_load.py
@@ -8,6 +8,7 @@ import pytest
 
 from usaspending_api.awards.models import Award
 from usaspending_api.awards.management.commands import loadcontracts
+from usaspending_api.references.models import Location
 
 
 # Transaction test cases so threads can find the data
@@ -40,3 +41,131 @@ def test_evaluate_contract_award_type(contract_type, expected):
     row = dict(contractactiontype=contract_type)
     result = loadcontracts.evaluate_contract_award_type(row)
     assert result == expected
+
+
+@pytest.mark.django_db
+def test_get_or_create_location_ref_country_code():
+    """Grab the location with this reference country code"""
+    # dummy data
+    mommy.make('references.RefCountryCode', _quantity=3, _fill_optional=True)
+    mommy.make('references.Location', _quantity=3, _fill_optional=True)
+    ref = mommy.make('references.RefCountryCode', country_code='USA',
+                     _fill_optional=True)
+    expected = mommy.make(
+        'references.Location', location_country_code=ref,
+        location_zip5='12345', location_zip_last4='6789',
+        _fill_optional=True
+    )
+
+    row = dict(vendorcountrycode='USA', zipcode='12345-6789',
+               streetaddress=expected.location_address_line1,
+               streetaddress2=expected.location_address_line2,
+               streetaddress3=expected.location_address_line3,
+               state=expected.location_state_code,
+               city=expected.location_city_name)
+    assert loadcontracts.get_or_create_location(row) == expected
+
+
+@pytest.mark.django_db
+def test_get_or_create_location_ref_country_name():
+    """Grab the location with this reference country name, accounting for
+    capitialization differences"""
+    # dummy data
+    mommy.make('references.RefCountryCode', _quantity=3, _fill_optional=True)
+    mommy.make('references.Location', _quantity=3, _fill_optional=True)
+    ref = mommy.make('references.RefCountryCode', country_code='USA',
+                     country_name='AmErIcA', _fill_optional=True)
+    expected = mommy.make(
+        'references.Location', location_country_code=ref,
+        location_zip5='12345', location_zip_last4='6789',
+        _fill_optional=True
+    )
+
+    row = dict(vendorcountrycode='america', zipcode='12345-6789',
+               streetaddress=expected.location_address_line1,
+               streetaddress2=expected.location_address_line2,
+               streetaddress3=expected.location_address_line3,
+               state=expected.location_state_code,
+               city=expected.location_city_name)
+    assert loadcontracts.get_or_create_location(row) == expected
+
+
+@pytest.mark.django_db
+def test_get_or_create_location_ref_country_name_complicated():
+    """If we can't find a suitable reference country name, we try to re-order
+    the words"""
+    # dummy data
+    mommy.make('references.RefCountryCode', _quantity=3, _fill_optional=True)
+    mommy.make('references.Location', _quantity=3, _fill_optional=True)
+    ref = mommy.make('references.RefCountryCode', country_code='USA',
+                     country_name='aMerIca United States of (U.S.A.)',
+                     _fill_optional=True)
+    expected = mommy.make(
+        'references.Location', location_country_code=ref,
+        location_zip5='12345', location_zip_last4='6789',
+        _fill_optional=True
+    )
+
+    row = dict(vendorcountrycode='america (u.s.a.)', zipcode='12345-6789',
+               streetaddress=expected.location_address_line1,
+               streetaddress2=expected.location_address_line2,
+               streetaddress3=expected.location_address_line3,
+               state=expected.location_state_code,
+               city=expected.location_city_name)
+    assert loadcontracts.get_or_create_location(row) == expected
+
+
+@pytest.mark.django_db
+def test_get_or_create_location_non_usa():
+    """We should query different fields if it's a non-US row"""
+    ref = mommy.make('references.RefCountryCode', country_code='UAE',
+                     _fill_optional=True)
+    expected = mommy.make(
+        'references.Location', location_country_code=ref,
+        location_zip5='12345', location_zip_last4='6789',
+        # @todo: city_name has a different length than foreign_city_name, so
+        # we can't use the random value
+        location_city_name='AAAAAAAA',
+        _fill_optional=True
+    )
+
+    row = dict(vendorcountrycode='UAE', zipcode='12345-6789',
+               streetaddress=expected.location_address_line1,
+               streetaddress2=expected.location_address_line2,
+               streetaddress3=expected.location_address_line3,
+               state=expected.location_state_code,
+               city=expected.location_city_name)
+
+    # can't find it because we're looking at the US fields
+    assert loadcontracts.get_or_create_location(row) != expected
+
+    row['zipcode'] = expected.location_foreign_postal_code
+    row['state'] = expected.location_foreign_province
+    row['city'] = expected.location_foreign_city_name
+    assert loadcontracts.get_or_create_location(row) == expected
+
+
+@pytest.mark.django_db
+def test_get_or_create_location_creates_new_locations():
+    """If no location is found, we create a new one"""
+    ref = mommy.make('references.RefCountryCode', country_code='USA',
+                     _fill_optional=True)
+    row = dict(vendorcountrycode='USA', zipcode='12345-6789',
+               streetaddress='Addy1', streetaddress2='Addy2',
+               streetaddress3=None, state='ST', city='My Town')
+
+    # can't find it because we're looking at the US fields
+    assert Location.objects.count() == 0
+    
+    loadcontracts.get_or_create_location(row)
+    assert Location.objects.count() == 1
+
+    loc = Location.objects.all().first()
+    assert loc.location_country_code == ref
+    assert loc.location_zip5 == '12345'
+    assert loc.location_zip_last4 == '6789'
+    assert loc.location_address_line1 == 'Addy1'
+    assert loc.location_address_line2 == 'Addy2'
+    assert loc.location_address_line3 is None
+    assert loc.location_state_code == 'ST'
+    assert loc.location_city_name == 'My Town'

--- a/usaspending_api/awards/test_contracts_load.py
+++ b/usaspending_api/awards/test_contracts_load.py
@@ -44,75 +44,25 @@ def test_evaluate_contract_award_type(contract_type, expected):
 
 
 @pytest.mark.django_db
-def test_get_or_create_location_ref_country_code():
+def test_fetch_country_code():
     """Grab the location with this reference country code"""
     # dummy data
     mommy.make('references.RefCountryCode', _quantity=3, _fill_optional=True)
-    mommy.make('references.Location', _quantity=3, _fill_optional=True)
-    ref = mommy.make('references.RefCountryCode', country_code='USA',
-                     _fill_optional=True)
-    expected = mommy.make(
-        'references.Location', location_country_code=ref,
-        location_zip5='12345', location_zip_last4='6789',
+    code_match = mommy.make('references.RefCountryCode', country_code='USA',
+                            _fill_optional=True)
+    name_match = mommy.make('references.RefCountryCode', country_name='AmErIcA',
+                            _fill_optional=True)
+    complex_name = mommy.make(
+        'references.RefCountryCode',
+        country_name='aMerIca United States of (U.S.A.)',
         _fill_optional=True
     )
-
-    row = dict(vendorcountrycode='USA', zipcode='12345-6789',
-               streetaddress=expected.location_address_line1,
-               streetaddress2=expected.location_address_line2,
-               streetaddress3=expected.location_address_line3,
-               state=expected.location_state_code,
-               city=expected.location_city_name)
-    assert loadcontracts.get_or_create_location(row) == expected
-
-
-@pytest.mark.django_db
-def test_get_or_create_location_ref_country_name():
-    """Grab the location with this reference country name, accounting for
-    capitialization differences"""
-    # dummy data
-    mommy.make('references.RefCountryCode', _quantity=3, _fill_optional=True)
-    mommy.make('references.Location', _quantity=3, _fill_optional=True)
-    ref = mommy.make('references.RefCountryCode', country_code='USA',
-                     country_name='AmErIcA', _fill_optional=True)
-    expected = mommy.make(
-        'references.Location', location_country_code=ref,
-        location_zip5='12345', location_zip_last4='6789',
-        _fill_optional=True
-    )
-
-    row = dict(vendorcountrycode='america', zipcode='12345-6789',
-               streetaddress=expected.location_address_line1,
-               streetaddress2=expected.location_address_line2,
-               streetaddress3=expected.location_address_line3,
-               state=expected.location_state_code,
-               city=expected.location_city_name)
-    assert loadcontracts.get_or_create_location(row) == expected
-
-
-@pytest.mark.django_db
-def test_get_or_create_location_ref_country_name_complicated():
-    """If we can't find a suitable reference country name, we try to re-order
-    the words"""
-    # dummy data
-    mommy.make('references.RefCountryCode', _quantity=3, _fill_optional=True)
-    mommy.make('references.Location', _quantity=3, _fill_optional=True)
-    ref = mommy.make('references.RefCountryCode', country_code='USA',
-                     country_name='aMerIca United States of (U.S.A.)',
-                     _fill_optional=True)
-    expected = mommy.make(
-        'references.Location', location_country_code=ref,
-        location_zip5='12345', location_zip_last4='6789',
-        _fill_optional=True
-    )
-
-    row = dict(vendorcountrycode='america (u.s.a.)', zipcode='12345-6789',
-               streetaddress=expected.location_address_line1,
-               streetaddress2=expected.location_address_line2,
-               streetaddress3=expected.location_address_line3,
-               state=expected.location_state_code,
-               city=expected.location_city_name)
-    assert loadcontracts.get_or_create_location(row) == expected
+    assert loadcontracts.fetch_country_code('USA') == code_match
+    assert loadcontracts.fetch_country_code('USA:more:stuff') == code_match
+    assert loadcontracts.fetch_country_code('america') == name_match
+    assert loadcontracts.fetch_country_code('aMEriCA: : : :') == name_match
+    assert loadcontracts.fetch_country_code(
+        'america (u.s.a.):stuff') == complex_name
 
 
 @pytest.mark.django_db

--- a/usaspending_api/awards/test_contracts_load.py
+++ b/usaspending_api/awards/test_contracts_load.py
@@ -37,7 +37,6 @@ class ContractsLoadTests(TransactionTestCase):
 ])
 def test_evaluate_contract_award_type(contract_type, expected):
     """Verify that contract types are converted correctly"""
-    command = loadcontracts.Command()
     row = dict(contractactiontype=contract_type)
-    result = command.evaluate_contract_award_type(row)
+    result = loadcontracts.evaluate_contract_award_type(row)
     assert result == expected

--- a/usaspending_api/awards/test_contracts_load.py
+++ b/usaspending_api/awards/test_contracts_load.py
@@ -2,29 +2,23 @@ import os
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TransactionTestCase, Client
 from model_mommy import mommy
 import pytest
 
-from usaspending_api.awards.models import Award
 from usaspending_api.awards.management.commands import loadcontracts
 from usaspending_api.references.models import Location
 
 
 # Transaction test cases so threads can find the data
-class ContractsLoadTests(TransactionTestCase):
-
-    fixtures = ['endpoint_fixture_db']
-
-    @pytest.mark.django_db
-    def test_contract_load(self):
-        """
-        Ensure contract awards can be loaded from usaspending
-        """
-        call_command('loadcontracts', os.path.join(settings.BASE_DIR, 'usaspending_api/data/usaspending_treasury_contracts.csv'))
-
-    def teardown():
-        Award.objects.all().delete()
+@pytest.mark.django_db(transaction=True)
+def test_contract_load():
+    """Ensure contract awards can be loaded from usaspending"""
+    call_command('loaddata', 'endpoint_fixture_db')
+    call_command('loadcontracts', os.path.join(
+        settings.BASE_DIR, 'usaspending_api', 'data',
+        'usaspending_treasury_contracts.csv'
+    ))
+    # @todo - should there be an assert here?
 
 
 @pytest.mark.parametrize('contract_type,expected', [


### PR DESCRIPTION
@bsweger kindly asked that I write some unit tests in py.test style to demonstrate the value of both. This PR (which is best reviewed commit by commit) hopefully does that, by writing tests and refactoring (in sequence) a few chunks of the logic in the contract loading admin command. Several edge cases for each chunk are tested.

This doesn't make use of pytests' monkeypatch test fixture (which is great for code with lots of dependencies,) but I can probably find a use case if desired.