### PR TITLE
Load submissions atomically

### DIFF
--- a/usaspending_api/etl/management/commands/load_historical.py
+++ b/usaspending_api/etl/management/commands/load_historical.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import logging
 
 from django.utils.dateparse import parse_date
+from django.db import transaction
 
 from usaspending_api.submissions.models import SubmissionAttributes
 from usaspending_api.etl.broker_etl_helpers import dictfetchall
@@ -39,6 +40,7 @@ class Command(load_base.Command):
         parser.add_argument('--action_date_end', type=parse_date, default=None, help='Last action_date to get - YYYY-MM-DD')
         parser.add_argument('--cgac', default=None)
 
+    @transaction.atomic
     def handle_loading(self, db_cursor, *args, **options):
 
         submission_attributes = SubmissionAttributes()

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -5,7 +5,7 @@ import logging
 import re
 
 from django.core.management import call_command
-from django.db import connections
+from django.db import connections, transaction
 from django.db.models import Q
 from django.core.cache import caches
 import pandas as pd
@@ -54,6 +54,7 @@ class Command(load_base.Command):
         parser.add_argument('submission_id', nargs=1, help='the data broker submission id to load', type=int)
         super(Command, self).add_arguments(parser)
 
+    @transaction.atomic
     def handle_loading(self, db_cursor, *args, **options):
 
         # Grab the submission id


### PR DESCRIPTION
It was mentioned during sprint planning that we would like the loading of submissions to be atomic (if it fails or is cancelled, all changes should be rolled back).  This simple change makes that happen.  I don't know if we created a ticket for it.

I've verified its working manually (temporarily embedding a `sys.exit()` and checking the state of the database), but I haven't thought of a great way to actually write a test for this.  I'm open to suggestions.