### PR TITLE
Nested field limiting

### DIFF
--- a/usaspending_api/accounts/models.py
+++ b/usaspending_api/accounts/models.py
@@ -89,49 +89,6 @@ class TreasuryAppropriationAccount(DataSourceTrackedModel):
         concatenated_tas = ATA + AID + TYPECODE + POAPHRASE + ACCTPHRASE
         return concatenated_tas
 
-    @staticmethod
-    def get_default_fields(path=None):
-        if "awards" in path:
-            return [
-                "treasury_account_identifier",
-                "tas_rendering_label",
-                "account_title",
-                "reporting_agency_id",
-                "reporting_agency_name",
-                "federal_account"
-            ]
-
-        return [
-            "treasury_account_identifier",
-            "tas_rendering_label",
-            "federal_account",
-            "allocation_transfer_agency_id",
-            "agency_id",
-            "beginning_period_of_availability",
-            "ending_period_of_availability",
-            "availability_type_code",
-            "main_account_code",
-            "sub_account_code",
-            "account_title",
-            "reporting_agency_id",
-            "reporting_agency_name",
-            "budget_bureau_code",
-            "budget_bureau_name",
-            "fr_entity_code",
-            "fr_entity_description",
-            "budget_function_code",
-            "budget_function_title",
-            "budget_subfunction_code",
-            "budget_subfunction_title",
-            "account_balances",
-            "program_balances",
-            "program_activities",
-            "object_classes",
-            "totals_program_activity",
-            "totals_object_class",
-            "totals",
-        ]
-
     @property
     def program_activities(self):
         return [

--- a/usaspending_api/accounts/serializers.py
+++ b/usaspending_api/accounts/serializers.py
@@ -25,6 +25,36 @@ class TasSerializer(LimitableSerializer):
 
         model = TreasuryAppropriationAccount
         fields = '__all__'
+        default_fields = [
+            "treasury_account_identifier",
+            "tas_rendering_label",
+            "federal_account",
+            "allocation_transfer_agency_id",
+            "agency_id",
+            "beginning_period_of_availability",
+            "ending_period_of_availability",
+            "availability_type_code",
+            "main_account_code",
+            "sub_account_code",
+            "account_title",
+            "reporting_agency_id",
+            "reporting_agency_name",
+            "budget_bureau_code",
+            "budget_bureau_name",
+            "fr_entity_code",
+            "fr_entity_description",
+            "budget_function_code",
+            "budget_function_title",
+            "budget_subfunction_code",
+            "budget_subfunction_title",
+            "account_balances",
+            "program_balances",
+            "program_activities",
+            "object_classes",
+            "totals_program_activity",
+            "totals_object_class",
+            "totals",
+        ]
         nested_serializers = {
             "federal_account": {
                 "class": FederalAccountSerializer,

--- a/usaspending_api/awards/models.py
+++ b/usaspending_api/awards/models.py
@@ -69,24 +69,6 @@ class FinancialAccountsByAwards(DataSourceTrackedModel):
     create_date = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     update_date = models.DateTimeField(auto_now=True, null=True)
 
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "financial_accounts_by_awards_id",
-            "award",
-            "treasury_account",
-            "transaction_obligated_amount",
-            "object_class",
-            "program_activity",
-            "piid",
-            "fain",
-            "uri",
-            "gross_outlay_amount_by_award_cpe",
-            "gross_outlay_amount_by_award_fyb",
-            "certified_date",
-            "last_modified_date"
-        ]
-
     class Meta:
         managed = True
         db_table = 'financial_accounts_by_awards'
@@ -171,31 +153,6 @@ class Award(DataSourceTrackedModel):
                      (self.parent_award.piid,
                       self.parent_award.fain,
                       self.parent_award.uri))))
-
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "id",
-            "type",
-            "type_description",
-            "total_obligation",
-            "total_outlay",
-            "date_signed",
-            "description",
-            "piid",
-            "fain",
-            "uri",
-            "period_of_performance_start_date",
-            "period_of_performance_current_end_date",
-            "potential_total_value_of_award",
-            "place_of_performance",
-            "awarding_agency",
-            "funding_agency",
-            "recipient",
-            "date_signed__fy",
-            "subaward_count",
-            "total_subaward_amount"
-        ]
 
     def __str__(self):
         return '%s piid: %s fain: %s uri: %s' % (self.type_description, self.piid, self.fain, self.uri)
@@ -340,29 +297,6 @@ class Transaction(DataSourceTrackedModel, TransactionAgeComparisonMixin):
     def __str__(self):
         return '%s award: %s' % (self.type_description, self.award)
 
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "id",
-            "type",
-            "type_description",
-            "period_of_performance_start_date",
-            "period_of_performance_current_end_date",
-            "action_date",
-            "action_type",
-            "action_type_description",
-            "action_date__fy",
-            "federal_action_obligation",
-            "modification_number",
-            "awarding_agency",
-            "funding_agency",
-            "recipient",
-            "description",
-            "place_of_performance",
-            "contract_data",  # must match related_name in TransactionContract
-            "assistance_data"  # must match related_name in TransactionAssistance
-        ]
-
     @classmethod
     def get_or_create_transaction(cls, **kwargs):
         """Gets and updates, or creates, a Transaction
@@ -498,21 +432,6 @@ class TransactionContract(DataSourceTrackedModel):
     reporting_period_end = models.DateField(blank=True, null=True, help_text="The date marking the end of the reporting period")
     history = HistoricalRecords()
 
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "piid",
-            "parent_award_id",
-            "type",
-            "type_description",
-            "cost_or_pricing_data",
-            "type_of_contract_pricing",
-            "type_of_contract_pricing_description",
-            "naics",
-            "naics_description",
-            "product_or_service_code"
-        ]
-
     @classmethod
     def get_or_create(cls, transaction, **kwargs):
         try:
@@ -561,19 +480,6 @@ class TransactionAssistance(DataSourceTrackedModel):
     period_of_performance_start_date = models.DateField(blank=True, null=True)
     period_of_performance_current_end_date = models.DateField(blank=True, null=True)
     history = HistoricalRecords()
-
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "fain",
-            "uri",
-            "cfda",
-            "cfda_number",
-            "cfda_title",
-            "face_value_loan_guarantee",
-            "original_loan_subsidy_cost",
-            "type"
-        ]
 
     @classmethod
     def get_or_create(cls, transaction, **kwargs):

--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -15,10 +15,35 @@ class FinancialAccountsByAwardsSerializer(LimitableSerializer):
     class Meta:
         model = FinancialAccountsByAwards
         fields = '__all__'
+        default_fields = [
+            "financial_accounts_by_awards_id",
+            "award",
+            "treasury_account",
+            "transaction_obligated_amount",
+            "object_class",
+            "program_activity",
+            "piid",
+            "fain",
+            "uri",
+            "gross_outlay_amount_by_award_cpe",
+            "gross_outlay_amount_by_award_fyb",
+            "certified_date",
+            "last_modified_date"
+        ]
         nested_serializers = {
             "treasury_account": {
                 "class": TasSerializer,
-                "kwargs": {"read_only": True}
+                "kwargs": {
+                    "read_only": True,
+                    "default_fields": [
+                        "treasury_account_identifier",
+                        "tas_rendering_label",
+                        "account_title",
+                        "reporting_agency_id",
+                        "reporting_agency_name",
+                        "federal_account"
+                    ]
+                }
             },
             "program_activity": {
                 "class": ProgramActivitySerializer,
@@ -36,7 +61,16 @@ class TransactionAssistanceSerializer(LimitableSerializer):
     class Meta:
         model = TransactionAssistance
         fields = '__all__'
-
+        default_fields = [
+            "fain",
+            "uri",
+            "cfda",
+            "cfda_number",
+            "cfda_title",
+            "face_value_loan_guarantee",
+            "original_loan_subsidy_cost",
+            "type"
+        ]
         nested_serializers = {
             "cfda": {
                 "class": CfdaSerializer,
@@ -50,6 +84,18 @@ class TransactionContractSerializer(LimitableSerializer):
     class Meta:
         model = TransactionContract
         fields = '__all__'
+        default_fields = [
+            "piid",
+            "parent_award_id",
+            "type",
+            "type_description",
+            "cost_or_pricing_data",
+            "type_of_contract_pricing",
+            "type_of_contract_pricing_description",
+            "naics",
+            "naics_description",
+            "product_or_service_code"
+        ]
 
 
 class TransactionSerializer(LimitableSerializer):
@@ -59,7 +105,26 @@ class TransactionSerializer(LimitableSerializer):
 
         model = Transaction
         fields = '__all__'
-
+        default_fields = [
+            "id",
+            "type",
+            "type_description",
+            "period_of_performance_start_date",
+            "period_of_performance_current_end_date",
+            "action_date",
+            "action_type",
+            "action_type_description",
+            "action_date__fy",
+            "federal_action_obligation",
+            "modification_number",
+            "awarding_agency",
+            "funding_agency",
+            "recipient",
+            "description",
+            "place_of_performance",
+            "contract_data",  # must match related_name in TransactionContract
+            "assistance_data"  # must match related_name in TransactionAssistance
+        ]
         nested_serializers = {
             # name below must match related_name in TransactionAssistance
             "assistance_data": {
@@ -125,6 +190,28 @@ class AwardSerializer(LimitableSerializer):
 
         model = Award
         fields = '__all__'
+        default_fields = [
+            "id",
+            "type",
+            "type_description",
+            "total_obligation",
+            "total_outlay",
+            "date_signed",
+            "description",
+            "piid",
+            "fain",
+            "uri",
+            "period_of_performance_start_date",
+            "period_of_performance_current_end_date",
+            "potential_total_value_of_award",
+            "place_of_performance",
+            "awarding_agency",
+            "funding_agency",
+            "recipient",
+            "date_signed__fy",
+            "subaward_count",
+            "total_subaward_amount"
+        ]
         nested_serializers = {
             "recipient": {
                 "class": LegalEntitySerializer,

--- a/usaspending_api/common/api_request_utils.py
+++ b/usaspending_api/common/api_request_utils.py
@@ -71,7 +71,7 @@ class FilterGenerator():
     def __init__(self, model, filter_map={}, ignored_parameters=[]):
         self.filter_map = filter_map
         self.model = model
-        self.ignored_parameters = ['page', 'limit', 'last', 'req'] + ignored_parameters
+        self.ignored_parameters = ['page', 'limit', 'last', 'req', 'verbose'] + ignored_parameters
         # When using full-text search the surrounding code must check for search vectors!
         self.search_vectors = []
 

--- a/usaspending_api/common/helpers.py
+++ b/usaspending_api/common/helpers.py
@@ -8,7 +8,7 @@ def get_params_from_req_or_request(request=None, req=None):
     Uses requests and req to return a single param dictionary combining query params and data
     Prefers the data from req, if available
     """
-    params = None
+    params = {}
     if request:
         params = dict(request.query_params)
         params.update(dict(request.data))

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -56,7 +56,7 @@ class LimitableSerializer(serializers.ModelSerializer):
                 include_fields = include_fields + self.identify_missing_children(self.Meta.model, include_fields)
 
         # Create and initialize the child serializers
-        try:
+        if hasattr(self.Meta, "nested_serializers"):
             # Initialize the child serializers
             children = self.Meta.nested_serializers
             for field in children.keys():
@@ -84,11 +84,8 @@ class LimitableSerializer(serializers.ModelSerializer):
                     "context": {**self.context, 'verbose': False},  # Do not verbos-ify child objects
                     "fields": child_include_fields,
                     "exclude": child_exclude_fields
-                }  # The child tag should be removed when child field limiting is implemented
+                }
                 self.fields[field] = children[field]["class"](**child_args)
-        except AttributeError:
-            # We don't have any nested serializers
-            pass
 
         # Now we alter our own field sets
         # We must exclude before include to avoid conflicts from user error

--- a/usaspending_api/common/serializers.py
+++ b/usaspending_api/common/serializers.py
@@ -7,83 +7,130 @@ class LimitableSerializer(serializers.ModelSerializer):
 
     """Extends the model serializer to support field limiting."""
     def __init__(self, *args, **kwargs):
-        # next two lines are deprecated and will be removed
-        # once all views inherit from a generic class or are
-        # refactored into viewsets (i.e., once the serializer
-        # consistently has direct access to the request)
-        include_fields = kwargs.pop('fields', None)
-        exclude_fields = kwargs.pop('exclude', None)
+        # Grab any kwargs include and exclude fields, these are typically
+        # passed in by a parent serializer to the child serializer
+        kwargs_has_include = 'fields' in kwargs
+        kwargs_has_exclude = 'exclude' in kwargs
+        kwargs_include_fields = kwargs.pop('fields', [])
+        kwargs_exclude_fields = kwargs.pop('exclude', [])
+
+        # Intialize now that kwargs have been cleared
         super(LimitableSerializer, self).__init__(*args, **kwargs)
+
+        # Get params from our request or req object
+        req = self.context.get('req', None)
+        request = self.context.get('request', None)
+        current_viewset = self.context.get('view')
+        params = get_params_from_req_or_request(request=request, req=req)
+
+        param_exclude_fields = []
+        param_include_fields = []
+
+        # If no kwargs excludes, check the request
+        if not kwargs_has_exclude:
+            param_exclude_fields = params.get('exclude', [])
+
+        if not kwargs_has_include:
+            param_include_fields = params.get('fields', [])
+
+        exclude_fields = []
+        include_fields = []
+
+        # Allow excluded and included fields if we are not verbose
+        if not self.context.get('verbose', True) or not params.get("verbose", False):
+            # Otherwise, use the fields from the lists
+            exclude_fields = param_exclude_fields + kwargs_exclude_fields
+
+            if len(exclude_fields) == 0 and hasattr(self.Meta, "default_exclude"):
+                exclude_fields = self.Meta.default_exclude
+
+            # If we're not in a detail view, we can use the include lists
+            if not current_viewset or current_viewset.action != "retrieve":
+                include_fields = param_include_fields + kwargs_include_fields
+
+                if len(include_fields) == 0 and hasattr(self.Meta, "default_fields"):
+                    include_fields = self.Meta.default_fields
+
+                # For the include list, we need to include the parent field of
+                # any nested fields
+                include_fields = include_fields + self.identify_missing_children(self.Meta.model, include_fields)
 
         # Create and initialize the child serializers
         try:
             # Initialize the child serializers
             children = self.Meta.nested_serializers
             for field in children.keys():
+                # Get child kwargs
+                kwargs = children[field].get("kwargs", {})
+
+                # Pop the default fields from the child serializer kwargs
+                default_fields = kwargs.pop("default_fields", [])
+                default_exclude = kwargs.pop("default_exclude", [])
+
+                child_include_fields, matched_include = self.get_child_fields(field, include_fields)
+                child_exclude_fields, matched_exclude = self.get_child_fields(field, exclude_fields)
+
+                # If the excluded field belongs to a child, we cannot include it in the parent
+                # exclusion, otherwise we would run into a KeyError
+                exclude_fields = [x for x in exclude_fields if x not in matched_exclude]
+
+                if len(child_include_fields) == 0:
+                    child_include_fields = default_fields
+                if len(child_exclude_fields) == 0:
+                    child_exclude_fields = default_exclude
+
                 child_args = {
-                    **children[field].get("kwargs", {}),
-                    "context": {**self.context, "child": True}
+                    **kwargs,
+                    "context": {**self.context, 'verbose': False},  # Do not verbos-ify child objects
+                    "fields": child_include_fields,
+                    "exclude": child_exclude_fields
                 }  # The child tag should be removed when child field limiting is implemented
                 self.fields[field] = children[field]["class"](**child_args)
         except AttributeError:
             # We don't have any nested serializers
             pass
 
-        req = self.context.get('req')
-        request = self.context.get('request')
+        # Now we alter our own field sets
+        # We must exclude before include to avoid conflicts from user error
+        for field_name in exclude_fields:
+            self.fields.pop(field_name)
 
-        if request:
-            params = get_params_from_req_or_request(request=request, req=req)
+        if len(include_fields) > 0:
+            allowed = set(include_fields)
+            existing = set(self.fields.keys())
+            for field_name in existing - allowed:
+                # If we have a coded field, always include its description
+                if field_name.split("_")[-1] == "description" and "_".join(field_name.split("_")[:-1]) not in allowed:
+                    continue
+                self.fields.pop(field_name)
 
-            exclude_fields = params.get('exclude')
-            include_fields = params.get('fields')
-            current_viewset = self.context.get('view')
+    # Returns a list of child names for fields in the field list
+    # This is necessary so that if a user requests "recipient__recipient_name"
+    # we also include "recipient" so that it is serialized
+    def identify_missing_children(self, model, fields):
+        children = []
+        model_fields = [f.name for f in model._meta.get_fields()]
+        for field in fields:
+            split = field.split("__")
+            if len(split) > 0 and split[0] in model_fields and split[0] not in fields:
+                children.append(split[0])
 
-            if params.get('verbose', False):
-                # We have a request for verbose, so we return here so that we
-                # return all fields
-                return
+        return children
 
-            # We must exclude before include to avoid conflicts from user error
-            if exclude_fields is not None and not self.context.get("child", False):  # the child check should be removed when child field limiting is implemented
-                for field_name in exclude_fields:
-                    try:
-                        self.fields.pop(field_name)
-                    except KeyError:
-                        # Because we're not currently handling nested serializer field
-                        # limiting pass-down, this can happen due to the context pass down
-                        pass
+    # Takes a child's name and a list of fields, and returns a set of fields
+    # that belong to that child
+    def get_child_fields(self, child, fields):
+        # An included field is a child's field if the field begins with that
+        # child's name and two underscores
+        pattern = "{}__".format(child)
 
-            if include_fields is not None and not self.context.get("child", False):  # the child check should be removed when child field limiting is implemented
-                allowed = set(include_fields)
-                existing = set(self.fields.keys())
-                for field_name in existing - allowed:
-                    try:
-                        # If we have a coded field, always include its description
-                        if field_name.split("_")[-1] == "description" and "_".join(field_name.split("_")[:-1]) not in allowed:
-                            continue
-                        self.fields.pop(field_name)
-                    except KeyError:
-                        # Because we're not currently handling nested serializer field
-                        # limiting pass-down, this can happen due to the context pass down
-                        pass
-
-            elif current_viewset and current_viewset.action == 'retrieve':
-                # The view has specifically asked that all fields should
-                # be returned (for example, when the request url follows
-                # the item/{pk} pattern)
-                return
-
-            else:
-                try:
-                    include_fields = self.Meta.model.get_default_fields(path=request._request.path_info)
-                    allowed = set(include_fields)
-                    existing = set(self.fields.keys())
-                    for field_name in existing - allowed:
-                        self.fields.pop(field_name)
-                except AttributeError:
-                    # We don't have get default fields available
-                    pass
+        matched = []
+        child_fields = []
+        for field in fields:
+            if field[:len(pattern)] == pattern:
+                child_fields.append(field[len(pattern):])
+                matched.append(field)
+        return child_fields, matched
 
     @classmethod
     def setup_eager_loading(cls, queryset, prefix=""):

--- a/usaspending_api/common/tests/test_limitable_serializer.py
+++ b/usaspending_api/common/tests/test_limitable_serializer.py
@@ -1,0 +1,52 @@
+import pytest
+import json
+from datetime import date
+
+from model_mommy import mommy
+from rest_framework import status
+
+from usaspending_api.awards.models import Award
+from usaspending_api.common.api_request_utils import FilterGenerator
+
+
+@pytest.fixture
+def mock_limitable_data():
+    mommy.make(Award, _fill_optional=True)
+
+
+@pytest.mark.django_db
+def test_nested_field_limiting(client, mock_limitable_data):
+    request_object = {
+        "fields": ["piid", "recipient__recipient_name"]
+    }
+
+    response = client.post(
+        "/api/v1/awards/",
+        content_type='application/json',
+        data=json.dumps(request_object),
+        format='json')
+
+    results = response.data["results"][0]
+
+    assert "piid" in results.keys()
+    assert "recipient" in results.keys()
+    assert "recipient_name" in results.get("recipient", {}).keys()
+
+
+@pytest.mark.django_db
+def test_nested_field_exclusion(client, mock_limitable_data):
+    request_object = {
+        "exclude": ["piid", "recipient__recipient_name"]
+    }
+
+    response = client.post(
+        "/api/v1/awards/",
+        content_type='application/json',
+        data=json.dumps(request_object),
+        format='json')
+
+    results = response.data["results"][0]
+
+    assert "piid" not in results.keys()
+    assert "recipient" in results.keys()
+    assert "recipient_name" not in results.get("recipient").keys()

--- a/usaspending_api/references/models.py
+++ b/usaspending_api/references/models.py
@@ -81,16 +81,6 @@ class Agency(models.Model):
     toptier_flag = models.BooleanField(default=False)
 
     @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "id",
-            "toptier_agency",
-            "subtier_agency",
-            "office_agency",
-            "toptier_flag"
-        ]
-
-    @staticmethod
     def get_by_toptier(toptier_cgac_code):
         """
         Get an agency record by toptier information only
@@ -164,15 +154,6 @@ class ToptierAgency(models.Model):
     abbreviation = models.TextField(blank=True, null=True, verbose_name="Agency Abbreviation")
     name = models.TextField(blank=True, null=True, verbose_name="Top-Tier Agency Name")
 
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "cgac_code",
-            "fpds_code",
-            "name",
-            "abbreviation"
-        ]
-
     class Meta:
         managed = True
         db_table = 'toptier_agency'
@@ -186,14 +167,6 @@ class SubtierAgency(models.Model):
     abbreviation = models.TextField(blank=True, null=True, verbose_name="Agency Abbreviation")
     name = models.TextField(blank=True, null=True, verbose_name="Sub-Tier Agency Name")
 
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "subtier_code",
-            "name",
-            "abbreviation"
-        ]
-
     class Meta:
         managed = True
         db_table = 'subtier_agency'
@@ -205,13 +178,6 @@ class OfficeAgency(models.Model):
     update_date = models.DateTimeField(auto_now=True, null=True)
     aac_code = models.TextField(blank=True, null=True, verbose_name="Office Code")
     name = models.TextField(blank=True, null=True, verbose_name="Office Name")
-
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "aac_code",
-            "name"
-        ]
 
     class Meta:
         managed = True
@@ -253,23 +219,6 @@ class Location(DataSourceTrackedModel):
     # location, or both
     place_of_performance_flag = models.BooleanField(default=False, verbose_name="Location used as place of performance")
     recipient_flag = models.BooleanField(default=False, verbose_name="Location used as recipient location")
-
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "address_line1",
-            "address_line2",
-            "address_line3",
-            "city_name",
-            "state_name",
-            "country_name",
-            "state_code",
-            "location_country_code",
-            "zip5",
-            "foreign_province",
-            "foreign_city_name",
-            "foreign_postal_code"
-        ]
 
     def save(self, *args, **kwargs):
         self.load_country_data()
@@ -470,17 +419,6 @@ class LegalEntity(DataSourceTrackedModel):
         else:
             return cls.objects.get_or_create(recipient_unique_id=duns)
 
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "legal_entity_id",
-            "parent_recipient_unique_id",
-            "recipient_name",
-            "business_types",
-            "business_types_description",
-            "location"
-        ]
-
     class Meta:
         managed = True
         db_table = 'legal_entity'
@@ -503,21 +441,6 @@ class LegalEntityOfficers(models.Model):
     officer_5_amount = models.DecimalField(max_digits=20, decimal_places=2, blank=True, null=True)
 
     update_date = models.DateField(auto_now_add=True, blank=True, null=True)
-
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "officer_1_name",
-            "officer_1_amount",
-            "officer_2_name",
-            "officer_2_amount",
-            "officer_3_name",
-            "officer_3_amount",
-            "officer_4_name",
-            "officer_4_amount",
-            "officer_5_name",
-            "officer_5_amount",
-        ]
 
     class Meta:
         managed = True
@@ -611,16 +534,6 @@ class CFDAProgram(DataSourceTrackedModel):
 
     def __str__(self):
         return "%s" % (self.program_title)
-
-    @staticmethod
-    def get_default_fields(path=None):
-        return [
-            "program_number",
-            "program_title",
-            "popular_name",
-            "website_address",
-            "objectives",
-        ]
 
 
 class Definition(models.Model):

--- a/usaspending_api/references/serializers.py
+++ b/usaspending_api/references/serializers.py
@@ -10,6 +10,12 @@ class ToptierAgencySerializer(LimitableSerializer):
     class Meta:
         model = ToptierAgency
         fields = '__all__'
+        default_fields = [
+            "cgac_code",
+            "fpds_code",
+            "name",
+            "abbreviation"
+        ]
 
 
 class SubtierAgencySerializer(LimitableSerializer):
@@ -17,6 +23,11 @@ class SubtierAgencySerializer(LimitableSerializer):
     class Meta:
         model = SubtierAgency
         fields = '__all__'
+        default_fields = [
+            "subtier_code",
+            "name",
+            "abbreviation"
+        ]
 
 
 class OfficeAgencySerializer(LimitableSerializer):
@@ -24,6 +35,10 @@ class OfficeAgencySerializer(LimitableSerializer):
     class Meta:
         model = OfficeAgency
         fields = '__all__'
+        default_fields = [
+            "aac_code",
+            "name"
+        ]
 
 
 class AgencySerializer(LimitableSerializer):
@@ -31,6 +46,13 @@ class AgencySerializer(LimitableSerializer):
     class Meta:
         model = Agency
         fields = '__all__'
+        default_fields = [
+            "id",
+            "toptier_agency",
+            "subtier_agency",
+            "office_agency",
+            "toptier_flag"
+        ]
         nested_serializers = {
             "toptier_agency": {
                 "class": ToptierAgencySerializer,
@@ -52,6 +74,13 @@ class CfdaSerializer(LimitableSerializer):
     class Meta:
         model = CFDAProgram
         fields = '__all__'
+        default_fields = [
+            "program_number",
+            "program_title",
+            "popular_name",
+            "website_address",
+            "objectives",
+        ]
 
 
 class LocationSerializer(LimitableSerializer):
@@ -60,6 +89,20 @@ class LocationSerializer(LimitableSerializer):
 
         model = Location
         fields = '__all__'
+        default_fields = [
+            "address_line1",
+            "address_line2",
+            "address_line3",
+            "city_name",
+            "state_name",
+            "country_name",
+            "state_code",
+            "location_country_code",
+            "zip5",
+            "foreign_province",
+            "foreign_city_name",
+            "foreign_postal_code"
+        ]
 
 
 class LegalEntityOfficersSerializer(LimitableSerializer):
@@ -67,6 +110,18 @@ class LegalEntityOfficersSerializer(LimitableSerializer):
     class Meta:
         model = LegalEntityOfficers
         fields = '__all__'
+        default_fields = [
+            "officer_1_name",
+            "officer_1_amount",
+            "officer_2_name",
+            "officer_2_amount",
+            "officer_3_name",
+            "officer_3_amount",
+            "officer_4_name",
+            "officer_4_amount",
+            "officer_5_name",
+            "officer_5_amount",
+        ]
 
 
 class LegalEntitySerializer(LimitableSerializer):
@@ -74,6 +129,14 @@ class LegalEntitySerializer(LimitableSerializer):
     class Meta:
         model = LegalEntity
         fields = '__all__'
+        default_fields = [
+            "legal_entity_id",
+            "parent_recipient_unique_id",
+            "recipient_name",
+            "business_types",
+            "business_types_description",
+            "location"
+        ]
         nested_serializers = {
             "location": {
                 "class": LocationSerializer,

--- a/usaspending_api/submissions/serializers.py
+++ b/usaspending_api/submissions/serializers.py
@@ -7,6 +7,10 @@ class SubmissionAttributesSerializer(LimitableSerializer):
     class Meta:
 
         model = SubmissionAttributes
-        fields = (
-            'submission_id', 'cgac_code',
-            'reporting_fiscal_year', 'reporting_fiscal_quarter')
+        fields = "__all__"
+        default_fields = [
+            'submission_id',
+            'cgac_code',
+            'reporting_fiscal_year',
+            'reporting_fiscal_quarter'
+            ]


### PR DESCRIPTION
This resolves issue #342 which also affected @ebdabbs front-end work

* Move default fields from models to serializers
* Limitable serializer meta objects now support `default_fields` and
`default_exclude`, which take an array of strings and provide the
default exclude and include fields. (The `fields` variable should
remain '__all__' to allow access to all variables by API users)
* Nested serializers can now include `default_fields` and
`default_exclude` in their kwargs
* Limitable serializer now properly passes down include/exclude fields
to nested objects using Django double-underscore traversal
* If a child object's field is requested, but the child itself is not
requested, it will be automatically added (otherwise it would not
serialize)
* The verbose flag now _only_ applies to the top-level request object.
That is, if you request verbose on `/awards/` only the award will be
verbose, the nested objects will still use their defaults. This
super-full-detail view is still available by `retrieve`ing an object
using the `/awards/pk` endpoint (or any other retrieve route)
* Added tests to support nested object include and exclude fields