### PR TITLE
Removed financing accounts and stopped adding them to db

### DIFF
--- a/usaspending_api/references/management/commands/loadtas.py
+++ b/usaspending_api/references/management/commands/loadtas.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 
 from usaspending_api.accounts.models import TreasuryAppropriationAccount
 from usaspending_api.references.models import ToptierAgency
-from usaspending_api.common.threaded_data_loader import ThreadedDataLoader
+from usaspending_api.common.threaded_data_loader import ThreadedDataLoader, SkipRowException
 from usaspending_api.references.reference_helpers import insert_federal_accounts, update_federal_accounts
 
 
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             "funding_toptier_agency": lambda row: ToptierAgency.objects.filter(cgac_code=row["AID"].strip()).order_by("fpds_code").first()
         }
 
-        loader = ThreadedDataLoader(model_class=TreasuryAppropriationAccount, field_map=field_map, value_map=value_map, collision_field='treasury_account_identifier', collision_behavior='update')
+        loader = ThreadedDataLoader(model_class=TreasuryAppropriationAccount, field_map=field_map, value_map=value_map, collision_field='treasury_account_identifier', collision_behavior='update', pre_row_function=self.skip_and_remove_financing_tas)
         loader.load_from_file(options['file'][0])
 
         # update TAS fk relationships to federal accounts
@@ -61,3 +61,11 @@ class Command(BaseCommand):
                                                                          row["EPOA"],
                                                                          row["MAIN"],
                                                                          row["SUB"])
+
+    def skip_and_remove_financing_tas(self, row, instance):
+        if row["Financial Indicator Type2"] == "F":
+            # If the instance already exists in the db, delete the instance.
+            if instance.treasury_account_identifier:
+                instance.delete()
+            # If the row indicates the TAS is a financing account, skip that row by throwing an Exception.
+            raise SkipRowException("Row contains Financing TAS, Skipping...")


### PR DESCRIPTION
This is done by adding a function in loadtas.py called
skip_and_remove_financing_tas and calling that function before every
row.  

loadtas.py MUST BE CALLED AFTER PR is accepted to remove all current financing accounts!!!