### PR TITLE
Fix up a copy and paste error on tas/oc/pa quarterly endpoint

### DIFF
--- a/usaspending_api/accounts/tests/test_tas_endpoints.py
+++ b/usaspending_api/accounts/tests/test_tas_endpoints.py
@@ -19,7 +19,10 @@ def account_models():
     AppropriationAccountBalances.populate_final_of_fy()
     mommy.make('financial_activities.FinancialAccountsByProgramActivityObjectClass', object_class=obj_clas_1, program_activity=prg_atvy_1, treasury_account=tas_2, obligations_undelivered_orders_unpaid_total_cpe=1000, _quantity=2, _fill_optional=True)
     mommy.make('financial_activities.FinancialAccountsByProgramActivityObjectClass', object_class=obj_clas_2, program_activity=prg_atvy_2, treasury_account=tas_2, obligations_undelivered_orders_unpaid_total_cpe=2000, _quantity=2, _fill_optional=True)
-    mommy.make('financial_activities.FinancialAccountsByProgramActivityObjectClass', object_class=obj_clas_2, program_activity=prg_atvy_1, treasury_account=tas_1, obligations_undelivered_orders_unpaid_total_cpe=50, _fill_optional=True)
+    mommy.make('financial_activities.FinancialAccountsByProgramActivityObjectClass', object_class=obj_clas_2, program_activity=prg_atvy_1, treasury_account=tas_1, obligations_undelivered_orders_unpaid_total_cpe=50, _fill_optional=True),
+    mommy.make('financial_activities.TasProgramActivityObjectClassQuarterly', object_class=obj_clas_1, program_activity=prg_atvy_1, treasury_account=tas_2, obligations_undelivered_orders_unpaid_total_cpe=5000, _quantity=2, _fill_optional=True)
+    mommy.make('financial_activities.TasProgramActivityObjectClassQuarterly', object_class=obj_clas_2, program_activity=prg_atvy_2, treasury_account=tas_2, obligations_undelivered_orders_unpaid_total_cpe=3000, _quantity=2, _fill_optional=True)
+    mommy.make('financial_activities.TasProgramActivityObjectClassQuarterly', object_class=obj_clas_2, program_activity=prg_atvy_1, treasury_account=tas_1, obligations_undelivered_orders_unpaid_total_cpe=100, _fill_optional=True)
 
 
 @pytest.mark.django_db

--- a/usaspending_api/accounts/views/tas.py
+++ b/usaspending_api/accounts/views/tas.py
@@ -110,27 +110,6 @@ class TASCategoryQuarterList(SuperLoggingMixin,
     serializer_class = TasCategorySerializer
 
     def get_queryset(self):
-        queryset = FinancialAccountsByProgramActivityObjectClass.objects.all()
-        queryset = self.serializer_class.setup_eager_loading(queryset)
-        filtered_queryset = self.filter_records(self.request, queryset=queryset)
-        ordered_queryset = self.order_records(self.request, queryset=filtered_queryset)
-        return ordered_queryset
-
-
-class TasCategoryQuarterListViewSet(
-        SuperLoggingMixin,
-        FilterQuerysetMixin,
-        DetailViewSet):
-    """
-    Handles requests for quarterly financial data grouped by treasury
-    account symbol (aka appropriations account, aka TAS), program
-    activity, and object class.
-    """
-
-    serializer_class = TasCategorySerializer
-
-    def get_queryset(self):
-        """Return the view's queryset."""
         queryset = TasProgramActivityObjectClassQuarterly.objects.all()
         queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)


### PR DESCRIPTION
Thanks @afrasier for noting that there were duplicative viewsets for the tas/oc/pa quarterly queryset. Not only were they duplicated, the one that `urls.py` pointed to was using the wrong `get_queryset`, so this was a great catch.

This PR fixes and updates the tests. 