### PR TITLE
Add /v2/financial_balances/agencies endpoint

### DIFF
--- a/usaspending_api/accounts/serializers.py
+++ b/usaspending_api/accounts/serializers.py
@@ -115,3 +115,11 @@ class TasCategorySerializer(LimitableSerializer):
                 "kwargs": {"read_only": True}
             }
         }
+
+
+class AgenciesFinancialBalancesSerializer(serializers.Serializer):
+
+    fiscal_year = serializers.IntegerField()
+    budget_authority_amount = serializers.DecimalField(21, 2)
+    obligated_amount = serializers.DecimalField(21, 2)
+    outlay_amount = serializers.DecimalField(21, 2)

--- a/usaspending_api/accounts/tests/test_financial_balances.py
+++ b/usaspending_api/accounts/tests/test_financial_balances.py
@@ -1,0 +1,62 @@
+import pytest
+
+from model_mommy import mommy
+from rest_framework import status
+
+
+@pytest.fixture
+def financial_balances_models():
+    sub = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2016)
+    agency1_toptier = mommy.make('references.TopTierAgency', toptier_agency_id=123)
+    agency1 = mommy.make('references.Agency', id=456, toptier_agency_id=123)
+    tas1 = mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        funding_toptier_agency=agency1_toptier)
+    tas2 = mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        funding_toptier_agency=agency1_toptier)
+    tas_bal1 = mommy.make(
+        'accounts.AppropriationAccountBalances',
+        final_of_fy=True,
+        treasury_account_identifier=tas1,
+        budget_authority_available_amount_total_cpe=1000,
+        obligations_incurred_total_by_tas_cpe=2000,
+        gross_outlay_amount_by_tas_cpe=3000,
+        submission=sub
+    )
+    tas_bal2 = mommy.make(
+        'accounts.AppropriationAccountBalances',
+        final_of_fy=True,
+        treasury_account_identifier=tas2,
+        budget_authority_available_amount_total_cpe=1000,
+        obligations_incurred_total_by_tas_cpe=2000.01,
+        gross_outlay_amount_by_tas_cpe=-2000,
+        submission=sub
+    )
+    # throw in some random noise to ensure only the balances for the specified
+    # agency are returned in the response
+    mommy.make(
+        'accounts.AppropriationAccountBalances',
+        _quantity=3,
+        _fill_optional=True)
+
+
+@pytest.mark.django_db
+def test_financial_balances_agencies(client, financial_balances_models):
+    """Test the financial_balances/agencies endpoint."""
+    resp = client.get('/api/v2/financial_balances/agencies/?funding_agency_id=456&fiscal_year=2016')
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.data['results']) == 1
+    result = resp.data['results'][0]
+    assert result['fiscal_year'] == 2016
+    assert result['budget_authority_amount'] == '2000.00'
+    assert result['obligated_amount'] == '4000.01'
+    assert result['outlay_amount'] == '1000.00'
+
+
+@pytest.mark.django_db
+def test_financial_balances_agencies_params(client, financial_balances_models):
+    """Test invalid financial_balances/agencies parameters."""
+    # funding_agency_id is missing
+    resp = client.get('/api/v2/financial_balances/agencies/?fiscal_year=2016')
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/usaspending_api/accounts/urls_financial_balances.py
+++ b/usaspending_api/accounts/urls_financial_balances.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url
+
+from usaspending_api.accounts.views import financial_balances as views
+
+# bind ViewSets to URLs
+financial_balances_agencies = views.AgenciesFinancialBalancesViewSet.as_view(
+    {'get': 'list'})
+
+urlpatterns = [
+    url(r'^agencies/$', financial_balances_agencies),
+]

--- a/usaspending_api/accounts/views/financial_balances.py
+++ b/usaspending_api/accounts/views/financial_balances.py
@@ -5,6 +5,7 @@ from usaspending_api.accounts.serializers import AgenciesFinancialBalancesSerial
 from usaspending_api.accounts.models import AppropriationAccountBalances
 from usaspending_api.references.models import Agency
 from usaspending_api.common.views import DetailViewSet
+from usaspending_api.common.exceptions import InvalidParameterException
 
 
 class AgenciesFinancialBalancesViewSet(DetailViewSet):
@@ -21,7 +22,7 @@ class AgenciesFinancialBalancesViewSet(DetailViewSet):
 
         # required query parameters were not provided
         if not (fiscal_year and funding_agency_id):
-            raise ParseError('Missing one or more required query parameters: fiscal_year, funding_agency_id')
+            raise InvalidParameterException('Missing one or more required query parameters: fiscal_year, funding_agency_id')
 
         # using final_objects below ensures that we're only pulling the latest
         # set of financial information for each fiscal year

--- a/usaspending_api/accounts/views/financial_balances.py
+++ b/usaspending_api/accounts/views/financial_balances.py
@@ -1,0 +1,48 @@
+from django.db.models import F, Sum
+from rest_framework.exceptions import ParseError
+
+from usaspending_api.accounts.serializers import AgenciesFinancialBalancesSerializer
+from usaspending_api.accounts.models import AppropriationAccountBalances
+from usaspending_api.references.models import Agency
+from usaspending_api.common.views import DetailViewSet
+
+
+class AgenciesFinancialBalancesViewSet(DetailViewSet):
+    """Returns financial balances by agency and fiscal year."""
+
+    serializer_class = AgenciesFinancialBalancesSerializer
+
+    def get_queryset(self, pk=None):
+        # retrieve post request payload
+        json_request = self.request.query_params
+        # retrieve fiscal_year from request
+        fiscal_year = json_request.get('fiscal_year', None)
+        funding_agency_id = json_request.get('funding_agency_id', None)
+
+        # required query parameters were not provided
+        if not (fiscal_year and funding_agency_id):
+            raise ParseError('Missing one or more required query parameters: fiscal_year, funding_agency_id')
+
+        # using final_objects below ensures that we're only pulling the latest
+        # set of financial information for each fiscal year
+        queryset = AppropriationAccountBalances.final_objects.all()
+        # get the incoming agency's toptier agency, because that's what we'll
+        # need to filter on
+        # (used filter() instead of get() b/c we likely don't want to raise an
+        # error on a bad agency id)
+        toptier_agency = Agency.objects.filter(id=funding_agency_id).first().toptier_agency
+        queryset = queryset.filter(
+            submission__reporting_fiscal_year=fiscal_year,
+            treasury_account_identifier__funding_toptier_agency=toptier_agency
+        )
+
+        queryset = queryset.annotate(
+            fiscal_year=F('submission__reporting_fiscal_year'))
+
+        # sum balances by treasury appropriation account (TAS)
+        queryset = queryset.values('fiscal_year').annotate(
+            budget_authority_amount=Sum('budget_authority_available_amount_total_cpe'),
+            obligated_amount=Sum('obligations_incurred_total_by_tas_cpe'),
+            outlay_amount=Sum('gross_outlay_amount_by_tas_cpe'))
+
+        return queryset

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -49,6 +49,7 @@ To reduce unnecessary data transfer, most endpoints return a default set of info
 | [/api/v1/federal_accounts/](/api/v1/federal_accounts/) | GET, POST | Returns a list of federal accounts |
 | /api/v1/federal_accounts/:id | GET, POST | Returns a single federal account record with all fields |
 | [/api/v1/federal_accounts/autocomplete/](/api/v1/federal_accounts/autocomplete/) | POST | Supports autocomplete on federal account records |
+| [/api/v2/financial_balances/agencies/](/api/v2/financial_balances/agencies/) | GET | Returns financial balance information for a specified fiscal year and funding agency |
 | [/api/v1/tas/](/api/v1/tas/) | GET, POST | Returns a list of treasury appropriation accounts (TAS) |
 | /api/v1/tas/:id | GET, POST | Returns a single treasury appropriation account record with all fields |
 | [/api/v1/tas/autocomplete/](/api/v1/tas/autocomplete/) | POST | Supports autocomplete on TAS records |

--- a/usaspending_api/urls.py
+++ b/usaspending_api/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls import url, include
 from usaspending_api import views as views
-from django.views.generic import TemplateView
 from usaspending_api.common.views import MarkdownView
 from usaspending_api.common.csv_views import CsvDownloadView
 from django.conf.urls.static import static
@@ -30,6 +29,7 @@ urlpatterns = [
     url(r'^api/v1/submissions/', include('usaspending_api.submissions.urls')),
     url(r'^api/v1/accounts/', include('usaspending_api.accounts.urls')),
     url(r'^api/v1/federal_accounts/', include('usaspending_api.accounts.urls_federal_account')),
+    url(r'^api/v2/financial_balances/', include('usaspending_api.accounts.urls_financial_balances')),
     url(r'^api/v1/tas/', include('usaspending_api.accounts.urls_tas')),
     url(r'^api/v1/references/', include('usaspending_api.references.urls')),
     url(r'^api/v1/download/(?P<path>.*)', CsvDownloadView.as_view()),


### PR DESCRIPTION
This PR is part of the work for [DS-1316](https://federal-spending-transparency.atlassian.net/browse/DS-1316). The acceptance criteria for the `financial_balances/agencies/` endpoint have changed as the sprint progressed--our latest thinking for how this endpoint should behave is here: https://gist.github.com/bsweger/91d85b7f4ef1fb9c4f0a54c541ef5da6

