### PR TITLE
Adding extra ArrayField specific operations

### DIFF
--- a/usaspending_api/api_docs/markdown/using_the_api.md
+++ b/usaspending_api/api_docs/markdown/using_the_api.md
@@ -164,6 +164,30 @@ Below is an example body for the `/v1/awards/?page=1&limit=200` POST request. Th
       "value": "BOEING"
     }
     ```
+    * `contained_by` - A special operation for array fields, matches where the value of the field is entirely contained by the specified array.
+    ```
+    {
+      "field": "business_categories",
+      "operation": "contained_by",
+      "value": ["local_government", "woman_owned_business"]
+    }
+    ```
+    * `overlap` - A special operation for array fields, matches where the value of the field has any overlap with the specified array.
+    ```
+    {
+      "field": "business_categories",
+      "operation": "overlap",
+      "value": ["local_government"]
+    }
+    ```
+    * `length_greater_than` and `length_less_than` - A special operation for array fields. As `less_than` and `greater_than`, but on the length of the data in the ArrayField.
+    ```
+    {
+      "field": "business_categories",
+      "operation": "length_greater_than",
+      "value": "0"
+    }
+    ```
     * `is_null` - Evaluates if the field is null or not null. `value` must be either `true` or `false`.
     ```
     {

--- a/usaspending_api/common/api_request_utils.py
+++ b/usaspending_api/common/api_request_utils.py
@@ -54,6 +54,12 @@ class FilterGenerator():
         'is_null': '__isnull',
         'search': '__search',
 
+        # ArrayField operations
+        'overlap': '__overlap',
+        'contained_by': '__contained_by',
+        'length_greater_than': '__len__gt',
+        'length_less_than': '__len__lt',
+
         # Special operations follow
         'in': 'in',
         'fy': 'fy',
@@ -258,6 +264,8 @@ class FilterGenerator():
                                 raise InvalidParameterException("Invalid field, operation 'range_intersect' requires an array of length 2 for field")
                             if (not isinstance(filt['value'], list) or len(filt['value']) != 2) and 'value_format' not in filt:
                                 raise InvalidParameterException("Invalid value, operation 'range_intersect' requires an array value of length 2, or a single value with value_format set to a ranged format (such as fy)")
+                        if filt['operation'] in ["overlap", "contained_by"] and not isinstance(filt['value'], list):
+                            raise InvalidParameterException("Invalid value. When using operation {}, value must be an array of strings.".format(filt["operation"]))
                         if filt['operation'] == 'search':
                             if not isinstance(filt['field'], list) and not self.is_string_field(filt['field']):
                                 raise InvalidParameterException("Invalid field: '" + filt['field'] + "', operation 'search' requires a text-field for searching")


### PR DESCRIPTION
Adding extra ArrayField specific operations to allowable operations to
make working with business categories easier.

Adds:
* `overlap` - Returns values where the specified array and the stored array intersect
* `contained_by` - Returns values where the specified array entirely contains the stored array
* `length_greater_than` and `length_less_than` - As less_than and greater_than, but on the length of the array
* Adds documentation for these