### PR TITLE
updated submission loader to capture PA name

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -205,14 +205,11 @@ def get_or_create_program_activity(row, submission_attributes):
                'main_account_code': row['main_account_code'], }
     prg_activity = RefProgramActivity.objects.filter(**filters).first()
     if prg_activity is None and row['program_activity_code'] is not None:
-        prg_activity = RefProgramActivity.objects.create(**filters)
+        # If the PA has a blank name, create it with the value in the row.
+        # PA loader should overwrite the names for the unique PAs from the official
+        # domain values list if the title needs updating, but for now grab it from the submission
+        prg_activity = RefProgramActivity.objects.create(**filters, program_activity_name=row['program_activity_name'])
         logger.warning('Created missing program activity record for {}'.format(str(filters)))
-    # If the PA has a blank name, update it with the value in the row.
-    # PA loader should overwrite the names for the unique PAs from the official
-    # domain values list if the title needs updating, but for now grab it from the submission
-    if prg_activity and not prg_activity.program_activity_name:
-        prg_activity.program_activity_name = row['program_activity_name']
-        prg_activity.save()
 
     return prg_activity
 

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -207,6 +207,13 @@ def get_or_create_program_activity(row, submission_attributes):
     if prg_activity is None and row['program_activity_code'] is not None:
         prg_activity = RefProgramActivity.objects.create(**filters)
         logger.warning('Created missing program activity record for {}'.format(str(filters)))
+    # If the PA has a blank name, update it with the value in the row.
+    # PA loader should overwrite the names for the unique PAs from the official
+    # domain values list if the title needs updating, but for now grab it from the submission
+    if prg_activity and not prg_activity.program_activity_name:
+        prg_activity.program_activity_name = row['program_activity_name']
+        prg_activity.save()
+
     return prg_activity
 
 


### PR DESCRIPTION
After noticing that a bunch of program activities were being created but remaining nameless, I added an update to at least capture the name as we first see it in a submission. We won't necessarily track all variations that exist for a particular PA across submissions and if an agency needs to update the title of a PA, we can ask agency submitters to update their PA lists with OMB and provide the "official" name. 

Also include a quicky unit test. 