### PR TITLE
Hotfix correct recipient type filter

### DIFF
--- a/usaspending_api/awards/v2/filters/matview_transaction.py
+++ b/usaspending_api/awards/v2/filters/matview_transaction.py
@@ -267,13 +267,8 @@ def transaction_filter(filters):
 
         # recipient_type_names
         elif key == "recipient_type_names":
-            or_queryset = []
-            for v in value:
-                or_queryset.append(v)
-            if len(or_queryset) != 0:
-                queryset &= UniversalTransactionView.objects.filter(
-                    business_categories__overlap=value
-                )
+            if len(value) != 0:
+                queryset &= UniversalTransactionView.objects.filter(business_categories__overlap=value)
 
         # place_of_performance_scope
         elif key == "place_of_performance_scope":
@@ -513,13 +508,8 @@ def award_filter(filters):
             queryset &= or_queryset
 
         elif key == "recipient_type_names":
-            or_queryset = []
-            for v in value:
-                or_queryset.append(v)
-            if len(or_queryset) != 0:
-                duns_values = LegalEntity.objects.filter(business_categories__overlap=or_queryset).\
-                    values('recipient_unique_id')
-                queryset &= UniversalAwardView.objects.filter(recipient_unique_id__in=duns_values)
+            if len(value) != 0:
+                queryset &= UniversalAwardView.objects.filter(business_categories__overlap=value)
 
         elif key == "place_of_performance_scope":
             if value == "domestic":

--- a/usaspending_api/awards/v2/filters/matview_transaction.py
+++ b/usaspending_api/awards/v2/filters/matview_transaction.py
@@ -4,7 +4,7 @@ from django.db.models import Q
 from usaspending_api.awards.models_matviews import UniversalTransactionView, UniversalAwardView
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.awards.v2.filters.location_filter_geocode import geocode_filter_locations
-from usaspending_api.references.models import PSC, NAICS, LegalEntity
+from usaspending_api.references.models import PSC, NAICS
 from usaspending_api.awards.v2.lookups.lookups import contract_type_mapping
 from usaspending_api.references.constants import WEBSITE_AWARD_BINS
 from usaspending_api.common.helpers import dates_are_fiscal_year_bookends


### PR DESCRIPTION
- Recipient type filter for awards was passing for DUNS that had that type in any of their instances, plus it was slower.
- Cleaned up transaction filter a little because it was doing extraneous work