### PR TITLE
Hotfix: Updating additional endpoints for the correct dollar amounts on the agency page

### DIFF
--- a/usaspending_api/accounts/views/financial_spending.py
+++ b/usaspending_api/accounts/views/financial_spending.py
@@ -3,12 +3,13 @@ from usaspending_api.accounts.serializers import (ObjectClassFinancialSpendingSe
                                                   MinorObjectClassFinancialSpendingSerializer)
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 from usaspending_api.references.models import Agency
+from usaspending_api.submissions.models import SubmissionAttributes
 from usaspending_api.common.views import DetailViewSet
 from usaspending_api.common.exceptions import InvalidParameterException
 
 
 class ObjectClassFinancialSpendingViewSet(DetailViewSet):
-    """Returns financial spending data by object class."""
+    """Returns financial spending data by object class for the latest quarter based on the given fiscal year."""
 
     serializer_class = ObjectClassFinancialSpendingSerializer
 
@@ -26,6 +27,23 @@ class ObjectClassFinancialSpendingViewSet(DetailViewSet):
                 'Missing one or more required query parameters: fiscal_year, funding_agency_id'
             )
 
+        toptier_agency = Agency.objects.filter(id=funding_agency_id).first()
+        if toptier_agency is None:
+            return FinancialAccountsByProgramActivityObjectClass.objects.none()
+        toptier_agency = toptier_agency.toptier_agency
+
+        submission_queryset = SubmissionAttributes.objects.all()
+        submission_queryset = submission_queryset.filter(cgac_code=toptier_agency.cgac_code,
+                                                         reporting_fiscal_year=fiscal_year).\
+            order_by('-reporting_fiscal_year', '-reporting_fiscal_quarter').\
+            annotate(fiscal_year=F('reporting_fiscal_year'), fiscal_quarter=F('reporting_fiscal_quarter'))
+        submission = submission_queryset.first()
+
+        if submission is None:
+            return FinancialAccountsByProgramActivityObjectClass.objects.none()
+        active_fiscal_year = submission.reporting_fiscal_year
+        active_fiscal_quarter = submission.fiscal_quarter
+
         # using final_objects below ensures that we're only pulling the latest
         # set of financial information for each fiscal year
         queryset = FinancialAccountsByProgramActivityObjectClass.final_objects.all()
@@ -33,9 +51,9 @@ class ObjectClassFinancialSpendingViewSet(DetailViewSet):
         # need to filter on
         # (used filter() instead of get() b/c we likely don't want to raise an
         # error on a bad agency id)
-        toptier_agency = Agency.objects.filter(id=funding_agency_id).first().toptier_agency
         queryset = queryset.filter(
-            submission__reporting_fiscal_year=fiscal_year,
+            submission__reporting_fiscal_year=active_fiscal_year,
+            submission__reporting_fiscal_quarter=active_fiscal_quarter,
             treasury_account__funding_toptier_agency=toptier_agency
         )
         queryset = queryset.annotate(
@@ -49,7 +67,7 @@ class ObjectClassFinancialSpendingViewSet(DetailViewSet):
 
 
 class MinorObjectClassFinancialSpendingViewSet(DetailViewSet):
-    """Returns financial spending data by object class."""
+    """Returns financial spending data by object class for the latest quarter in the given fiscal year."""
 
     serializer_class = MinorObjectClassFinancialSpendingSerializer
 
@@ -68,6 +86,23 @@ class MinorObjectClassFinancialSpendingViewSet(DetailViewSet):
                 'Missing one or more required query parameters: fiscal_year, funding_agency_id, major_object_class_code'
             )
 
+        toptier_agency = Agency.objects.filter(id=funding_agency_id).first()
+        if toptier_agency is None:
+            return FinancialAccountsByProgramActivityObjectClass.objects.none()
+        toptier_agency = toptier_agency.toptier_agency
+
+        submission_queryset = SubmissionAttributes.objects.all()
+        submission_queryset = submission_queryset.filter(cgac_code=toptier_agency.cgac_code,
+                                                         reporting_fiscal_year=fiscal_year).\
+            order_by('-reporting_fiscal_year', '-reporting_fiscal_quarter').\
+            annotate(fiscal_year=F('reporting_fiscal_year'), fiscal_quarter=F('reporting_fiscal_quarter'))
+        submission = submission_queryset.first()
+
+        if submission is None:
+            return FinancialAccountsByProgramActivityObjectClass.objects.none()
+        active_fiscal_year = submission.reporting_fiscal_year
+        active_fiscal_quarter = submission.fiscal_quarter
+
         # using final_objects below ensures that we're only pulling the latest
         # set of financial information for each fiscal year
         queryset = FinancialAccountsByProgramActivityObjectClass.final_objects.all()
@@ -75,16 +110,12 @@ class MinorObjectClassFinancialSpendingViewSet(DetailViewSet):
         # need to filter on
         # (used filter() instead of get() b/c we likely don't want to raise an
         # error on a bad agency id)
-        agency = Agency.objects.filter(id=funding_agency_id).first()
-        if agency is None:
-            return Agency.objects.none()
-        else:
-            toptier_agency = agency.toptier_agency
-            queryset = queryset.filter(
-                submission__reporting_fiscal_year=fiscal_year,
-                treasury_account__funding_toptier_agency=toptier_agency,
-                object_class__major_object_class=major_object_class_code
-            )
+        queryset = queryset.filter(
+            submission__reporting_fiscal_year=active_fiscal_year,
+            submission__reporting_fiscal_quarter=active_fiscal_quarter,
+            treasury_account__funding_toptier_agency=toptier_agency,
+            object_class__major_object_class=major_object_class_code
+        )
         queryset = queryset.annotate(
             object_class_name=F('object_class__object_class_name'),
             object_class_code=F('object_class__object_class'))


### PR DESCRIPTION
Adding additional filter based on active fiscal quarter for /v2/financial_balances/agencies/, /v2/financial_spending/major_object_class/, and /v2/financial_spending/object_class/ endpoints