### PR TITLE
Docs warning

### DIFF
--- a/usaspending_api/templates/index.html
+++ b/usaspending_api/templates/index.html
@@ -21,6 +21,7 @@
     </style>
   </head>
   <body>
+    {% include "warning.html" %}
     <div class="container-fluid usa-da-header">
         <div class="row">
             <nav class="navbar">

--- a/usaspending_api/templates/rest_framework/api.html
+++ b/usaspending_api/templates/rest_framework/api.html
@@ -19,6 +19,7 @@
 {% endblock %}
 {% block breadcrumbs %}{% endblock %}
 {% block navbar %}
+{% include "warning.html" %}
 <div class="container-fluid usa-da-header">
 <div class="navbar">
 <div class="container usa-da-header-container">

--- a/usaspending_api/templates/warning.html
+++ b/usaspending_api/templates/warning.html
@@ -1,0 +1,54 @@
+<style>
+/* You probably wont need to define this body style */
+body {
+    padding: 0;
+    margin: 0;
+}
+/* You probably wont need to define this body style */
+
+
+.warning-banner-wrap {
+    background: rgba(255, 241, 210, 0.95);
+    min-height: 35px;
+    padding: 15px 0;
+    width: 100%;
+    border-bottom: 1px solid #fad980;
+}
+
+.warning-banner-wrap .warning-banner {
+    padding: 0;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.warning-banner-wrap .warning-banner .usa-da-icon {
+    margin: -5px 10px 0 0;
+    height: 30px;
+    width: 30px;
+    float: left;
+}
+
+.warning-banner-wrap .warning-banner .top-alert-text p {
+    max-width: 100%;
+    margin: 5px 0;
+    font-size: 14px;
+}
+</style>
+
+<div class="warning-banner-wrap">
+    <div class="warning-banner">
+        <div class="top-alert-icon">
+            <i class="usa-da-icon">
+              <svg viewBox="0 0 512 512" aria-label="Exclamation Mark Icon"><title>Exclamation Mark Icon</title>
+                <g>
+                  <path d="M502.7 491.8l-240-480c-4-8-10.3-8-14.3 0l-240 480c-3.8 7.8 0 14.2 9 14.2h476.3c9 0 13-6.4 9-14.2zM282 438c0 .6-.3 1-1 1h-51.4c-.6 0-1-.4-1-1v-47h-.3c0-.5.4-1 1-1H281c.7 0 1 .5 1 1v47zm2-74.7h-57l-7-178.5h71l-7 178.5z">
+                  </path>
+                </g>
+              </svg>
+            </i>
+        </div>
+        <div class="top-alert-text">
+            <p>This site is not intended to be an official resource for federal spending data. To submit official federal spending data, please visit&nbsp;<a href="http://www.usaspending.gov" target="_blank" rel="noopener noreferrer">USAspending.gov</a></p>
+        </div>
+    </div>
+</div>

--- a/usaspending_api/templates/warning.html
+++ b/usaspending_api/templates/warning.html
@@ -1,11 +1,9 @@
 <style>
-/* You probably wont need to define this body style */
+
 body {
     padding: 0;
     margin: 0;
 }
-/* You probably wont need to define this body style */
-
 
 .warning-banner-wrap {
     background: rgba(255, 241, 210, 0.95);
@@ -17,7 +15,7 @@ body {
 
 .warning-banner-wrap .warning-banner {
     padding: 0;
-    max-width: 900px;
+    max-width: 1170px;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
This adds a little "hat" to the top of the API docs pages to make clear it's not the official source of data and that users should still visit usaspending.gov for that. 