### PR TITLE
Fixing overeager loading

### DIFF
--- a/usaspending_api/common/api_request_utils.py
+++ b/usaspending_api/common/api_request_utils.py
@@ -326,7 +326,7 @@ class AutoCompleteHandler():
         for field in fields:
             q_args = {}
             q_args[field + mode] = value
-            filter_matched_ids[field] = data_set.all().filter(Q(**q_args)).select_related(field)[:limit].values_list(pk_name, flat=True)
+            filter_matched_ids[field] = data_set.all().filter(Q(**q_args))[:limit].values_list(pk_name, flat=True)
 
         return filter_matched_ids, pk_name
 


### PR DESCRIPTION
Looks like I left an extra select_related (which is redundant) in this section of code; which ended up causing errors on autocompletes that wanted to return matching objects. this fixes the issue