### PR TITLE
Cache parents of award objects where appropriate for bulk creation

### DIFF
--- a/usaspending_api/awards/models.py
+++ b/usaspending_api/awards/models.py
@@ -236,7 +236,11 @@ class Award(DataSourceTrackedModel):
     @staticmethod
     def get_or_create_summary_award(piid=None, fain=None, uri=None, awarding_agency=None, parent_award_id=None, use_cache=False):
         """
-        Returns a boolean and award, the boolean being True if the award was created (or needs to be created, if using cache)
+        Returns a list and award
+
+        Tuple contains all the awards that were created
+        (or need to be created, if using cache) -
+        so that correct records can be bulk_created
         """
         # If an award transaction's ID is a piid, it's contract data
         # If the ID is fain or a uri, it's financial assistance. If the award transaction
@@ -260,25 +264,28 @@ class Award(DataSourceTrackedModel):
                     q_kwargs_fixed.sort()
                     summary_award = awards_cache.get(q_kwargs_fixed)
                     if summary_award:
-                        return False, summary_award
+                        return [], summary_award
 
                 summary_award = Award.objects.all().filter(Q(**q_kwargs)).filter(awarding_agency=awarding_agency).first()
                 if summary_award:
                     if use_cache:
                         awards_cache.set(q_kwargs_fixed, summary_award)
-                    return False, summary_award
+                    return [], summary_award
                 else:
-                    parent_award = None
                     if parent_award_id:
                         # If we have a parent award id, recursively get/create the award for it
                         parent_created, parent_award = Award.get_or_create_summary_award(use_cache=use_cache, **{i[1]: parent_award_id, 'awarding_agency': awarding_agency})
+                    else:
+                        parent_created, parent_award = [], None
                     # Now create the award record for this award transaction
                     summary_award = Award(**{i[1]: i[0], "parent_award": parent_award, "awarding_agency": awarding_agency})
+                    created = [summary_award, ]
+                    created.extend(parent_created)
                     if use_cache:
                         awards_cache.set(q_kwargs_fixed, summary_award)
                     else:
                         summary_award.save()
-                    return True, summary_award
+                    return created, summary_award
 
         raise ValueError(
             'Unable to find or create an award with the provided information: piid={}, fain={}, uri={}, parent_id={}'.format(

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -214,8 +214,8 @@ class Command(BaseCommand):
                         parent_award_id=row.get('parent_award_id'),
                         use_cache=True)
                 award.latest_submission = submission_attributes
-                if created:
-                    award_queue[award.manual_hash()] = award
+                for aw in created:
+                    award_queue[aw.manual_hash()] = aw
             except:   # TODO: silently swallowing a bare exception is bad mojo
                 continue
 

--- a/usaspending_api/etl/tests/test_load_submission.py
+++ b/usaspending_api/etl/tests/test_load_submission.py
@@ -50,7 +50,7 @@ def test_load_submission_command(endpoint_data, partially_flushed):
         # for testing, data pulled from etl_test_data.json
     assert Location.objects.count() == 4
     assert LegalEntity.objects.count() == 2
-    assert Award.objects.count() == 5
+    assert Award.objects.count() == 7
     assert Transaction.objects.count() == 2
     assert TransactionContract.objects.count() == 1
     assert TransactionAssistance.objects.count() == 1


### PR DESCRIPTION
Fixes the duplicate load bug that Kaitlin found on Friday.

