### PR TITLE
Remove fiscal_year from AgenciesFinancialBalancesSerializer

### DIFF
--- a/usaspending_api/accounts/serializers.py
+++ b/usaspending_api/accounts/serializers.py
@@ -126,7 +126,6 @@ class ObjectClassFinancialSpendingSerializer(serializers.Serializer):
 
 class AgenciesFinancialBalancesSerializer(serializers.Serializer):
 
-    fiscal_year = serializers.IntegerField()
     budget_authority_amount = serializers.DecimalField(None, 2)
     obligated_amount = serializers.DecimalField(None, 2)
     outlay_amount = serializers.DecimalField(None, 2)

--- a/usaspending_api/accounts/tests/test_financial_balances.py
+++ b/usaspending_api/accounts/tests/test_financial_balances.py
@@ -48,7 +48,6 @@ def test_financial_balances_agencies(client, financial_balances_models):
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.data['results']) == 1
     result = resp.data['results'][0]
-    assert result['fiscal_year'] == 2016
     assert result['budget_authority_amount'] == '2000.00'
     assert result['obligated_amount'] == '4000.01'
     assert result['outlay_amount'] == '1000.00'


### PR DESCRIPTION
Because fiscal_year is required in the request parameters,
remove it from the response. This change makes the
/financial_balances/agencies/ endpoint behavior consistent
with the others that we're building out for the agency page.