### PR TITLE
WIP: Positive obligated amounts, DS-1601

### DIFF
--- a/usaspending_api/references/tests/test_agency_v2.py
+++ b/usaspending_api/references/tests/test_agency_v2.py
@@ -24,12 +24,20 @@ def financial_spending_data(db):
     # submission_3 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2015, cgac_code='100')
     submission_1 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2017,
                               reporting_fiscal_quarter=2, cgac_code='100')
-    # submission_2 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2016, cgac_code='100')
+    submission_2 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2017,
+                              reporting_fiscal_quarter=2, cgac_code='100')
 
     # CREATE AppropriationAccountBalances
     aab = mommy.make('accounts.AppropriationAccountBalances', final_of_fy=True, reporting_period_start="2017-1-1",
                      submission=submission_1, budget_authority_available_amount_total_cpe=2,
                      obligations_incurred_total_by_tas_cpe=2, gross_outlay_amount_by_tas_cpe=2,
+                     treasury_account_identifier=tas)
+
+    # A negative appropriation account balance; this one should not
+    # show up in `obligated_amount`
+    mommy.make('accounts.AppropriationAccountBalances', final_of_fy=True, reporting_period_start="2016-1-1",
+                     submission=submission_2, budget_authority_available_amount_total_cpe=-0.5,
+                     obligations_incurred_total_by_tas_cpe=-0.5, gross_outlay_amount_by_tas_cpe=-0.5,
                      treasury_account_identifier=tas)
 
     # CREATE OverallTotals
@@ -43,8 +51,8 @@ def test_award_type_endpoint(client, financial_spending_data):
     resp = client.get('/api/v2/references/agency/1/')
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data == {'results': {'agency_name': 'tta_name', 'active_fy': '2017', 'active_fq': '2',
-                                     'outlay_amount': '2.00', 'obligated_amount': '2.00',
-                                     'budget_authority_amount': '2.00',
+                                     'outlay_amount': '1.50', 'obligated_amount': '2.00',
+                                     'budget_authority_amount': '1.50',
                                      'current_total_budget_authority_amount': '3860000000.00',
                                      'website': 'http://test.com',
                                      'mission': 'test',

--- a/usaspending_api/references/v2/views/agency.py
+++ b/usaspending_api/references/v2/views/agency.py
@@ -48,10 +48,14 @@ class AgencyViewSet(APIView):
             submission__reporting_fiscal_year=active_fiscal_year,
             treasury_account_identifier__funding_toptier_agency=toptier_agency
         )
+
         aggregate_dict = queryset.aggregate(
             budget_authority_amount=Sum('budget_authority_available_amount_total_cpe'),
-            obligated_amount=Sum('obligations_incurred_total_by_tas_cpe'),
             outlay_amount=Sum('gross_outlay_amount_by_tas_cpe'))
+
+        # obligated_amount should omit negative amounts
+        positive_aggregate_dict = queryset.filter(obligations_incurred_total_by_tas_cpe__gt=0) \
+            .aggregate(obligated_amount=Sum('obligations_incurred_total_by_tas_cpe'))
 
         # get the overall total government budget authority (to craft a budget authority percentage)
         total_budget_authority_queryset = OverallTotals.objects.all()
@@ -68,7 +72,7 @@ class AgencyViewSet(APIView):
                                'active_fy': str(active_fiscal_year),
                                'active_fq': str(active_fiscal_quarter),
                                'outlay_amount': str(aggregate_dict['outlay_amount']),
-                               'obligated_amount': str(aggregate_dict['obligated_amount']),
+                               'obligated_amount': str(positive_aggregate_dict['obligated_amount']),
                                'budget_authority_amount': str(aggregate_dict['budget_authority_amount']),
                                'current_total_budget_authority_amount': total_budget_authority_amount,
                                'mission': toptier_agency.mission,


### PR DESCRIPTION
WORK IN PROGRESS - hold off merging while I ask for clarification

Should fulfill backend part of DS-1601, https://federal-spending-transparency.atlassian.net/browse/DS-1601

The v2/references/agency/${id}/
endpoint returns an obligated amount that is outflow only 
(does not include negative obligations)