### PR TITLE
Fixing matview for geofilters state/county/district

### DIFF
--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -500,7 +500,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         else:
             # Adding null filter for state for specific partial index
             # when not using geocode_filter
-            filter_args['{}_{}'.format(loc_lookup, 'isnull')] = False
+            filter_args['{}__isnull'.format(loc_lookup)] = False
 
         self.geo_queryset = self.queryset.filter(**filter_args) \
             .values(*lookup_fields) \
@@ -551,7 +551,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
             self.queryset &= geocode_filter_locations(scope_field_name, [
                 {'state': fips_to_code.get(x[:2]), self.geo_layer: x[2:], 'country': 'USA'}
                 for x in self.geo_layer_filters
-            ], 'UniversalTransactionView')
+            ], 'UniversalTransactionView', True)
         else:
             # Adding null,USA, not number filters for specific partial index
             # when not using geocode_filter


### PR DESCRIPTION
Fixing matview mappings throwing 500 errors:
- State: no geolayer_filters throwing an error when no geo layer filters
- County District geolayer_filters were not mapping correctly because geocode location filter was not set to matview = True