### PR TITLE
Update ETL to support missing OBJCLASS/PRGACTVT

### DIFF
--- a/usaspending_api/submissions/management/commands/load_submission.py
+++ b/usaspending_api/submissions/management/commands/load_submission.py
@@ -432,7 +432,7 @@ def get_or_create_object_class(object_class):
     # We do it this way rather than .get_or_create because we do not want to
     # duplicate existing pk's with null values
     obj_class = RefObjectClassCode.objects.filter(object_class=object_class).first()
-    if obj_class is None and obj_class is not None:
+    if obj_class is None and object_class is not None:
         obj_class = RefObjectClassCode.objects.create(object_class=object_class)
     return obj_class
 

--- a/usaspending_api/submissions/management/commands/load_submission.py
+++ b/usaspending_api/submissions/management/commands/load_submission.py
@@ -168,6 +168,7 @@ class Command(BaseCommand):
                 'submission': submission_attributes,
                 'reporting_period_start': submission_attributes.reporting_period_start,
                 'reporting_period_end': submission_attributes.reporting_period_end,
+                'treasury_account': treasury_account,
                 'appropriation_account_balances': account_balances,
                 'object_class': RefObjectClassCode.objects.filter(pk=row['object_class']).first(),
                 'program_activity_code': RefProgramActivity.objects.filter(pk=row['program_activity_code']).first(),


### PR DESCRIPTION
*
After this has been merged into dev, I will re-load SBA, Treasury submissions and load Energy submission into dev to ensure all data is correct for broker submission loads.

* Adding support method to get_or_create object_class/program_activity
* Fixed location maps to use the new location field names
* Fixed a problem with loading D2 data with foreign province data
classed as state_code
* Fixed a missing treasury_account field