### PR TITLE
Hotfix update awarding agencies

### DIFF
--- a/usaspending_api/broker/management/commands/update_awarding_agencies.py
+++ b/usaspending_api/broker/management/commands/update_awarding_agencies.py
@@ -36,10 +36,7 @@ class Command(BaseCommand):
                                                 'funding_subtier_code': transaction['funding_sub_tier_agency_co']
                                                }
                                                for transaction in TransactionFPDS.objects
-                                               .filter(Q(transaction__fiscal_year=fiscal_year) &
-                                                       (Q(transaction__awarding_agency__isnull=True) |
-                                                        Q(transaction__funding_agency__isnull=True))
-                                                       )
+                                               .filter(Q(transaction__fiscal_year=fiscal_year))
                                                .values('transaction_id',
                                                        'awarding_agency_code',
                                                        'funding_agency_code',
@@ -59,10 +56,7 @@ class Command(BaseCommand):
                                                  'funding_subtier_code': transaction['funding_sub_tier_agency_co']
                                                 }
                                                 for transaction in TransactionFABS.objects
-                                                .filter(Q(transaction__fiscal_year=fiscal_year) &
-                                                        (Q(transaction__awarding_agency__isnull=True) |
-                                                         Q(transaction__funding_agency__isnull=True))
-                                                        )
+                                                .filter(Q(transaction__fiscal_year=fiscal_year))
                                                 .values('transaction_id',
                                                         'awarding_agency_code',
                                                         'funding_agency_code',

--- a/usaspending_api/broker/management/commands/update_awarding_agencies.py
+++ b/usaspending_api/broker/management/commands/update_awarding_agencies.py
@@ -2,7 +2,6 @@ import logging
 import timeit
 
 from django.core.management.base import BaseCommand
-from django.db.models import Q
 
 from usaspending_api.awards.models import TransactionNormalized, TransactionFABS, TransactionFPDS
 from usaspending_api.awards.models import Award
@@ -26,7 +25,7 @@ class Command(BaseCommand):
 
         if file_type == 'D1':
             # List of Transaction FPDS mapping transaction ids, cgac code, and subtier code
-            # Filters out FPDS transactions where the transaction's awarding or funding agency is null and by fiscal year
+            # Filters out FPDS transactions where the transaction is equal to the fiscal year
             transaction_cgac_subtier_map = [
                                                {
                                                 'transaction_id': transaction_FPDS['transaction_id'],
@@ -46,7 +45,7 @@ class Command(BaseCommand):
                                             ]
         elif file_type == 'D2':
             # List of Transaction FABS mapping transaction ids, cgac code, and subtier code
-            # Filters out FABS transactions where the transaction's awarding or funding agency is null and by fiscal year
+            # Filters out FABS transactions where the where the transaction is equal to the fiscal year
             transaction_cgac_subtier_map = [
                                                 {
                                                  'transaction_id': transaction_FABS['transaction_id'],

--- a/usaspending_api/broker/management/commands/update_awarding_agencies.py
+++ b/usaspending_api/broker/management/commands/update_awarding_agencies.py
@@ -29,14 +29,14 @@ class Command(BaseCommand):
             # Filters out FPDS transactions where the transaction's awarding or funding agency is null and by fiscal year
             transaction_cgac_subtier_map = [
                                                {
-                                                'transaction_id': transaction['transaction_id'],
-                                                'awarding_cgac_code': transaction['awarding_agency_code'],
-                                                'funding_cgac_code': transaction['funding_agency_code'],
-                                                'awarding_subtier_code': transaction['awarding_sub_tier_agency_c'],
-                                                'funding_subtier_code': transaction['funding_sub_tier_agency_co']
+                                                'transaction_id': transaction_FPDS['transaction_id'],
+                                                'awarding_cgac_code': transaction_FPDS['awarding_agency_code'],
+                                                'funding_cgac_code': transaction_FPDS['funding_agency_code'],
+                                                'awarding_subtier_code': transaction_FPDS['awarding_sub_tier_agency_c'],
+                                                'funding_subtier_code': transaction_FPDS['funding_sub_tier_agency_co']
                                                }
-                                               for transaction in TransactionFPDS.objects
-                                               .filter(Q(transaction__fiscal_year=fiscal_year))
+                                               for transaction_FPDS in TransactionFPDS.objects
+                                               .filter(transaction__fiscal_year=fiscal_year)
                                                .values('transaction_id',
                                                        'awarding_agency_code',
                                                        'funding_agency_code',
@@ -49,14 +49,14 @@ class Command(BaseCommand):
             # Filters out FABS transactions where the transaction's awarding or funding agency is null and by fiscal year
             transaction_cgac_subtier_map = [
                                                 {
-                                                 'transaction_id': transaction['transaction_id'],
-                                                 'awarding_cgac_code': transaction['awarding_agency_code'],
-                                                 'funding_cgac_code': transaction['funding_agency_code'],
-                                                 'awarding_subtier_code': transaction['awarding_sub_tier_agency_c'],
-                                                 'funding_subtier_code': transaction['funding_sub_tier_agency_co']
+                                                 'transaction_id': transaction_FABS['transaction_id'],
+                                                 'awarding_cgac_code': transaction_FABS['awarding_agency_code'],
+                                                 'funding_cgac_code': transaction_FABS['funding_agency_code'],
+                                                 'awarding_subtier_code': transaction_FABS['awarding_sub_tier_agency_c'],
+                                                 'funding_subtier_code': transaction_FABS['funding_sub_tier_agency_co']
                                                 }
-                                                for transaction in TransactionFABS.objects
-                                                .filter(Q(transaction__fiscal_year=fiscal_year))
+                                                for transaction_FABS in TransactionFABS.objects
+                                                # .filter(transaction__fiscal_year=fiscal_year)
                                                 .values('transaction_id',
                                                         'awarding_agency_code',
                                                         'funding_agency_code',

--- a/usaspending_api/broker/tests/test_update_awarding_agencies.py
+++ b/usaspending_api/broker/tests/test_update_awarding_agencies.py
@@ -49,8 +49,6 @@ def transaction_data():
                                 subtier_agency=subtier_funding_agency)
 
 
-
-
 @pytest.mark.django_db
 def test_contracts_command(transaction_data):
     """
@@ -76,6 +74,7 @@ def test_contracts_command(transaction_data):
     assert fabs_transaction_2017.funding_agency is None
     assert fabs_award_2017.awarding_agency is None
     assert fabs_award_2017.funding_agency is None
+
 
 @pytest.mark.django_db
 def test_assistance_command(transaction_data):

--- a/usaspending_api/broker/tests/test_update_awarding_agencies.py
+++ b/usaspending_api/broker/tests/test_update_awarding_agencies.py
@@ -1,5 +1,6 @@
 from model_mommy import mommy
 import pytest
+from datetime import datetime
 
 from django.core.management import call_command
 
@@ -16,7 +17,7 @@ def transaction_data():
 
     transaction_normalized_fpds_2017 = mommy.make(TransactionNormalized, id=1234, awarding_agency=None,
                                                   funding_agency=None,
-                                                  fiscal_year=2017, award=award_fpds_2017)
+                                                  action_date=datetime(2017, 7, 1), award=award_fpds_2017)
 
     transaction_fpds_2017 = mommy.make(TransactionFPDS, transaction=transaction_normalized_fpds_2017,
                                        awarding_agency_code='001', awarding_sub_tier_agency_c='011',
@@ -27,7 +28,7 @@ def transaction_data():
     award_fabs_2017 = mommy.make(Award, id=40, awarding_agency=None, funding_agency=None)
     transaction_normalized_fabs_2017 = mommy.make(TransactionNormalized, id=13141516, awarding_agency=None,
                                                   funding_agency=None,
-                                                  fiscal_year=2017, award=award_fabs_2017)
+                                                  action_date=datetime(2016, 7, 1), award=award_fabs_2017)
 
     transaction_fabs_2017 = mommy.make(TransactionFABS, transaction=transaction_normalized_fabs_2017,
                                        awarding_agency_code='001', awarding_sub_tier_agency_c='011',
@@ -83,7 +84,7 @@ def test_assistance_command(transaction_data):
     :return: tests FABS data FY 2017 to make sure it correct funding and awarding agency data is added
     takes into account when funding agency code is missing from transaction data
     """
-    call_command('update_awarding_agencies', '--fiscal_year', 2017, '--assistance')
+    call_command('update_awarding_agencies', '--fiscal_year', 2016, '--assistance')
 
     fpds_transaction_2017 = TransactionNormalized.objects.filter(id=1234).first()
     fpds_award_2017 = Award.objects.filter(id=10).first()


### PR DESCRIPTION
Update awarding agencies cleaning script to include all transactions in order to fix wrong mappings between agencies and transactions and awards. 

Fixed test to make sure test was correctly filtering transactions.