### PR TITLE
Adding ERD to docs

### DIFF
--- a/usaspending_api/api_docs/markdown/documentation_index.md
+++ b/usaspending_api/api_docs/markdown/documentation_index.md
@@ -14,6 +14,7 @@
 
 ## Technical <a name="technical"></a>
 * [Using the API](/docs/using-the-api) - General overview of all API endpoints, functionality, and filters
+* [Entity Relationship Diagram](/docs/entity-relationships) - A diagram of the relationships between the various entities available through the endpoints
 
 ## Data <a name="data"></a>
 * [Data Dictionary](/docs/data-dictionary) - Reference table of endpoints and what data is provided by those endpoints

--- a/usaspending_api/api_docs/urls.py
+++ b/usaspending_api/api_docs/urls.py
@@ -12,5 +12,4 @@ urlpatterns = [
     url(r'^recipes', MarkdownView.as_view(markdown='request_recipes.md')),
     url(r'^using-the-api', MarkdownView.as_view(markdown='using_the_api.md')),
     url(r'^entity-relationships', Plate.as_view(plate_template_name='plate.html'), name='plate'),
-    url(r'^erd', include('django_spaghetti.urls')),
 ]

--- a/usaspending_api/api_docs/urls.py
+++ b/usaspending_api/api_docs/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import url, include
 from usaspending_api import views as views
 from usaspending_api.common.views import MarkdownView
+from django_spaghetti.views import Plate
 
 
 urlpatterns = [
@@ -10,4 +11,6 @@ urlpatterns = [
     url(r'^data-dictionary', MarkdownView.as_view(markdown='data_dictionary.md')),
     url(r'^recipes', MarkdownView.as_view(markdown='request_recipes.md')),
     url(r'^using-the-api', MarkdownView.as_view(markdown='using_the_api.md')),
+    url(r'^entity-relationships', Plate.as_view(plate_template_name='plate.html'), name='plate'),
+    url(r'^erd', include('django_spaghetti.urls')),
 ]

--- a/usaspending_api/templates/plate.html
+++ b/usaspending_api/templates/plate.html
@@ -1,0 +1,124 @@
+{% load docs %}
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>USAspending Prototype API</title>
+    <link rel="stylesheet" href='{% static "css/google-fonts.css" %}'>
+    <link rel="stylesheet" href='{% static "css/monokai-sublime.css" %}'>
+    <link rel="stylesheet" href='{% static "css/main.css" %}'>
+    <script src='{% static "js/modernizr.js" %}'></script>
+    <style>
+      .logo {width:350px;background-color:white;padding:15px;margin-right:20px;}
+      .row-fluid outter-wrap {padding-top: 30px;}
+      p { max-width: 80rem;}
+      h1{ font-size: 5rem;}
+      h2 {font-size: 4rem;}
+      .outter-wrap { margin-top:204px; }
+      #sidebar{margin-top: 100px;}
+    </style>
+  </head>
+  <body>
+    <div class="container-fluid usa-da-header">
+      {% include "warning.html" %}
+        <div class="row">
+            <nav class="navbar">
+                <div class="container usa-da-header-container">
+                    <h1><a href="/"><img class="logo" src='{% static "img/logo.png" %}'/>Prototype API</a></h1>
+                    <ul id="usa-da-header-link-holder" class="nav nav-row">
+
+                        <li class="element first active ">
+                            <a href="/docs/">Docs</a>
+                        </li>
+
+                        <li class="element   last">
+                            <a href="https://github.com/fedspendingtransparency/usaspending-api">Github</a>
+                        </li>
+
+                    </ul>
+                </div>
+            </nav>
+        </div>
+    </div>
+    <div class="usa-da-outter-wrap">
+      <div class="container homepage">
+        <div class="row-fluid outter-wrap">
+          <div class="container">
+            <div class="row">
+              <div class="col-md-3" id="leftCol">
+                <section class="wrap">
+                <div class="row">
+                  <p>The diagram to the right is an entity relationship diagram displaying the relationships among database models.</p>
+                  <p>You can pan around the diagram using your cursor, and zoom in and out using a scroll wheel.</p>
+                </div>
+              </section>
+              </div>
+              <div class="col-md-9">
+                <section class="wrap">
+                <div id="visualization">
+                </div>
+                </section>
+              </div>
+            </div>
+          </div>
+          </div>
+        </div>
+      </div>
+
+      <script src='{% static "js/jquery-2.2.0.min.js" %}'></script>
+      <script src='{% static "js/bootstrap.min.js" %}'></script>
+      <script src='{% static "js/mobile-head.js" %}'></script>
+      <script src='{% static "js/Chart.js" %}'></script>
+      <script src='{% static "js/fedSpend_base.js" %}'></script>
+      <script src='{% static "js/highlight.pack.js" %}'></script>
+      <script src='{% static "js/flyLabel.js" %}'></script>
+      <script>
+            if (Modernizr.input.placeholder) {
+              $('body').flyLabels();
+            }
+      </script>
+
+
+      <script>hljs.initHighlightingOnLoad();</script>
+
+      {% block extra_scripts %}
+      <script src="//cdnjs.cloudflare.com/ajax/libs/vis/4.7.0/vis.min.js"></script>
+      <link href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.7.0/vis.min.css" rel="stylesheet" type="text/css" />
+      {% endblock %}
+
+      <script>
+        var nodes = new vis.DataSet(
+            {{ meatballs|safe }}
+        );
+        var edges = new vis.DataSet(
+            {{ spaghetti|safe }}
+        );
+        var data = {
+          nodes: nodes,
+          edges: edges
+        };
+        var container = document.getElementById('visualization');
+        var options = {
+          "edges": {
+            "smooth": {
+              "type": "cubicBezier",
+              "roundness": 0.55
+            }
+          },
+
+          "layout": {
+              hierarchical: {
+                  sortMethod: 'hubsize',
+                  direction:'LR'
+              }
+          },
+        };
+
+        var timeline = new vis.Network(container, data, options);
+        $('#visualization .vis-network canvas')[0].height = window.innerHeight;
+      </script>
+
+  </body>
+</html>

--- a/usaspending_api/urls.py
+++ b/usaspending_api/urls.py
@@ -32,7 +32,6 @@ urlpatterns = [
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^docs/', include('usaspending_api.api_docs.urls')),
     url(r'^$', MarkdownView.as_view(markdown='landing_page.md')),
-    url(r'^entity-relationships/', include('django_spaghetti.urls')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 


### PR DESCRIPTION
We should refactor the templates in the future to be more django-ific.

This is a PR into my documentation branch that will add the ERD diagrams @catherinedevlin added to the documentation pages, and style it according the the templates we use across the docs. 

Using a separate PR so we have the option of not merging this in, but I think we should as the diagram does provide some value (and we can polish it all up during next sprint!)