### PR TITLE
Rm submission updates

### DIFF
--- a/usaspending_api/common/management/commands/clear_usaspending_cache.py
+++ b/usaspending_api/common/management/commands/clear_usaspending_cache.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+import logging
+import os
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.cache import caches
+
+class Command(BaseCommand):
+    """
+    This command will clear the usaspending-cache (useful after a load or a deletion
+    to ensure end users don't see stale data)
+    """
+    help = "Clears the usaspending-cache"
+    logger = logging.getLogger('console')
+
+    def handle(self, *args, **options):
+        self.logger.info("Clearing usaspending-cache...")
+        cache = caches["usaspending-cache"]
+        cache.clear()
+        self.logger.info("Done.")

--- a/usaspending_api/common/management/commands/clear_usaspending_cache.py
+++ b/usaspending_api/common/management/commands/clear_usaspending_cache.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.cache import caches
 
+
 class Command(BaseCommand):
     """
     This command will clear the usaspending-cache (useful after a load or a deletion

--- a/usaspending_api/submissions/management/commands/rm_submission.py
+++ b/usaspending_api/submissions/management/commands/rm_submission.py
@@ -26,4 +26,10 @@ class Command(BaseCommand):
             self.logger.error("Submission with broker id " + str(options["submission_id"][0]) + " does not exist")
             return
 
-        submission.delete()
+        deleted = submission.delete()
+
+        statistics = "Statistics:\n  Total objects Removed: " + str(deleted[0])
+        for model in deleted[1].keys():
+            statistics = statistics + "\n  " + model + ": " + str(deleted[1][model])
+
+        self.logger.info("Deleted submission " + str(options["submission_id"][0]) + ". " + statistics)


### PR DESCRIPTION
Update `rm_submission` command to give more information back.

```
(usaspending-api) Armans-MBP:usaspending-api afrasier$ python manage.py
load_submission 1195
Acquired appropriation data for 1195, there are 1 rows.
Acquired program activity object class data for 1195, there are 39 rows.
Acquired award financial data for 1195, there are 3790 rows.
Acquired award financial assistance data for 1195, there are 3 rows.
Acquired award procurement data for 1195, there are 319 rows.
(usaspending-api) Armans-MBP:usaspending-api afrasier$ python manage.py
rm_submission 1195
Deleted submission 1195. Statistics:
  Total objects Removed: 5057
  awards.SubAward: 0
  submissions.SubmissionAttributes: 1
  awards.FinancialAccountsByAwards: 3790
  awards.TransactionContract: 319
  financial_activities.FinancialAccountsByProgramActivityObjectClass: 39
  accounts.AppropriationAccountBalances: 1
  awards.Award: 582
  awards.Transaction: 322
  awards.TransactionAssistance: 3
```

Add a `clear_usaspending_cache` command which will clear the cache (good to use post load and post deletion)