### PR TITLE
Fixing n+1 problem

### DIFF
--- a/usaspending_api/accounts/serializers.py
+++ b/usaspending_api/accounts/serializers.py
@@ -12,9 +12,14 @@ class TreasuryAppropriationAccountSerializer(LimitableSerializer):
 
 
 class AppropriationAccountBalancesSerializer(LimitableSerializer):
-    treasury_account_identifier = TreasuryAppropriationAccountSerializer(read_only=True)
 
     class Meta:
 
         model = AppropriationAccountBalances
+        nested_serializers = {
+            "treasury_account_identifier": {
+                "class": TreasuryAppropriationAccountSerializer,
+                "kwargs": {"read_only": True}
+            },
+        }
         fields = '__all__'

--- a/usaspending_api/accounts/views.py
+++ b/usaspending_api/accounts/views.py
@@ -15,6 +15,7 @@ class TreasuryAppropriationAccountViewSet(FilterQuerysetMixin,
     def get_queryset(self):
         """Return the view's queryset."""
         queryset = TreasuryAppropriationAccount.objects.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset
@@ -28,6 +29,7 @@ class TreasuryAppropriationAccountBalancesViewSet(FilterQuerysetMixin,
 
     def get_queryset(self):
         queryset = AppropriationAccountBalances.objects.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset

--- a/usaspending_api/awards/management/commands/loadcontracts.py
+++ b/usaspending_api/awards/management/commands/loadcontracts.py
@@ -185,7 +185,6 @@ class Command(BaseCommand):
 
         return le
 
-
     def get_or_create_award(self, row):
         piid = row.get("piid", None)
         parent_award_id = row.get("idvpiid", None)
@@ -233,6 +232,7 @@ def location_mapper_place_of_performance(row):
         )  # Format is VA: VIRGINIA, so we need to grab the first bit
     }
     return loc
+
 
 def location_mapper_vendor(row):
     loc = {

--- a/usaspending_api/awards/views.py
+++ b/usaspending_api/awards/views.py
@@ -34,6 +34,7 @@ class AwardViewSet(FilterQuerysetMixin,
     def get_queryset(self):
         """Return the view's queryset."""
         queryset = Award.nonempty.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset, filter_map=self.filter_map)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset
@@ -76,6 +77,7 @@ class TransactionViewset(FilterQuerysetMixin,
     def get_queryset(self):
         """Return the view's queryset."""
         queryset = Procurement.objects.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset

--- a/usaspending_api/common/api_request_utils.py
+++ b/usaspending_api/common/api_request_utils.py
@@ -349,6 +349,11 @@ class AutoCompleteHandler():
         except:
             raise
 
+        # If the serializer supports eager loading, set it up
+        if serializer:
+            if hasattr(serializer, "setup_eager_loading") and callable(serializer.setup_eager_loading):
+                data_set = serializer.setup_eager_loading(data_set)
+
         return_object = {}
 
         filter_matched_ids, pk_name = AutoCompleteHandler.get_filter_matched_ids(data_set.all(), body["fields"], body["value"], body.get("mode", "contains"), body.get("limit", 10))

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -77,22 +77,21 @@ class LimitableSerializer(serializers.ModelSerializer):
                     # We don't have get default fields available
                     pass
 
-    '''
-    This method will set up prefetch and selected related statements appropriately
-    on a specified query set based upon the serializer's nested_serializer parameter
-    in the Meta class. It will return the modified queryset.
-    The prefix flag is for cascading down to children, that is, when we eager load
-    a child of this serializer, we must prefix that child's field name to their field name.
-    For example:
-    AwardSerializer has a nested serializer of funding_agency with a nested serializer for toptier agency
-    Thus, when we prefetch, we want to prefetch 'funding_agency' and 'funding_agency__toptier_agency'
-    This prefix flag allows us toa ccomplish this
-    '''
     @classmethod
     def setup_eager_loading(cls, queryset, prefix=""):
-        # We have a list of nested fields
-        # We want to use pre-fetch related for "many" fields
-        # while we want to use select related for all others
+        '''
+        This method will set up prefetch and selected related statements appropriately
+        on a specified query set based upon the serializer's nested_serializer parameter
+        in the Meta class. It will return the modified queryset.
+        The prefix flag is for cascading down to children, that is, when we eager load
+        a child of this serializer, we must prefix that child's field name to their field name.
+        For example:
+        AwardSerializer has a nested serializer of funding_agency with a nested serializer for toptier agency
+        Thus, when we prefetch, we want to prefetch 'funding_agency' and 'funding_agency__toptier_agency'
+        This prefix flag allows us to accomplish this.
+        N.B.: When doing a 1-1 fk relation, select_related() should be used (this join is performed in the SQL);
+              When doing a 1-m or m-m relation, prefetch_related() should be used (this join is performed via Python)
+        '''
         try:
             # Grab the nested serializers (aka children)
             children = cls.Meta.nested_serializers

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -16,7 +16,6 @@ class LimitableSerializer(serializers.ModelSerializer):
         try:
             # Initialize the child serializers, and set up eager loading
             children = self.Meta.nested_serializers
-            self.setup_eager_loading(children)
             for field in children.keys():
                 child_args = {
                     **children[field].get("kwargs", {}),

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -14,8 +14,9 @@ class LimitableSerializer(serializers.ModelSerializer):
 
         # Create and initialize the child serializers
         try:
-            # Initialize the child serializers
+            # Initialize the child serializers, and set up eager loading
             children = self.Meta.nested_serializers
+            self.setup_eager_loading(children)
             for field in children.keys():
                 child_args = {
                     **children[field].get("kwargs", {}),
@@ -28,7 +29,6 @@ class LimitableSerializer(serializers.ModelSerializer):
 
         request = self.context.get('request')
         if request:
-
             params = dict(request.query_params)
             params.update(dict(request.data))
             exclude_fields = params.get('exclude')
@@ -77,6 +77,38 @@ class LimitableSerializer(serializers.ModelSerializer):
                 except AttributeError:
                     # We don't have get default fields available
                     pass
+
+    '''
+    This method will set up prefetch and selected related statements appropriately
+    on a specified query set based upon the serializer's nested_serializer parameter
+    in the Meta class. It will return the modified queryset.
+    The prefix flag is for cascading down to children, that is, when we eager load
+    a child of this serializer, we must prefix that child's field name to their field name.
+    For example:
+    AwardSerializer has a nested serializer of funding_agency with a nested serializer for toptier agency
+    Thus, when we prefetch, we want to prefetch 'funding_agency' and 'funding_agency__toptier_agency'
+    This prefix flag allows us toa ccomplish this
+    '''
+    @classmethod
+    def setup_eager_loading(cls, queryset, prefix=""):
+        # We have a list of nested fields
+        # We want to use pre-fetch related for "many" fields
+        # while we want to use select related for all others
+        try:
+            # Grab the nested serializers (aka children)
+            children = cls.Meta.nested_serializers
+            for child in children:
+                if children[child].get("kwargs", {}).get("many", False):
+                    queryset = queryset.prefetch_related(prefix + child)
+                else:
+                    queryset = queryset.select_related(prefix + child)
+                # Since the child might have nested serializers, we set up on that too
+                queryset = children[child]["class"].setup_eager_loading(queryset, prefix=prefix + child + "__")
+        except AttributeError:
+            # We don't have any nested serializers
+            pass
+
+        return queryset
 
 
 class AggregateSerializer(serializers.Serializer):

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -14,7 +14,7 @@ class LimitableSerializer(serializers.ModelSerializer):
 
         # Create and initialize the child serializers
         try:
-            # Initialize the child serializers, and set up eager loading
+            # Initialize the child serializers
             children = self.Meta.nested_serializers
             for field in children.keys():
                 child_args = {

--- a/usaspending_api/common/tests/test_threaded_data_loader.py
+++ b/usaspending_api/common/tests/test_threaded_data_loader.py
@@ -70,20 +70,21 @@ def test_threaded_data_loader():
     gwa_tas = TreasuryAppropriationAccount.objects.get(treasury_account_identifier='45736')
     assert gwa_tas.account_title == file_1_account_title
 
+
 def test_cleanse_values():
     """Test that sloppy values in CSV are cleaned before use"""
 
     row = {"a": "  15",
-        "b": "abcde",
-        "c": "null",
-        "d": "Null",
-        "e": "   ",
-        "f": " abc def "}
+           "b": "abcde",
+           "c": "null",
+           "d": "Null",
+           "e": "   ",
+           "f": " abc def "}
     result = cleanse_values(row)
     expected = {"a": "15",
-        "b": "abcde",
-        "c": None,
-        "d": None,
-        "e": "",
-        "f": "abc def"}
+                "b": "abcde",
+                "c": None,
+                "d": None,
+                "e": "",
+                "f": "abc def"}
     assert result == expected

--- a/usaspending_api/common/threaded_data_loader.py
+++ b/usaspending_api/common/threaded_data_loader.py
@@ -240,6 +240,7 @@ class DataLoaderThread(Process):
         else:
             setattr(model_instance_or_dict, field, value)
 
+
 def cleanse_values(row):
     """
     Remove textual quirks from CSV values.

--- a/usaspending_api/financial_activities/serializers.py
+++ b/usaspending_api/financial_activities/serializers.py
@@ -4,9 +4,14 @@ from usaspending_api.financial_activities.models import FinancialAccountsByProgr
 
 
 class FinancialAccountsByProgramActivityObjectClassSerializer(LimitableSerializer):
-    appropriation_account_balances = AppropriationAccountBalancesSerializer(read_only=True)
 
     class Meta:
 
         model = FinancialAccountsByProgramActivityObjectClass
+        nested_serializers = {
+            "appropriation_account_balances": {
+                "class": AppropriationAccountBalancesSerializer,
+                "kwargs": {"read_only": True}
+            },
+        }
         fields = '__all__'

--- a/usaspending_api/financial_activities/views.py
+++ b/usaspending_api/financial_activities/views.py
@@ -18,6 +18,7 @@ class FinancialAccountsByProgramActivityObjectClassListViewSet(
     def get_queryset(self):
         """Return the view's queryset."""
         queryset = FinancialAccountsByProgramActivityObjectClass.objects.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset

--- a/usaspending_api/references/management/commands/loadcfda.py
+++ b/usaspending_api/references/management/commands/loadcfda.py
@@ -17,10 +17,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
             parser.add_argument(
-            '-f', '--file',
-            default=self.DEFAULT_FILEPATH,
-            help='path to CSV file to load',
-        )
+                '-f', '--file',
+                default=self.DEFAULT_FILEPATH,
+                help='path to CSV file to load',
+            )
 
     def handle(self, *args, **options):
 
@@ -29,12 +29,13 @@ class Command(BaseCommand):
 
         load_cfda(fullpath)
 
+
 def load_cfda(fullpath):
     """
     Create CFDAProgram records from a CSV of historical data.
     """
     try:
-        with open(fullpath, errors='backslashreplace')  as csvfile:
+        with open(fullpath, errors='backslashreplace') as csvfile:
 
             reader = csv.DictReader(csvfile, delimiter=',', quotechar='"', skipinitialspace='true')
             for row in reader:

--- a/usaspending_api/references/views.py
+++ b/usaspending_api/references/views.py
@@ -49,6 +49,7 @@ class AgencyEndpoint(FilterQuerysetMixin,
     def get_queryset(self):
         """Return the view's queryset."""
         queryset = Agency.objects.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset

--- a/usaspending_api/submissions/views.py
+++ b/usaspending_api/submissions/views.py
@@ -14,6 +14,7 @@ class SubmissionAttributesViewSet(FilterQuerysetMixin,
     def get_queryset(self):
         """Return the view's queryset."""
         queryset = SubmissionAttributes.objects.all()
+        queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
         return ordered_queryset


### PR DESCRIPTION
This PR fixes performance issues relating to the typical ORM N+1 issue.
Locally, this took a 3,600 query, 40s call to `/awards/` down to 5 queries, 1.2s 


* Changed a bunch of serializers to `LimitableSerializer` and moved
nested serializers into `Meta.nested_serializers`
* Added code to prefetch and select related nested serializer fields
based upon the `Meta` class
* Updated views to use the new eager loading method
* Updated autocomplete to use eager loaded when needed
* Codeclimate fixes