### PR TITLE
Pass a copy of `location_value_map` to `get_or_create_location`

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -924,7 +924,7 @@ def load_file_d2(submission_attributes, award_financial_assistance_data, db_curs
 
     for row in award_financial_assistance_data:
 
-        legal_entity_location, created = get_or_create_location(legal_entity_location_field_map, row, legal_entity_location_value_map)
+        legal_entity_location, created = get_or_create_location(legal_entity_location_field_map, row, copy(legal_entity_location_value_map))
 
         # Create the legal entity if it doesn't exist
         legal_entity, created = LegalEntity.get_or_create_by_duns(duns=row['awardee_or_recipient_uniqu'])
@@ -935,7 +935,7 @@ def load_file_d2(submission_attributes, award_financial_assistance_data, db_curs
             legal_entity = load_data_into_model(legal_entity, row, value_map=legal_entity_value_map, save=True)
 
         # Create the place of performance location
-        pop_location, created = get_or_create_location(place_of_performance_field_map, row, place_of_performance_value_map)
+        pop_location, created = get_or_create_location(place_of_performance_field_map, row, copy(place_of_performance_value_map))
 
         # If awarding toptier agency code (aka CGAC) is not supplied on the D2 record,
         # use the sub tier code to look it up. This code assumes that all incoming

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from copy import copy
 from decimal import Decimal
 import logging
 import os
@@ -420,7 +421,7 @@ def get_submission_attributes(broker_submission_id, submission_data):
         field_map=field_map, value_map=value_map, save=True)
 
 
-def get_or_create_location(location_map, row, location_value_map={}):
+def get_or_create_location(location_map, row, location_value_map=None):
     """
     Retrieve or create a location object
 
@@ -429,6 +430,9 @@ def get_or_create_location(location_map, row, location_value_map={}):
             and value = corresponding field name on the current row of data
         - row: the row of data currently being loaded
     """
+    if location_value_map is None:
+        location_value_map = {}
+
     row = canonicalize_location_dict(row)
 
     location_country = RefCountryCode.objects.filter(
@@ -783,7 +787,8 @@ def load_file_d1(submission_attributes, procurement_data, db_cursor):
     }
 
     for row in procurement_data:
-        legal_entity_location, created = get_or_create_location(legal_entity_location_field_map, row, legal_entity_location_value_map)
+
+        legal_entity_location, created = get_or_create_location(legal_entity_location_field_map, row, copy(legal_entity_location_value_map))
 
         # Create the legal entity if it doesn't exist
         legal_entity, created = LegalEntity.get_or_create_by_duns(duns=row['awardee_or_recipient_uniqu'])
@@ -795,7 +800,7 @@ def load_file_d1(submission_attributes, procurement_data, db_cursor):
 
         # Create the place of performance location
         pop_location, created = get_or_create_location(
-            place_of_performance_field_map, row, place_of_performance_value_map)
+            place_of_performance_field_map, row, copy(place_of_performance_value_map))
 
         # If awarding toptier agency code (aka CGAC) is not supplied on the D1 record,
         # use the sub tier code to look it up. This code assumes that all incoming


### PR DESCRIPTION
Because `get_or_create_location` updates `location_value_map`,
it was not safe to pass the actual dictionary - it could be
updated on one call, then inappropriately keep those updates
and use them the next time it's called, on a different record
entirely.