### PR TITLE
Add openpyxl to the requirements list

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,6 +14,7 @@ drf-extensions==0.3.1
 drf-tracking==1.1.0
 Markdown==2.6.6
 model-mommy==1.3.0
+openpyxl==2.4.7
 psycopg2==2.6.2
 py==1.4.31
 py-gfm==0.1.3


### PR DESCRIPTION
We'll need this library to import the glossary import command