### PR TITLE
Update to recipient and award_type v2 endpoints

### DIFF
--- a/usaspending_api/awards/tests/test_award_spending.py
+++ b/usaspending_api/awards/tests/test_award_spending.py
@@ -5,7 +5,7 @@ from rest_framework import status
 
 @pytest.fixture
 def award_spending_data(db):
-    agency = mommy.make('references.Agency', id=111)
+    agency = mommy.make('references.Agency', id=111, toptier_flag=True)
     legal_entity = mommy.make('references.LegalEntity')
     award = mommy.make('awards.Award', category='grants', awarding_agency=agency)
     mommy.make(

--- a/usaspending_api/awards/views.py
+++ b/usaspending_api/awards/views.py
@@ -1,18 +1,13 @@
 from collections import namedtuple
-import json
-
-from rest_framework import status
-from rest_framework.views import APIView
-from rest_framework.response import Response
 
 from usaspending_api.awards.models import Award, Transaction, Subaward
 from usaspending_api.awards.serializers import AwardSerializer, AwardTypeAwardSpendingSerializer, \
     RecipientAwardSpendingSerializer, SubawardSerializer, TransactionSerializer
-from usaspending_api.common.api_request_utils import AutoCompleteHandler
 from usaspending_api.common.mixins import FilterQuerysetMixin, SuperLoggingMixin, AggregateQuerysetMixin
 from usaspending_api.common.views import DetailViewSet, AutocompleteView
 from usaspending_api.common.serializers import AggregateSerializer
 from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.common.helpers import check_valid_toptier_agency
 from django.db.models import F, Sum
 
 
@@ -67,6 +62,9 @@ class AwardTypeAwardSpendingViewSet(DetailViewSet):
         if not (fiscal_year and awarding_agency_id):
             raise InvalidParameterException('Missing one or more required query parameters: fiscal_year, awarding_agency_id')
 
+        if not check_valid_toptier_agency(awarding_agency_id):
+            raise InvalidParameterException('Awarding Agency ID provided must correspond to a toptier agency')
+
         queryset = Transaction.objects.all()
         # Filter based on fiscal year and agency id
         queryset = queryset.filter(fiscal_year=fiscal_year, awarding_agency=awarding_agency_id)
@@ -120,6 +118,9 @@ class RecipientAwardSpendingViewSet(DetailViewSet):
         # required query parameters were not provided
         if not (fiscal_year and awarding_agency_id):
             raise InvalidParameterException('Missing one or more required query parameters: fiscal_year, awarding_agency_id')
+
+        if not check_valid_toptier_agency(awarding_agency_id):
+            raise InvalidParameterException('Awarding Agency ID provided must correspond to a toptier agency')
 
         queryset = Transaction.objects.all()
         # Filter based on fiscal year and agency id

--- a/usaspending_api/common/helpers.py
+++ b/usaspending_api/common/helpers.py
@@ -1,6 +1,14 @@
 import datetime
 
 from django.utils.dateparse import parse_date
+from usaspending_api.references.models import Agency
+
+
+def check_valid_toptier_agency(agency_id):
+    """ Check if the ID provided (corresponding to Agency.id) is a valid toptier agency """
+
+    agency = Agency.objects.filter(id=agency_id, toptier_flag=True).first()
+    return agency is not None
 
 
 def get_params_from_req_or_request(request=None, req=None):


### PR DESCRIPTION
adding check to ensure awarding_agency_id actually corresponds to a toptier agency. if not, an appropriate error message is returned. Also removed unused imports.