### PR TITLE
PSC description

### DIFF
--- a/.idea/dictionaries/johnfroiland.xml
+++ b/.idea/dictionaries/johnfroiland.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="johnfroiland">
+    <words>
+      <w>naics</w>
+    </words>
+  </dictionary>
+</component>

--- a/usaspending_api/awards/serializers_v2/serializers.py
+++ b/usaspending_api/awards/serializers_v2/serializers.py
@@ -6,11 +6,18 @@ class AwardTypeAwardSpendingSerializer(serializers.Serializer):
     obligated_amount = serializers.DecimalField(None, 2)
 
 
-class RecipientSeriallizer(serializers.Serializer):
+class RecipientSerializer(serializers.Serializer):
     recipient_id = serializers.IntegerField()
     recipient_name = serializers.CharField()
 
 
 class RecipientAwardSpendingSerializer(serializers.Serializer):
-    recipient = RecipientSeriallizer(source='*')
+    recipient = RecipientSerializer(source='*')
+    obligated_amount = serializers.DecimalField(None, 2)
+
+
+class TransactionContractSerializer(serializers.Serializer):
+    psc = serializers.CharField()
+    naics = serializers.CharField()
+    description = serializers.CharField()
     obligated_amount = serializers.DecimalField(None, 2)

--- a/usaspending_api/awards/tests/test_industry_codes.py
+++ b/usaspending_api/awards/tests/test_industry_codes.py
@@ -1,0 +1,78 @@
+import pytest
+
+from model_mommy import mommy
+from rest_framework import status
+
+
+@pytest.fixture
+def industry_codes_data():
+
+    # CREATE obligated_amount(s)
+    amount1 = mommy.make('awards.Transaction', federal_action_obligation=20.00)
+    amount2 = mommy.make('awards.Transaction', federal_action_obligation=10.00)
+    amount3 = mommy.make('awards.Transaction', federal_action_obligation=10.00)
+    amount4 = mommy.make('awards.Transaction', federal_action_obligation=5.00)
+
+    # CREATE PSC - NAICS relationships
+    mommy.make(
+        'awards.TransactionContract',
+        product_or_service_code='A123',
+        naics='123456',
+        naics_description='Cleaning Services',
+        transaction=amount1,
+    )
+    mommy.make(
+        'awards.TransactionContract',
+        product_or_service_code='B456',
+        naics='456789',
+        naics_description='Cooking Services',
+        transaction=amount2
+    )
+    mommy.make(
+        'awards.TransactionContract',
+        product_or_service_code='A123',
+        naics='456789',
+        naics_description='Cooking Services',
+        transaction=amount3,
+    )
+    mommy.make(
+        'awards.TransactionContract',
+        product_or_service_code='A123',
+        naics='456789',
+        naics_description='Cooking Services',
+        transaction=amount4
+    )
+
+
+@pytest.mark.django_db
+def test_industry_codes(client, industry_codes_data):
+    """
+        Test the industry_codes endpoint.
+        Test obligated amounts sorted from high to low.
+        Test obligated amounts sum for group2.
+    """
+    resp = client.get('/api/v2/industry_codes/?fiscal_year=2017')
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.data['results']) == 3
+    group1 = resp.data['results'][0]
+    assert group1['psc'] == 'A123'
+    assert group1['naics'] == '123456'
+    assert group1['description'] == 'Cleaning Services'
+    assert group1['obligated_amount'] == '20.00'
+    group2 = resp.data['results'][1]
+    assert group2['psc'] == 'A123'
+    assert group2['naics'] == '456789'
+    assert group2['description'] == 'Cooking Services'
+    assert group2['obligated_amount'] == '15.00'
+    group3 = resp.data['results'][2]
+    assert group3['psc'] == 'B456'
+    assert group3['naics'] == '456789'
+    assert group3['description'] == 'Cooking Services'
+    assert group3['obligated_amount'] == '10.00'
+
+
+@pytest.mark.django_db
+def test_industry_codes_params(client, industry_codes_data):
+    """Test for bad request due to missing params."""
+    resp = client.get('/api/v2/industry_codes/')
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/usaspending_api/awards/urls_industry_codes.py
+++ b/usaspending_api/awards/urls_industry_codes.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from usaspending_api.awards.views_v2 import industry_codes as views
+
+industry_codes = views.TransactionContractViewSet.as_view({'get': 'list'})
+
+urlpatterns = [
+    url(r'^$', industry_codes, name='industry-codes')
+]

--- a/usaspending_api/awards/urls_transactions.py
+++ b/usaspending_api/awards/urls_transactions.py
@@ -7,8 +7,8 @@ transaction_list = views.TransactionViewset.as_view(
     {'get': 'list', 'post': 'list'})
 transaction_detail = views.TransactionViewset.as_view(
     {'get': 'retrieve', 'post': 'retrieve'})
-transaction_total = views.TransactionAggregateViewSet.as_view({
-    'get': 'list', 'post': 'list'})
+transaction_total = views.TransactionAggregateViewSet.as_view(
+    {'get': 'list', 'post': 'list'})
 
 urlpatterns = [
     url(r'^$', transaction_list, name='transaction-list'),

--- a/usaspending_api/awards/views_v2/industry_codes.py
+++ b/usaspending_api/awards/views_v2/industry_codes.py
@@ -1,0 +1,43 @@
+from django.db.models import F, Sum
+
+from usaspending_api.awards.models import TransactionContract
+from usaspending_api.awards.serializers_v2.serializers import TransactionContractSerializer
+from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.common.views import DetailViewSet
+
+
+class TransactionContractViewSet(DetailViewSet):
+    """
+        Return PSC and NAICS industry codes, description, and awards for a given fiscal year.
+        Note:
+            There is no description field for PSC in the database.
+            PSC and NAICS have a many-to-many relationship.
+            PSC Codes describe “WHAT” was bought for each contract action reported.
+            NAICS Codes describe “HOW” purchased products and services will be used.
+    """
+    serializer_class = TransactionContractSerializer
+
+    def get_queryset(self):
+        # retrieve post request payload
+        json_request = self.request.query_params
+        # retrieve fiscal_year from request
+        fiscal_year = json_request.get('fiscal_year', None)
+        # required query parameters were not provided
+        if not fiscal_year:
+            raise InvalidParameterException(
+                'Missing one or more required query parameters: fiscal_year'
+            )
+        queryset = TransactionContract.objects.all()
+        # get PSC and NAICS relationships
+        queryset = queryset.filter(
+            transaction__fiscal_year=fiscal_year
+        ).annotate(
+            psc=F('product_or_service_code'),
+            description=F('naics_description')
+        )
+        # sum obligations for each PSC & NAICS pair, sort descending
+        queryset = queryset.values('psc', 'naics', 'description').annotate(
+            obligated_amount=Sum('transaction__federal_action_obligation')
+        ).order_by('-obligated_amount')
+
+        return queryset

--- a/usaspending_api/urls.py
+++ b/usaspending_api/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     url(r'^api/v2/federal_obligations/', include('usaspending_api.accounts.urls_federal_obligations')),
     url(r'^api/v2/financial_balances/', include('usaspending_api.accounts.urls_financial_balances')),
     url(r'^api/v2/financial_spending/', include('usaspending_api.accounts.urls_financial_spending')),
+    url(r'^api/v2/industry_codes/', include('usaspending_api.awards.urls_industry_codes')),
     url(r'^api/v2/references/', include('usaspending_api.references.urls_v2')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^docs/', include('usaspending_api.api_docs.urls')),


### PR DESCRIPTION
Built industry_codes scripts to represent screenshots in DS-1195.
There is no description field for PSC in the database, so NAICS was used instead.
PSC and NAICS have a many-to-many relationship.
PSC Codes describe “WHAT” was bought for each contract action reported.
NAICS Codes describe “HOW” purchased products and services will be used.

https://gist.github.com/phroiland/5791b961b4c624b2a2b0687adc1ed129