### PR TITLE
Add federal account model and data migrations

### DIFF
--- a/usaspending_api/accounts/migrations/0018_auto_20170322_2024.py
+++ b/usaspending_api/accounts/migrations/0018_auto_20170322_2024.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0017_auto_20170320_1455'),
+    ]
+
+    tas_fk_sql = '''
+        update treasury_appropriation_account t
+        set federal_account_id = fa.id
+        from federal_account fa
+        where t.agency_id = fa.agency_identifier
+        and t.main_account_code = fa.main_account_code
+        '''
+
+    ab_fk_sql = '''
+        update appropriation_account_balances ab
+        set federal_account_id = t.federal_account_id
+        from treasury_appropriation_account t
+        where ab.treasury_account_identifier = t.treasury_account_identifier
+        '''
+
+    def insert_federal_accounts(apps, schema_editor):
+        TreasuryAppropriationAccount = apps.get_model(
+            "accounts", "TreasuryAppropriationAccount")
+        FederalAccount = apps.get_model("accounts", "FederalAccount")
+        # Get a count of distinct combinations of agency id/main acct code
+        # in the TAS table.
+        expected_federal_accounts = TreasuryAppropriationAccount.objects.distinct(
+            'main_account_code', 'agency_id').count()
+
+        # Get TAS agency id (AID), main acct code (MAC), and the acct title for the most
+        # recent period end date for each agency/acct code combo. These
+        # will be the federal account records.
+        federal_accounts = TreasuryAppropriationAccount.objects.values_list(
+            'agency_id', 'main_account_code', 'account_title').distinct(
+                'agency_id', 'main_account_code').order_by(
+                'agency_id', 'main_account_code', '-ending_period_of_availability')
+        fa_objects = [FederalAccount(
+            agency_identifier=f[0],
+            main_account_code=f[1],
+            account_title=f[2]) for f in federal_accounts]
+        FederalAccount.objects.bulk_create(fa_objects)
+
+        # Make sure the distinct query we run above to get the federal acct
+        # records returns the same number of rows as doing a straight up
+        # distinct on AID/MAC. If not, abort the mission.
+        if expected_federal_accounts != federal_accounts.count():
+            raise ValueError('Federal account check failed: aborting migration')
+
+    def get_temp_federal_account_fk(apps):
+        """
+        Return a valid federal account pk that we can use as a temporary
+        default value when adding federal_account FKs to tables
+        """
+        FederalAccount = apps.get_model("accounts", "FederalAccount")
+        return FederalAccount.objects.values_list('id').first()[0]
+
+    operations = [
+        migrations.CreateModel(
+            name='FederalAccount',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('agency_identifier', models.CharField(db_index=True, max_length=3)),
+                ('main_account_code', models.CharField(db_index=True, max_length=4)),
+                ('account_title', models.CharField(max_length=300)),
+            ],
+            options={
+                'managed': True,
+                'db_table': 'federal_account',
+            },
+        ),
+
+        migrations.AlterUniqueTogether(
+            name='federalaccount',
+            unique_together=set([('agency_identifier', 'main_account_code')]),
+        ),
+
+        # insert records to newly-created finanical_accouns table
+        migrations.RunPython(insert_federal_accounts, migrations.RunPython.noop),
+
+        # add federal account foreign keys to TAS-related tables
+        migrations.AddField(
+            model_name='appropriationaccountbalances',
+            name='federal_account',
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                to='accounts.FederalAccount'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='treasuryappropriationaccount',
+            name='federal_account',
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                to='accounts.FederalAccount'),
+            preserve_default=False,
+        ),
+
+        # set values for new federal account FKs
+        migrations.RunSQL(tas_fk_sql, migrations.RunSQL.noop),
+        migrations.RunSQL(ab_fk_sql, migrations.RunSQL.noop),
+    ]

--- a/usaspending_api/accounts/models.py
+++ b/usaspending_api/accounts/models.py
@@ -3,11 +3,33 @@ from usaspending_api.submissions.models import SubmissionAttributes
 from usaspending_api.common.models import DataSourceTrackedModel
 
 
-# Table #3 - Treasury Appropriation Accounts.
+class FederalAccount(models.Model):
+    """
+    Represents a single federal account. A federal account encompasses
+    multiple Treasury Account Symbols (TAS), represented by
+    :model:`accounts.TreasuryAppropriationAccount`.
+    """
+    agency_identifier = models.CharField(max_length=3, db_index=True)
+    main_account_code = models.CharField(max_length=4, db_index=True)
+    account_title = account_title = models.CharField(max_length=300)
+
+    class Meta:
+        managed = True
+        db_table = 'federal_account'
+        unique_together = ('agency_identifier', 'main_account_code')
+
+
 class TreasuryAppropriationAccount(DataSourceTrackedModel):
+    """Represents a single Treasury Account Symbol (TAS)."""
     treasury_account_identifier = models.AutoField(primary_key=True)
+    federal_account = models.ForeignKey('FederalAccount', models.DO_NOTHING, null=True)
     tas_rendering_label = models.CharField(max_length=50, blank=True, null=True)
     allocation_transfer_agency_id = models.CharField(max_length=3, blank=True, null=True)
+    # todo: update the agency details to match FederalAccounts. Is there a way that we can
+    # retain the text-based agency TAS components (since those are attributes of TAS
+    # while still having a convenient FK that links to our agency tables using Django's
+    # default fk naming standard? Something like agency_identifier for the 3 digit TAS
+    # component and agency_id for the FK?)
     agency_id = models.CharField(max_length=3)
     beginning_period_of_availability = models.CharField(max_length=4, blank=True, null=True)
     ending_period_of_availability = models.CharField(max_length=4, blank=True, null=True)
@@ -105,9 +127,17 @@ class TreasuryAppropriationAccount(DataSourceTrackedModel):
         return "%s" % (self.tas_rendering_label)
 
 
-# Table #4 - Appropriation Account Balances
 class AppropriationAccountBalances(DataSourceTrackedModel):
+    """
+    Represents Treasury Account Symbol (TAS) balances for each DATA Act
+    broker submission. Each submission provides a snapshot of the most
+    recent numbers for that fiscal year. In other words, the lastest
+    submission for a fiscal year reflects the balances for the entire
+    fiscal year.
+    """
     appropriation_account_balances_id = models.AutoField(primary_key=True)
+    # a convenience FK back to federal accounts for ease of traversal
+    federal_account = models.ForeignKey('FederalAccount', models.DO_NOTHING, null=True)
     treasury_account_identifier = models.ForeignKey('TreasuryAppropriationAccount', models.CASCADE, db_column='treasury_account_identifier', related_name="account_balances")
     submission = models.ForeignKey(SubmissionAttributes, models.CASCADE)
     budget_authority_unobligated_balance_brought_forward_fyb = models.DecimalField(max_digits=21, decimal_places=2, blank=True, null=True)

--- a/usaspending_api/accounts/models.py
+++ b/usaspending_api/accounts/models.py
@@ -136,8 +136,6 @@ class AppropriationAccountBalances(DataSourceTrackedModel):
     fiscal year.
     """
     appropriation_account_balances_id = models.AutoField(primary_key=True)
-    # a convenience FK back to federal accounts for ease of traversal
-    federal_account = models.ForeignKey('FederalAccount', models.DO_NOTHING, null=True)
     treasury_account_identifier = models.ForeignKey('TreasuryAppropriationAccount', models.CASCADE, db_column='treasury_account_identifier', related_name="account_balances")
     submission = models.ForeignKey(SubmissionAttributes, models.CASCADE)
     budget_authority_unobligated_balance_brought_forward_fyb = models.DecimalField(max_digits=21, decimal_places=2, blank=True, null=True)


### PR DESCRIPTION
New federal account model and data migration. Doing this in two parts to minimize blocking
some of the downstream stories that need this new table.

This is part one:
* add FederalAccount model
* add nullable foreign keys to FederalAccount on the TreasuryAppropriationAccount and AppropriationAccountBalances models
* add new data to test fixture .json

A follow-up PR will:
* update the submission loader to populate the FederalAccount FKs
* update the initial data load to populate FederalAccount FKs
* depending on how the above plays out, maybe make the FKs non-nullable