### PR TITLE
Hotfix Geocode Filter for Transaction endpoints on Award Search

### DIFF
--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -1,14 +1,6 @@
 from django.apps import apps
 from usaspending_api.common.exceptions import InvalidParameterException
 
-loc_dict = {
-    'country': 'location_country_code',
-    'state': 'state_code',
-    'county': 'county_code',
-    'district': 'congressional_code',
-    'zip': 'zip5',
-}
-
 
 def geocode_filter_locations(scope, values, model, use_matview=False, default_model='awards'):
     """
@@ -58,7 +50,7 @@ def check_location_fields(fields):
 
 def get_fields_list(scope, field_value):
     """List of values to search for; `field_value`, plus possibly variants on it"""
-    if scope not in ['state_code', 'location_country_code', 'zip5']:
+    if scope not in ['state_code', 'location_country_code', 'country_code', 'zip5']:
         return [str(int(field_value)), field_value, str(float(field_value))]
 
     return [field_value]
@@ -66,6 +58,14 @@ def get_fields_list(scope, field_value):
 
 def return_query_strings(use_matview):
     # Returns query strings according based on mat view or database
+
+    loc_dict = {
+        'country': 'location_country_code',
+        'state': 'state_code',
+        'county': 'county_code',
+        'district': 'congressional_code',
+        'zip': 'zip5',
+    }
 
     q_str = '{0}__{1}__in'
 

--- a/usaspending_api/awards/v2/filters/matview_transaction.py
+++ b/usaspending_api/awards/v2/filters/matview_transaction.py
@@ -245,8 +245,7 @@ def transaction_filter(filters):
         # recipient_location
         elif key == "recipient_locations":
             or_queryset = geocode_filter_locations(
-                'recipient_location', value, 'UniversalTransactionView', True,
-                'universal_transaction_matview'
+                'recipient_location', value, 'UniversalTransactionView', True
             )
 
             queryset &= or_queryset
@@ -273,8 +272,7 @@ def transaction_filter(filters):
         # place_of_performance
         elif key == "place_of_performance_locations":
             or_queryset = geocode_filter_locations(
-                'pop', value, 'UniversalTransactionView', True,
-                'universal_transaction_matview'
+                'pop', value, 'UniversalTransactionView', True
             )
             queryset &= or_queryset
 
@@ -493,8 +491,7 @@ def award_filter(filters):
 
         elif key == "recipient_locations":
             or_queryset = geocode_filter_locations(
-                'recipient_location', value, 'UniversalAwardView', True,
-                'universal_award_matview'
+                'recipient_location', value, 'UniversalAwardView', True
             )
             queryset &= or_queryset
 
@@ -517,8 +514,7 @@ def award_filter(filters):
 
         elif key == "place_of_performance_locations":
             or_queryset = geocode_filter_locations(
-                'pop', value, 'UniversalAwardView', True,
-                'universal_award_matview'
+                'pop', value, 'UniversalAwardView', True
             )
 
             queryset &= or_queryset


### PR DESCRIPTION
Updated geocode filter since country_code was not correctly getting correctly mapped in the filter. 
Updated removed default model in call, since mat views are under awards