### PR TITLE
Import CommandError

### DIFF
--- a/usaspending_api/etl/management/commands/load_historical.py
+++ b/usaspending_api/etl/management/commands/load_historical.py
@@ -3,6 +3,7 @@ import logging
 
 from django.utils.dateparse import parse_date
 from django.db import transaction
+from django.core.management.base import CommandError
 
 from usaspending_api.submissions.models import SubmissionAttributes
 from usaspending_api.etl.broker_etl_helpers import dictfetchall


### PR DESCRIPTION
Noticed this little nuisance: when the command tried to throw a CommandError,
it had not been imported, so threw NameError instead