### PR TITLE
Resolving state code to state name conversion in case there is no match found

### DIFF
--- a/usaspending_api/references/models.py
+++ b/usaspending_api/references/models.py
@@ -297,7 +297,10 @@ class Location(DataSourceTrackedModel, DeleteIfChildlessMixin):
             if not self.state_code:
                 self.state_code = state_to_code.get(self.state_name)
             elif not self.state_name:
-                self.state_name = code_to_state.get(self.state_code)['name']
+                state_obj = code_to_state.get(self.state_code)
+
+                if state_obj:
+                    self.state_name = state_obj['name']
 
     zip_code_pattern = re.compile('^(\d{5})\-?(\d{4})?$')
 


### PR DESCRIPTION
Updating fill_missing_state_data to check if the state code returned a valid state. if it's none, don't do anything.