### PR TITLE
API performance improvements (minus cache)

### DIFF
--- a/usaspending_api/common/mixins.py
+++ b/usaspending_api/common/mixins.py
@@ -214,12 +214,12 @@ class ResponseMetadatasetMixin(object):
         params = self.request.query_params.copy()  # copy() creates mutable copy of a QueryDict
         params.update(self.request.data.copy())
 
-        # construct metadata of entire set of data that matches the request specifications
-        total_metadata = {"count": queryset.count()}
-
         # get paged data for this request
         paged_data = ResponsePaginator.get_paged_data(
             queryset, request_parameters=params)
+
+        # construct metadata of entire set of data that matches the request specifications
+        total_metadata = {"count": paged_data.paginator.count}
 
         # construct page-specific metadata
         page_metadata = {

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -78,7 +78,7 @@ class LimitableSerializer(serializers.ModelSerializer):
                     pass
 
     @classmethod
-    def setup_eager_loading(cls, queryset, prefix="", parent_is_many=False):
+    def setup_eager_loading(cls, queryset, prefix=""):
         '''
         This method will set up prefetch and selected related statements appropriately
         on a specified query set based upon the serializer's nested_serializer parameter
@@ -96,13 +96,9 @@ class LimitableSerializer(serializers.ModelSerializer):
             # Grab the nested serializers (aka children)
             children = cls.Meta.nested_serializers
             for child in children:
-                is_many = children[child].get("kwargs", {}).get("many", False)
-                if is_many or parent_is_many:
-                    queryset = queryset.prefetch_related(prefix + child)
-                else:
-                    queryset = queryset.select_related(prefix + child)
+                queryset = queryset.prefetch_related(prefix + child)
                 # Since the child might have nested serializers, we set up on that too
-                queryset = children[child]["class"].setup_eager_loading(queryset, prefix=prefix + child + "__", parent_is_many=is_many)
+                queryset = children[child]["class"].setup_eager_loading(queryset, prefix=prefix + child + "__")
         except AttributeError:
             # We don't have any nested serializers
             pass

--- a/usaspending_api/common/views.py
+++ b/usaspending_api/common/views.py
@@ -32,13 +32,13 @@ class AggregateView(AggregateQuerysetMixin,
         try:
             queryset = self.aggregate(request, *args, **kwargs)
 
-            # construct metadata of entire queryset
-            metadata = {"count": queryset.count()}
-
             # get paged data for this request
             paged_data = ResponsePaginator.get_paged_data(
                 queryset, request_parameters=request.data)
             paged_queryset = paged_data.object_list.all()
+
+            # construct metadata of entire queryset
+            metadata = {"count": paged_data.paginator.count}
 
             # construct page-specific metadata
             page_metadata = {

--- a/usaspending_api/data/testing_data/endpoint_testing_data.json
+++ b/usaspending_api/data/testing_data/endpoint_testing_data.json
@@ -1,7 +1,5 @@
 [
     {
-        "name": "Test field limiting on awards/",
-        "url": "/api/v1/awards/?page=1&limit=1",
         "request_object": {
             "fields": [
                 "fain",
@@ -9,16 +7,14 @@
                 "piid"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 26
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 26,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
@@ -27,30 +23,30 @@
                     "uri": null
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/?page=1&limit=1",
+        "name": "Test field limiting on awards/",
+        "status_code": 200
     },
     {
-        "name": "Testing field exclusion on awards/",
-        "url": "/api/v1/awards/",
         "request_object": {
             "page": 1,
-            "limit": 1,
             "exclude": [
                 "fain",
                 "uri",
                 "piid"
-            ]
+            ],
+            "limit": 1
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 26
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 26,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
@@ -132,33 +128,33 @@
                     }
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/",
+        "name": "Testing field exclusion on awards/",
+        "status_code": 200
     },
     {
-        "name": "Testing filter operation 'equals' on awards",
-        "url": "/api/v1/awards/?page=1&limit=1",
         "request_object": {
-            "fields": [
-                "funding_agency"
-            ],
             "filters": [
                 {
                     "value": "DEPARTMENT OF POORLY NAMED TEST DATA",
                     "field": "funding_agency__toptier_agency__name",
                     "operation": "equals"
                 }
+            ],
+            "fields": [
+                "funding_agency"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 5
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 5,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
@@ -179,16 +175,14 @@
                     }
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/?page=1&limit=1",
+        "name": "Testing filter operation 'equals' on awards",
+        "status_code": 200
     },
     {
-        "name": "Testing filter operation 'range_intersect' on awards",
-        "url": "/api/v1/awards/?page=1&limit=1",
         "request_object": {
-            "fields": [
-                "create_date",
-                "update_date"
-            ],
             "filters": [
                 {
                     "value": [
@@ -201,54 +195,56 @@
                     ],
                     "operation": "range_intersect"
                 }
+            ],
+            "fields": [
+                "create_date",
+                "update_date"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 0
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 0,
                 "num_pages": 1,
-                "count": 0
+                "page_number": 1
             },
             "results": []
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/?page=1&limit=1",
+        "name": "Testing filter operation 'range_intersect' on awards",
+        "status_code": 200
     },
     {
-        "name": "Testing filter operation 'search' on awards",
-        "url": "/api/v1/awards/?page=1&limit=5",
         "request_object": {
-            "fields": [
-                "fain",
-                "create_date",
-                "funding_agency"
-            ],
             "filters": [
                 {
                     "value": "poorly",
                     "field": "funding_agency__toptier_agency__name",
                     "operation": "search"
                 }
+            ],
+            "fields": [
+                "fain",
+                "create_date",
+                "funding_agency"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 5
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 5,
                 "num_pages": 1,
-                "count": 5
+                "page_number": 1
             },
             "results": [
                 {
-                    "fain": "SBAHQ16B0017",
-                    "create_date": "2016-12-20T22:50:56.135000Z",
+                    "fain": "SBAHQ15J0005",
+                    "create_date": "2016-12-20T22:50:52.650000Z",
                     "funding_agency": {
                         "id": 1234567,
                         "toptier_agency": {
@@ -266,8 +262,8 @@
                     }
                 },
                 {
-                    "fain": "SBAHQ15J0005",
-                    "create_date": "2016-12-20T22:50:52.650000Z",
+                    "fain": "SBAHQ16B0070",
+                    "create_date": "2016-12-20T22:50:52.907000Z",
                     "funding_agency": {
                         "id": 1234567,
                         "toptier_agency": {
@@ -323,8 +319,8 @@
                     }
                 },
                 {
-                    "fain": "SBAHQ16B0070",
-                    "create_date": "2016-12-20T22:50:52.907000Z",
+                    "fain": "SBAHQ16B0017",
+                    "create_date": "2016-12-20T22:50:56.135000Z",
                     "funding_agency": {
                         "id": 1234567,
                         "toptier_agency": {
@@ -342,18 +338,17 @@
                     }
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/?page=1&limit=5",
+        "name": "Testing filter operation 'search' on awards",
+        "status_code": 200
     },
     {
-        "name": "Testing filter combinations via OR on awards",
-        "url": "/api/v1/awards/?page=1&limit=100",
         "request_object": {
-            "fields": [
-                "fain",
-                "uri"
-            ],
             "filters": [
                 {
+                    "combine_method": "OR",
                     "filters": [
                         {
                             "value": false,
@@ -365,21 +360,22 @@
                             "field": "funding_agency__toptier_agency__name",
                             "operation": "equals"
                         }
-                    ],
-                    "combine_method": "OR"
+                    ]
                 }
+            ],
+            "fields": [
+                "fain",
+                "uri"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 5
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 5,
                 "num_pages": 1,
-                "count": 5
+                "page_number": 1
             },
             "results": [
                 {
@@ -403,20 +399,20 @@
                     "uri": null
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/?page=1&limit=100",
+        "name": "Testing filter combinations via OR on awards",
+        "status_code": 200
     },
     {
-        "name": "Testing mode 'contains' awards/autocomplete",
-        "url": "/api/v1/awards/autocomplete/",
         "request_object": {
+            "value": "a",
             "fields": [
                 "recipient__location__state_code",
                 "recipient__location__state_name"
-            ],
-            "value": "a"
+            ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "counts": {
                 "recipient__location__state_code": 2,
@@ -424,32 +420,32 @@
             },
             "results": {
                 "recipient__location__state_code": [
-                    "LA",
-                    "VA"
+                    "VA",
+                    "LA"
                 ],
                 "recipient__location__state_name": [
-                    "Louisiana",
-                    "South Dakota",
-                    "Minnesota",
                     "Virginia",
-                    "Utah"
+                    "Louisiana",
+                    "Utah",
+                    "South Dakota",
+                    "Minnesota"
                 ]
             }
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/autocomplete/",
+        "name": "Testing mode 'contains' awards/autocomplete",
+        "status_code": 200
     },
     {
-        "name": "Testing mode 'startswith' awards/autocomplete",
-        "url": "/api/v1/awards/autocomplete/",
         "request_object": {
+            "value": "l",
+            "mode": "startswith",
             "fields": [
                 "recipient__location__state_code",
                 "recipient__location__state_name"
-            ],
-            "value": "l",
-            "mode": "startswith"
+            ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "counts": {
                 "recipient__location__state_code": 1,
@@ -463,25 +459,20 @@
                     "Louisiana"
                 ]
             }
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/autocomplete/",
+        "name": "Testing mode 'startswith' awards/autocomplete",
+        "status_code": 200
     },
     {
-        "name": "Testing awards/total",
-        "url": "/api/v1/awards/total/",
         "request_object": {
-            "aggregate": "sum",
             "group": "type_description",
+            "aggregate": "sum",
             "field": "total_obligation"
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
-                "count": 2
-            },
-            "page_metadata": {
-                "page_number": 1,
-                "num_pages": 1,
                 "count": 2
             },
             "results": [
@@ -493,143 +484,149 @@
                     "item": "Unknown Type",
                     "aggregate": "1612311.83"
                 }
-            ]
-        }
+            ],
+            "page_metadata": {
+                "count": 2,
+                "num_pages": 1,
+                "page_number": 1
+            }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/total/",
+        "name": "Testing awards/total",
+        "status_code": 200
     },
     {
-        "name": "Test accounts endpoint POST request",
-        "url": "/api/v1/accounts/",
         "request_object": {
-            "fields": [
-                "budget_authority_unobligated_balance_brought_forward_fyb"
-            ],
             "filters": [
                 {
                     "value": 530,
                     "field": "appropriation_account_balances_id",
                     "operation": "equals"
                 }
+            ],
+            "fields": [
+                "budget_authority_unobligated_balance_brought_forward_fyb"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 1
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 1,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
                     "budget_authority_unobligated_balance_brought_forward_fyb": "864120.58"
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/accounts/",
+        "name": "Test accounts endpoint POST request",
+        "status_code": 200
     },
     {
-        "name": "Test TAS endpoint POST request",
-        "url": "/api/v1/accounts/tas/",
         "request_object": {
-            "fields": [
-                "main_account_code"
-            ],
             "filters": [
                 {
                     "value": 63031,
                     "field": "treasury_account_identifier",
                     "operation": "equals"
                 }
+            ],
+            "fields": [
+                "main_account_code"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 1
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 1,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
                     "main_account_code": "0100"
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/accounts/tas/",
+        "name": "Test TAS endpoint POST request",
+        "status_code": 200
     },
     {
-        "name": "Test submission endpoint POST request",
-        "url": "/api/v1/submissions/",
         "request_object": {
-            "fields": [
-                "cgac_code"
-            ],
             "filters": [
                 {
                     "value": 12,
                     "field": "submission_id",
                     "operation": "equals"
                 }
+            ],
+            "fields": [
+                "cgac_code"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 1
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 1,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
                     "cgac_code": "073"
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/submissions/",
+        "name": "Test submission endpoint POST request",
+        "status_code": 200
     },
     {
-        "name": "Test transaction endpoint POST request",
-        "url": "/api/v1/transactions/?page=1&limit=1",
         "request_object": {
             "order": [
                 "award"
             ]
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 32
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 32,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
-                    "id": 3,
+                    "id": 4,
                     "type": "05",
                     "type_description": "Cooperative Agreement",
                     "period_of_performance_start_date": null,
                     "period_of_performance_current_end_date": null,
                     "action_date": "2016-09-20",
                     "action_type": "A",
-                    "federal_action_obligation": "8901.33",
-                    "modification_number": "0003:560400DB",
+                    "federal_action_obligation": "6098.67",
+                    "modification_number": "0003:670400DB",
                     "description": "FY 15 7J",
                     "awarding_agency": null,
                     "funding_agency": null,
                     "recipient": null,
                     "place_of_performance": null,
+                    "contract_data": null,
                     "assistance_data": {
                         "fain": "SBAHQ15J0005",
                         "uri": null,
@@ -638,30 +635,24 @@
                         "face_value_loan_guarantee": null,
                         "original_loan_subsidy_cost": null,
                         "cfda": null
-                    },
-                    "contract_data": null
+                    }
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/transactions/?page=1&limit=1",
+        "name": "Test transaction endpoint POST request",
+        "status_code": 200
     },
     {
-        "name": "Test transaction total POST request",
-        "url": "/api/v1/transactions/total/",
         "request_object": {
+            "group": "action_date",
             "aggregate": "sum",
             "date_part": "year",
-            "group": "action_date",
             "field": "federal_action_obligation"
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
-                "count": 1
-            },
-            "page_metadata": {
-                "page_number": 1,
-                "num_pages": 1,
                 "count": 1
             },
             "results": [
@@ -669,15 +660,20 @@
                     "item": "2016",
                     "aggregate": "2566703.84"
                 }
-            ]
-        }
+            ],
+            "page_metadata": {
+                "count": 1,
+                "num_pages": 1,
+                "page_number": 1
+            }
+        },
+        "method": "POST",
+        "url": "/api/v1/transactions/total/",
+        "name": "Test transaction total POST request",
+        "status_code": 200
     },
     {
-        "name": "Test single award endpoint",
-        "url": "/api/v1/awards/47691/",
         "request_object": {},
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "id": 47691,
             "date_signed__fy": 2016,
@@ -705,16 +701,16 @@
             "place_of_performance": null,
             "latest_submission": 12,
             "latest_transaction": null
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/awards/47691/",
+        "name": "Test single award endpoint",
+        "status_code": 200
     },
     {
-        "name": "Test single transaction endpoint",
-        "url": "/api/v1/transactions/21/",
         "request_object": {
             "verbose": true
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "id": 21,
             "data_source": "DBR",
@@ -741,7 +737,6 @@
             "funding_agency": null,
             "recipient": null,
             "place_of_performance": null,
-            "assistance_data": null,
             "contract_data": {
                 "transaction": 21,
                 "data_source": "DBR",
@@ -824,25 +819,26 @@
                 "reporting_period_start": null,
                 "reporting_period_end": null,
                 "submission": 12
-            }
-        }
+            },
+            "assistance_data": null
+        },
+        "method": "POST",
+        "url": "/api/v1/transactions/21/",
+        "name": "Test single transaction endpoint",
+        "status_code": 200
     },
     {
-        "name": "Test financial accounts by awards endpoint",
-        "url": "/api/v1/accounts/awards/",
         "request_object": {
             "verbose": true
         },
-        "status_code": 200,
-        "method": "POST",
         "response_object": {
             "total_metadata": {
                 "count": 1
             },
             "page_metadata": {
-                "page_number": 1,
+                "count": 1,
                 "num_pages": 1,
-                "count": 1
+                "page_number": 1
             },
             "results": [
                 {
@@ -903,6 +899,10 @@
                     "object_class": "310"
                 }
             ]
-        }
+        },
+        "method": "POST",
+        "url": "/api/v1/accounts/awards/",
+        "name": "Test financial accounts by awards endpoint",
+        "status_code": 200
     }
 ]

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -104,7 +104,7 @@ CORS_ORIGIN_ALLOW_ALL = True  # Temporary while in development
 # import an environment variable, DATABASE_URL
 # see https://github.com/kennethreitz/dj-database-url for more info
 
-DATABASES = {'default': dj_database_url.config(conn_max_age=600)}
+DATABASES = {'default': dj_database_url.config(conn_max_age=10)}
 
 # import a second database connection for ETL, connecting to the data broker
 # using the environemnt variable, DATA_BROKER_DATABASE_URL - only if it is set


### PR DESCRIPTION
This PR combines several performance improvement initiatives for the API. Shout out to @catherinedevlin and @afrasier for these ideas and work.

1. Remove `.distinct()`
2. Get all response metadata counts from paginator stored data
3. Use `prefetch_related` for all API queries
4. Log response only, not the HTML
5. Reduce the max db connection age from 10 min to 10 sec