### PR TITLE
Avoid crashing when no File C records

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -526,6 +526,11 @@ def load_file_c(submission_attributes, db_cursor, award_financial_frame):
     # this matches the file b reverse directive, but am repeating it here
     # to ensure that we don't overwrite it as we change up the order of
     # file loading
+
+    if not award_financial_frame.size:
+        logger.warning('No award financial data found; skipping file C load')
+        return
+
     reverse = re.compile(r'(_(cpe|fyb)$)|^transaction_obligated_amount$')
 
     award_financial_frame['txn'] = award_financial_frame.apply(get_award_financial_transaction, axis=1)


### PR DESCRIPTION
Pandas throws a ValueError when trying to operate on a
zero-size data frame.

This is currently producing a crash when loading submission 4590.  

Our structure for testing submission loads is currently very awkward, and I'm not clear how I can write a test for this... suggestions welcome.