### PR TITLE
Update transaction lookup to separate fain and uri

### DIFF
--- a/usaspending_api/etl/award_helpers.py
+++ b/usaspending_api/etl/award_helpers.py
@@ -181,30 +181,29 @@ def get_award_financial_transaction(
     Returns:
         A Transaction model instance
     """
-    # if both fain and uri are supplied as paramaters, look up by fain first
-    incoming_fain = fain
-    incoming_uri = uri
-    if incoming_fain is not None and incoming_uri is not None:
-        uri = None
+    # @todo: refactor this into methods on the TransactionAssistance
+    # and TransactionContract models
 
-    txn = Transaction.objects.filter(
-        awarding_agency__toptier_agency__cgac_code=toptier_agency_cgac,
-        contract_data__piid=piid,
-        contract_data__parent_award_id=parent_award_id,
-        assistance_data__fain=fain,
-        assistance_data__uri=uri) \
-        .order_by('-action_date').first()
+    if fain is not None:
+        # this is an assistance award id'd by fain
+        txn = Transaction.objects.filter(
+            awarding_agency__toptier_agency__cgac_code=toptier_agency_cgac,
+            assistance_data__fain=fain) \
+            .order_by('-action_date').first()
 
-    if txn is None and incoming_fain is not None and incoming_uri is not None:
-        # we didn't find a match and both fain and uri were supplied
-        # as parameters, now try searching by uri
-        uri = incoming_uri
+    elif uri is not None:
+        # this is an assistance award id'd by uri
+        txn = Transaction.objects.filter(
+            awarding_agency__toptier_agency__cgac_code=toptier_agency_cgac,
+            assistance_data__uri=uri) \
+            .order_by('-action_date').first()
+
+    else:
+        # this is a contract award
         txn = Transaction.objects.filter(
             awarding_agency__toptier_agency__cgac_code=toptier_agency_cgac,
             contract_data__piid=piid,
-            contract_data__parent_award_id=parent_award_id,
-            assistance_data__fain=None,
-            assistance_data__uri=uri) \
+            contract_data__parent_award_id=parent_award_id) \
             .order_by('-action_date').first()
 
     return txn

--- a/usaspending_api/etl/tests/test_award_helpers.py
+++ b/usaspending_api/etl/tests/test_award_helpers.py
@@ -290,6 +290,10 @@ def test_get_award_financial_transaction():
     mommy.make(
         'awards.TransactionAssistance', transaction=txn4, uri='456')
 
+    txn5 = mommy.make('awards.Transaction', awarding_agency=agency)
+    mommy.make(
+        'awards.TransactionAssistance', transaction=txn5, fain='789', uri='nah')
+
     # match on piid
     txn = get_award_financial_transaction(cgac, piid='abc')
     assert txn == txn1
@@ -310,21 +314,30 @@ def test_get_award_financial_transaction():
     txn = get_award_financial_transaction(cgac, uri='456')
     assert txn == txn4
 
+    # if there's an unmatched fain, we should not find a txn match,
+    # even if there's a match on the URI
+    txn = get_award_financial_transaction(cgac, fain='fakefain', uri='456')
+    assert txn is None
+
+    # match on fain alone, even when there's no uri = Null record in the txn table
+    txn = get_award_financial_transaction(cgac, fain='789')
+    assert txn == txn5
+
     # should not match on award id fields for a different cgac
     txn = get_award_financial_transaction('999', piid='abc')
     assert txn is None
 
     # if there is more than one txn match, we should get the one with
     # the most recent action date
-    txn5 = mommy.make(
+    txn6 = mommy.make(
         'awards.Transaction',
         awarding_agency=agency,
         action_date=datetime.date(2017, 5, 8))
     mommy.make(
         'awards.TransactionContract',
-        transaction=txn5,
+        transaction=txn6,
         piid='abc',
         parent_award_id='def'
     )
     txn = get_award_financial_transaction(cgac, piid='abc', parent_award_id='def')
-    assert txn == txn5
+    assert txn == txn6


### PR DESCRIPTION
This simplifies get_award_financial_transaction to try the
lookup by fain and then by uri (and not together as we were
previously doing). @catherinedevlin had suggested this approach
as a better way in a prior code review, and she was right!