### PR TITLE
Rearrangement to API Docs for Hackathon

### DIFF
--- a/usaspending_api/api_docs/markdown/api_tutorial.md
+++ b/usaspending_api/api_docs/markdown/api_tutorial.md
@@ -1,16 +1,26 @@
 <ul class="nav nav-stacked" id="sidebar">
-  <li><a href="#introduction">Introduction</a></li>
-  <li><a href="#whats-an-api">What's an API?</a></li>
-  <li><a href="#using-the-api">Using the API</a></li>
-  <li><a href="#endpoint-overview">Endpoint Overview</a></li>
-  <li><a href="#data-endpoints">Data Endpoints</a></li>
-  <li><a href="#get-vs-post">GET vs POST Requests</a></li>
-  <li><a href="#filtering">Filtering</a></li>
-  <li><a href="#ordering">Ordering Responses</a></li>
-  <li><a href="#pagination">Pagination</a></li>
-  <li><a href="#aggregation">Aggregation</a></li>
-  <li><a href="#other">Other Information</a></li>
+  <li><a href="/docs/intro-tutorial">Introductory Tutorial</a>
+  <!--<ul class="">
+    <li><a href="#introduction">Introduction</a></li>
+    <li><a href="#whats-an-api">What's an API?</a></li>
+    <li><a href="#using-the-api">Using the API</a></li>
+    <li><a href="#endpoint-overview">Endpoint Overview</a></li>
+    <li><a href="#data-endpoints">Data Endpoints</a></li>
+    <li><a href="#get-vs-post">GET vs POST Requests</a></li>
+    <li><a href="#filtering">Filtering</a></li>
+    <li><a href="#ordering">Ordering Responses</a></li>
+    <li><a href="#pagination">Pagination</a></li>
+    <li><a href="#aggregation">Aggregation</a></li>
+    <li><a href="#other">Other Information</a></li>
+  </ul>-->
+  </li>
+  <li><a href="/docs/using-the-api">Using this API</a></li>
+  <li><a href="/docs/endpoints">Endpoints</a></li>
+  <li><a href="/docs/data-dictionary">Data Dictionary</a></li>
+  <li><a href="/docs/recipes">Request Recipes</a></li>
+
 </ul>
+
 [//]: # (Begin Content)
 
 # Introductory Tutorial <a name="introduction"></a>
@@ -23,7 +33,7 @@ Welcome to the introductory USASpending API tutorial. This tutorial is designed 
 
 If you're looking for federal spending data that's designed to be read by humans instead of computer programs, you should head to <a href="https://www.usaspending.gov/Pages/Default.aspx">usaspending.gov</a>, or visit <a href="https://openbeta.usaspending.gov">openbeta.usaspending.gov</a> for information on the updated version of the site that's currently in development.
 
-## Using the API <a name="using-the-api"></a> 
+## Using the API <a name="using-the-api"></a>
 
 Over the next few sections, we will discuss the different methods for accessing the API, how to filter the data, how to use autocomplete endpoints, and how to find more information.
 
@@ -33,7 +43,7 @@ You do not need to complete this tutorial in its entirety to get started. Feel f
 
 When you type a url into your browser, it usually returns a web page: a document that your browser knows how to display for you to read. APIs use urls, too--but instead of returning formated web pages, API urls return data structured to be easy for computers to parse. API urls are called "endpoints." Just as many webpages make up a web site, many endpoints make up an API.
 
-The USASpending API supports a number of endpoints. For example `/api/v1/awards/` is our awards endpoint. 
+The USASpending API supports a number of endpoints. For example `/api/v1/awards/` is our awards endpoint.
 
 Our endpoints are broken into a few groups:
 
@@ -71,7 +81,7 @@ For more information on the record objects for each endpoint, check out the [dat
 
 #### GET vs POST requests <a name="get-vs-post"></a>
 
-Most endpoints support both GET and POST methods for making a request. 
+Most endpoints support both GET and POST methods for making a request.
 
 Requests for a specific record where the <span title="This is a numerical identifier referencing the specific item">identifier<sup>?</sup></span> is known are done via a GET request. For example, a request to `/api/v1/awards/1234` would retreive the award with identifier `1234`.
 
@@ -324,7 +334,7 @@ You can combine these POST parameters with any other POST parameter or filters.
 
 Aggregation endpoints allow you to perform simple aggregations on the data. For example, let's say you want to get the sum of all <span title="The amount of money obligated by the federal government">total obligations<sup>?</sup></span> for each award record, summed up by fiscal year. Sure, you could query the data, gather it all up, and process it - or we can use an aggregation endpoint.
 
-Currently, they only support POST requests. 
+Currently, they only support POST requests.
 
 Let's try it with `/api/v1/awards/total`.
 

--- a/usaspending_api/api_docs/markdown/data_dictionary.md
+++ b/usaspending_api/api_docs/markdown/data_dictionary.md
@@ -1,131 +1,27 @@
 <ul class="nav nav-stacked" id="sidebar">
-  <li><a href="#lexicon">Lexicon</a></li>
-  <li><a href="#endpoint-index">Endpoint Index</a></li>
-  <li><a href="#endpoint-details">Endpoint Details</a></li>
-  <li>
-    <ul>
-      <li><a href="#type-description">Type Descriptions</a></li>
-      <li><a href="#award">Award Endpoints</a></li>
-      <li><a href="#transaction">Transaction Endpoints</a></li>
-      <li><a href="#accounts">Accounts Endpoints</a></li>
-      <li><a href="#references">Reference Endpoints</a></li>
-      <li><a href="#submission">Submission Endpoint</a></li>
-    </ul>
+  <li><a href="/docs/intro-tutorial">Introductory Tutorial</a></li>
+  <li><a href="/docs/using-the-api">Using this API</a></li>
+  <li><a href="/docs/endpoints">Endpoints</a></li>
+  <li><a href="/docs/data-dictionary">Data Dictionary</a>
+  <!--<ul>
+    <li><a href="#datadictionary">Data Dictionary</a>
+    <li><a href="#type-description">Type Descriptions</a>
+    <li><a href="#award">Award Endpoints</a>
+    <li><a href="#transaction">Transaction Endpoints</a>
+    <li><a href="#accounts">Accounts Endpoints</a>
+    <li><a href="#references">Reference Endpoints</a>
+  </ul>-->
   </li>
+  <li><a href="/docs/recipes">Request Recipes</a></li>
 </ul>
+
 [//]: # (Begin Content)
-
 **Please note, the data dictionary is under heavy development. As a result, some information may be missing**
+## Data Dictionary <a name="datadictionary"></a>
 
-## Lexicon <a name="lexicon"></a>
+Federal spending has a vocabulary all its own. This page is under construction, but will strive to help you understand the most commonly requested endpoints and fields returned.
 
-In this section you will find definitions for common terms used in the API. For detailed explanations of specific fields, please see that endpoint's entry in the Endpoint Details section.
-
-| Term | Explanation |
-| ----- | ----- |
-|Agency|	On this website we use the term agency to mean any federal department, agency, office, or other U.S. government entity.|
-|Agency Identifier|	Identifies the agency responsible for a Treasury account. This is a 1-3 digit number that is a part of a Treasury Account Symbol (TAS).|
-|Allocation Transfer Agency (ATA) Identifier|	Identifies an agency that receives funds through an allocation (non-expenditure) transfer. This is a 1-3 digit number that is a part of a Treasury Account Symbol (TAS).|
-|Appropriation Account|	When Congress passes a law, it often gives an agency authority to carry out a project. When this happens, Congress may set aside money for the project. An appropriation account tracks the money, much like a bank account.|
-|Availability Type Code|	Within a Treasury Account Symbol (TAS), the code will have an "X" in it if there is an unlimited period to incur new obligations. The &ldquo;X&rdquo; is called the Availability Type Code.|
-|Award|	Money the federal government has promised to pay a recipient. Funding may be awarded to a company, organization, or individual. It may be obligated (promised) in the form of a contract, grant, loan, or direct payment.|
-|Award Amount|	The amount that the federal government has promised to pay a recipient, either now or in the future. An award amount includes option years which have not yet been exercised. For example, if a recipient is promised a $10M on a base contract with 3 option years at $1M each, the award amount is $13M.|
-|Award Ceiling|	The maximum amount of money that the government may pay a recipient. For a contract, this total includes the base amount plus the amounts of all possible options.|
-|Award ID|	A unique identification number for each individual award. An award may be a contract, grant, loan, direct payment, purchase order, or blanket purchase agreement.|
-|Award Type|	The mechanism used to distribute funding. The federal government can distribute funding in several forms. These award types include contracts, grants, loans, and direct payments.|
-|Awarding Agency|	An Awarding Agency is the agency who agrees to pay a recipient. This agency usually pays for the funding out of its own budget. In rare cases, the money is financed by another agency, called the Funding Agency.|
-|Basic Ordering Agreement (BOA)|	A BOA is a type of Indefinite Delivery Vehicle. It is not a contract; it is a written understanding between government and contractor. It details the supplies or services offered. It also details pricing and delivery for future orders. This agreement can speed contracting when requirements are uncertain. For instance, when specifications, quantities, and prices are not yet known. These agreements can also help the government achieve economies of scale for part orders. For the contractor, they can lessen lead-time, enable a larger inventory investment, and lessen old inventory.|
-|Beginning Period of Availability|	Identifies the first year that an appropriation account may incur new obligations. This is for annual and multi-year funds only. This is a 2-digit number representing the year. For example, &ldquo;17&rdquo; means 2017. It is a part of a Treasury Account Symbol (TAS).|
-|Blanket Purchase Agreement (BPA)|	A BPA is a method federal agencies use to make repeat purchases of supplies or services. A type of Indirect Delivery Vehicle, a BPA operates by essentially setting up a &ldquo;charge account&rdquo; with trusted vendors. Both agencies and vendors like BPAs because they help trim the red tape associated with repetitive purchasing. Once a BPA is set up, repeat purchases are easy for both sides. A BPA is an agreement with an individual agency, meaning only a handful of offices can place orders on a BPA. A BPA can be awarded to a set of vendors, who will then be able to bid on upcoming orders. A BPA can be set up with or without GSA schedules. Without GSA schedules, orders are capped at the Simplified Acquisition Threshold (SAT) of $100,000. <br/>Examples of BPAs: <br/>- Agency A establishes a BPA with a computer manufacturer for repeat laptop purchases<br/>- Agency B establishes a BPA with a graphic design agency for design of brochures and event signage
-|
-|Budget Function|	The federal budget is divided into 19 categories known as budget functions. These categories organize federal spending into topics based on the major purpose the spending serves (e.g., National Defense, Transportation, Health). These are further broken down into budget subfunctions.|
-|Budget Subfunction| The federal budget is divided into functions and subfunctions. These categories organize federal spending into topics based on the major purpose the spending serves. There are 19 major functions (e.g., National Defense, Transportation, Health). Most of these functions are further divided into subfunctions. For example, the budget function for Health (500) is divided into subfunctions for Health care services (551), Health research and training (552), and Consumer and occupational health and safety (554).|
-|Clinger-Cohen Act|	The Clinger-Cohen Act (CCA) of 1996 is a federal law designed to improve the way the federal government acquires, uses, and disposes of IT. It strives to make IT purchases more strategic.|
-|CFDA Program|	The Catalog of Federal Domestic Assistance (CFDA) provides a full listing of federal programs that are available to organizations, government agencies (state, local, tribal), U.S. territories, and individuals who are authorized to do business with the government. A CFDA program can be a project, service, or activity. Each CFDA program has a unique, 5-digit number in the form of XX.XXX. The first two digits represent the funding agency. The last three digits represent the program.|
-|Contractor|	A company, organization, agency, or individual who receives funding and/or performs work on a contract. A contractor may be a corporation, small business, university, non-profit, individual, or other entity. When a company has a contract with the U.S. government, they may hire another company to perform part of the work. When this happens, the company who received the award is called the prime contractor. The company hired by the prime is called the sub-contractor.|
-|Cooperative Agreement|	Grant awarded to provide assistance. It is characterized by extended involvement between recipient and agency. It requires substantial oversight by the agency, and includes reporting requirements.|
-|Davis-Bacon Act|	This act applies to construction, alteration, or repair (including painting and decorating) of public buildings or public works. Contractors and subcontractors on federal contracts over $2,000 must pay laborers and mechanics no less than the locally prevailing wages and fringe benefits for corresponding work on similar projects in the area. The Department of Labor determines wage rates.|
-|Delivery Order Contract|	An Indefinite Quantity Contract for supplies (not services) is sometimes referred to as a Delivery Order Contract. With this type of contract, the government promises to buy supplies over a period of time from a vendor. But instead of an exact amount, it sets a quantity range with a min and max.|
-|DOD Claimant Program Code|	Designates a grouping of supplies, construction, or other services. Each code has letters and numbers.|
-|DUNS (9-Digit Number)|	A unique identification number assigned to a company or organization by Dun & Bradstreet, Inc. A DUNS is required to register in the System for Award Management (SAM). An organization must be registered in SAM (and thus must first obtain a DUNS) in order to do business with the federal government. A DUNS number is 9 digits. There is a separate DUNS number for each business location in the Dun & Bradstreet database. The DUNS number is random, and specific digits have no significance.|
-|Ending Period of Availability|	Identifies the last year that an appropriation account may incur new obligations. This is for annual and multi-year funds only. This is a 2-digit number representing the year. For example, &ldquo;18&rdquo; means 2018. It is a part of a Treasury Account Symbol (TAS).|
-|Extent Competed|	A code that represents the competitive nature of the contract. Values include:<br/>- Full and open competition (competitive proposal, no sources excluded)<br/>- Not available for competition<br/>- Not competed<br/>- Full and open competition after exclusion of sources<br/>- Follow-on to competed action (a follow-on to an existing competed contract)<br/>- Competed under Simplified Acquisition Threshold (SAP)<br/>- Not competed under Simplified Acquisition Threshold (SAP)|
-|FAIN|	An identification code assigned to each financial assistance award tracking purposes. The FAIN is tied to that award (and all future modifications to that award) throughout the award&rsquo;s life. Each FAIN is assigned by an agency. Within an agency, FAIN are unique: each new award must be issued a new FAIN. FAIN stands for Federal Award Identification Number, though the digits are letters, not numbers.|
-|Fund Family|	[definition to come]|
-|Federal Supply Schedule (FSS)|	A listing of contractors that have been awarded a contract by GSA that can be used by all Federal agencies. This is also known as a Multiple Award Schedule (MAS).|
-|Federal Assistance|	A federal program, service, or activity that directly aids organizations, individuals, or state/local/tribal governments. Sectors include education, health, public safety and public welfare - to name a few. It can be in the form of a grant, loan, or insurance.|
-|Fiscal Year (FY)|	The fiscal year is an accounting period that spans 12 months. For the federal government, it runs from October 1 to September 30. For example, Fiscal Year 2017 (FY 2017) starts October 1, 2016 and ends September 30, 2017. A fiscal year may be broken down into quarters. For the federal government, these quarters are:<br/>Q1: October - December<br/>Q2: January - March<br/>Q3: April - June<br/>Q4: July - September|"
-|Funding Agency|	A Funding Agency pays for the majority of funds for an award out of its budget. Typically, the Funding Agency is the same as the Awarding Agency. In some cases, one agency will present an award (Awarding Agency) and another agency will pay for it (Funding Agency).|
-|Governmentwide Acquisition Contract (GWAC)|	This is a multi-agency contract. It offers Information Technology (IT) services to agencies across the government. It is an Indefinite Delivery Vehicle for certain types of IT work:<br/>- Systems design<br/>- Software engineering<br/>- Information assurance<br/>- Enterprise architecture<br/>Vendors compete for the initial contracts. Once selected, they are eligible to compete further for agency-specific tasks.|"
-|Indefinite Delivery Contract|	"Facilitates the delivery of supply and service orders during a set timeframe. This type of contract can be awarded to one or more vendors.<br/>Types of Indefinite Delivery Contracts Include:<br/>- Indefinite Delivery, Definite Quantity Contract<br/>- Indefinite Delivery, Requirements Contract<br/>- Indefinite Delivery, Indefinite Quantity (IDIQ) Contract
-|
-|Indefinite Delivery, Indefinite Quantity (IDIQ) Contract|	An Indefinite Quantity Contract is a type of Indefinite Delivery Contract (IDC). Sometimes the government contracts to buy supplies or services from a vendor over a period of time. But the government may not know the exact quantity it will need. In this case, an Indefinite Quantity Contract sets a quantity range with a min and max. It does not specify an exact number. For services, this is often called a Task Order Contract. For supplies, this is often called a Delivery Order Contract.|
-|Indirect Delivery Vehicle (IDV)|	Vehicle to facilitate the delivery of supply and service orders. IDV Types include:<br/>- Blanket Purchase Agreement (BPA)<br/>- Basic Ordering Agreement (BOA)<br/>- Government-Wide Acquisition Contract (GWAC)<br/>- Multi-Agency Contract<br/>- Indefinite Delivery Contract (IDC)<br/>- Federal Supply Schedule (FSS)<br/>- Other Transaction (OT) Indirect Delivery Vehicle (IDV)
-|
-|Multiple Award Schedule (MAS)|	A listing of contractors that have been awarded a contract by GSA that can be used by all Federal agencies. This is also known as a Federal Supply Schedule (FSS).|
-|McNamara-O&rsquo;Hara Service Contract Act (SCA)|	This act applies to federal service contracts over $2,000. Contractors and subcontractors must pay service employees no less than local prevailing wages and fringe benefits. The Department of Labor determines wage rates.|
-|NAICS (6-Digit Code)|	"This code tells you what industry the work falls into. Each contract record has a NAICS code. That means you can look up how much money the U.S. government spent in a specific industry. NAICS stands for the North American Industrial Classification System. Codes are 6 digits, all numbers. The list of industries and codes is updated every 5 years.|
-|Object Class|	An object class is a category within an appropriation account. An object class groups obligations by the types of items or services purchased by the federal government. Examples: government employee salaries, or equipment.|
-|Obligation|	When awarding funding, the U.S. government enters a binding agreement called an obligation. The government promises to spend the money, either immediately or in the future.|
-|Other Transaction (OT) Indirect Delivery Vehicle (IDV)|	A transaction other than a procurement contract, grant, or cooperative agreement. Since this transaction is defined in the negative, it could take unlimited potential forms.<br/>This term is often used to refer to transactions designed to:<br/>- Support research & development for homeland security;<br/>- Advance the development, testing, and deployment of critical homeland security technologies;<br/>- Speed up prototyping and deployment of technologies addressing homeland security vulnerabilities.<br/>The Department of Homeland Security (DHS) often splits its use of Other Transactions into OT's for Research and OT's for Prototype Projects. |
-|Outlay|	An outlay occurs when federal money is actually paid out, not just obligated.|
-|Pricing Type|	Payment model for a contract. Each has a different way of accounting for costs, fees, and profits.<br/>Pricing types include:<br/>Fixed Price Redetermination<br/>Fixed Price Level of Effort<br/>Firm Fixed Price<br/>Fixed Price with Economic Price Adjustment<br/>Fixed Price Incentive<br/>Fixed Price Award Fee<br/>Cost Plus Award Fee<br/>Cost No Fee<br/>Cost Sharing<br/>Cost Plus<br/>Fixed Fee<br/>Cost Plus Incentive Fee<br/>Time and Materials<br/>Labor Hours
-|
-|Primary Place of Performance|	The principal place of business, where the majority of the work is performed. For example, in a manufacturing contract, this would be the main plant where items are produced.|
-|Prime Contractor|	A company, organization, or agency who receives a contract with the federal government. A prime contractor may be a corporation, small business, university, non-profit, or other entity. A prime contractor may be able to hire a sub-contractor to perform work on the contract.|
-|Procurement Instrument Identifier (PIID)|	A unique identifier assigned to a federal contract, purchase order, basic ordering agreement, basic agreement, and blanket purchase agreement. It is used to track the contract, and any modifications or transactions related to it. After October 2017, it is between 13 and 17 digits, both letters and numbers.|
-|Program Activity|	A program activity is a category within an appropriation account. A program activity is a specific activity or project, as listed in the program and financing schedules of the annual budget of the U.S. government.|
-|Program, System, and Equipment Code|	A system-generated Department of Defense (DoD) code, also known as the Acquisition Program (AP) Code. This code identifies the DoD program, weapons system, or equipment being acquired. It can be categorized as a Major Defense Acquisition Program (MDAP) or a Major Automated Information System (MAIS).|
-|PSC (4-Digit Code)|	A Product Service Code (PSC) identifies the type of product or service purchased. While NAICS codes identify industry, PSCs tell you the type of product or service. PSCs start with 3 categories: Services, Products, and R&D. They then break down into 100+ classes. PSCs are 4 digits with numbers and letters. They are more granular than NAICS codes: there are twice as many.|
-|Recipient|	A company, non-profit, individual, or other agency (including state, local, tribal) that receives funding from the U.S. government.|
-|Recipient Location|	Legal business address of the recipient.|
-|Recipient Name|	A recipient is a company, organization, individual, or agency (including state, local, tribal) that is awarded funding by the U.S. government. The recipient name is the same as what's registered in the System for Award Management (SAM.gov). This is usually the official name of the business.|
-|Recipient Type|	"A recipient is a company, organization, individual, or agency (including state, local, tribal) that is awarded funding by the U.S. government. The government categorizes recipients by:<br/>- Structure (e.g., LLC, Sole Proprietorship, Non-Profit)<br/>- Entity (e.g., Federal Agency, State Government, Township)<br/>- Educational (e.g., Educational Institution, Tribal College, HBCU)<br/>- Business Ownership (e.g., Woman Owned, Veteran Owned)<br/>- Special Status (e.g., 8a, Domestic Shelter, Community Developed Corporation)<br/>These are all different kinds of recipient types that you can search by on this site.<br/>|<br/>|Set Aside|	"A tool used to award contracts to specific types of businesses. Most set asides reserve contracts for small businesses. Others are more specific, to support small businesses with specific designations:<br/>- 8(a) Business Development<br/>- HUBZone<br/>- Native American<br/>- Women Owned (includes Economically Disadvantaged Women Owned)<br/>- SBIR/STTR<br/>- Service Disabled Veteran Owned<br/>- Veteran Owned<br/>- Small Disadvantaged Business|
-|Simplified Acquisition Threshold (SAT)|	For certain types of government purchases between $3,000 and $150,000. These purchases may require less approval and less documentation.|
-|Solicitation|	When an agency needs work done, it can ask for information or bids on the work. These requests are called solicitations. They often come as a RFI (Request for Information) or RFP (Request for Proposal).|
-|Sub-account Code|	Identifies a sub-division of the Treasury Account Symbol (TAS). This is a 3-digit number. It cannot be blank. A sub-account code of "000" means that the TAS is the parent account.|
-|Sub-agency|	A component of a larger department or agency. Also known as a sub-tier agency. For example, Bureau of Indian Affairs is a sub-agency of Department of Interior.|
-|Sub-contractor|	When a company has a contract with the U.S. government, they may hire another company to perform work on the contract. When this happens, the company who received the contract is called the prime contractor. The company hired by the prime is called the sub-contractor.|
-|Task Order Contract|	An Indefinite Quantity Contract for services (not supplies) is sometimes referred to as a Task Order Contract. With this type of contract, the government promises to buy services over a period of time from a vendor. But instead of an exact amount, it sets a range with a min and max.|
-|Treasury Account Symbol (TAS)|	Treasury and OMB assign a code to each appropriation, receipt, or fund account. This code is similar to a bank account number. It helps identify financial transactions in the federal government. It also aids in reporting accuracy.<br/>7 components make up the TAS:<br/>- Allocation Transfer Agency Identifier<br/>- Agency Identifier<br/>- Beginning Period of Availability<br/>- Ending Period of Availability<br/>- Availability Type Code<br/>- Fund Family<br/>- Sub-Account Code<br/>|
-|Walsh Healy Act|	Law that applies to federal contracts over $10,000 for the manufacture or furnishing of goods. It establishes minimum wage, maximum hours, and safety and health standards.|
-
-## Endpoint Index <a name="endpoint-index"></a>
-
-| Endpoint | Methods | Response Object | Data
-| -------- | ---: | ------ | ------ |
-| [/api/v1/awards/](/api/v1/awards/) | GET, POST | <a href="#award">Awards</a> | Returns a list of award records |
-| /api/v1/awards/:id | GET, POST | <a href="#award">Award</a> | Returns a single award records with all fields |
-| [/api/v1/awards/autocomplete/](/api/v1/awards/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api))| Supports autocomplete on award records |
-| [/api/v1/awards/total/](/api/v1/awards/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on award records |
-| [/api/v1/federal_accounts/](/api/v1/federal_accounts/) | GET, POST | <a href="#federal-account">Federal Account</a> | Returns a list of federal accounts |
-| [/api/v1/federal_accounts/autocomplete/](/api/v1/federal_accounts/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api))| Supports autocomplete on federal account records |
-| [/api/v1/tas/balances/](/api/v1/tas/balances/) | GET, POST | <a href="#appropriation-account">Yearly Appropriation Account Balances</a> | Returns a list of appropriation account balances by fiscal year |
-| [/api/v1/tas/balances/total/](/api/v1/tas/balances/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on appropriation account records |
-| [/api/v1/tas/balances/quarters/](/api/v1/tas/balances/quarters/) | GET, POST | <a href="#appropriation-account-balances-quarterly">Quarterly Appropriation Account Balances</a> | Returns a list of appropriation account balances by fiscal quarter|
-| [/api/v1/tas/balances/quarters/total/](/api/v1/tas/balances/quarters/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on quarterly appropriation account records |
-| [/api/v1/tas/categories/](/api/v1/tas/categories/) | GET, POST | <a href="#accounts-prg-obj">Yearly Appropriation Account Balances (by Category)</a> | Returns a list of appropriation account balances by fiscal year broken up by program activities and object class |
-| [/api/v1/tas/categories/total/](/api/v1/tas/categories/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on appropriation account (by category) records |
-| [/api/v1/tas/categories/quarters/](/api/v1/tas/categories/quarters/) | GET, POST | <a href="#accounts-prg-obj-quarterly">Quarterly Appropriation Account Balances (by Category)</a> | Returns a list of appropriation account balances by fiscal quarter broken up by program activities and object class |
-| [/api/v1/tas/categories/quarters/total/](/api/v1/tas/categories/quarters/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on quarterly appropriation account (by category) records |
-| [/api/v1/tas/](/api/v1/tas/) | GET, POST | <a href="#tas">Treasury Appropriation Account</a> | Returns a list of treasury appropriation accounts, by TAS |
-| [/api/v1/tas/autocomplete/](/api/v1/tas/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api))| Supports autocomplete on TAS records |
-| [/api/v1/accounts/awards/](/api/v1/accounts/awards/) | GET, POST | <a href="#accounts-by-award">Financial Accounts (by Award)</a> | Returns a list of financial account data grouped by TAS and broken up by Program Activity and Object Class codes |
-| /api/v1/accounts/awards/:id | GET, POST | <a href="#accounts-by-award">Financial Account (by Award)</a> | Returns a single financial account record, grouped by TAS, with all fields |
-| [/api/v1/transactions/](/api/v1/transactions/) | GET, POST | <a href="#transaction">Transaction</a> | Returns a list of transactions - contracts, grants, loans, etc. |
-| /api/v1/transactions/:id | GET, POST | <a href="#transaction">Transaction</a> | Returns a single transaction record with all fields |
-| [/api/v1/transactions/total/](/api/v1/transactions/total/) | POST | Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on transaction records |
-| [/api/v1/references/locations/](/api/v1/references/locations/) | POST | <a href="#locations">Location</a> | Returns a list of locations - places of performance or vendor locations |
-| [/api/v1/references/locations/geocomplete/](/api/v1/references/locations/geocomplete/) | POST | Location Hierarchy (see [Using the API](/docs/using-the-api)) | Supports geocomplete queries, see [Using the API](/docs/using-the-api) |
-| [/api/v1/references/agency/](/api/v1/references/agency/) | GET, POST | <a href="#agencies">Agency</a> | Returns a list of agency records |
-| [/api/v1/references/agency/autocomplete/](/api/v1/references/agency/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api)) | Supports autocomplete on agency records |
-| [/api/v1/references/cfda/](/api/v1/references/cfda/) | GET, POST | <a href="#cfda-programs">CFDA Programs</a> | Returns a list of CFDA Programs |
-| /api/v1/references/cfda/:id | GET, POST | <a href="#cfda-programs">CFDA Program</a> | Returns a single CFDA program, with all fields |
-| [/api/v1/references/recipients/autocomplete/](/api/v1/references/recipients/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api)) | Supports autocomplete on recipient records |
-| [/api/v1/submissions/](/api/v1/submissions/) | GET, POST | <a href="#submissions">SubmissionAttributes</a> | Returns a list of submissions |
-
-
-## Endpoint Details <a name="endpoint-details"></a>
+You can also visit our [online spreadsheet](https://docs.google.com/spreadsheets/d/1KbP55qhrcrxtwyDXBfXnWAFhokAH2Gx4R_U0rYOyJVg/edit#gid=0) for additional term descriptions and references.
 
 #### Type Descriptions <a name="type-description"></a>
 

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -1,0 +1,72 @@
+
+<ul class="nav nav-stacked" id="sidebar">
+  <li><a href="/docs/intro-tutorial">Introductory Tutorial</a></li>
+  <li><a href="/docs/using-the-api">Using this API</a></li>
+  <li><a href="/docs/endpoints">Endpoints</a>
+  <!--<ul>
+    <li><a href="#status-codes">Status Codes</a></li>
+    <li><a href="#endpoints-and-methods">Endpoints and Methods</a></li>
+    <li><a href="#endpoint-index">Endpoint Index</a></li>
+  </ul>-->  
+  </li>
+  <li><a href="/docs/data-dictionary">Data Dictionary</a></li>
+  <li><a href="/docs/recipes">Request Recipes</a></li>
+
+</ul>
+
+[//]: # (Begin Content)
+
+# API Endpoints
+
+This page is intended for users who are already familiar with APIs. If you're not sure what "endpoint" means, and what GET and POST requests are, you may find the [introductory tutorial](/docs/intro-tutorial) more useful to start.
+
+While the API is under development, we are gradually increasing the amount of available data, which is currently limited to a few federal agency submissions and small slices of USAspending.gov historical data.
+
+Endpoints do not currently require any authorization.
+
+### Status Codes <a name="status-codes"></a>
+In general, status codes returned are as follows:
+
+* 200 if successful
+* 400 if the request is malformed
+* 500 for server-side errors
+
+## Endpoints and Methods <a name="endpoints-and-methods"></a>
+
+The currently available endpoints are listed below. Our [data dictionary](/docs/data-dictionary) provides more comprehensive definitions of the technical terms and government-specific language we use in the API.
+
+To reduce unnecessary data transfer, most endpoints return a default set of information about the items being requested. To override the default field list, use the `fields`, `exclude`, and `verbose` options (see [POST Requests](#post-requests) for more information).
+
+## Endpoint Index <a name="endpoint-index"></a>
+
+| Endpoint | Methods | Response Object | Data
+| -------- | ---: | ------ | ------ |
+| [/api/v1/awards/](/api/v1/awards/) | GET, POST | <a href="#award">Awards</a> | Returns a list of award records |
+| /api/v1/awards/:id | GET, POST | <a href="#award">Award</a> | Returns a single award records with all fields |
+| [/api/v1/awards/autocomplete/](/api/v1/awards/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api))| Supports autocomplete on award records |
+| [/api/v1/awards/total/](/api/v1/awards/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on award records |
+| [/api/v1/federal_accounts/](/api/v1/federal_accounts/) | GET, POST | <a href="#federal-account">Federal Account</a> | Returns a list of federal accounts |
+| [/api/v1/federal_accounts/autocomplete/](/api/v1/federal_accounts/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api))| Supports autocomplete on federal account records |
+| [/api/v1/tas/balances/](/api/v1/tas/balances/) | GET, POST | <a href="#appropriation-account">Yearly Appropriation Account Balances</a> | Returns a list of appropriation account balances by fiscal year |
+| [/api/v1/tas/balances/total/](/api/v1/tas/balances/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on appropriation account records |
+| [/api/v1/tas/balances/quarters/](/api/v1/tas/balances/quarters/) | GET, POST | <a href="#appropriation-account-balances-quarterly">Quarterly Appropriation Account Balances</a> | Returns a list of appropriation account balances by fiscal quarter|
+| [/api/v1/tas/balances/quarters/total/](/api/v1/tas/balances/quarters/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on quarterly appropriation account records |
+| [/api/v1/tas/categories/](/api/v1/tas/categories/) | GET, POST | <a href="#accounts-prg-obj">Yearly Appropriation Account Balances (by Category)</a> | Returns a list of appropriation account balances by fiscal year broken up by program activities and object class |
+| [/api/v1/tas/categories/total/](/api/v1/tas/categories/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on appropriation account (by category) records |
+| [/api/v1/tas/categories/quarters/](/api/v1/tas/categories/quarters/) | GET, POST | <a href="#accounts-prg-obj-quarterly">Quarterly Appropriation Account Balances (by Category)</a> | Returns a list of appropriation account balances by fiscal quarter broken up by program activities and object class |
+| [/api/v1/tas/categories/quarters/total/](/api/v1/tas/categories/quarters/total/) | POST |  Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on quarterly appropriation account (by category) records |
+| [/api/v1/tas/](/api/v1/tas/) | GET, POST | <a href="#tas">Treasury Appropriation Account</a> | Returns a list of treasury appropriation accounts, by TAS |
+| [/api/v1/tas/autocomplete/](/api/v1/tas/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api))| Supports autocomplete on TAS records |
+| [/api/v1/accounts/awards/](/api/v1/accounts/awards/) | GET, POST | <a href="#accounts-by-award">Financial Accounts (by Award)</a> | Returns a list of financial account data grouped by TAS and broken up by Program Activity and Object Class codes |
+| /api/v1/accounts/awards/:id | GET, POST | <a href="#accounts-by-award">Financial Account (by Award)</a> | Returns a single financial account record, grouped by TAS, with all fields |
+| [/api/v1/transactions/](/api/v1/transactions/) | GET, POST | <a href="#transaction">Transaction</a> | Returns a list of transactions - contracts, grants, loans, etc. |
+| /api/v1/transactions/:id | GET, POST | <a href="#transaction">Transaction</a> | Returns a single transaction record with all fields |
+| [/api/v1/transactions/total/](/api/v1/transactions/total/) | POST | Aggregate (see [Using the API](/docs/using-the-api)) | Supports aggregation on transaction records |
+| [/api/v1/references/locations/](/api/v1/references/locations/) | POST | <a href="#locations">Location</a> | Returns a list of locations - places of performance or vendor locations |
+| [/api/v1/references/locations/geocomplete/](/api/v1/references/locations/geocomplete/) | POST | Location Hierarchy (see [Using the API](/docs/using-the-api)) | Supports geocomplete queries, see [Using the API](/docs/using-the-api) |
+| [/api/v1/references/agency/](/api/v1/references/agency/) | GET, POST | <a href="#agencies">Agency</a> | Returns a list of agency records |
+| [/api/v1/references/agency/autocomplete/](/api/v1/references/agency/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api)) | Supports autocomplete on agency records |
+| [/api/v1/references/cfda/](/api/v1/references/cfda/) | GET, POST | <a href="#cfda-programs">CFDA Programs</a> | Returns a list of CFDA Programs |
+| /api/v1/references/cfda/:id | GET, POST | <a href="#cfda-programs">CFDA Program</a> | Returns a single CFDA program, with all fields |
+| [/api/v1/references/recipients/autocomplete/](/api/v1/references/recipients/autocomplete/) | POST | Autocomplete (see [Using the API](/docs/using-the-api)) | Supports autocomplete on recipient records |
+| [/api/v1/submissions/](/api/v1/submissions/) | GET, POST | <a href="#submissions">SubmissionAttributes</a> | Returns a list of submissions |

--- a/usaspending_api/api_docs/markdown/landing_page.md
+++ b/usaspending_api/api_docs/markdown/landing_page.md
@@ -1,19 +1,26 @@
 <ul class="nav nav-stacked" id="sidebar">
-  <li><a href="#getting-started">Getting Started</a></li>
-  <li><a href="#background">Background</a></li>
-  <li><a href="#documentation">Documentation</a></li>
+  <li><a href="/docs/intro-tutorial">Introductory Tutorial</a></li>
+  <li><a href="/docs/using-the-api">Using this API</a></li>
+  <li><a href="/docs/endpoints">Endpoints</a></li>
+  <li><a href="/docs/data-dictionary">Data Dictionary</a></li>
+  <li><a href="/docs/recipes">Request Recipes</a></li>
+
 </ul>
 [//]: # (Begin Content)
 
 # The USAspending Application Programming Interface (API)
 
-The USAspending API allows the public to access data published under the DATA Act. While the API is under development, we are gradually increasing the amount of available data and the capabilities of the API. Data in the current API comes from a selection of submissions the DATA Act Data Broker and the current USASpending.gov.
+The USAspending API (Application Programming Interface) allows the public to access comprehensive U.S. government spending data.
+
+The data include spending on "awards" (e.g.,who received federal contracts or grants, amounts, geographic breakdowns, agency breakdowns, and much more). The data also include non-award at the account level, like federal employee compensation, You can learn more about the data and the federal law that requires it to be publicly accessible (the DATA Act) at http://fedspendingtransparency.github.io.
+
+_NOTE:  While this API is under development, we are gradually increasing the amount of available data and the capabilities of the API. Data in the current API comes from a selection of agency submissions and the current USASpending.gov._
 
 ## Getting Started <a name="getting-started"></a>
 
 **New to APIs?** Check out our [introductory tutorial](/docs/intro-tutorial) on the API to learn the ropes
 
-**Familiar with APIs?** Roll up your sleeves with our more technical documentation [Using the API](/docs/using-the-api), or jump right into the data with some [request recipes](/docs/recipes/)
+**Familiar with APIs?** Familiar with APIs? See the [Using this API](/docs/using-the-api) section for how to request specific sets of data, and examples of filters. OR jump right into the data with our [list of available Endpoints](/docs/endpoints).
 
 **New to government financial data?** Check out our [data dictionary](/docs/data-dictionary) to learn to navigate it
 
@@ -21,8 +28,4 @@ The USAspending API allows the public to access data published under the DATA Ac
 
 The U.S. Department of the Treasury is building a suite of open-source tools to help federal agencies comply with the [DATA Act](http://fedspendingtransparency.github.io/about/ "Federal Spending Transparency Background") and to deliver the resulting standardized federal spending information back to agencies and to the public.
 
-For more information about the DATA Act Broker codebase, please visit this repository's [main README](https://github.com/fedspendingtransparency/data-act-broker-backend/README.md "DATA Act Broker Backend README").
-
-## Documentation <a name="documentation"></a>
-
-All documentation is available via our [documentation index](/docs/)
+For more information about the USAspending API codebase, please visit this repository's [main README](https://github.com/fedspendingtransparency/usaspending-api/blob/master/README.md "USAspending API README").

--- a/usaspending_api/api_docs/markdown/request_recipes.md
+++ b/usaspending_api/api_docs/markdown/request_recipes.md
@@ -1,6 +1,18 @@
 <ul class="nav nav-stacked" id="sidebar">
-  <li><a href="#award-recipes">Award Recipes</a></li>
+  <li><a href="/docs/intro-tutorial">Introductory Tutorial</a></li>
+  <li><a href="/docs/using-the-api">Using this API</a></li>
+  <li><a href="/docs/endpoints">Endpoints</a></li>
+  <li><a href="/docs/data-dictionary">Data Dictionary</a></li>
+  <li><a href="/docs/recipes">Request Recipes</a>
+  <ul>
+    <li><a href="#award-recipes">Award Recipes</a></li>
+    <li><a href="#postman">Postman Collection</a></li>
+  </ul>
+  </li>
+
 </ul>
+
+
 [//]: # (Begin Content)
 
 # Award Recipes <a name="award-recipes"></a>
@@ -81,3 +93,8 @@ POST
   ]
 }
 ```
+
+
+# Postman Collections <a name="postman"></a>
+
+[Postman](https://www.getpostman.com/) is a free app for making easy API requests. You can also use it to import and inspect a collection of pre-generated API requests. [Here is a postman collection](https://raw.githubusercontent.com/fedspendingtransparency/usaspending-api/doc-styles/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json) you can use to see how we generate the visualizations on [the prototype search page](https://spendingdata.us/#/search/).

--- a/usaspending_api/api_docs/markdown/request_recipes.md
+++ b/usaspending_api/api_docs/markdown/request_recipes.md
@@ -4,10 +4,10 @@
   <li><a href="/docs/endpoints">Endpoints</a></li>
   <li><a href="/docs/data-dictionary">Data Dictionary</a></li>
   <li><a href="/docs/recipes">Request Recipes</a>
-  <ul>
+  <!--<ul>
     <li><a href="#award-recipes">Award Recipes</a></li>
     <li><a href="#postman">Postman Collection</a></li>
-  </ul>
+  </ul>-->
   </li>
 
 </ul>
@@ -97,4 +97,4 @@ POST
 
 # Postman Collections <a name="postman"></a>
 
-[Postman](https://www.getpostman.com/) is a free app for making easy API requests. You can also use it to import and inspect a collection of pre-generated API requests. [Here is a postman collection](https://raw.githubusercontent.com/fedspendingtransparency/usaspending-api/doc-styles/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json) you can use to see how we generate the visualizations on [the prototype search page](https://spendingdata.us/#/search/).
+[Postman](https://www.getpostman.com/) is a free app for making easy API requests. You can also use it to import and inspect a collection of pre-generated API requests. [Here is a postman collection](https://raw.githubusercontent.com/fedspendingtransparency/usaspending-api/master/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json) you can use to see how we generate the visualizations on [the prototype search page](https://spendingdata.us/#/search/).

--- a/usaspending_api/api_docs/markdown/using_the_api.md
+++ b/usaspending_api/api_docs/markdown/using_the_api.md
@@ -40,12 +40,12 @@ The currently available endpoints are listed below. Our [data dictionary](/docs/
 
 To reduce unnecessary data transfer, most endpoints return a default set of information about the items being requested. To override the default field list, use the `fields`, `exclude`, and `verbose` options (see [POST Requests](#post-requests) for more information).
 
-  * **[/v1/accounts/](https://spending-api.us/api/v1/accounts/)**
-    - _Description_: Provides financial information by appropriations account. Financial information is data such as total budget authority, outlays, obligations, and unobligated balance. _Note_: This endpoint is due for a rework in the near future.
+  * **[/v1/federal_accounts/](https://spending-api.us/api/v1/federal_accounts/)**
+    - _Description_: Provides financial information by federal account. Financial information is data such as total budget authority, outlays, obligations, and unobligated balance. _Note_: This endpoint is due for a rework in the near future.
     - _Methods_: GET, POST
 
 
-  * **[/v1/accounts/tas/](https://spending-api.us/api/v1/accounts/tas/)**
+  * **[/v1/tas/](https://spending-api.us/api/v1/tas/)**
     - _Description_: Returns a list of appropriations accounts, including the account name, Treasury Account Symbol (TAS) components, the associated budget function, and the corresponding agency information. _Note_: This endpoint is due for a rework in the near future.
     - _Methods_: GET, POST
 

--- a/usaspending_api/api_docs/markdown/using_the_api.md
+++ b/usaspending_api/api_docs/markdown/using_the_api.md
@@ -1,14 +1,18 @@
 <ul class="nav nav-stacked" id="sidebar">
-  <li><a href="#introduction">Introduction</a></li>
-  <li><a href="#status-codes">Status Codes</a></li>
-  <li><a href="#data-endpoints">Data Endpoints</a></li>
-  <li><a href="#endpoints-and-methods">Endpoints and Methods</a></li>
-  <li><a href="#summary-endpoints-and-methods">Summary Endpoints & Methods</a></li>
-  <li><a href="#pagination">Pagination</a></li>
-  <li><a href="#get-requests">GET Requests</a></li>
-  <li><a href="#post-requests">POST Requests</a></li>
-  <li><a href="#autocomplete-queries">Autocomplete Queries</a></li>
-  <li><a href="#geographical-hierarchy-queries">Geographical Hierarchy Queries</a></li>
+  <li><a href="/docs/intro-tutorial">Introductory Tutorial</a></li>
+  <li><a href="/docs/using-the-api">Using this API</a>
+  <!--<ul>
+    <li><a href="#get-requests">GET Requests</a></li>
+    <li><a href="#post-requests">POST Requests</a></li>
+    <li><a href="#summary-endpoints-and-methods">Summary Endpoints & Methods</a></li>
+    <li><a href="#pagination">Pagination</a></li>
+    <li><a href="#autocomplete-queries">Autocomplete Queries</a></li>
+    <li><a href="#geographical-hierarchy-queries">Geographical Hierarchy Queries</a></li>
+  </ul>-->
+  </li>
+  <li><a href="/docs/endpoints">Endpoints</a></li>
+  <li><a href="/docs/data-dictionary">Data Dictionary</a></li>
+  <li><a href="/docs/recipes">Request Recipes</a></li>
 </ul>
 [//]: # (Begin Content)
 
@@ -18,222 +22,11 @@ The USAspending API allows the public to access data published via the DATA Act 
 
 This guide is intended for users who are already familiar with APIs. If you're not sure what "endpoint" means, and what `GET` and `POST` requests are, you'll probably find the [introductory tutorial](/docs/intro-tutorial) more useful.
 
-## DATA Act Data Store Endpoint Documentation
-
 While the API is under development, we are gradually increasing the amount of available data, which is currently limited to a few Data Broker submissions and small slices of USAspending history.
 
-Endpoints do not currently require any authorization.
-
-### Status Codes <a name="status-codes"></a>
-In general, status codes returned are as follows:
-
-* 200 if successful
-* 400 if the request is malformed
-* 500 for server-side errors
-
-### Data Endpoints <a name="data-endpoints"></a>
-
-Data endpoints are split by payload into POST and GET methods. In general, the format of a request and response will remain the same among endpoints.
-
-#### Endpoints and Methods <a name="endpoints-and-methods"></a>
-The currently available endpoints are listed below. Our [data dictionary](/docs/data-dictionary) provides more comprehensive definitions of the technical terms and government-specific language we use in the API.
-
-To reduce unnecessary data transfer, most endpoints return a default set of information about the items being requested. To override the default field list, use the `fields`, `exclude`, and `verbose` options (see [POST Requests](#post-requests) for more information).
-
-  * **[/v1/federal_accounts/](https://spending-api.us/api/v1/federal_accounts/)**
-    - _Description_: Provides financial information by federal account. Financial information is data such as total budget authority, outlays, obligations, and unobligated balance. _Note_: This endpoint is due for a rework in the near future.
-    - _Methods_: GET, POST
 
 
-  * **[/v1/tas/](https://spending-api.us/api/v1/tas/)**
-    - _Description_: Returns a list of appropriations accounts, including the account name, Treasury Account Symbol (TAS) components, the associated budget function, and the corresponding agency information. _Note_: This endpoint is due for a rework in the near future.
-    - _Methods_: GET, POST
 
-
-  * **/v1/accounts/tas/autocomplete/**
-    - _Description_: Provides a fast endpoint for evaluating autocomplete queries against the TAS endpoint.
-    - _Methods_: POST
-
-
-  * **[/v1/awards/](https://spending-api.us/api/v1/awards/)**
-    - _Description_: Provides a list of awards. Award data pertains to grants, loans, direct payments to individuals, and contracts.
-    - _Methods_: GET, POST
-
-
-  * **/v1/awards/{pk}**
-    - _Description_: Provides information about a single award. Unlike the awards list endpoint (`/awards`), this one returns all available fields instead of the default set. The value for `{pk}` is the `id` field returned in the `/awards/` response.
-    - _Methods_: GET, POST
-
-
-  * **/v1/awards/autocomplete/**
-      - _Description_: Provides a fast endpoint for evaluating autocomplete queries against the awards endpoint.
-    - _Methods_: POST
-
-
-  * **[/v1/transactions/](https://spending-api.us/api/v1/transactions/)**
-    - _Description_: Provides award transactions data. Awards transaction represent specific actions that apply to an award, such as a purchase order.
-    - _Methods_: GET, POST
-
-
-  * **/v1/transactions/{pk}**
-    - _Description_: Provides information about a single transaction. Unlike the transaction list endpoint (`/transactions`), this one returns all available fields instead of the default set.
-    - _Methods_: GET, POST
-
-
-  * **/v1/references/locations/**
-    - _Description_: Returns a list of locations. If a location's `recipient_flag` is set to true, it represents the location of award recipients like grantees and contractors. If its `place_of_performance_flag` is true, the location represents the place an award was executed. A single location can represent both a recipient and a place of performance.
-    - _Methods_: POST
-
-
-  * **/v1/references/locations/geocomplete/**
-    - _Description_: A structured hierarchy geographical autocomplete. See [Geographical Hierarchy Queries](#geographical-hierarchy-queries) for more information.
-    - _Methods_: POST
-
-
-  * **[/v1/references/agency/](https://spending-api.us/api/v1/references/agency/)**
-    - _Description_: Returns a list of agencies.
-    - _Methods_: GET, POST
-
-
-  * **[/v1/references/agency/autocomplete/](https://spending-api.us/api/v1/references/agency/autocomplete/)**
-    - _Description_: Provides a fast endpoint for evaluating autocomplete queries against the agency endpoint.
-    - _Methods_: POST
-
-
-  * **[/v1/references/cfda/](https://spending-api.us/api/v1/references/cfda/)**
-    - _Description_: Returns a list of CFDA programs
-    - _Methods_: GET, POST
-
-
-  * **/v1/references/cfda/{CFDA Program Code}**
-    - _Description_: Provides information about a single CFDA Program. Unlike the CFDA list endpoint (`/references/cfda`), this one returns all available fields instead of the default set.
-    - _Methods_: GET, POST
-
-
-  * **[/v1/submissions/](https://spending-api.us/api/v1/submissions/)**
-    - _Description_: Returns metadata about submissions loaded from the DATA Act broker. _Note_: This endpoint is due for a rework in the near future.
-    - _Methods_: GET, POST
-
-
-#### Summary Endpoints and Methods <a name="summary-endpoints-and-methods"></a>
-Summarized data is available for some of the endpoints listed above:
-
-* **/v1/awards/total/**
-* **/v1/transactions/total/**
-* more coming soon
-
-You can get summarized data via a `POST` request that specifies:
-
-* `field`: the field to be summarized (this supports Django's foreign key traversal; for more details on this see `field` in [POST Requests](#post-requests)).
-* `aggregate`: the aggregate function to use when summarizing the data (defaults to `sum`; `avg`, `count`, `min`, and `max` are also supported)
-* `group`: the field to group by (optional; if not specified, data will be summarized across all objects)
-* `date_part`: applies only when `group` is a data field and specifies which part of the date to group by; `year`, `month`, and `day` are currently supported, and `quarter` is coming soon
-
-Requests to the summary endpoints can also contain the `filters` parameters as described in [POST Requests](#post-requests). **Note:** If you're filtering the data, the filters are applied before the data is summarized.
-
-The `results` portion of the response will contain:
-
-* `item`: the value of the field in the request's `group` parameter (if the request did not supply `group`, `item` will not be included)
-* `aggregate`: the summarized data
-
-To order the response by the items being returned via the `group` parameter, you can specify an `order` in the request: `"order": ["item"]`. To order the response by the aggregate values themselves, add `"order": ["aggregate]` to the request.
-
-For example, to request the yearly sum of obligated dollars across transactions for award types "B" and "C" (_i.e._, purchase orders and delivery orders) and to ensure that the response is ordered by year:
-
-POST request to `/transactions/total`:
-
-```json
-{
-    "field": "federal_action_obligation",
-    "group": "action_date",
-    "date_part": "year",
-    "aggregate": "sum",
-    "order": ["item"],
-    "filters": [
-        {
-            "field": "type",
-            "operation": "in",
-            "value": ["A", "B", "C", "D"]
-        }
-     ]
-}
-```
-
-Response:
-
-```json
-{
-  "page_metadata": {
-   "page": 1,
-   "has_next_page": false,
-   "next": null,
-   "previous": null
-  },
-  "results": [
-    {
-      "item": "2015",
-      "aggregate": "44948.00"
-    },
-    {
-      "item": "2016",
-      "aggregate": "1621763.83"
-    }
-  ]
-}
-```
-
-To summarize a field using a foreign key and to order the response by the summarized values from highest to lowest:
-
-POST request to `/awards/total`:
-
-```json
-{
-    "field": "total_obligation",
-    "group": "place_of_performance__state_code",
-    "aggregate": "sum",
-    "order": ["-aggregate"]
-}
-```
-Response:
-
-```json
-{
-  "page_metadata": {
-   "page": 1,
-   "has_next_page": false,
-   "next": null,
-   "previous": null
-  },
-  "results": [
-    {
-      "item": "MO",
-      "aggregate": "500000.00"
-    },
-    {
-      "item": "DC",
-      "aggregate": "485795.43"
-    },
-    {
-      "item": "UT",
-      "aggregate": "0.00"
-    },
-    {
-      "item": "HI",
-      "aggregate": "-2891.33"
-    }
-  ],
-}
-```
-
-#### Pagination <a name="pagination"></a>
-To control the number of items returned on a single "page" of a request or to request a specific page number, use the following URL parameters:
-
-* `page` - specifies the page of results to return. The default is 1.
-* `limit` - specifies the maximum number of items to return in a response page. The default is 100.
-
-For example, the following request will limit the awards on a single page to 20 and will return page 5 of the results:
-
-`/v1/awards/?page=5&limit=20`
 
 #### GET Requests <a name="get-requests"></a>
 GET requests support simple equality filters for fields in the underlying data model. These can be specified by attaching field value pairs to the endpoint as URL parameters:
@@ -547,6 +340,125 @@ The response has three functional parts:
   * `req` - The special code corresponding to this POST request. See [Post request preservation]("#post-requests-preservation") for how to use this
   * `results` - An array of objects corresponding to the data returned by the specified endpoint. Will _always_ be an array, even if the number of results is only one.
 
+### Summary Endpoints and Methods <a name="summary-endpoints-and-methods"></a>
+  Summarized data is available for some of the endpoints listed above:
+
+  * **/v1/awards/total/**
+  * **/v1/transactions/total/**
+  * more coming soon
+
+  You can get summarized data via a `POST` request that specifies:
+
+  * `field`: the field to be summarized (this supports Django's foreign key traversal; for more details on this see `field` in [POST Requests](#post-requests)).
+  * `aggregate`: the aggregate function to use when summarizing the data (defaults to `sum`; `avg`, `count`, `min`, and `max` are also supported)
+  * `group`: the field to group by (optional; if not specified, data will be summarized across all objects)
+  * `date_part`: applies only when `group` is a data field and specifies which part of the date to group by; `year`, `month`, and `day` are currently supported, and `quarter` is coming soon
+
+  Requests to the summary endpoints can also contain the `filters` parameters as described in [POST Requests](#post-requests). **Note:** If you're filtering the data, the filters are applied before the data is summarized.
+
+  The `results` portion of the response will contain:
+
+  * `item`: the value of the field in the request's `group` parameter (if the request did not supply `group`, `item` will not be included)
+  * `aggregate`: the summarized data
+
+  To order the response by the items being returned via the `group` parameter, you can specify an `order` in the request: `"order": ["item"]`. To order the response by the aggregate values themselves, add `"order": ["aggregate]` to the request.
+
+  For example, to request the yearly sum of obligated dollars across transactions for award types "B" and "C" (_i.e._, purchase orders and delivery orders) and to ensure that the response is ordered by year:
+
+  POST request to `/transactions/total`:
+
+  ```json
+  {
+      "field": "federal_action_obligation",
+      "group": "action_date",
+      "date_part": "year",
+      "aggregate": "sum",
+      "order": ["item"],
+      "filters": [
+          {
+              "field": "type",
+              "operation": "in",
+              "value": ["A", "B", "C", "D"]
+          }
+       ]
+  }
+  ```
+
+  Response:
+
+  ```json
+  {
+    "page_metadata": {
+     "page": 1,
+     "has_next_page": false,
+     "next": null,
+     "previous": null
+    },
+    "results": [
+      {
+        "item": "2015",
+        "aggregate": "44948.00"
+      },
+      {
+        "item": "2016",
+        "aggregate": "1621763.83"
+      }
+    ]
+  }
+  ```
+
+  To summarize a field using a foreign key and to order the response by the summarized values from highest to lowest:
+
+  POST request to `/awards/total`:
+
+  ```json
+  {
+      "field": "total_obligation",
+      "group": "place_of_performance__state_code",
+      "aggregate": "sum",
+      "order": ["-aggregate"]
+  }
+  ```
+  Response:
+
+  ```json
+  {
+    "page_metadata": {
+     "page": 1,
+     "has_next_page": false,
+     "next": null,
+     "previous": null
+    },
+    "results": [
+      {
+        "item": "MO",
+        "aggregate": "500000.00"
+      },
+      {
+        "item": "DC",
+        "aggregate": "485795.43"
+      },
+      {
+        "item": "UT",
+        "aggregate": "0.00"
+      },
+      {
+        "item": "HI",
+        "aggregate": "-2891.33"
+      }
+    ],
+  }
+  ```
+
+### Pagination <a name="pagination"></a>
+  To control the number of items returned on a single "page" of a request or to request a specific page number, use the following URL parameters:
+
+  * `page` - specifies the page of results to return. The default is 1.
+  * `limit` - specifies the maximum number of items to return in a response page. The default is 100.
+
+  For example, the following request will limit the awards on a single page to 20 and will return page 5 of the results:
+
+  `/v1/awards/?page=5&limit=20`
 
 ### Autocomplete Queries <a name="autocomplete-queries"></a>
 

--- a/usaspending_api/api_docs/urls.py
+++ b/usaspending_api/api_docs/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     url(r'^recipes', MarkdownView.as_view(markdown='request_recipes.md')),
     url(r'^using-the-api', MarkdownView.as_view(markdown='using_the_api.md')),
     url(r'^entity-relationships', Plate.as_view(plate_template_name='plate.html'), name='plate'),
+    url(r'^endpoints', MarkdownView.as_view(markdown='endpoints.md')),
 ]

--- a/usaspending_api/static_doc_files/css/main.css
+++ b/usaspending_api/static_doc_files/css/main.css
@@ -2525,7 +2525,7 @@ a.list-group-item { color: #0071bc; }
 .mb-60 { margin-bottom: 60px; }
 
 .usa-da-header { margin: 0; }
-.usa-da-header .usa-da-header-container h1 { font-size: 3.1rem; font-weight: 700; color: #5b616b; line-height: 2.9rem; margin: 30px auto 30px 0; }
+.usa-da-header .usa-da-header-container h1 { font-size: 3.1rem; font-weight: 700; color: #5b616b; line-height: 2.9rem; margin: 10px auto 1px 0; }
 .usa-da-header .usa-da-header-container h1 a { color: #f1f1f1; }
 
 .nav-row { display: none; }
@@ -2733,7 +2733,7 @@ h2.styleguide-only { border-bottom: 1px solid #ccc; padding: 0 0 10px; }
 .code-block-toggle-html:before { content: 'View Code'; }
 .code-block-toggle-html[aria-expanded="true"]:before { content: 'Hide Code'; }
 
-pre { display: block; padding: 0; margin: 0 0 10px; font-size: 13px; line-height: 1.42857; word-break: break-all; word-wrap: break-word; color: #333333; background-color: transparent; border: none; border-radius: 0; }
+pre { display: block; padding: 0; margin: 0 0 30px; font-size: 13px; line-height: 1.42857; word-break: break-all; word-wrap: break-word; color: #333333; background-color: transparent; border: none; border-radius: 0; }
 
 .hljs { padding: 1.4em; font-size: 1.2rem; }
 

--- a/usaspending_api/static_doc_files/css/main.css
+++ b/usaspending_api/static_doc_files/css/main.css
@@ -1088,20 +1088,20 @@ caption { padding-top: 8px; padding-bottom: 8px; color: #777777; text-align: lef
 
 th { text-align: left; }
 
-.table { width: 100%; max-width: 100%; margin-bottom: 20px; }
-.table > thead > tr > th, .table > thead > tr > td, .table > tbody > tr > th, .table > tbody > tr > td, .table > tfoot > tr > th, .table > tfoot > tr > td { padding: 8px; line-height: 1.42857; vertical-align: top; border-top: 1px solid #ddd; }
-.table > thead > tr > th { vertical-align: bottom; border-bottom: 2px solid #ddd; }
-.table > caption + thead > tr:first-child > th, .table > caption + thead > tr:first-child > td, .table > colgroup + thead > tr:first-child > th, .table > colgroup + thead > tr:first-child > td, .table > thead:first-child > tr:first-child > th, .table > thead:first-child > tr:first-child > td { border-top: 0; }
-.table > tbody + tbody { border-top: 2px solid #ddd; }
-.table .table { background-color: #fff; }
+table { width: 100%; max-width: 100%; margin-bottom: 20px; }
+table > thead > tr > th, .table > thead > tr > td, .table > tbody > tr > th, .table > tbody > tr > td, .table > tfoot > tr > th, .table > tfoot > tr > td { padding: 8px; line-height: 1.42857; vertical-align: top; border-top: 1px solid #ddd; }
+table > thead > tr > th { vertical-align: bottom; border-bottom: 2px solid #ddd; }
+table > caption + thead > tr:first-child > th, .table > caption + thead > tr:first-child > td, .table > colgroup + thead > tr:first-child > th, .table > colgroup + thead > tr:first-child > td, .table > thead:first-child > tr:first-child > th, .table > thead:first-child > tr:first-child > td { border-top: 0; }
+table > tbody + tbody { border-top: 2px solid #ddd; }
+table { background-color: #fff; }
 
 .table-condensed > thead > tr > th, .table-condensed > thead > tr > td, .table-condensed > tbody > tr > th, .table-condensed > tbody > tr > td, .table-condensed > tfoot > tr > th, .table-condensed > tfoot > tr > td { padding: 5px; }
 
-.table-bordered { border: 1px solid #ddd; }
-.table-bordered > thead > tr > th, .table-bordered > thead > tr > td, .table-bordered > tbody > tr > th, .table-bordered > tbody > tr > td, .table-bordered > tfoot > tr > th, .table-bordered > tfoot > tr > td { border: 1px solid #ddd; }
-.table-bordered > thead > tr > th, .table-bordered > thead > tr > td { border-bottom-width: 2px; }
+table { border: 1px solid #ddd; }
+table > thead > tr > th, .table-bordered > thead > tr > td, .table-bordered > tbody > tr > th, .table-bordered > tbody > tr > td, .table-bordered > tfoot > tr > th, .table-bordered > tfoot > tr > td { border: 1px solid #ddd; }
+table > thead > tr > th, .table-bordered > thead > tr > td { border-bottom-width: 2px; }
 
-.table-striped > tbody > tr:nth-of-type(odd) { background-color: #f9f9f9; }
+table > tbody > tr:nth-of-type(odd) { background-color: #f9f9f9; }
 
 .table-hover > tbody > tr:hover { background-color: #f5f5f5; }
 
@@ -2371,17 +2371,17 @@ ul.no-bullet li { margin: 0 !important; }
 @media screen and (max-width: 767px) { .modal-sm { width: 98%; } }
 
 /***** TABLE STYLES *****/
-table.table, table.table-bordered { width: 100%; }
-table.table thead, table.table-bordered thead { font-size: 1.4rem; font-weight: 700; }
-table.table thead tr th, table.table-bordered thead tr th { padding: 15px; border-bottom: none; }
-table.table tbody tr td, table.table-bordered tbody tr td { padding: 15px; font-size: 1.4rem; color: #5b616b; }
+table, table.table-bordered { width: 100%; }
+table thead, table.table-bordered thead { font-size: 1.4rem; font-weight: 700; }
+table thead tr th, table.table-bordered thead tr th { padding: 15px; border-bottom: none; }
+table tbody tr td, table.table-bordered tbody tr td { padding: 15px; font-size: 1.4rem; color: #5b616b; }
 
-table.table-bordered thead { color: #ffffff; background: #5b616b; }
+table thead { color: #ffffff; background: #5b616b; }
 
-table.table thead { color: #212121; background: #f1f1f1; }
-table.table thead tr th { border-bottom: none; vertical-align: middle; }
-table.table tbody tr:last-child { border-bottom: 1px solid #ddd; }
-table.table tbody tr td { vertical-align: middle; }
+/* table thead { color: #212121; background: #f1f1f1; }*/
+table thead tr th { border-bottom: none; vertical-align: middle; }
+table tbody tr:last-child { border-bottom: 1px solid #ddd; }
+table tbody tr td { vertical-align: middle; }
 
 .list-group-item { padding: 15px; }
 .list-group-item:first-child { border-top-right-radius: 0; border-top-left-radius: 0; }

--- a/usaspending_api/static_doc_files/css/main.css
+++ b/usaspending_api/static_doc_files/css/main.css
@@ -2365,7 +2365,7 @@ ul.no-bullet li { margin: 0 !important; }
 
 .panel-heading h3 { margin: 0; font-weight: 700; font-size: 2.0rem; line-height: 2.8rem; color: #555; }
 
-.navbar { margin-bottom: 0; }
+.navbar { margin-bottom: 10px; }
 
 .modal-sm { width: 400px; }
 @media screen and (max-width: 767px) { .modal-sm { width: 98%; } }

--- a/usaspending_api/static_doc_files/css/main.css
+++ b/usaspending_api/static_doc_files/css/main.css
@@ -2596,7 +2596,7 @@ html, body { background: #f6f6f6; }
 
 #sidebar li a:focus { background: none; }
 
-#sidebar li li.active { background: red; }
+#sidebar li li.active { background: #eee; }
 
 section.wrap { border: 1px solid #ddd; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.025); background: #fff; padding: 20px 20px; margin: 30px 0; }
 

--- a/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json
+++ b/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json
@@ -1,0 +1,337 @@
+{
+	"variables": [],
+	"info": {
+		"name": "DATA Act Frontend",
+		"_postman_id": "e8e6c1e2-7070-e23d-d3cb-3f233a0d8ad3",
+		"description": "",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Search Page - Visualizations",
+			"description": "",
+			"item": [
+				{
+					"name": "Spending Over Time - Unfiltered",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/tas/categories/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"obligations_incurred_by_program_object_class_cpe\",\n\t\"group\": \"submission__reporting_fiscal_year\",\n\t\"order\": [\"submission__reporting_fiscal_year\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": []\n}"
+						},
+						"description": "**Rationale:** Spending over time by default should show all spending, including non-award spending, both of which are aggregated within `/tas/categories/total/`."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending Over Time - Budget Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/tas/categories/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"obligations_incurred_by_program_object_class_cpe\",\n\t\"group\": \"submission__reporting_fiscal_year\",\n\t\"order\": [\"submission__reporting_fiscal_year\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": [\"reporting_period_start\", \"reporting_period_end\"],\n\t\t\t\"operation\": \"range_intersect\",\n\t\t\t\"value\": \"2017\",\n\t\t\t\"value_format\": \"fy\"\n\t\t}]\n\t}, {\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": \"treasury_account__budget_function_title\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": []\n\t\t}, {\n\t\t\t\"field\": \"treasury_account__budget_subfunction_title\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": [\"Other income security\"]\n\t\t}]\n\t}, {\n\t\t\"field\": \"object_class__major_object_class\",\n\t\t\"operation\": \"in\",\n\t\t\"value\": [\"10\"]\n\t}]\n}"
+						},
+						"description": "**Rationale:** This endpoint utilizes File C linkage to apply budget filters to spending data. We use `/tas/categories/total/` because we want to search within both award and non-award spending.\n\n*Note:* Budget filters are:\n* Time Period (FY only)\n* Object class\n* Budget function\n* Federal account\n* Funding agency"
+					},
+					"response": []
+				},
+				{
+					"name": "Spending Over Time - Award Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"action_date__fy\",\n\t\"order\": [\"action_date__fy\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": \"federal_action_obligation\",\n\t\t\t\"operation\": \"range\",\n\t\t\t\"value\": [1000000, 25000000]\n\t\t}]\n\t}]\n}"
+						},
+						"description": "**Rationale:** Once award filters (anything that is not a budget filter) are applied, we can only search within awards, since that is the only place where the filter data exists. This requires an endpoint change to `/transactions/total/`. It is safe to use `/transactions/total/` because we are not grouping on a File C field, so there is no risk of multiple aggregations occurring."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending Over Time - Both",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"submission__reporting_fiscal_year\",\n\t\"order\": [\"submission__reporting_fiscal_year\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": [\"period_of_performance_start_date\", \"period_of_performance_current_end_date\"],\n\t\t\t\"operation\": \"range_intersect\",\n\t\t\t\"value\": \"2017\",\n\t\t\t\"value_format\": \"fy\"\n\t\t}]\n\t}, {\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": \"award__financial_set__treasury_account__budget_function_title\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": []\n\t\t}, {\n\t\t\t\"field\": \"award__financial_set__treasury_account__budget_subfunction_title\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": [\"Other income security\"]\n\t\t}]\n\t}]\n}"
+						},
+						"description": "**Rationale:** Because award filters are included, we can only search within awards, which requires us to use `/transactions/total`.  It is safe to use `/transactions/total/` because we are not grouping on a File C field, so there is no risk of multiple aggregations occurring.\n\n*Note:* File C fields are prepended with `awards__financial_set__`"
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Budget Category - Unfiltered",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/tas/categories/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"obligations_incurred_by_program_object_class_cpe\",\n\t\"group\": [\"treasury_account__budget_function_title\"],\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** This visualization by default should group all spending (both award and non-award) by their budget function titles. We are using `/tas/categories/total/` because we want both award and non-award spending."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Budget Category - Budget Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/tas/categories/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"obligations_incurred_by_program_object_class_cpe\",\n\t\"group\": [\"treasury_account__budget_function_title\"],\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [\n\t\t{\n\t\t\t\"field\": \"object_class__major_object_class\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": [\"10\"]\n\t\t}\n\t],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** We use `/tas/categories/total/` because we want to return spending for both award and non-award spending."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Budget Category - Award Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/accounts/awards/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"transaction_obligated_amount\",\n\t\"group\": [\"treasury_account__budget_function_title\"],\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": \"award__awarding_agency__toptier_agency__name\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": [\"Department of Health and Human Services\"]\n\t\t}]\n\t}],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** We use `/accounts/awards/total` because this endpoint provides linkage via File C to award-only spending, grouped by budget function. We are only searching within awards because award filters can only be applied to awards. We cannot use `/transactions/total/` because we are grouping on a File C field, which has the risk of multiple aggregations occurring in the `/transactions/total` endpoint but not on `/accounts/awards/total/`."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Budget Category - Both",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/accounts/awards/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"transaction_obligated_amount\",\n\t\"group\": [\"treasury_account__budget_function_title\"],\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"combine_method\": \"AND\",\n\t\t\t\"filters\": [{\n\t\t\t\t\"field\": \"award__date_signed\",\n\t\t\t\t\"operation\": \"greater_than_or_equal\",\n\t\t\t\t\"value\": \"2016-10-01\"\n\t\t\t}, {\n\t\t\t\t\"field\": \"award__date_signed\",\n\t\t\t\t\"operation\": \"less_than_or_equal\",\n\t\t\t\t\"value\": \"2017-09-30\"\n\t\t\t}]\n\t\t}]\n\t}, {\n\t\t\"field\": \"award__financial_set__object_class__major_object_class\",\n\t\t\"operation\": \"in\",\n\t\t\"value\": [\"10\"]\n\t}],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** We can only search within awards because award filters are included in this query (and we can only apply award filters to award spending). As a result, we will use `/accounts/awards/total/` just like in the Awards Filter query. We cannot use `/transactions/total/` because we are grouping on a File C field, which has the risk of multiple aggregations occurring in the `/transactions/total` endpoint but not on `/accounts/awards/total/`."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Awarding Agency - Unfiltered",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"awarding_agency__toptier_agency__name\",\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** This visualization returns only award spending, grouped by Awarding Agency. It does not return non-award spending because Awarding Agency is an award filter - which can only be applied to awards. Awarding Agency is not a File C field and we are not applying File C filters, so we can safely use `/transactions/total/` without risk of multiple aggregations occurring."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Awarding Agency - Budget Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/accounts/awards/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"transaction_obligated_amount\",\n\t\"group\": \"award__awarding_agency__toptier_agency__name\",\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"field\": \"object_class__major_object_class\",\n\t\t\"operation\": \"in\",\n\t\t\"value\": [\"40\"]\n\t}],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** This query utilizes the `/accounts/awards/total/` endpoint to take advantage of the endpoint's File C linkage in order to query using budget filters. We cannot use `/transactions/total/` because we are applying a File C filter, which may result in duplicate values being aggregated."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Awarding Agency - Award Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"awarding_agency__toptier_agency__name\",\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": \"federal_action_obligation\",\n\t\t\t\"operation\": \"range\",\n\t\t\t\"value\": [1000000, 25000000]\n\t\t}]\n\t}],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** This query utilizes `/transactions/total/` because it only needs award spending. This is because Awarding Agency is an award filter - which can only be applied to awards. Awarding Agency is not a File C field and we are not applying File C filters, so we can safely use `/transactions/total/` without risk of multiple aggregations occurring."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Awarding Agency - Both",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/accounts/awards/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"transaction_obligated_amount\",\n\t\"group\": \"award__awarding_agency__toptier_agency__name\",\n\t\"order\": [\"-aggregate\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [\n\t\t{\n\t\t\t\"combine_method\": \"OR\",\n\t\t\t\"filters\": [{\n\t\t\t\t\"field\": \"transaction_obligated_amount\",\n\t\t\t\t\"operation\": \"less_than_or_equal\",\n\t\t\t\t\"value\": 1000000\n\t\t\t}]\n\t\t},\n\t\t{\n\t\t\t\"field\"\t: \"award__type\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": [\"A\", \"B\", \"C\", \"D\"]\n\t\t},\n\t\t{\n\t\t\"field\": \"object_class__major_object_class\",\n\t\t\"operation\": \"in\",\n\t\t\"value\": [\"40\"]\n\t}],\n\t\"limit\": 5,\n\t\"page\": 1\n}"
+						},
+						"description": "**Rationale:** Because budget filters are included the query, we use the `/accounts/awards/total` endpoint. We cannot use `/transactions/total/` because we are applying a File C filter, which may result in duplicate values being aggregated.\n\n*Note:* Most award parameters will require an `award__` prefix, with the exception of award parameters that begin with `award__financial_set__`, which can be queried without any prefix (because the prefix represents File C, which this endpoint also represents)."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Geography - Unfiltered",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"place_of_performance__state_code\",\n\t\"order\": [\"item\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [],\n\t\"limit\": 60\n}"
+						},
+						"description": "**Rationale:** This visualization populates the map by returning award spending data, grouped by state code. This query only returns award data because place of performance and recipient location are award filters, which can only be applied to awards."
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Geography - Budget Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"place_of_performance__state_code\",\n\t\"order\": [\"item\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"field\": \"award__financial_set__object_class__major_object_class\",\n\t\t\"operation\": \"in\",\n\t\t\"value\": [\"10\"]\n\t}],\n\t\"limit\": 60\n}"
+						},
+						"description": "**Rationale:** This query returns award-only spending, with budget filters applied. It is safe to use `/transactions/total` because we are grouping only by place of performance or recipient location (which are not File C fields and thus won't be aggregated multiple times.)\n\n*Note:* File C fields are prepended with `awards__financial_set__`"
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Geography - Award Filters",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"place_of_performance__state_code\",\n\t\"order\": [\"item\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [{\n\t\t\"combine_method\": \"OR\",\n\t\t\"filters\": [{\n\t\t\t\"field\": \"federal_action_obligation\",\n\t\t\t\"operation\": \"less_than_or_equal\",\n\t\t\t\"value\": 1000000\n\t\t}]\n\t}],\n\t\"limit\": 60\n}"
+						},
+						"description": "**Rationale:** This query returns award-only spending, with budget filters applied. It is safe to use `/transactions/total` because we are grouping only by place of performance or recipient location (which are not File C fields and thus won't be aggregated multiple times.)"
+					},
+					"response": []
+				},
+				{
+					"name": "Spending by Geography - Both",
+					"request": {
+						"url": "https://spending-api-dev.us/api/v1/transactions/total/",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"field\": \"federal_action_obligation\",\n\t\"group\": \"place_of_performance__state_code\",\n\t\"order\": [\"item\"],\n\t\"aggregate\": \"sum\",\n\t\"filters\": [\n\t\t{\n\t\t\t\"field\": \"award__financial_set__object_class__major_object_class\",\n\t\t\t\"operation\": \"in\",\n\t\t\t\"value\": [\"10\"]\n\t\t},\n\t\t{\n\t\t\t\"field\": \"federal_action_obligation\",\n\t\t\t\"operation\": \"less_than_or_equal\",\n\t\t\t\"value\": 1000000\n\t\t}\n\t],\n\t\"limit\": 60\n}"
+						},
+						"description": "**Rationale:** This query returns award-only spending, with budget filters applied. It is safe to use `/transactions/total` because we are grouping only by place of performance or recipient location (which are not File C fields and thus won't be aggregated multiple times.)"
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/usaspending_api/templates/warning.html
+++ b/usaspending_api/templates/warning.html
@@ -8,7 +8,7 @@ body {
 .warning-banner-wrap {
     background: rgba(255, 241, 210, 0.95);
     min-height: 35px;
-    padding: 15px 0;
+    padding: 5px 0;
     width: 100%;
     border-bottom: 1px solid #fad980;
 }


### PR DESCRIPTION
This PR includes some styling and formatting updates based on April's testing results from PUB-613. Most of the content is relatively unchanged, just reorganized.

I also included subnavs for the different pages, but commented them out until we have time to go back in and update the styling/js to work with it properly. 