### PR TITLE
Update tests to include action date where testing fiscal year for awa…

### DIFF
--- a/usaspending_api/awards/tests/test_award_spending.py
+++ b/usaspending_api/awards/tests/test_award_spending.py
@@ -1,7 +1,7 @@
 import pytest
 from model_mommy import mommy
 from rest_framework import status
-
+from datetime import datetime
 
 @pytest.fixture
 def award_spending_data(db):
@@ -15,6 +15,7 @@ def award_spending_data(db):
         award=award,
         awarding_agency=agency,
         federal_action_obligation=10,
+        action_date=datetime(2017, 1, 1),
         fiscal_year=2017,
         recipient=legal_entity
     )
@@ -23,6 +24,7 @@ def award_spending_data(db):
         award=award1,
         awarding_agency=agency,
         federal_action_obligation=20,
+        action_date=datetime(2017, 9, 1),
         fiscal_year=2017,
         recipient=legal_entity
     )
@@ -31,6 +33,7 @@ def award_spending_data(db):
         award=award1,
         awarding_agency=agency,
         federal_action_obligation=20,
+        action_date=datetime(2016, 12, 1),
         fiscal_year=2017,
         recipient=legal_entity
     )
@@ -39,6 +42,7 @@ def award_spending_data(db):
         award=award2,
         awarding_agency=agency,
         federal_action_obligation=20,
+        action_date=datetime(2016, 10, 2),
         fiscal_year=2017,
         recipient=legal_entity
     )

--- a/usaspending_api/broker/tests/test_update_awarding_agencies.py
+++ b/usaspending_api/broker/tests/test_update_awarding_agencies.py
@@ -1,5 +1,6 @@
 from model_mommy import mommy
 import pytest
+from datetime import datetime
 
 from django.core.management import call_command
 
@@ -15,7 +16,7 @@ def transaction_data():
     award_fpds_2017 = mommy.make(Award, id=10, awarding_agency=None, funding_agency=None)
 
     transaction_normalized_fpds_2017 = mommy.make(TransactionNormalized, id=1234, awarding_agency=None,
-                                                  funding_agency=None,
+                                                  funding_agency=None, action_date=datetime(2017, 6, 1),
                                                   fiscal_year=2017, award=award_fpds_2017)
 
     transaction_fpds_2017 = mommy.make(TransactionFPDS, transaction=transaction_normalized_fpds_2017,
@@ -26,7 +27,7 @@ def transaction_data():
     # Assistance Transaction - Fiscal Year 20176
     award_fabs_2017 = mommy.make(Award, id=40, awarding_agency=None, funding_agency=None)
     transaction_normalized_fabs_2017 = mommy.make(TransactionNormalized, id=13141516, awarding_agency=None,
-                                                  funding_agency=None,
+                                                  funding_agency=None, action_date=datetime(2017, 7, 1),
                                                   fiscal_year=2017, award=award_fabs_2017)
 
     transaction_fabs_2017 = mommy.make(TransactionFABS, transaction=transaction_normalized_fabs_2017,


### PR DESCRIPTION
Update tests where the fiscal_year field under Transaction Normalized is being use
- Updated stub models to have a action_date field
- Updated test award category and award recipient endpoings
- Updated awarding agency cleaning script