### PR TITLE
Logging Tweaks (pt. 2)

### DIFF
--- a/usaspending_api/common/mixins.py
+++ b/usaspending_api/common/mixins.py
@@ -258,7 +258,7 @@ class SuperLoggingMixin(LoggingMixin):
         # be stored in the table
         if "results" in response_data:
             del response_data["results"]
-            data["response"] = response_data
+        data["response"] = response_data
         self.events_logger.info(data)
         # Return response
         return response

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -164,6 +164,9 @@ LOGGING = {
         'specifics': {
             '()': "pythonjsonlogger.jsonlogger.JsonFormatter",
             'format': "%(asctime)s %(filename)s %(funcName)s %(levelname)s %(lineno)s %(module)s %(message)s %(name)s %(pathname)s"
+        },
+        'json': {
+            '()': "pythonjsonlogger.jsonlogger.JsonFormatter",
         }
     },
     'handlers': {
@@ -182,6 +185,7 @@ LOGGING = {
             'level': 'INFO',
             'class': 'logging.FileHandler',
             'filename': os.path.join(BASE_DIR, 'usaspending_api/logs/events.log'),
+            'formatter': 'json'
         },
         'exceptions_file': {
             'level': 'ERROR',


### PR DESCRIPTION
per @klrBAH request:

Ensure proper json format is followed for event output (double quotes instead of single quotes) (This also results in proper string-ifying of timestamps)

Ensure only the response object is captured in the data response,
instead of the entire HTML body for queries to the interactive api docs