### PR TITLE
Fixing 'retrieve' action quirk

### DIFF
--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -43,7 +43,8 @@ class AwardSerializer(LimitableSerializer):
         nested_serializers = {
             "recipient": {
                 "class": LegalEntitySerializer,
-                "kwargs": {"read_only": True}
+                "kwargs": {"read_only": True},
+                "retrieve": True
             },
             "awarding_agency": {
                 "class": AgencySerializer,
@@ -55,11 +56,12 @@ class AwardSerializer(LimitableSerializer):
             },
             "financial_set": {
                 "class": FinancialAccountsByAwardsSerializer,
-                "kwargs": {"read_only": True, "many": True}
+                "kwargs": {"read_only": True, "many": True},
             },
             "place_of_performance": {
                 "class": LocationSerializer,
-                "kwargs": {"read_only": True}
+                "kwargs": {"read_only": True},
+                "retrieve": True
             },
         }
 

--- a/usaspending_api/data/testing_data/endpoint_testing_data.json
+++ b/usaspending_api/data/testing_data/endpoint_testing_data.json
@@ -1,5 +1,15 @@
 [
     {
+        "status_code": 200,
+        "request_object": {
+            "fields": [
+                "fain",
+                "uri",
+                "piid"
+            ]
+        },
+        "method": "POST",
+        "name": "Test field limiting on awards/",
         "url": "/api/v1/awards/?page=1&limit=1",
         "response_object": {
             "total_metadata": {
@@ -7,8 +17,8 @@
             },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 26
+                "num_pages": 26,
+                "page_number": 1
             },
             "results": [
                 {
@@ -17,19 +27,21 @@
                     "uri": null
                 }
             ]
-        },
-        "name": "Test field limiting on awards/",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "fields": [
-                "fain",
-                "uri",
-                "piid"
-            ]
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "exclude": [
+                "fain",
+                "uri",
+                "piid"
+            ],
+            "limit": 1,
+            "page": 1
+        },
+        "method": "POST",
+        "name": "Testing field exclusion on awards/",
         "url": "/api/v1/awards/",
         "response_object": {
             "total_metadata": {
@@ -37,8 +49,8 @@
             },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 26
+                "num_pages": 26,
+                "page_number": 1
             },
             "results": [
                 {
@@ -117,21 +129,24 @@
                     "financial_set": []
                 }
             ]
-        },
-        "name": "Testing field exclusion on awards/",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "exclude": [
-                "fain",
-                "uri",
-                "piid"
-            ],
-            "limit": 1,
-            "page": 1
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "fields": [
+                "funding_agency"
+            ],
+            "filters": [
+                {
+                    "operation": "equals",
+                    "value": "DEPARTMENT OF POORLY NAMED TEST DATA",
+                    "field": "funding_agency__toptier_agency__name"
+                }
+            ]
+        },
+        "method": "POST",
+        "name": "Testing filter operation 'equals' on awards",
         "url": "/api/v1/awards/?page=1&limit=1",
         "response_object": {
             "total_metadata": {
@@ -139,8 +154,8 @@
             },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 5
+                "num_pages": 5,
+                "page_number": 1
             },
             "results": [
                 {
@@ -159,38 +174,9 @@
                     }
                 }
             ]
-        },
-        "name": "Testing filter operation 'equals' on awards",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "fields": [
-                "funding_agency"
-            ],
-            "filters": [
-                {
-                    "value": "DEPARTMENT OF POORLY NAMED TEST DATA",
-                    "field": "funding_agency__toptier_agency__name",
-                    "operation": "equals"
-                }
-            ]
         }
     },
     {
-        "url": "/api/v1/awards/?page=1&limit=1",
-        "response_object": {
-            "total_metadata": {
-                "count": 0
-            },
-            "page_metadata": {
-                "count": 0,
-                "page_number": 1,
-                "num_pages": 1
-            },
-            "results": []
-        },
-        "name": "Testing filter operation 'range_intersect' on awards",
-        "method": "POST",
         "status_code": 200,
         "request_object": {
             "fields": [
@@ -199,6 +185,7 @@
             ],
             "filters": [
                 {
+                    "operation": "range_intersect",
                     "value": [
                         "2015-10-05",
                         "2016-12-10"
@@ -206,13 +193,43 @@
                     "field": [
                         "create_date",
                         "update_date"
-                    ],
-                    "operation": "range_intersect"
+                    ]
                 }
             ]
+        },
+        "method": "POST",
+        "name": "Testing filter operation 'range_intersect' on awards",
+        "url": "/api/v1/awards/?page=1&limit=1",
+        "response_object": {
+            "total_metadata": {
+                "count": 0
+            },
+            "page_metadata": {
+                "count": 0,
+                "num_pages": 1,
+                "page_number": 1
+            },
+            "results": []
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "fields": [
+                "fain",
+                "create_date",
+                "funding_agency"
+            ],
+            "filters": [
+                {
+                    "operation": "search",
+                    "value": "poorly",
+                    "field": "funding_agency__toptier_agency__name"
+                }
+            ]
+        },
+        "method": "POST",
+        "name": "Testing filter operation 'search' on awards",
         "url": "/api/v1/awards/?page=1&limit=5",
         "response_object": {
             "total_metadata": {
@@ -220,8 +237,8 @@
             },
             "page_metadata": {
                 "count": 5,
-                "page_number": 1,
-                "num_pages": 1
+                "num_pages": 1,
+                "page_number": 1
             },
             "results": [
                 {
@@ -242,8 +259,8 @@
                     }
                 },
                 {
-                    "fain": "SBAHQ16B0017",
-                    "create_date": "2016-12-20T22:50:56.135000Z",
+                    "fain": "SBAHQ15J0005",
+                    "create_date": "2016-12-20T22:50:52.650000Z",
                     "funding_agency": {
                         "id": 1234567,
                         "toptier_agency": {
@@ -259,8 +276,8 @@
                     }
                 },
                 {
-                    "fain": "SBAHQ15J0005",
-                    "create_date": "2016-12-20T22:50:52.650000Z",
+                    "fain": "SBAHQ16B0017",
+                    "create_date": "2016-12-20T22:50:56.135000Z",
                     "funding_agency": {
                         "id": 1234567,
                         "toptier_agency": {
@@ -310,26 +327,35 @@
                     }
                 }
             ]
-        },
-        "name": "Testing filter operation 'search' on awards",
-        "method": "POST",
+        }
+    },
+    {
         "status_code": 200,
         "request_object": {
             "fields": [
                 "fain",
-                "create_date",
-                "funding_agency"
+                "uri"
             ],
             "filters": [
                 {
-                    "value": "poorly",
-                    "field": "funding_agency__toptier_agency__name",
-                    "operation": "search"
+                    "combine_method": "OR",
+                    "filters": [
+                        {
+                            "operation": "is_null",
+                            "value": false,
+                            "field": "fain"
+                        },
+                        {
+                            "operation": "equals",
+                            "value": "DEPARTMENT OF POORLY NAMED TEST DATA",
+                            "field": "funding_agency__toptier_agency__name"
+                        }
+                    ]
                 }
             ]
-        }
-    },
-    {
+        },
+        "method": "POST",
+        "name": "Testing filter combinations via OR on awards",
         "url": "/api/v1/awards/?page=1&limit=100",
         "response_object": {
             "total_metadata": {
@@ -337,8 +363,8 @@
             },
             "page_metadata": {
                 "count": 5,
-                "page_number": 1,
-                "num_pages": 1
+                "num_pages": 1,
+                "page_number": 1
             },
             "results": [
                 {
@@ -362,37 +388,25 @@
                     "uri": null
                 }
             ]
-        },
-        "name": "Testing filter combinations via OR on awards",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "fields": [
-                "fain",
-                "uri"
-            ],
-            "filters": [
-                {
-                    "combine_method": "OR",
-                    "filters": [
-                        {
-                            "value": false,
-                            "field": "fain",
-                            "operation": "is_null"
-                        },
-                        {
-                            "value": "DEPARTMENT OF POORLY NAMED TEST DATA",
-                            "field": "funding_agency__toptier_agency__name",
-                            "operation": "equals"
-                        }
-                    ]
-                }
-            ]
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "fields": [
+                "recipient__location__state_code",
+                "recipient__location__state_name"
+            ],
+            "value": "a"
+        },
+        "method": "POST",
+        "name": "Testing mode 'contains' awards/autocomplete",
         "url": "/api/v1/awards/autocomplete/",
         "response_object": {
+            "counts": {
+                "recipient__location__state_code": 2,
+                "recipient__location__state_name": 5
+            },
             "results": {
                 "recipient__location__state_code": [
                     "LA",
@@ -401,30 +415,31 @@
                 "recipient__location__state_name": [
                     "Minnesota",
                     "South Dakota",
-                    "Utah",
                     "Virginia",
-                    "Louisiana"
+                    "Louisiana",
+                    "Utah"
                 ]
-            },
-            "counts": {
-                "recipient__location__state_code": 2,
-                "recipient__location__state_name": 5
             }
-        },
-        "name": "Testing mode 'contains' awards/autocomplete",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "value": "a",
-            "fields": [
-                "recipient__location__state_code",
-                "recipient__location__state_name"
-            ]
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "mode": "startswith",
+            "fields": [
+                "recipient__location__state_code",
+                "recipient__location__state_name"
+            ],
+            "value": "l"
+        },
+        "method": "POST",
+        "name": "Testing mode 'startswith' awards/autocomplete",
         "url": "/api/v1/awards/autocomplete/",
         "response_object": {
+            "counts": {
+                "recipient__location__state_code": 1,
+                "recipient__location__state_name": 1
+            },
             "results": {
                 "recipient__location__state_code": [
                     "LA"
@@ -432,27 +447,23 @@
                 "recipient__location__state_name": [
                     "Louisiana"
                 ]
-            },
-            "counts": {
-                "recipient__location__state_code": 1,
-                "recipient__location__state_name": 1
             }
-        },
-        "name": "Testing mode 'startswith' awards/autocomplete",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "value": "l",
-            "fields": [
-                "recipient__location__state_code",
-                "recipient__location__state_name"
-            ],
-            "mode": "startswith"
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "group": "type_description",
+            "aggregate": "sum",
+            "field": "total_obligation"
+        },
+        "method": "POST",
+        "name": "Testing awards/total",
         "url": "/api/v1/awards/total/",
         "response_object": {
+            "total_metadata": {
+                "count": 2
+            },
             "results": [
                 {
                     "item": "Cooperative Agreement",
@@ -463,43 +474,14 @@
                     "aggregate": "1612311.83"
                 }
             ],
-            "total_metadata": {
-                "count": 2
-            },
             "page_metadata": {
                 "count": 2,
-                "page_number": 1,
-                "num_pages": 1
+                "num_pages": 1,
+                "page_number": 1
             }
-        },
-        "name": "Testing awards/total",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "group": "type_description",
-            "aggregate": "sum",
-            "field": "total_obligation"
         }
     },
     {
-        "url": "/api/v1/accounts/",
-        "response_object": {
-            "total_metadata": {
-                "count": 1
-            },
-            "page_metadata": {
-                "count": 1,
-                "page_number": 1,
-                "num_pages": 1
-            },
-            "results": [
-                {
-                    "budget_authority_unobligated_balance_brought_forward_fyb": "864120.58"
-                }
-            ]
-        },
-        "name": "Test accounts endpoint POST request",
-        "method": "POST",
         "status_code": 200,
         "request_object": {
             "fields": [
@@ -507,32 +489,32 @@
             ],
             "filters": [
                 {
+                    "operation": "equals",
                     "value": 530,
-                    "field": "appropriation_account_balances_id",
-                    "operation": "equals"
+                    "field": "appropriation_account_balances_id"
                 }
             ]
-        }
-    },
-    {
-        "url": "/api/v1/accounts/tas/",
+        },
+        "method": "POST",
+        "name": "Test accounts endpoint POST request",
+        "url": "/api/v1/accounts/",
         "response_object": {
             "total_metadata": {
                 "count": 1
             },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 1
+                "num_pages": 1,
+                "page_number": 1
             },
             "results": [
                 {
-                    "main_account_code": "0100"
+                    "budget_authority_unobligated_balance_brought_forward_fyb": "864120.58"
                 }
             ]
-        },
-        "name": "Test TAS endpoint POST request",
-        "method": "POST",
+        }
+    },
+    {
         "status_code": 200,
         "request_object": {
             "fields": [
@@ -540,32 +522,32 @@
             ],
             "filters": [
                 {
+                    "operation": "equals",
                     "value": 63031,
-                    "field": "treasury_account_identifier",
-                    "operation": "equals"
+                    "field": "treasury_account_identifier"
                 }
             ]
-        }
-    },
-    {
-        "url": "/api/v1/submissions/",
+        },
+        "method": "POST",
+        "name": "Test TAS endpoint POST request",
+        "url": "/api/v1/accounts/tas/",
         "response_object": {
             "total_metadata": {
                 "count": 1
             },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 1
+                "num_pages": 1,
+                "page_number": 1
             },
             "results": [
                 {
-                    "cgac_code": "073"
+                    "main_account_code": "0100"
                 }
             ]
-        },
-        "name": "Test submission endpoint POST request",
-        "method": "POST",
+        }
+    },
+    {
         "status_code": 200,
         "request_object": {
             "fields": [
@@ -573,14 +555,40 @@
             ],
             "filters": [
                 {
+                    "operation": "equals",
                     "value": 12,
-                    "field": "submission_id",
-                    "operation": "equals"
+                    "field": "submission_id"
+                }
+            ]
+        },
+        "method": "POST",
+        "name": "Test submission endpoint POST request",
+        "url": "/api/v1/submissions/",
+        "response_object": {
+            "total_metadata": {
+                "count": 1
+            },
+            "page_metadata": {
+                "count": 1,
+                "num_pages": 1,
+                "page_number": 1
+            },
+            "results": [
+                {
+                    "cgac_code": "073"
                 }
             ]
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "order": [
+                "award"
+            ]
+        },
+        "method": "POST",
+        "name": "Test transaction endpoint POST request",
         "url": "/api/v1/transactions/?page=1&limit=1",
         "response_object": {
             "total_metadata": {
@@ -588,8 +596,8 @@
             },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 32
+                "num_pages": 32,
+                "page_number": 1
             },
             "results": [
                 {
@@ -607,6 +615,7 @@
                     "funding_agency": null,
                     "recipient": null,
                     "place_of_performance": null,
+                    "contract_data": null,
                     "assistance_data": {
                         "fain": "SBAHQ15J0005",
                         "uri": null,
@@ -614,49 +623,44 @@
                         "cfda_title": "7(j) Technical Assistance",
                         "face_value_loan_guarantee": null,
                         "original_loan_subsidy_cost": null
-                    },
-                    "contract_data": null
+                    }
                 }
-            ]
-        },
-        "name": "Test transaction endpoint POST request",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "order": [
-                "award"
             ]
         }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "group": "action_date",
+            "aggregate": "sum",
+            "date_part": "year",
+            "field": "federal_action_obligation"
+        },
+        "method": "POST",
+        "name": "Test transaction total POST request",
         "url": "/api/v1/transactions/total/",
         "response_object": {
+            "total_metadata": {
+                "count": 1
+            },
             "results": [
                 {
                     "item": "2016",
                     "aggregate": "2566703.84"
                 }
             ],
-            "total_metadata": {
-                "count": 1
-            },
             "page_metadata": {
                 "count": 1,
-                "page_number": 1,
-                "num_pages": 1
+                "num_pages": 1,
+                "page_number": 1
             }
-        },
-        "name": "Test transaction total POST request",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "group": "action_date",
-            "date_part": "year",
-            "aggregate": "sum",
-            "field": "federal_action_obligation"
         }
     },
     {
+        "status_code": 200,
+        "request_object": {},
+        "method": "POST",
+        "name": "Test single award endpoint",
         "url": "/api/v1/awards/47691/",
         "response_object": {
             "id": 47691,
@@ -685,13 +689,15 @@
             "place_of_performance": null,
             "latest_submission": 12,
             "financial_set": []
-        },
-        "name": "Test single award endpoint",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {}
+        }
     },
     {
+        "status_code": 200,
+        "request_object": {
+            "verbose": true
+        },
+        "method": "POST",
+        "name": "Test single transaction endpoint",
         "url": "/api/v1/transactions/21/",
         "response_object": {
             "id": 21,
@@ -719,96 +725,8 @@
             "funding_agency": null,
             "recipient": null,
             "place_of_performance": null,
-            "assistance_data": null,
-            "contract_data": {
-                "transaction": 21,
-                "data_source": "DBR",
-                "piid": "SBAHQ16F0159",
-                "parent_award_id": "NNG15SC89B",
-                "cost_or_pricing_data": "J",
-                "type_of_contract_pricing": "J",
-                "type_of_contract_pricing_description": null,
-                "naics": "541519",
-                "naics_description": "541519: OTHER COMPUTER RELATED SERVICES",
-                "period_of_performance_potential_end_date": "2016-09-24",
-                "ordering_period_end_date": null,
-                "current_total_value_award": "600.00",
-                "potential_total_value_of_award": "600.00",
-                "referenced_idv_agency_identifier": "8000",
-                "idv_type": "C",
-                "multiple_or_single_award_idv": null,
-                "type_of_idc": null,
-                "a76_fair_act_action": null,
-                "dod_claimant_program_code": null,
-                "clinger_cohen_act_planning": "0",
-                "commercial_item_acquisition_procedures": "A",
-                "commercial_item_test_program": "0",
-                "consolidated_contract": "0",
-                "contingency_humanitarian_or_peacekeeping_operation": null,
-                "contract_bundling": "D",
-                "contract_financing": null,
-                "contracting_officers_determination_of_business_size": "S",
-                "cost_accounting_standards": null,
-                "country_of_product_or_service_origin": "USA",
-                "davis_bacon_act": "X",
-                "evaluated_preference": "NONE",
-                "extent_competed": "D",
-                "fed_biz_opps": "Y",
-                "foreign_funding": "X",
-                "gfe_gfp": null,
-                "information_technology_commercial_item_category": null,
-                "interagency_contracting_authority": "X",
-                "local_area_set_aside": "0",
-                "major_program": null,
-                "purchase_card_as_payment_method": "0",
-                "multi_year_contract": null,
-                "national_interest_action": "NONE",
-                "number_of_actions": "1",
-                "number_of_offers_received": "5",
-                "other_statutory_authority": null,
-                "performance_based_service_acquisition": "X",
-                "place_of_manufacture": "D",
-                "price_evaluation_adjustment_preference_percent_difference": null,
-                "product_or_service_code": "7035",
-                "program_acronym": null,
-                "other_than_full_and_open_competition": null,
-                "recovered_materials_sustainability": "C",
-                "research": null,
-                "sea_transportation": null,
-                "service_contract_act": "X",
-                "small_business_competitiveness_demonstration_program": null,
-                "solicitation_identifier": null,
-                "solicitation_procedures": "MAFO",
-                "fair_opportunity_limited_sources": "FAIR",
-                "subcontracting_plan": null,
-                "program_system_or_equipment_code": null,
-                "type_set_aside": "SBA",
-                "epa_designated_product": "E",
-                "walsh_healey_act": "X",
-                "transaction_number": "0",
-                "referenced_idv_modification_number": "NNG15SC89B",
-                "rec_flag": null,
-                "drv_parent_award_awarding_agency_code": null,
-                "drv_current_aggregated_total_value_of_award": null,
-                "drv_current_total_value_of_award": null,
-                "drv_potential_award_idv_amount_total_estimate": null,
-                "drv_potential_aggregated_award_idv_amount_total_estimate": null,
-                "drv_potential_aggregated_total_value_of_award": null,
-                "drv_potential_total_value_of_award": null,
-                "create_date": "2016-12-20T22:50:57.575000Z",
-                "update_date": "2016-12-20T22:50:57.575000Z",
-                "last_modified_date": null,
-                "certified_date": null,
-                "reporting_period_start": null,
-                "reporting_period_end": null,
-                "submission": 12
-            }
-        },
-        "name": "Test single transaction endpoint",
-        "method": "POST",
-        "status_code": 200,
-        "request_object": {
-            "verbose": true
+            "contract_data": 21,
+            "assistance_data": null
         }
     }
 ]

--- a/usaspending_api/references/serializers.py
+++ b/usaspending_api/references/serializers.py
@@ -61,6 +61,7 @@ class LegalEntitySerializer(LimitableSerializer):
         nested_serializers = {
             "location": {
                 "class": LocationSerializer,
-                "kwargs": {"read_only": True}
+                "kwargs": {"read_only": True},
+                "retrieve": True
             },
         }


### PR DESCRIPTION
* Add’s ‘retrieve’ option to nested_serializers; specifying this tells
the serializer to serialize even on retrieve actions
* By default, retrieve actions no longer serialize all children,
instead using a ‘PrimaryKeyRelatedField serializer to list primary keys
for the relations
* Added retrieve flags to recipients and locations
* Updated endpoint testing data to reflect new serializer changes