### PR TITLE
Bugfix: Removing extraneous IS NOT NULL check on category

### DIFF
--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -794,8 +794,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
 
         # define what values are needed in the sql query
         queryset = queryset.values('category')
-        queryset = queryset.annotate(category_count=Count('category')).exclude(category__isnull=True). \
-            values('category', 'category_count')
+        queryset = queryset.annotate(category_count=Count('category')).values('category', 'category_count')
 
         results = self.get_results(queryset)
 


### PR DESCRIPTION
When processing awards filters using UniversalAwardMatview, we don't need to exclude categories because the mat view is made with a category IS NOT NULL clause