### PR TITLE
Recipient duns fixes

### DIFF
--- a/usaspending_api/etl/executive_compensation_etl.py
+++ b/usaspending_api/etl/executive_compensation_etl.py
@@ -24,7 +24,7 @@ def load_executive_compensation(db_cursor, duns_list=None):
     Loads File E from the broker. db_cursor should be the db_cursor for Broker
     """
     if duns_list is None:
-        duns_list = list(set(LegalEntity.objects.all().values_list("recipient_unique_id", flat=True)))
+        duns_list = list(set(LegalEntity.objects.all().exclude(recipient_unique_id__isnull=True).values_list("recipient_unique_id", flat=True)))
 
     duns_list = [str(x) for x in duns_list]
 

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -783,8 +783,7 @@ def load_file_d2(submission_attributes, award_financial_assistance_data, db_curs
         legal_entity_location, created = get_or_create_location(legal_entity_location_field_map, row, legal_entity_location_value_map)
 
         # Create the legal entity if it doesn't exist
-        try:
-            legal_entity, created = LegalEntity.get_or_create_by_duns(duns=row['awardee_or_recipient_uniqu'])
+        legal_entity, created = LegalEntity.get_or_create_by_duns(duns=row['awardee_or_recipient_uniqu'])
         if created:
             legal_entity_value_map = {
                 "location": legal_entity_location,

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -647,14 +647,12 @@ def load_file_d1(submission_attributes, procurement_data, db_cursor):
         legal_entity_location, created = get_or_create_location(legal_entity_location_field_map, row, legal_entity_location_value_map)
 
         # Create the legal entity if it doesn't exist
-        try:
-            legal_entity = LegalEntity.objects.get(recipient_unique_id=row['awardee_or_recipient_uniqu'])
-        except ObjectDoesNotExist:
+        legal_entity, created = LegalEntity.get_or_create_by_duns(duns=row['awardee_or_recipient_uniqu'])
+        if created:
             legal_entity_value_map = {
                 "location": legal_entity_location,
-                "legal_entity_id": row['awardee_or_recipient_uniqu'],
             }
-            legal_entity = load_data_into_model(LegalEntity(), row, value_map=legal_entity_value_map, save=True)
+            legal_entity = load_data_into_model(legal_entity, row, value_map=legal_entity_value_map, save=True)
 
         # Create the place of performance location
         pop_location, created = get_or_create_location(
@@ -786,13 +784,12 @@ def load_file_d2(submission_attributes, award_financial_assistance_data, db_curs
 
         # Create the legal entity if it doesn't exist
         try:
-            legal_entity = LegalEntity.objects.get(recipient_unique_id=row['awardee_or_recipient_uniqu'])
-        except ObjectDoesNotExist:
+            legal_entity, created = LegalEntity.get_or_create_by_duns(duns=row['awardee_or_recipient_uniqu'])
+        if created:
             legal_entity_value_map = {
                 "location": legal_entity_location,
-                "legal_entity_id": row['awardee_or_recipient_uniqu']
             }
-            legal_entity = load_data_into_model(LegalEntity(), row, value_map=legal_entity_value_map, save=True)
+            legal_entity = load_data_into_model(legal_entity, row, value_map=legal_entity_value_map, save=True)
 
         # Create the place of performance location
         pop_location, created = get_or_create_location(place_of_performance_field_map, row, place_of_performance_value_map)

--- a/usaspending_api/etl/management/commands/load_usaspending_assistance.py
+++ b/usaspending_api/etl/management/commands/load_usaspending_assistance.py
@@ -176,7 +176,7 @@ class Command(BaseCommand):
         le, created = LegalEntity.get_or_create_by_duns(duns=row['duns_no'])
         if created:
             # Update from our recipient dictionary
-            for attr, value in recipient_dict.iteritems():
+            for attr, value in recipient_dict.items():
                 setattr(le, attr, value)
             le.save()
 

--- a/usaspending_api/etl/management/commands/load_usaspending_contracts.py
+++ b/usaspending_api/etl/management/commands/load_usaspending_contracts.py
@@ -264,7 +264,7 @@ class Command(BaseCommand):
         le, created = LegalEntity.get_or_create_by_duns(duns=row['dunsnumber'])
         if created:
             # Update from our recipient dictionary
-            for attr, value in recipient_dict.iteritems():
+            for attr, value in recipient_dict.items():
                 setattr(le, attr, value)
             le.save()
 

--- a/usaspending_api/etl/subaward_etl.py
+++ b/usaspending_api/etl/subaward_etl.py
@@ -88,14 +88,13 @@ def load_subawards(submission_attributes, db_cursor):
         award_ids_to_update.add(award.id)
 
         # Find the recipient by looking up by duns
-        recipient = LegalEntity.objects.filter(recipient_unique_id=row['duns']).first()
+        recipient, created = LegalEntity.get_or_create_by_duns(duns=row['duns'])
 
-        if not recipient and row['duns']:
-            recipient, created = LegalEntity.objects.get_or_create(recipient_unique_id=row['duns'],
-                                                                   parent_recipient_unique_id=row['parent_duns'],
-                                                                   recipient_name=row["company_name"],
-                                                                   location=get_or_create_location(row, location_d1_recipient_mapper)
-                                                                   )
+        if created:
+            recipient.parent_recipient_unique_id = row['parent_duns']
+            recipient.recipient_name = row['company_name']
+            recipient.location = get_or_create_location(row, location_d1_recipient_mapper)
+            recipient.save()
 
         # Get or create POP
         place_of_performance = get_or_create_location(row, pop_mapper)
@@ -177,20 +176,19 @@ def load_subawards(submission_attributes, db_cursor):
         award_ids_to_update.add(award.id)
 
         # Find the recipient by looking up by duns
-        recipient = LegalEntity.objects.filter(recipient_unique_id=row['duns']).first()
+        recipient, created = LegalEntity.get_or_create_by_duns(duns=row['duns'])
 
-        if not recipient and row['duns']:
+        if created:
             recipient_name = row['awardee_name']
             if recipient_name is None:
                 recipient_name = row['awardee_or_recipient_legal']
             if recipient_name is None:
                 recipient_name = ""
 
-            recipient, created = LegalEntity.objects.get_or_create(recipient_unique_id=row['duns'],
-                                                                   parent_recipient_unique_id=row['parent_duns'],
-                                                                   recipient_name=recipient_name,
-                                                                   location=get_or_create_location(row, location_d2_recipient_mapper)
-                                                                   )
+            recipient.recipient_name = recipient_name
+            recipient.parent_recipient_unique_id = row['parent_duns']
+            recipient.location = get_or_create_location(row, location_d2_recipient_mapper)
+            recipient.save()
 
         # Get or create POP
         place_of_performance = get_or_create_location(row, pop_mapper)

--- a/usaspending_api/references/models.py
+++ b/usaspending_api/references/models.py
@@ -450,6 +450,20 @@ class LegalEntity(DataSourceTrackedModel):
 
         LegalEntityOfficers.objects.get_or_create(legal_entity=self)
 
+    @classmethod
+    def get_or_create_by_duns(cls, duns):
+        """
+        Finds a legal entity with the matching duns, or creates it if it does
+        not exist. If the duns is null, will always create a new instance.
+
+        Returns a single legal entity instance, and a boolean indicating if the
+        record was created or retrieved (i.e. mimicing the return of get_or_create)
+        """
+        if duns is None or len(duns) == 0:
+            return cls.objects.create(), True
+        else:
+            return cls.objects.get_or_create(recipient_unique_id=duns)
+
     @staticmethod
     def get_default_fields(path=None):
         return [
@@ -464,7 +478,6 @@ class LegalEntity(DataSourceTrackedModel):
     class Meta:
         managed = True
         db_table = 'legal_entity'
-        unique_together = (('recipient_unique_id'),)
 
 
 class LegalEntityOfficers(models.Model):

--- a/usaspending_api/references/tests/test_legal_entity.py
+++ b/usaspending_api/references/tests/test_legal_entity.py
@@ -1,0 +1,17 @@
+import pytest
+
+from usaspending_api.references.models import LegalEntity
+
+
+@pytest.mark.django_db
+def test_get_or_create_by_duns():
+    # Null duns should always return True for created
+    assert LegalEntity.get_or_create_by_duns(duns=None)[1]  # Assert created is True
+    assert LegalEntity.get_or_create_by_duns(duns=None)[1]  # Assert created is True
+    assert LegalEntity.get_or_create_by_duns(duns=None)[1]  # Assert created is True
+
+    # Let's create a new record with a DUNS
+    entity, created = LegalEntity.get_or_create_by_duns(duns="123456789")
+    assert created
+    assert LegalEntity.get_or_create_by_duns(duns="123456789")[0] == entity
+    assert not LegalEntity.get_or_create_by_duns(duns="123456789")[1]

--- a/usaspending_api/references/tests/test_legal_entity.py
+++ b/usaspending_api/references/tests/test_legal_entity.py
@@ -10,6 +10,10 @@ def test_get_or_create_by_duns():
     assert LegalEntity.get_or_create_by_duns(duns=None)[1]  # Assert created is True
     assert LegalEntity.get_or_create_by_duns(duns=None)[1]  # Assert created is True
 
+    assert LegalEntity.get_or_create_by_duns(duns="")[1]  # Assert created is True
+    assert LegalEntity.get_or_create_by_duns(duns="")[1]  # Assert created is True
+    assert LegalEntity.get_or_create_by_duns(duns="")[1]  # Assert created is True
+
     # Let's create a new record with a DUNS
     entity, created = LegalEntity.get_or_create_by_duns(duns="123456789")
     assert created

--- a/usaspending_api/references/tests/test_recipients_autocomplete.py
+++ b/usaspending_api/references/tests/test_recipients_autocomplete.py
@@ -18,6 +18,10 @@ def recipients_data(db):
         LegalEntity,
         recipient_name="Cerean Mineral Extraction Corp.",
         recipient_unique_id="CMEC")
+    mommy.make(
+        LegalEntity,
+        recipient_name="LOOK NO DUNS.",
+        recipient_unique_id=None)
 
 
 @pytest.mark.parametrize("fields,value,expected", [
@@ -47,3 +51,12 @@ def test_bad_recipients_autocomplete_request(client):
         content_type='application/json',
         data=json.dumps({}))
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_recipient_autocomplete_null_duns_exclusion(client, recipients_data):
+    resp = client.post(
+        '/api/v1/references/recipients/autocomplete/',
+        content_type='application/json',
+        data=json.dumps({"fields": ["recipient_name"], "value": "LOOK NO DUNS"}))
+    assert len(resp.data["results"]["recipient_name"]) == 0

--- a/usaspending_api/references/views.py
+++ b/usaspending_api/references/views.py
@@ -90,7 +90,7 @@ class RecipientAutocomplete(FilterQuerysetMixin,
 
     def get_queryset(self):
         """Return the view's queryset."""
-        queryset = LegalEntity.objects.all()
+        queryset = LegalEntity.objects.all().exclude(recipient_unique_id__isnull=True)
         queryset = self.serializer_class.setup_eager_loading(queryset)
         filtered_queryset = self.filter_records(self.request, queryset=queryset)
         return filtered_queryset


### PR DESCRIPTION
* This duplicate PR fixes an issue with github not liking a rebase

This fixes the issue brought up in DS-1143 where null DUNS's were causing some serious linkage issues.

* Adds `get_or_create_by_duns(duns)` to the `LegalEntity` Objects
  * This method returns `LegalEntity, Boolean` similar to other django get_or_create patterns.
  * If the specified DUNS is null, it will always create a new LegalEntity
  * If the specified DUNS exists, it will return that LegalEntity
  * If the specified DUNS does not exist, it will create a LegalEntity with that DUNS
* Update all usages of `.get()`, `.filter().first()` and other accessor methods for `LegalEntity` throughout the codebase where DUNS were used to `get_or_create_by_duns`
* Update recipient autocomplete to exclude any null DUNS, per acceptance criteria
* Update file E ETL to not check for null DUNS to prevent erroneous executive compensation linkages
* Added tests to verify the behavior of `get_or_create_by_duns`