### PR TITLE
DS-1139 - no agency when toptier and subtier are both None

### DIFF
--- a/usaspending_api/references/models.py
+++ b/usaspending_api/references/models.py
@@ -111,9 +111,11 @@ class Agency(models.Model):
         Returns:
             an Agency instance
 
+        If called with None / empty subtier code, returns None
         """
-        return Agency.objects.filter(
-            subtier_agency__subtier_code=subtier_code).order_by('-update_date').first()
+        if subtier_code:
+            return Agency.objects.filter(
+                subtier_agency__subtier_code=subtier_code).order_by('-update_date').first()
 
     @staticmethod
     def get_by_toptier_subtier(toptier_cgac_code, subtier_code):

--- a/usaspending_api/references/tests/test_agency.py
+++ b/usaspending_api/references/tests/test_agency.py
@@ -83,6 +83,9 @@ def test_get_by_subtier():
     assert Agency.get_by_subtier('abc') == agency1
     # if there's no match, we should get none
     assert Agency.get_by_subtier('nope') is None
+    # if called with an empty argument, we should get None
+    assert Agency.get_by_subtier('') is None
+    assert Agency.get_by_subtier(None) is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Go ahead and call .get_by_subtier with the `None` subtier code, just return `None` instead of the first agency that happens to have a null subtier code 