### PR TITLE
Hotfix api doc

### DIFF
--- a/using_the_api.md
+++ b/using_the_api.md
@@ -1,6 +1,6 @@
 # The USAspending Application Programming Interface (API)
 
-The USAspending API allows the public to accesss data published via the Broker or USAspending.
+The USAspending API allows the public to access data published via the Broker or USAspending.
 
 ## Background
 
@@ -10,18 +10,18 @@ For more information about the DATA Act Broker codebase, please visit this repos
 
 ## Table of Contents
   * [Status Codes](#status-codes)
-  * [Data Routes](#data-routes)
-    * [Routes and Methods](#routes-and-methods)
-    * [Summary Routes and Methods](#summary-routes-and-methods)
+  * [Data Endpoints](#data-endpoints)
+    * [Endpoints and Methods](#endpoints-and-methods)
+    * [Summary Endpoints and Methods](#summary-endpoints-and-methods)
   * [GET Requests](#get-requests)
   * [POST Requests](#post-requests)
   * [Autocomplete Queries](#autocomplete-queries)
   * [Geographical Hierarchy Queries](#geographical-hierarchy-queries)
 
 
-## DATA Act Data Store Route Documentation
+## DATA Act Data Store Endpoint Documentation
 
-Routes do not currently require any authorization
+Endpoints do not currently require any authorization
 
 ### Status Codes
 In general, status codes returned are as follows:
@@ -30,12 +30,12 @@ In general, status codes returned are as follows:
 * 400 if the request is malformed
 * 500 for server-side errors
 
-### Data Routes
+### Data Endpoints
 
-Data routes are split by payload into POST and GET methods. In general, the format of a request and response will remain the same with the route only changing the data provided in the response.
+Data endpoints are split by payload into POST and GET methods. In general, the format of a request and response will remain the same with the endpoint only changing the data provided in the response.
 
-#### Routes and Methods
-The currently available routes are:
+#### Endpoints and Methods
+The currently available endpoints are:
   * **/v1/awards/summary/**
     - _Description_: Provides award level summary data
     - _Methods_: GET, POST
@@ -72,8 +72,8 @@ The currently available routes are:
     - _Description_: Returns all `SubmissionAttributes` data. _NB_: This endpoint is due for a rework in the near future
     - _Methods_: GET
 
-#### Summary Routes and Methods
-Summarized data is available for some of the routes listed above:
+#### Summary Endpoints and Methods
+Summarized data is available for some of the endpoints listed above:
 
 * **/v1/awards/total/**
 * more coming soon
@@ -85,7 +85,7 @@ You can get summarized data via a `POST` request that specifies:
 * `group`: the field to group by (optional; if not specified, data will be summarized across all objects)
 * `date_part`: applies only when `group` is a data field and specifies which part of the date to group by; `year`, `month`, and `day` are currently supported, and `quarter` is coming soon
 
-Requests to the summary routes can also contain the `page`, `limit`, and `filters` parameters as described in [POST Requests](#post-requests). **Note:** If you're filtering the data, the filters are applied before the data is summarized.
+Requests to the summary endpoints can also contain the `page`, `limit`, and `filters` parameters as described in [POST Requests](#post-requests). **Note:** If you're filtering the data, the filters are applied before the data is summarized.
 
 The `results` portion of the response will contain:
 
@@ -136,7 +136,7 @@ Response:
 ```
 
 #### GET Requests
-GET requests can be specified by attaching any field value pair to the route. This method supports any fields present in the data object and only the `equals` operation. It also supports pagination variables. Additionally, you may specifcy complex fields that use Django's foreign key traversal; for more details on this see `field` from the POST request. Examples below:
+GET requests can be specified by attaching any field value pair to the endpoint. This method supports any fields present in the data object and only the `equals` operation. It also supports pagination variables. Additionally, you may specifcy complex fields that use Django's foreign key traversal; for more details on this see `field` from the POST request. Examples below:
 
 `/v1/awards/summary/?page=5&limit=1000`
 
@@ -500,7 +500,7 @@ The response has three functional parts:
     * `count` - The length of the `results` array for this page
   * `total_metadata` - Includes data about the total dataset and any dataset-level metadata specific to the endpoint
     * `count` - The total number of items in this dataset, spanning all pages
-  * `results` - An array of objects corresponding to the data returned by the specified route. Will _always_ be an array, even if the number of results is only one.
+  * `results` - An array of objects corresponding to the data returned by the specified endpoint. Will _always_ be an array, even if the number of results is only one.
 
 ### Autocomplete Queries
 Autocomplete queries currently require the endpoint to have additional handling, as such, only a few have been implemented (notably awards/summary).

--- a/using_the_api.md
+++ b/using_the_api.md
@@ -36,46 +36,46 @@ Data endpoints are split by payload into POST and GET methods. In general, the f
 
 #### Endpoints and Methods
 The currently available endpoints are:
-  * **/v1/awards/summary/**
+  * **[/v1/awards/summary/](https://api.usaspending.gov/api/v1/awards/summary/)**
     - _Description_: Provides award level summary data
     - _Methods_: GET, POST
 
-  * **/v1/awards/summary/autocomplete/**
+  * **[/v1/awards/summary/autocomplete/](https://api.usaspending.gov/api/v1/awards/summary/autocomplete/)**
     - _Description_: Provides a fast endpoint for evaluating autocomplete queries against the awards/summary endpoint
     - _Methods_: POST
 
-  * **/v1/references/locations/**
+  * **[/v1/references/locations/](https://api.usaspending.gov/api/v1/references/locations/)**
     - _Description_: Returns all `Location` data.
     - _Methods_: POST
 
-  * **/v1/references/locations/geocomplete**
+  * **[/v1/references/locations/geocomplete](https://api.usaspending.gov/api/v1/references/locations/geocomplete/)**
     - _Description_: A structured hierarchy geographical autocomplete. See [Geographical Hierarchy Queries](#geographical-hierarchy-queries) for more information
     - _Methods_: POST
 
-  * **/v1/awards/**
+  * **[/v1/awards/](https://api.usaspending.gov/api/v1/awards/)**
     - _Description_: Returns all `FinancialAccountsByAwardsTransactionObligations` data. _NB_: This endpoint is due for a rework in the near future
     - _Methods_: GET
 
-  * **/v1/accounts/**
+  * **[/v1/accounts/](https://api.usaspending.gov/api/v1/accounts/)**
     - _Description_: Returns all `AppropriationAccountBalances` data. _NB_: This endpoint is due for a rework in the near future
     - _Methods_: GET
 
-  * **/v1/accounts/tas/**
+  * **[/v1/accounts/tas/](https://api.usaspending.gov/api/v1/accounts/tas/)**
     - _Description_: Returns all `TreasuryAppropriationAccount` data. _NB_: This endpoint is due for a rework in the near future
     - _Methods_: GET
 
-  * **/v1/financial_activities/**
+  * **[/v1/financial_activities/](https://api.usaspending.gov/api/v1/financial_activities/)**
     - _Description_: Returns all `FinancialAccountsByProgramActivityObjectClass` data. _NB_: This endpoint is due for a rework in the near future
     - _Methods_: GET
 
-  * **/v1/submissions/**
+  * **[/v1/submissions/](https://api.usaspending.gov/api/v1/submissions/)**
     - _Description_: Returns all `SubmissionAttributes` data. _NB_: This endpoint is due for a rework in the near future
     - _Methods_: GET
 
 #### Summary Endpoints and Methods
 Summarized data is available for some of the endpoints listed above:
 
-* **/v1/awards/total/**
+* **[/v1/awards/total/](https://api.usaspending.gov/api/v1/awards/total/)**
 * more coming soon
 
 You can get summarized data via a `POST` request that specifies:


### PR DESCRIPTION
Because our story to create an API landing page got delayed in favor of data loads, this PR makes a few tweaks that will allow our current "using the api" file to server as a place to start when talking to folks about our API and doing user research.

The most notable change is hyperlinking the endpoint list at the top of the page. Note that a few of them (e.g., the references/locations endpoints) 404 because we haven't deployed them to prod yet. That should be ok, since those new endpoints will also be part of the next deploy.