### PR TITLE
Fixing value map on contract loader

### DIFF
--- a/usaspending_api/awards/management/commands/loadcontracts.py
+++ b/usaspending_api/awards/management/commands/loadcontracts.py
@@ -29,7 +29,8 @@ class Command(BaseCommand):
             "description": "descriptionofcontractrequirement",
             "other_statutory_authority": "otherstatutoryauthority",
             "modification_number": "modnumber",
-            "parent_award_id": "idvpiid"
+            "parent_award_id": "idvpiid",
+            "usaspending_unique_transaction_id": "unique_transaction_id"
         }
 
         value_map = {


### PR DESCRIPTION
When the field “unique_transaction_id” was renamed to
“usaspending_unique_transaction_id” this was not updated to match.

Does not need to be in for sprint review.