### PR TITLE
Clean up old Location records when redoing a submission

### DIFF
--- a/usaspending_api/common/models.py
+++ b/usaspending_api/common/models.py
@@ -25,6 +25,23 @@ class DataSourceTrackedModel(models.Model):
         abstract = True
 
 
+class DeleteIfChildlessMixin(object):
+
+    def delete_if_childless(self):
+        """Deletes the instance if no child records point to it.
+
+        For cleaning up leftover parent records after child deletions."""
+
+        for attr_name in dir(self):
+            if attr_name.endswith('_set'):
+                children = getattr(self, attr_name)
+                if children.exists():
+                    return (0, {})  # was not an orphan
+
+        # No child records found, so
+        return self.delete()
+
+
 class RequestCatalog(models.Model):
     """Stores a POST request and generates a string identifier (checksum), allowing it to be re-run via a GET request"""
 

--- a/usaspending_api/etl/management/load_base.py
+++ b/usaspending_api/etl/management/load_base.py
@@ -463,7 +463,9 @@ def get_or_create_location(location_map, row, location_value_map=None):
     if location_country:
         location_value_map.update({
             'location_country_code': location_country,
-            'country_name': location_country.country_name
+            'country_name': location_country.country_name,
+            'state_code': None,  # expired
+            'state_name': None,
         })
     else:
         # no country found for this code

--- a/usaspending_api/references/models.py
+++ b/usaspending_api/references/models.py
@@ -5,7 +5,7 @@ from django.db.models import F, Q
 from django.utils.text import slugify
 from django.contrib.postgres.fields import ArrayField, JSONField
 
-from usaspending_api.common.models import DataSourceTrackedModel
+from usaspending_api.common.models import DataSourceTrackedModel, DeleteIfChildlessMixin
 from usaspending_api.references.abbreviations import code_to_state, state_to_code
 from usaspending_api.references.helpers import canonicalize_string
 
@@ -198,7 +198,7 @@ class FilterHash(models.Model):
         db_table = 'filter_hash'
 
 
-class Location(DataSourceTrackedModel):
+class Location(DataSourceTrackedModel, DeleteIfChildlessMixin):
     location_id = models.AutoField(primary_key=True)
     location_country_code = models.ForeignKey('RefCountryCode', models.DO_NOTHING, db_column='location_country_code', blank=True, null=True, verbose_name="Country Code")
     country_name = models.TextField(blank=True, null=True, verbose_name="Country Name")

--- a/usaspending_api/submissions/management/commands/rm_submission.py
+++ b/usaspending_api/submissions/management/commands/rm_submission.py
@@ -1,6 +1,8 @@
+from collections import defaultdict
 from datetime import datetime
 import logging
 import os
+
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -18,6 +20,25 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('submission_id', nargs=1, help='the broker submission id to delete', type=int)
 
+    def instances_potentially_left_childless(self, submission):
+        """All Location instances to check for delete-ability after this deletion.
+
+        Could be expanded to other models.
+        """
+
+        potential_childless = []
+        for transaction in submission.transaction_set.all():
+            potential_childless.append(transaction.award.place_of_performance)
+            potential_childless.append(transaction.award.recipient.location)
+            for subaward in transaction.award.subawards.all():
+                # potential_childless.append(subaward)
+                potential_childless.append(subaward.place_of_performance)
+                potential_childless.append(subaward.recipient.place_of_performance)
+            # potential_childless.append(transaction.award)
+            # could get the LegalEntities, too
+
+        return potential_childless
+
     def handle(self, *args, **options):
         # This will throw an exception and exit the command if the id doesn't exist
         try:
@@ -26,10 +47,21 @@ class Command(BaseCommand):
             self.logger.error("Submission with broker id " + str(options["submission_id"][0]) + " does not exist")
             return
 
-        deleted = submission.delete()
+        potentially_childless = self.instances_potentially_left_childless(submission)
 
-        statistics = "Statistics:\n  Total objects Removed: " + str(deleted[0])
-        for model in deleted[1].keys():
-            statistics = statistics + "\n  " + model + ": " + str(deleted[1][model])
+        deleted = defaultdict(int)
+        deleted_total = 0
+        deletion_tally = submission.delete()
+        deleted_total += deletion_tally[0]
+        deleted.update(deletion_tally[1])
+        for instance in potentially_childless:
+            deletions = instance.delete_if_childless()
+            deleted_total += deletions[0]
+            for (key, value) in deletions[1].items():
+                deleted[key] += value
+
+        statistics = "Statistics:\n  Total objects Removed: {}".format(deleted_total)
+        for (model, count) in deleted.items():
+            statistics = statistics + "\n  {}: {}".format(model, count)
 
         self.logger.info("Deleted submission " + str(options["submission_id"][0]) + ". " + statistics)

--- a/usaspending_api/submissions/management/commands/rm_submission.py
+++ b/usaspending_api/submissions/management/commands/rm_submission.py
@@ -33,11 +33,9 @@ class Command(BaseCommand):
             if transaction.award.recipient:
                 potential_childless.append(transaction.award.recipient.location)
             for subaward in transaction.award.subawards.all():
-                # potential_childless.append(subaward)
                 potential_childless.append(subaward.place_of_performance)
                 if subaward.recipient:
                     potential_childless.append(subaward.recipient.place_of_performance)
-            # potential_childless.append(transaction.award)
             # could get the LegalEntities, too
 
         # Return without `None`s

--- a/usaspending_api/submissions/management/commands/rm_submission.py
+++ b/usaspending_api/submissions/management/commands/rm_submission.py
@@ -28,16 +28,20 @@ class Command(BaseCommand):
 
         potential_childless = []
         for transaction in submission.transaction_set.all():
+            potential_childless.append(transaction.place_of_performance)
             potential_childless.append(transaction.award.place_of_performance)
-            potential_childless.append(transaction.award.recipient.location)
+            if transaction.award.recipient:
+                potential_childless.append(transaction.award.recipient.location)
             for subaward in transaction.award.subawards.all():
                 # potential_childless.append(subaward)
                 potential_childless.append(subaward.place_of_performance)
-                potential_childless.append(subaward.recipient.place_of_performance)
+                if subaward.recipient:
+                    potential_childless.append(subaward.recipient.place_of_performance)
             # potential_childless.append(transaction.award)
             # could get the LegalEntities, too
 
-        return potential_childless
+        # Return without `None`s
+        return [p for p in potential_childless if p]
 
     def handle(self, *args, **options):
         # This will throw an exception and exit the command if the id doesn't exist


### PR DESCRIPTION
An old bug in the submission loader left bogus Location instances
in the database.  This forces non-US Locations to specifically
seek or create locations without states, and removes Location
intances attached only to the old, deleted version of the submission.