### PR TITLE
Fixing Full Text Search

### DIFF
--- a/usaspending_api/common/api_request_utils.py
+++ b/usaspending_api/common/api_request_utils.py
@@ -253,6 +253,13 @@ class FilterGenerator():
                                 raise InvalidParameterException("Invalid field, operation 'range_intersect' requires an array of length 2 for field")
                             if (not isinstance(filt['value'], list) or len(filt['value']) != 2) and 'value_format' not in filt:
                                 raise InvalidParameterException("Invalid value, operation 'range_intersect' requires an array value of length 2, or a single value with value_format set to a ranged format (such as fy)")
+                        if filt['operation'] == 'search':
+                            if not isinstance(filt['field'], list) and not self.is_string_field(filt['field']):
+                                raise InvalidParameterException("Invalid field: '" + filt['field'] + "', operation 'search' requires a text-field for searching")
+                            elif isinstance(filt['field'], list):
+                                for search_field in filt['field']:
+                                    if not self.is_string_field(search_field):
+                                        raise InvalidParameterException("Invalid field: '" + search_field + "', operation 'search' requires a text-field for searching")
                     else:
                         raise InvalidParameterException("Malformed filter - missing field, operation, or value")
 

--- a/usaspending_api/common/mixins.py
+++ b/usaspending_api/common/mixins.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from django.db.models import Avg, Count, F, Max, Min, Sum, Func, IntegerField, ExpressionWrapper
+from django.db.models import Avg, Count, F, Q, Max, Min, Sum, Func, IntegerField, ExpressionWrapper
 from django.db.models.functions import ExtractDay, ExtractMonth, ExtractYear
 from django.core.serializers.json import json, DjangoJSONEncoder
 
@@ -155,21 +155,24 @@ class FilterQuerysetMixin(object):
         # process to accept a list of paramaters
         # and create filters without needing to know about the structure
         # of the request itself.
+        filters = None
+        filter_map = kwargs.get('filter_map', {})
+        fg = FilterGenerator(queryset.model, filter_map=filter_map)
+
         if len(request.data):
             fg = FilterGenerator(queryset.model)
             filters = fg.create_from_request_body(request.data)
-            return queryset.filter(filters).distinct()
         else:
-            filter_map = kwargs.get('filter_map', {})
-            fg = FilterGenerator(queryset.model, filter_map=filter_map)
-            filters = fg.create_from_query_params(request.query_params)
-            # add fiscal year to filters if requested
-            # deprecated: we plan to start storing fiscal years in the database
-            if request.query_params.get('fy'):
-                fy = FiscalYear(request.query_params.get('fy'))
-                fy_arguments = fy.get_filter_object('date_signed', as_dict=True)
-                filters = {**filters, **fy_arguments}
-            return queryset.filter(**filters).distinct()
+            filters = Q(**fg.create_from_query_params(request.query_params))
+
+        # Handle FTS vectors
+        if len(fg.search_vectors) > 0:
+            vector_sum = fg.search_vectors[0]
+            for vector in fg.search_vectors[1:]:
+                vector_sum += vector
+            queryset = queryset.annotate(search=vector_sum)
+
+        return queryset.filter(filters).distinct()
 
     def order_records(self, request, *args, **kwargs):
         """Order a queryset based on request parameters."""

--- a/usaspending_api/common/tests/test_filter_generator.py
+++ b/usaspending_api/common/tests/test_filter_generator.py
@@ -51,7 +51,7 @@ def mock_data():
     mommy.make(
         'awards.Award',
         piid='zzz',
-        fain='abc123',
+        fain='small',
         type='B',
         total_obligation=1000,
         description='LARGE BUSINESS ADMINISTRATION',
@@ -74,6 +74,19 @@ def test_filter_generator_search_operation(client, mock_data):
 
     # Verify the filter returns the appropriate number of matches
     assert Award.objects.filter(q_obj).count() == 3
+
+    resp = client.post(
+        '/api/v1/awards/',
+        content_type='application/json',
+        data=json.dumps({"filters": [{
+            "field": ["description", "fain"],
+            "operation": "search",
+            "value": "small"
+        }]}))
+    assert resp.status_code == status.HTTP_200_OK
+    results = resp.data['results']
+
+    assert len(results) == 4
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
While helping @ejgullo on her full text search story, I discovered that we were missing the code that performed vector annotation. It appears that during refactoring to the new mixins, the annotation of full-text search vectors was left out. This code rectifies this, cleans up the filter mixin, adds validation for full text search operation, and introduces a test case to catch this problem.

* Added extra validations for full text search queries to the filter
validator
* Added search vector annotation to the filtering mixin
* Removed deprecated code from the filtering mixin
* Added test case for full text search on multiple fields