### PR TITLE
Null awards pre-filtering

### DIFF
--- a/usaspending_api/awards/models.py
+++ b/usaspending_api/awards/models.py
@@ -84,6 +84,17 @@ class FinancialAccountsByAwardsTransactionObligations(DataSourceTrackedModel):
         db_table = 'financial_accounts_by_awards_transaction_obligations'
 
 
+class AwardManager(models.Manager):
+    def get_queryset(self):
+        q_kwargs = {
+            "type": "U",
+            "total_obligation__isnull": True,
+            "date_signed__isnull": True,
+            "recipient__isnull": True
+        }
+        return super(AwardManager, self).get_queryset().filter(~Q(**q_kwargs))
+
+
 class Award(DataSourceTrackedModel):
 
     AWARD_TYPES = (
@@ -125,6 +136,9 @@ class Award(DataSourceTrackedModel):
     create_date = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     update_date = models.DateTimeField(auto_now=True, null=True)
     latest_submission = models.ForeignKey(SubmissionAttributes, null=True)
+
+    objects = models.Manager()
+    nonempty = AwardManager()
 
     def __str__(self):
         return '%s piid: %s fain: %s uri: %s' % (self.get_type_display(), self.piid, self.fain, self.uri)

--- a/usaspending_api/awards/models.py
+++ b/usaspending_api/awards/models.py
@@ -86,6 +86,13 @@ class FinancialAccountsByAwardsTransactionObligations(DataSourceTrackedModel):
 
 class AwardManager(models.Manager):
     def get_queryset(self):
+        '''
+        A generated award will have these set to null, but will also receive no
+        transactions. Thus, these will remain null. This finds those awards and
+        throws them out. As soon as one of those awards gets a transaction
+        (i.e. it is no longer empty), these will be updated via update_from_mod
+        and the award will no longer match these criteria
+        '''
         q_kwargs = {
             "type": "U",
             "total_obligation__isnull": True,

--- a/usaspending_api/awards/test_summary_awards.py
+++ b/usaspending_api/awards/test_summary_awards.py
@@ -1,0 +1,17 @@
+from django.test import TestCase, Client
+import pytest
+import json
+
+from model_mommy import mommy
+from usaspending_api.awards.models import Award
+
+
+class AwardSummaryTests(TestCase):
+
+    @pytest.mark.django_db
+    def test_null_awards(self):
+        nonempty = mommy.make('awards.Award', total_obligation="2000", _quantity=2)
+        empty = mommy.make('awards.Award', type="U", total_obligation=None, date_signed=None, recipient=None)
+
+        self.assertEqual(Award.objects.count(), 3)
+        self.assertEqual(Award.nonempty.count(), 2)

--- a/usaspending_api/awards/views.py
+++ b/usaspending_api/awards/views.py
@@ -66,7 +66,7 @@ class AwardListSummaryViewSet(FilterQuerysetMixin,
 
     def get_queryset(self):
         """Return the view's queryset."""
-        queryset = Award.objects.all()
+        queryset = Award.nonempty.all()
         filtered_queryset = self.filter_records(self.request, queryset=queryset, filter_map=self.filter_map)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset


### PR DESCRIPTION
Adding managers to award object.
To get awards that aren’t “generated null awards”, use Award.nonempty

Award.objects = gets all awards, including the empty ones
Award.nonempty = gets all awards, but filters out the empty ones