### PR TITLE
Hotfix pagination metadata v2 search

### DIFF
--- a/usaspending_api/common/helpers.py
+++ b/usaspending_api/common/helpers.py
@@ -55,20 +55,20 @@ def generate_fiscal_month(date):
 def get_pagination(results, limit, page, benchmarks=False):
     if benchmarks:
         start_pagination = time.time()
-    next_previous_metadata = {"next": None, "previous": None, "hasNext": False, "hasPrevious": False}
+    page_metadata = {"next": None, "previous": None, "hasNext": False, "hasPrevious": False}
     if limit < 1 or page < 1:
-        return [], next_previous_metadata
-    next_previous_metadata["hasNext"] = (limit*page < len(results))
-    next_previous_metadata["hasPrevious"] = (page > 1 and limit*(page-2) < len(results))
-    if not next_previous_metadata["hasNext"]:
+        return [], page_metadata
+    page_metadata["hasNext"] = (limit*page < len(results))
+    page_metadata["hasPrevious"] = (page > 1 and limit*(page-2) < len(results))
+    if not page_metadata["hasNext"]:
         paginated_results = results[limit*(page-1):]
     else:
         paginated_results = results[limit*(page-1):limit*page]
-    next_previous_metadata["next"] = page+1 if next_previous_metadata["hasNext"] else None
-    next_previous_metadata["previous"] = page-1 if next_previous_metadata["hasPrevious"] else None
+    page_metadata["next"] = page+1 if page_metadata["hasNext"] else None
+    page_metadata["previous"] = page-1 if page_metadata["hasPrevious"] else None
     if benchmarks:
         logger.info("get_pagination took {} seconds".format(time.time() - start_pagination))
-    return paginated_results, next_previous_metadata
+    return paginated_results, page_metadata
 
 
 def fy(raw_date):

--- a/usaspending_api/common/helpers.py
+++ b/usaspending_api/common/helpers.py
@@ -55,13 +55,20 @@ def generate_fiscal_month(date):
 def get_pagination(results, limit, page, benchmarks=False):
     if benchmarks:
         start_pagination = time.time()
-    if len(results) < limit*page:
+    next_previous_metadata = {"next": None, "previous": None, "hasNext": False, "hasPrevious": False}
+    if limit < 1 or page < 1:
+        return [], next_previous_metadata
+    next_previous_metadata["hasNext"] = (limit*page < len(results))
+    next_previous_metadata["hasPrevious"] = (page > 1 and limit*(page-2) < len(results))
+    if not next_previous_metadata["hasNext"]:
         paginated_results = results[limit*(page-1):]
     else:
         paginated_results = results[limit*(page-1):limit*page]
+    next_previous_metadata["next"] = page+1 if next_previous_metadata["hasNext"] else None
+    next_previous_metadata["previous"] = page-1 if next_previous_metadata["hasPrevious"] else None
     if benchmarks:
         logger.info("get_pagination took {} seconds".format(time.time() - start_pagination))
-    return paginated_results
+    return paginated_results, next_previous_metadata
 
 
 def fy(raw_date):

--- a/usaspending_api/common/helpers.py
+++ b/usaspending_api/common/helpers.py
@@ -55,7 +55,8 @@ def generate_fiscal_month(date):
 def get_pagination(results, limit, page, benchmarks=False):
     if benchmarks:
         start_pagination = time.time()
-    page_metadata = {"next": None, "previous": None, "hasNext": False, "hasPrevious": False}
+    page_metadata = {"page": page, "count": len(results), "next": None, "previous": None, "hasNext": False,
+                     "hasPrevious": False}
     if limit < 1 or page < 1:
         return [], page_metadata
     page_metadata["hasNext"] = (limit*page < len(results))

--- a/usaspending_api/common/tests/test_helpers.py
+++ b/usaspending_api/common/tests/test_helpers.py
@@ -17,32 +17,32 @@ not_dates = (0, 2017.2, 'forthwith')
 def test_pagination():
     # Testing for if anything breaks for the special case of an empty list
     results = []
-    empty_next_previous_metadata = {"next":None, "previous": None, "hasNext": False, "hasPrevious": False}
-    assert get_pagination(results, 1, 1) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 1, 4) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 3, 1) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 3, 2) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 1, 6) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 5, 2) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 1000, 1) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 1000, 2) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 0, 1) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 10, 0) == ([], empty_next_previous_metadata)
+    empty_page_metadata = {"next":None, "previous": None, "hasNext": False, "hasPrevious": False}
+    assert get_pagination(results, 1, 1) == ([], empty_page_metadata)
+    assert get_pagination(results, 1, 4) == ([], empty_page_metadata)
+    assert get_pagination(results, 3, 1) == ([], empty_page_metadata)
+    assert get_pagination(results, 3, 2) == ([], empty_page_metadata)
+    assert get_pagination(results, 1, 6) == ([], empty_page_metadata)
+    assert get_pagination(results, 5, 2) == ([], empty_page_metadata)
+    assert get_pagination(results, 1000, 1) == ([], empty_page_metadata)
+    assert get_pagination(results, 1000, 2) == ([], empty_page_metadata)
+    assert get_pagination(results, 0, 1) == ([], empty_page_metadata)
+    assert get_pagination(results, 10, 0) == ([], empty_page_metadata)
 
     # Normal tests
     results = ["A", "B", "C", "D", "E"]
-    assert get_pagination(results, 1, 1) == (["A"], {**empty_next_previous_metadata, **{"next":2, "hasNext": True}})
-    assert get_pagination(results, 1, 4) == (["D"], {**empty_next_previous_metadata, **{"next":5, "hasNext": True,
-                                                                                        "previous": 3, "hasPrevious": True}})
-    assert get_pagination(results, 3, 1) == (["A", "B", "C"], {**empty_next_previous_metadata, **{"next":2, "hasNext": True}})
-    assert get_pagination(results, 3, 2) == (["D", "E"], {**empty_next_previous_metadata, **{"previous":1, "hasPrevious": True}})
+    assert get_pagination(results, 1, 1) == (["A"], {**empty_page_metadata, **{"next":2, "hasNext": True}})
+    assert get_pagination(results, 1, 4) == (["D"], {**empty_page_metadata, **{"next":5, "hasNext": True,
+                                                                               "previous": 3, "hasPrevious": True}})
+    assert get_pagination(results, 3, 1) == (["A", "B", "C"], {**empty_page_metadata, **{"next":2, "hasNext": True}})
+    assert get_pagination(results, 3, 2) == (["D", "E"], {**empty_page_metadata, **{"previous":1, "hasPrevious": True}})
     # Testing special cases
-    assert get_pagination(results, 1, 6) == ([], {**empty_next_previous_metadata, **{"previous":5, "hasPrevious": True}})
-    assert get_pagination(results, 5, 2) == ([], {**empty_next_previous_metadata, **{"previous":1, "hasPrevious": True}})
-    assert get_pagination(results, 1000, 1) == (["A", "B", "C", "D", "E"], empty_next_previous_metadata)
-    assert get_pagination(results, 1000, 2) == ([], {**empty_next_previous_metadata, **{"previous":1, "hasPrevious": True}})
-    assert get_pagination(results, 0, 1) == ([], empty_next_previous_metadata)
-    assert get_pagination(results, 10, 0) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 1, 6) == ([], {**empty_page_metadata, **{"previous":5, "hasPrevious": True}})
+    assert get_pagination(results, 5, 2) == ([], {**empty_page_metadata, **{"previous":1, "hasPrevious": True}})
+    assert get_pagination(results, 1000, 1) == (["A", "B", "C", "D", "E"], empty_page_metadata)
+    assert get_pagination(results, 1000, 2) == ([], {**empty_page_metadata, **{"previous":1, "hasPrevious": True}})
+    assert get_pagination(results, 0, 1) == ([], empty_page_metadata)
+    assert get_pagination(results, 10, 0) == ([], empty_page_metadata)
 
 
 @pytest.mark.parametrize("raw_date, expected_fy", legal_dates.items())

--- a/usaspending_api/common/tests/test_helpers.py
+++ b/usaspending_api/common/tests/test_helpers.py
@@ -17,30 +17,32 @@ not_dates = (0, 2017.2, 'forthwith')
 def test_pagination():
     # Testing for if anything breaks for the special case of an empty list
     results = []
-    assert get_pagination(results, 1, 1) == []
-    assert get_pagination(results, 1, 4) == []
-    assert get_pagination(results, 3, 1) == []
-    assert get_pagination(results, 3, 2) == []
-    assert get_pagination(results, 1, 6) == []
-    assert get_pagination(results, 5, 2) == []
-    assert get_pagination(results, 1000, 1) == []
-    assert get_pagination(results, 1000, 2) == []
-    assert get_pagination(results, 0, 1) == []
-    assert get_pagination(results, 10, 0) == []
+    empty_next_previous_metadata = {"next":None, "previous": None, "hasNext": False, "hasPrevious": False}
+    assert get_pagination(results, 1, 1) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 1, 4) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 3, 1) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 3, 2) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 1, 6) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 5, 2) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 1000, 1) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 1000, 2) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 0, 1) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 10, 0) == ([], empty_next_previous_metadata)
 
     # Normal tests
     results = ["A", "B", "C", "D", "E"]
-    assert get_pagination(results, 1, 1) == ["A"]
-    assert get_pagination(results, 1, 4) == ["D"]
-    assert get_pagination(results, 3, 1) == ["A", "B", "C"]
-    assert get_pagination(results, 3, 2) == ["D", "E"]
+    assert get_pagination(results, 1, 1) == (["A"], {**empty_next_previous_metadata, **{"next":2, "hasNext": True}})
+    assert get_pagination(results, 1, 4) == (["D"], {**empty_next_previous_metadata, **{"next":5, "hasNext": True,
+                                                                                        "previous": 3, "hasPrevious": True}})
+    assert get_pagination(results, 3, 1) == (["A", "B", "C"], {**empty_next_previous_metadata, **{"next":2, "hasNext": True}})
+    assert get_pagination(results, 3, 2) == (["D", "E"], {**empty_next_previous_metadata, **{"previous":1, "hasPrevious": True}})
     # Testing special cases
-    assert get_pagination(results, 1, 6) == []
-    assert get_pagination(results, 5, 2) == []
-    assert get_pagination(results, 1000, 1) == ["A", "B", "C", "D", "E"]
-    assert get_pagination(results, 1000, 2) == []
-    assert get_pagination(results, 0, 1) == []
-    assert get_pagination(results, 10, 0) == []
+    assert get_pagination(results, 1, 6) == ([], {**empty_next_previous_metadata, **{"previous":5, "hasPrevious": True}})
+    assert get_pagination(results, 5, 2) == ([], {**empty_next_previous_metadata, **{"previous":1, "hasPrevious": True}})
+    assert get_pagination(results, 1000, 1) == (["A", "B", "C", "D", "E"], empty_next_previous_metadata)
+    assert get_pagination(results, 1000, 2) == ([], {**empty_next_previous_metadata, **{"previous":1, "hasPrevious": True}})
+    assert get_pagination(results, 0, 1) == ([], empty_next_previous_metadata)
+    assert get_pagination(results, 10, 0) == ([], empty_next_previous_metadata)
 
 
 @pytest.mark.parametrize("raw_date, expected_fy", legal_dates.items())

--- a/usaspending_api/common/tests/test_helpers.py
+++ b/usaspending_api/common/tests/test_helpers.py
@@ -17,32 +17,41 @@ not_dates = (0, 2017.2, 'forthwith')
 def test_pagination():
     # Testing for if anything breaks for the special case of an empty list
     results = []
-    empty_page_metadata = {"next":None, "previous": None, "hasNext": False, "hasPrevious": False}
-    assert get_pagination(results, 1, 1) == ([], empty_page_metadata)
-    assert get_pagination(results, 1, 4) == ([], empty_page_metadata)
-    assert get_pagination(results, 3, 1) == ([], empty_page_metadata)
-    assert get_pagination(results, 3, 2) == ([], empty_page_metadata)
-    assert get_pagination(results, 1, 6) == ([], empty_page_metadata)
-    assert get_pagination(results, 5, 2) == ([], empty_page_metadata)
-    assert get_pagination(results, 1000, 1) == ([], empty_page_metadata)
-    assert get_pagination(results, 1000, 2) == ([], empty_page_metadata)
-    assert get_pagination(results, 0, 1) == ([], empty_page_metadata)
-    assert get_pagination(results, 10, 0) == ([], empty_page_metadata)
+    empty_page_metadata = {"next":None, "previous": None, "hasNext": False, "hasPrevious": False, "count": 0}
+    assert get_pagination(results, 1, 1) == ([], {**empty_page_metadata, **{"page": 1}})
+    assert get_pagination(results, 1, 4) == ([], {**empty_page_metadata, **{"page": 4}})
+    assert get_pagination(results, 3, 1) == ([], {**empty_page_metadata, **{"page": 1}})
+    assert get_pagination(results, 3, 2) == ([], {**empty_page_metadata, **{"page": 2}})
+    assert get_pagination(results, 1, 6) == ([], {**empty_page_metadata, **{"page": 6}})
+    assert get_pagination(results, 5, 2) == ([], {**empty_page_metadata, **{"page": 2}})
+    assert get_pagination(results, 1000, 1) == ([], {**empty_page_metadata, **{"page": 1}})
+    assert get_pagination(results, 1000, 2) == ([], {**empty_page_metadata, **{"page": 2}})
+    assert get_pagination(results, 0, 1) == ([], {**empty_page_metadata, **{"page": 1}})
+    assert get_pagination(results, 10, 0) == ([], {**empty_page_metadata, **{"page": 0}})
 
     # Normal tests
     results = ["A", "B", "C", "D", "E"]
-    assert get_pagination(results, 1, 1) == (["A"], {**empty_page_metadata, **{"next":2, "hasNext": True}})
-    assert get_pagination(results, 1, 4) == (["D"], {**empty_page_metadata, **{"next":5, "hasNext": True,
-                                                                               "previous": 3, "hasPrevious": True}})
-    assert get_pagination(results, 3, 1) == (["A", "B", "C"], {**empty_page_metadata, **{"next":2, "hasNext": True}})
-    assert get_pagination(results, 3, 2) == (["D", "E"], {**empty_page_metadata, **{"previous":1, "hasPrevious": True}})
+    populated_page_metadata = {"next":2, "hasNext": True, "count": 5, "page": 1}
+    assert get_pagination(results, 1, 1) == (["A"], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"next":5, "hasNext": True, "previous": 3, "hasPrevious": True, "count": 5, "page": 4}
+    assert get_pagination(results, 1, 4) == (["D"], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"next":2, "hasNext": True, "count": 5, "page": 1}
+    assert get_pagination(results, 3, 1) == (["A", "B", "C"], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"previous":1, "hasPrevious": True, "count": 5, "page": 2}
+    assert get_pagination(results, 3, 2) == (["D", "E"], {**empty_page_metadata, **populated_page_metadata})
     # Testing special cases
-    assert get_pagination(results, 1, 6) == ([], {**empty_page_metadata, **{"previous":5, "hasPrevious": True}})
-    assert get_pagination(results, 5, 2) == ([], {**empty_page_metadata, **{"previous":1, "hasPrevious": True}})
-    assert get_pagination(results, 1000, 1) == (["A", "B", "C", "D", "E"], empty_page_metadata)
-    assert get_pagination(results, 1000, 2) == ([], {**empty_page_metadata, **{"previous":1, "hasPrevious": True}})
-    assert get_pagination(results, 0, 1) == ([], empty_page_metadata)
-    assert get_pagination(results, 10, 0) == ([], empty_page_metadata)
+    populated_page_metadata = {"previous":5, "hasPrevious": True, "count": 5, "page": 6}
+    assert get_pagination(results, 1, 6) == ([], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"previous":1, "hasPrevious": True, "count": 5, "page": 2}
+    assert get_pagination(results, 5, 2) == ([], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"page": 1, "count": 5}
+    assert get_pagination(results, 1000, 1) == (["A", "B", "C", "D", "E"], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"previous":1, "hasPrevious": True, "page": 2, "count": 5}
+    assert get_pagination(results, 1000, 2) == ([], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"page": 1, "count": 5}
+    assert get_pagination(results, 0, 1) == ([], {**empty_page_metadata, **populated_page_metadata})
+    populated_page_metadata = {"page": 0, "count": 5}
+    assert get_pagination(results, 10, 0) == ([], {**empty_page_metadata, **populated_page_metadata})
 
 
 @pytest.mark.parametrize("raw_date, expected_fy", legal_dates.items())

--- a/usaspending_api/common/tests/test_helpers.py
+++ b/usaspending_api/common/tests/test_helpers.py
@@ -17,7 +17,7 @@ not_dates = (0, 2017.2, 'forthwith')
 def test_pagination():
     # Testing for if anything breaks for the special case of an empty list
     results = []
-    empty_page_metadata = {"next":None, "previous": None, "hasNext": False, "hasPrevious": False, "count": 0}
+    empty_page_metadata = {"next": None, "previous": None, "hasNext": False, "hasPrevious": False, "count": 0}
     assert get_pagination(results, 1, 1) == ([], {**empty_page_metadata, **{"page": 1}})
     assert get_pagination(results, 1, 4) == ([], {**empty_page_metadata, **{"page": 4}})
     assert get_pagination(results, 3, 1) == ([], {**empty_page_metadata, **{"page": 1}})
@@ -31,22 +31,22 @@ def test_pagination():
 
     # Normal tests
     results = ["A", "B", "C", "D", "E"]
-    populated_page_metadata = {"next":2, "hasNext": True, "count": 5, "page": 1}
+    populated_page_metadata = {"next": 2, "hasNext": True, "count": 5, "page": 1}
     assert get_pagination(results, 1, 1) == (["A"], {**empty_page_metadata, **populated_page_metadata})
-    populated_page_metadata = {"next":5, "hasNext": True, "previous": 3, "hasPrevious": True, "count": 5, "page": 4}
+    populated_page_metadata = {"next": 5, "hasNext": True, "previous": 3, "hasPrevious": True, "count": 5, "page": 4}
     assert get_pagination(results, 1, 4) == (["D"], {**empty_page_metadata, **populated_page_metadata})
-    populated_page_metadata = {"next":2, "hasNext": True, "count": 5, "page": 1}
+    populated_page_metadata = {"next": 2, "hasNext": True, "count": 5, "page": 1}
     assert get_pagination(results, 3, 1) == (["A", "B", "C"], {**empty_page_metadata, **populated_page_metadata})
-    populated_page_metadata = {"previous":1, "hasPrevious": True, "count": 5, "page": 2}
+    populated_page_metadata = {"previous": 1, "hasPrevious": True, "count": 5, "page": 2}
     assert get_pagination(results, 3, 2) == (["D", "E"], {**empty_page_metadata, **populated_page_metadata})
     # Testing special cases
-    populated_page_metadata = {"previous":5, "hasPrevious": True, "count": 5, "page": 6}
+    populated_page_metadata = {"previous": 5, "hasPrevious": True, "count": 5, "page": 6}
     assert get_pagination(results, 1, 6) == ([], {**empty_page_metadata, **populated_page_metadata})
-    populated_page_metadata = {"previous":1, "hasPrevious": True, "count": 5, "page": 2}
+    populated_page_metadata = {"previous": 1, "hasPrevious": True, "count": 5, "page": 2}
     assert get_pagination(results, 5, 2) == ([], {**empty_page_metadata, **populated_page_metadata})
     populated_page_metadata = {"page": 1, "count": 5}
     assert get_pagination(results, 1000, 1) == (["A", "B", "C", "D", "E"], {**empty_page_metadata, **populated_page_metadata})
-    populated_page_metadata = {"previous":1, "hasPrevious": True, "page": 2, "count": 5}
+    populated_page_metadata = {"previous": 1, "hasPrevious": True, "page": 2, "count": 5}
     assert get_pagination(results, 1000, 2) == ([], {**empty_page_metadata, **populated_page_metadata})
     populated_page_metadata = {"page": 1, "count": 5}
     assert get_pagination(results, 0, 1) == ([], {**empty_page_metadata, **populated_page_metadata})

--- a/usaspending_api/search/tests/test_spending_by_award_type.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type.py
@@ -56,7 +56,7 @@ def test_spending_by_award_type_success(client, budget_function_data):
         '/api/v2/search/spending_by_award_type/',
         content_type='application/json',
         data=json.dumps({
-            "fields": ["id", "piid", "fain", "uri", "recipient__recipient_name"],
+            "fields": ["Award ID", "Recipient Name"],
             "filters": {
                 "award_type_codes": ["A", "B", "C"]
             }
@@ -116,7 +116,7 @@ def test_spending_by_award_type_success(client, budget_function_data):
         '/api/v2/search/spending_by_award_type',
         content_type='application/json',
         data=json.dumps({
-            "fields": ["id", "piid", "fain", "uri", "recipient__recipient_name"],
+            "fields": ["Award ID", "Recipient Name"],
             "filters": all_filters
         }))
     # test for similar matches (with no duplicates)

--- a/usaspending_api/search/tests/test_spending_by_award_type_count.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type_count.py
@@ -56,7 +56,6 @@ def test_spending_by_award_type_success(client, budget_function_data):
         '/api/v2/search/spending_by_award_type_count/',
         content_type='application/json',
         data=json.dumps({
-            "fields": ["id", "piid", "fain", "uri", "recipient__recipient_name"],
             "filters": {
                 "award_type_codes": ["A", "B", "C"]
             }
@@ -116,7 +115,6 @@ def test_spending_by_award_type_success(client, budget_function_data):
         '/api/v2/search/spending_by_award_type',
         content_type='application/json',
         data=json.dumps({
-            "fields": ["id", "piid", "fain", "uri", "recipient__recipient_name"],
             "filters": all_filters
         }))
     # test for similar matches (with no duplicates)

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -169,9 +169,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
             for key, value in name_dict.items():
                 results.append({"agency_name": key, "agency_abbreviation": value["abbreviation"],
                                 "aggregated_amount": value["aggregated_amount"]})
-
-            results = get_pagination(results, limit, page)
-            response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results}
+            results, next_previous_metadata = get_pagination(results, limit, page)
+            response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+                        **next_previous_metadata}
             return Response(response)
 
         elif category == "funding_agency":
@@ -232,9 +232,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
             for key, value in name_dict.items():
                 results.append({"agency_name": key, "agency_abbreviation": value["abbreviation"],
                                 "aggregated_amount": value["aggregated_amount"]})
-
-            results = get_pagination(results, limit, page)
-            response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results}
+            results, next_previous_metadata = get_pagination(results, limit, page)
+            response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+                        **next_previous_metadata}
             return Response(response)
         elif category == "recipient":
             # filter the transactions by scope name
@@ -265,8 +265,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 for key, value in name_dict.items():
                     results.append({"recipient_name": key, "legal_entity_id": value["legal_entity_id"],
                                     "aggregated_amount": value["aggregated_amount"]})
-                results = get_pagination(results, limit, page)
-                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results}
+                results, next_previous_metadata = get_pagination(results, limit, page)
+                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+                            **next_previous_metadata}
                 return Response(response)
 
             elif scope == "parent_duns":
@@ -289,8 +290,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 for key, value in name_dict.items():
                     results.append({"recipient_name": key, "parent_recipient_unique_id": value["parent_recipient_unique_id"],
                                     "aggregated_amount": value["aggregated_amount"]})
-                results = get_pagination(results, limit, page)
-                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results}
+                results, next_previous_metadata = get_pagination(results, limit, page)
+                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+                            **next_previous_metadata}
                 return Response(response)
             else:  # recipient_type
                 raise InvalidParameterException('recipient type is not yet implemented')
@@ -324,9 +326,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 results.append({"cfda_program_number": key, "program_title": value["program_title"],
                                 "popular_name": value["popular_name"],
                                 "aggregated_amount": value["aggregated_amount"]})
-            results = get_pagination(results, limit, page)
+            results, next_previous_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'limit': limit, 'page': page,
-                        'results': results}
+                        'results': results, **next_previous_metadata}
             return Response(response)
 
         elif category == "industry_codes":  # industry_codes
@@ -350,9 +352,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 for key, value in name_dict.items():
                     results.append({"psc_code": key,
                                     "aggregated_amount": value})
-                results = get_pagination(results, limit, page)
+                results, next_previous_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
-                            'results': results}
+                            'results': results, **next_previous_metadata}
                 return Response(response)
 
             elif scope == "naics":
@@ -372,9 +374,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                     results.append({"naics_code": key,
                                     "aggregated_amount": value["aggregated_amount"],
                                     "naics_description": value["naics_description"]})
-                results = get_pagination(results, limit, page)
+                results, next_previous_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
-                            'results': results}
+                            'results': results, **next_previous_metadata}
                 return Response(response)
 
             else:  # recipient_type
@@ -515,7 +517,9 @@ class SpendingByAwardVisualizationViewSet(APIView):
             results.append(row)
         sorted_results = sorted(results, key=lambda result: self.Min if result[sort] is None else result[sort],
                                 reverse=(order == "desc"))
-        response["results"] = get_pagination(sorted_results, limit, page)
+        results, next_previous_metadata = get_pagination(sorted_results, limit, page)
+        response["results"] = results
+        response.update(next_previous_metadata)
         return Response(response)
 
 

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -170,9 +170,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 results.append({"agency_name": key, "agency_abbreviation": value["abbreviation"],
                                 "aggregated_amount": value["aggregated_amount"]})
             results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-            results, next_previous_metadata = get_pagination(results, limit, page)
+            results, page_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
-                        **next_previous_metadata}
+                        "page_metadata": page_metadata}
             return Response(response)
 
         elif category == "funding_agency":
@@ -234,9 +234,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 results.append({"agency_name": key, "agency_abbreviation": value["abbreviation"],
                                 "aggregated_amount": value["aggregated_amount"]})
             results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-            results, next_previous_metadata = get_pagination(results, limit, page)
+            results, page_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
-                        **next_previous_metadata}
+                        "page_metadata": page_metadata}
             return Response(response)
         elif category == "recipient":
             # filter the transactions by scope name
@@ -268,9 +268,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                     results.append({"recipient_name": key, "legal_entity_id": value["legal_entity_id"],
                                     "aggregated_amount": value["aggregated_amount"]})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-                results, next_previous_metadata = get_pagination(results, limit, page)
+                results, page_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
-                            **next_previous_metadata}
+                            "page_metadata": page_metadata}
                 return Response(response)
 
             elif scope == "parent_duns":
@@ -294,9 +294,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                     results.append({"recipient_name": key, "parent_recipient_unique_id": value["parent_recipient_unique_id"],
                                     "aggregated_amount": value["aggregated_amount"]})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-                results, next_previous_metadata = get_pagination(results, limit, page)
+                results, page_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
-                            **next_previous_metadata}
+                            "page_metadata": page_metadata}
                 return Response(response)
             else:  # recipient_type
                 raise InvalidParameterException('recipient type is not yet implemented')
@@ -331,9 +331,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                 "popular_name": value["popular_name"],
                                 "aggregated_amount": value["aggregated_amount"]})
             results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-            results, next_previous_metadata = get_pagination(results, limit, page)
+            results, page_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'limit': limit, 'page': page,
-                        'results': results, **next_previous_metadata}
+                        'results': results, "page_metadata": page_metadata}
             return Response(response)
 
         elif category == "industry_codes":  # industry_codes
@@ -358,9 +358,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                     results.append({"psc_code": key,
                                     "aggregated_amount": value})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-                results, next_previous_metadata = get_pagination(results, limit, page)
+                results, page_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
-                            'results': results, **next_previous_metadata}
+                            'results': results, "page_metadata": page_metadata}
                 return Response(response)
 
             elif scope == "naics":
@@ -381,9 +381,9 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                     "aggregated_amount": value["aggregated_amount"],
                                     "naics_description": value["naics_description"]})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
-                results, next_previous_metadata = get_pagination(results, limit, page)
+                results, page_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
-                            'results': results, **next_previous_metadata}
+                            'results': results, "page_metadata": page_metadata}
                 return Response(response)
 
             else:  # recipient_type
@@ -524,9 +524,9 @@ class SpendingByAwardVisualizationViewSet(APIView):
             results.append(row)
         sorted_results = sorted(results, key=lambda result: self.Min if result[sort] is None else result[sort],
                                 reverse=(order == "desc"))
-        results, next_previous_metadata = get_pagination(sorted_results, limit, page)
+        results, page_metadata = get_pagination(sorted_results, limit, page)
         response["results"] = results
-        response.update(next_previous_metadata)
+        response["page_metadata"] = page_metadata
         return Response(response)
 
 

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -169,6 +169,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
             for key, value in name_dict.items():
                 results.append({"agency_name": key, "agency_abbreviation": value["abbreviation"],
                                 "aggregated_amount": value["aggregated_amount"]})
+            results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
             results, next_previous_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
                         **next_previous_metadata}
@@ -232,6 +233,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
             for key, value in name_dict.items():
                 results.append({"agency_name": key, "agency_abbreviation": value["abbreviation"],
                                 "aggregated_amount": value["aggregated_amount"]})
+            results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
             results, next_previous_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
                         **next_previous_metadata}
@@ -265,6 +267,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 for key, value in name_dict.items():
                     results.append({"recipient_name": key, "legal_entity_id": value["legal_entity_id"],
                                     "aggregated_amount": value["aggregated_amount"]})
+                results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, next_previous_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
                             **next_previous_metadata}
@@ -290,6 +293,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 for key, value in name_dict.items():
                     results.append({"recipient_name": key, "parent_recipient_unique_id": value["parent_recipient_unique_id"],
                                     "aggregated_amount": value["aggregated_amount"]})
+                results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, next_previous_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
                             **next_previous_metadata}
@@ -326,6 +330,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 results.append({"cfda_program_number": key, "program_title": value["program_title"],
                                 "popular_name": value["popular_name"],
                                 "aggregated_amount": value["aggregated_amount"]})
+            results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
             results, next_previous_metadata = get_pagination(results, limit, page)
             response = {'category': category, 'limit': limit, 'page': page,
                         'results': results, **next_previous_metadata}
@@ -352,6 +357,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                 for key, value in name_dict.items():
                     results.append({"psc_code": key,
                                     "aggregated_amount": value})
+                results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, next_previous_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
                             'results': results, **next_previous_metadata}
@@ -374,6 +380,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                     results.append({"naics_code": key,
                                     "aggregated_amount": value["aggregated_amount"],
                                     "naics_description": value["naics_description"]})
+                results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, next_previous_metadata = get_pagination(results, limit, page)
                 response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
                             'results': results, **next_previous_metadata}

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -171,7 +171,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                 "aggregated_amount": value["aggregated_amount"]})
             results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
             results, page_metadata = get_pagination(results, limit, page)
-            response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+            response = {'category': category, 'scope': scope, 'limit': limit, 'results': results,
                         "page_metadata": page_metadata}
             return Response(response)
 
@@ -235,7 +235,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                 "aggregated_amount": value["aggregated_amount"]})
             results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
             results, page_metadata = get_pagination(results, limit, page)
-            response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+            response = {'category': category, 'scope': scope, 'limit': limit, 'results': results,
                         "page_metadata": page_metadata}
             return Response(response)
         elif category == "recipient":
@@ -269,7 +269,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                     "aggregated_amount": value["aggregated_amount"]})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, page_metadata = get_pagination(results, limit, page)
-                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+                response = {'category': category, 'scope': scope, 'limit': limit, 'results': results,
                             "page_metadata": page_metadata}
                 return Response(response)
 
@@ -295,7 +295,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                     "aggregated_amount": value["aggregated_amount"]})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, page_metadata = get_pagination(results, limit, page)
-                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page, 'results': results,
+                response = {'category': category, 'scope': scope, 'limit': limit, 'results': results,
                             "page_metadata": page_metadata}
                 return Response(response)
             else:  # recipient_type
@@ -332,8 +332,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                 "aggregated_amount": value["aggregated_amount"]})
             results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
             results, page_metadata = get_pagination(results, limit, page)
-            response = {'category': category, 'limit': limit, 'page': page,
-                        'results': results, "page_metadata": page_metadata}
+            response = {'category': category, 'limit': limit, 'results': results, "page_metadata": page_metadata}
             return Response(response)
 
         elif category == "industry_codes":  # industry_codes
@@ -359,8 +358,8 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                     "aggregated_amount": value})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, page_metadata = get_pagination(results, limit, page)
-                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
-                            'results': results, "page_metadata": page_metadata}
+                response = {'category': category, 'scope': scope, 'limit': limit, 'results': results,
+                            "page_metadata": page_metadata}
                 return Response(response)
 
             elif scope == "naics":
@@ -382,8 +381,8 @@ class SpendingByCategoryVisualizationViewSet(APIView):
                                     "naics_description": value["naics_description"]})
                 results = sorted(results, key=lambda result: result["aggregated_amount"], reverse=True)
                 results, page_metadata = get_pagination(results, limit, page)
-                response = {'category': category, 'scope': scope, 'limit': limit, 'page': page,
-                            'results': results, "page_metadata": page_metadata}
+                response = {'category': category, 'scope': scope, 'limit': limit, 'results': results,
+                            "page_metadata": page_metadata}
                 return Response(response)
 
             else:  # recipient_type
@@ -489,7 +488,7 @@ class SpendingByAwardVisualizationViewSet(APIView):
         queryset = award_filter(filters)
 
         # build response
-        response = {'limit': limit, 'page': page, 'results': []}
+        response = {'limit': limit, 'results': []}
         results = []
 
         for award in queryset:


### PR DESCRIPTION
- [x] Updated gists below
- [x] Reviewed
- [x] Gists reviewed by @mab6bf  

- Including `page_metadata` object to pagination requests
- Sorting `spending-by-category` results by descending `aggregated_amount`

Updated Gists:
- [Spending by Category](https://gist.github.com/dpb-bah/7f12df270210d7a830c98af71cfa580d)
- [Spending by Award Type](https://gist.github.com/dpb-bah/6cf34627ae6d221fafab20b05fca7d58)