### PR TITLE
Subaward loader and endpoint enhancements

### DIFF
--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -58,37 +58,6 @@ class FinancialAccountsByAwardsSerializer(LimitableSerializer):
         }
 
 
-class SubawardSerializer(LimitableSerializer):
-
-    prefetchable = False
-
-    class Meta:
-        model = Subaward
-        fields = '__all__'
-        nested_serializers = {
-            "recipient": {
-                "class": LegalEntitySerializer,
-                "kwargs": {"read_only": True}
-            },
-            "awarding_agency": {
-                "class": AgencySerializer,
-                "kwargs": {"read_only": True}
-            },
-            "funding_agency": {
-                "class": AgencySerializer,
-                "kwargs": {"read_only": True}
-            },
-            "place_of_performance": {
-                "class": LocationSerializer,
-                "kwargs": {"read_only": True}
-            },
-            "cfda": {
-                "class": CfdaSerializer,
-                "kwargs": {"read_only": True}
-            },
-        }
-
-
 class TransactionFABSSerializer(LimitableSerializer):
 
     prefetchable = False
@@ -250,3 +219,38 @@ class AwardSerializer(LimitableSerializer):
 
     def get_date_signed__fy(self, obj):
         return fy(obj.date_signed)
+
+
+class SubawardSerializer(LimitableSerializer):
+
+    prefetchable = False
+
+    class Meta:
+        model = Subaward
+        fields = '__all__'
+        nested_serializers = {
+            "award": {
+                "class": AwardSerializer,
+                "kwargs": {"read_only": True}
+            },
+            "recipient": {
+                "class": LegalEntitySerializer,
+                "kwargs": {"read_only": True}
+            },
+            "awarding_agency": {
+                "class": AgencySerializer,
+                "kwargs": {"read_only": True}
+            },
+            "funding_agency": {
+                "class": AgencySerializer,
+                "kwargs": {"read_only": True}
+            },
+            "place_of_performance": {
+                "class": LocationSerializer,
+                "kwargs": {"read_only": True}
+            },
+            "cfda": {
+                "class": CfdaSerializer,
+                "kwargs": {"read_only": True}
+            },
+        }

--- a/usaspending_api/broker/management/commands/load_fsrs.py
+++ b/usaspending_api/broker/management/commands/load_fsrs.py
@@ -161,16 +161,21 @@ class Command(BaseCommand):
                                   'sub_award.overall_description', 'sub_award.recovery_model_q1 AS q1_flag',
                                   'sub_award.recovery_model_q2 AS q2_flag',
                                   'sub_award.subcontract_date AS subaward_date'])
+
+            query = "SELECT " + ",".join(query_columns) + " FROM fsrs_" + award_type + " AS award " + \
+                    "JOIN fsrs_" + subaward_type + " AS sub_award ON sub_award.parent_id = award.id WHERE award.id > " + \
+                    str(max_id) + " AND sub_award.subcontract_num IS NOT NULL ORDER BY award.id, sub_award.id LIMIT " + \
+                    str(QUERY_LIMIT) + " OFFSET " + str(offset)
         else:
             query_columns.extend(['sub_award.cfda_numbers', 'sub_award.subaward_num', 'sub_award.subaward_amount',
                                   'sub_award.project_description AS overall_description',
                                   'sub_award.compensation_q1 AS q1_flag', 'sub_award.compensation_q2 AS q2_flag',
                                   'sub_award.subaward_date'])
 
-        query = "SELECT " + ",".join(query_columns) + " FROM fsrs_" + award_type + " AS award " + \
-                "JOIN fsrs_" + subaward_type + " AS sub_award ON sub_award.parent_id = award.id WHERE award.id > " + \
-                str(max_id) + " ORDER BY award.id, sub_award.id LIMIT " + \
-                str(QUERY_LIMIT) + " OFFSET " + str(offset)
+            query = "SELECT " + ",".join(query_columns) + " FROM fsrs_" + award_type + " AS award " + \
+                    "JOIN fsrs_" + subaward_type + " AS sub_award ON sub_award.parent_id = award.id WHERE award.id > " + \
+                    str(max_id) + " ORDER BY award.id, sub_award.id LIMIT " + \
+                    str(QUERY_LIMIT) + " OFFSET " + str(offset)
 
         db_cursor.execute(query)
 

--- a/usaspending_api/broker/management/commands/load_fsrs.py
+++ b/usaspending_api/broker/management/commands/load_fsrs.py
@@ -15,6 +15,8 @@ logger = logging.getLogger('console')
 exception_logger = logging.getLogger("exceptions")
 
 QUERY_LIMIT = 10000
+LOG_LIMIT = 10000
+
 award_update_id_list = []
 
 
@@ -103,7 +105,7 @@ class Command(BaseCommand):
         skip_count = 0
         for row in data:
             counter += 1
-            if counter % 10000 == 0:
+            if counter % LOG_LIMIT == 0:
                 logger.info(
                     "Processed " + str(counter) + " of " + str(new_awards) + " new awards. Skipped " + str(skip_count)
                 )

--- a/usaspending_api/broker/management/commands/load_fsrs.py
+++ b/usaspending_api/broker/management/commands/load_fsrs.py
@@ -272,6 +272,7 @@ class Command(BaseCommand):
 
         logger.info('Load FSRS Script Complete!')
 
+
 def get_valid_awarding_agency(row):
     agency = None
 

--- a/usaspending_api/broker/management/commands/load_fsrs.py
+++ b/usaspending_api/broker/management/commands/load_fsrs.py
@@ -9,11 +9,13 @@ from usaspending_api.awards.models import Award, Subaward
 from usaspending_api.references.models import LegalEntity, Agency, Cfda
 from usaspending_api.etl.broker_etl_helpers import dictfetchall
 from usaspending_api.etl.helpers import get_or_create_location
+from usaspending_api.etl.award_helpers import update_award_subawards
 
 logger = logging.getLogger('console')
 exception_logger = logging.getLogger("exceptions")
 
 QUERY_LIMIT = 10000
+award_update_id_list = []
 
 
 class Command(BaseCommand):
@@ -53,9 +55,9 @@ class Command(BaseCommand):
             agency = get_valid_awarding_agency(row)
 
             if not agency:
-                logger.warning(
-                    "Internal ID {} cannot find matching agency with subtier code {}".
-                    format(row['internal_id'], row['contracting_office_aid']))
+                # logger.warning(
+                #     "Internal ID {} cannot find matching agency with subtier code {}".
+                #     format(row['internal_id'], row['contracting_office_aid']))
                 return None, None
 
             # Find the award to attach this sub-contract to. We perform this lookup by finding the Award containing
@@ -81,9 +83,9 @@ class Command(BaseCommand):
                 order_by("-date_signed").first()
             # We don't have a matching award for this subcontract, log a warning and continue to the next row
             if not award:
-                logger.warning(
-                    "Internal ID {} cannot find award with fain {}; skipping...".
-                    format(row['internal_id'], row['fain']))
+                # logger.warning(
+                #     "Internal ID {} cannot find award with fain {}; skipping...".
+                #     format(row['internal_id'], row['fain']))
                 return None, None
 
             recipient_name = row['awardee_name']
@@ -101,7 +103,7 @@ class Command(BaseCommand):
         skip_count = 0
         for row in data:
             counter += 1
-            if counter % 1000 == 0:
+            if counter % 10000 == 0:
                 logger.info(
                     "Processed " + str(counter) + " of " + str(new_awards) + " new awards. Skipped " + str(skip_count)
                 )
@@ -165,10 +167,8 @@ class Command(BaseCommand):
 
         query = "SELECT " + ",".join(query_columns) + " FROM fsrs_" + award_type + " AS award " + \
                 "JOIN fsrs_" + subaward_type + " AS sub_award ON sub_award.parent_id = award.id WHERE award.id > " + \
-                str(max_id) + "AND sub_award.subcontract_num IS NOT NULL ORDER BY award.id, sub_award.id LIMIT " + \
+                str(max_id) + " ORDER BY award.id, sub_award.id LIMIT " + \
                 str(QUERY_LIMIT) + " OFFSET " + str(offset)
-
-        print(query)
 
         db_cursor.execute(query)
 
@@ -214,6 +214,7 @@ class Command(BaseCommand):
             # Either we're starting with an empty table in regards to this award type or we've deleted all
             # subawards related to the internal_id, either way we just create the subaward
             Subaward.objects.create(**subaward_dict)
+            award_update_id_list.append(shared_mappings['award'].id)
 
     def process_subawards(self, db_cursor, shared_award_mappings, award_type, subaward_type, max_id):
         """ Process the subawards and insert them as we go """
@@ -265,6 +266,11 @@ class Command(BaseCommand):
 
         logger.info('Completed FSRS data load...')
 
+        logger.info('Updating related award metadata...')
+        update_award_subawards(tuple(award_update_id_list))
+        logger.info('Finished updating award metadata...')
+
+        logger.info('Load FSRS Script Complete!')
 
 def get_valid_awarding_agency(row):
     agency = None


### PR DESCRIPTION
Related JIRA Story: https://federal-spending-transparency.atlassian.net/browse/DS-1896

* Updating FSRS loader to account for updating related award metadata (subaward counts and totals).
* Updated subaward serializer to include associated award data to retrieve the metadata in the response.