### PR TITLE
Bugfix: DS 1966 total obligation speed and logic fixes

### DIFF
--- a/usaspending_api/awards/v2/filters/matview_transaction.py
+++ b/usaspending_api/awards/v2/filters/matview_transaction.py
@@ -50,7 +50,7 @@ def date_or_fy_queryset(date_dict, table, fiscal_year_column, action_date_column
     return False, None
 
 
-def total_obligation_queryset(amount_obj):
+def total_obligation_queryset(amount_obj, model):
     bins = []
     for v in amount_obj:
         lower_bound = v.get("lower_bound")
@@ -61,7 +61,7 @@ def total_obligation_queryset(amount_obj):
                 break
 
     if len(bins) == len(amount_obj):
-        return True, UniversalTransactionView.objects.filter(total_obl_bin__in=bins)
+        return True, model.objects.filter(total_obl_bin__in=bins)
     else:
         or_queryset = None
         queryset_init = False
@@ -69,33 +69,33 @@ def total_obligation_queryset(amount_obj):
         for v in amount_obj:
             if v.get("lower_bound") is not None and v.get("upper_bound") is not None:
                 if queryset_init:
-                    or_queryset |= UniversalTransactionView.objects.filter(
-                        total_obligation__gt=v["lower_bound"],
-                        total_obligation__lt=v["upper_bound"]
+                    or_queryset |= model.objects.filter(
+                        total_obligation__gte=v["lower_bound"],
+                        total_obligation__lte=v["upper_bound"]
                     )
                 else:
                     queryset_init = True
-                    or_queryset = UniversalTransactionView.objects.filter(
-                        total_obligation__gt=v["lower_bound"],
-                        total_obligation__lt=v["upper_bound"])
+                    or_queryset = model.objects.filter(
+                        total_obligation__gte=v["lower_bound"],
+                        total_obligation__lte=v["upper_bound"])
             elif v.get("lower_bound") is not None:
                 if queryset_init:
-                    or_queryset |= UniversalTransactionView.objects.filter(
-                        total_obligation__gt=v["lower_bound"]
+                    or_queryset |= model.objects.filter(
+                        total_obligation__gte=v["lower_bound"]
                     )
                 else:
                     queryset_init = True
-                    or_queryset = UniversalTransactionView.objects.filter(
-                        total_obligation__gt=v["lower_bound"])
+                    or_queryset = model.objects.filter(
+                        total_obligation__gte=v["lower_bound"])
             elif v.get("upper_bound") is not None:
                 if queryset_init:
-                    or_queryset |= UniversalTransactionView.objects.filter(
-                        total_obligation__lt=v["upper_bound"]
+                    or_queryset |= model.objects.filter(
+                        total_obligation__lte=v["upper_bound"]
                     )
                 else:
                     queryset_init = True
-                    or_queryset = UniversalTransactionView.objects.filter(
-                        total_obligation__lt=v["upper_bound"])
+                    or_queryset = model.objects.filter(
+                        total_obligation__lte=v["upper_bound"])
             else:
                 raise InvalidParameterException('Invalid filter: award amount has incorrect object.')
     if queryset_init:
@@ -293,7 +293,7 @@ def transaction_filter(filters):
 
         # award_amounts
         elif key == "award_amounts":
-            success, or_queryset = total_obligation_queryset(value)
+            success, or_queryset = total_obligation_queryset(value, UniversalTransactionView)
             if success:
                 queryset &= or_queryset
 
@@ -537,38 +537,8 @@ def award_filter(filters):
             queryset &= or_queryset
 
         elif key == "award_amounts":
-            or_queryset = None
-            queryset_init = False
-            for v in value:
-                if v.get("lower_bound") is not None and v.get("upper_bound") is not None:
-                    if queryset_init:
-                        or_queryset |= UniversalAwardView.objects.filter(
-                            total_obligation__gt=v["lower_bound"],
-                            total_obligation__lt=v["upper_bound"])
-                    else:
-                        queryset_init = True
-                        or_queryset = UniversalAwardView.objects.filter(
-                            total_obligation__gt=v["lower_bound"],
-                            total_obligation__lt=v["upper_bound"])
-                elif v.get("lower_bound") is not None:
-                    if queryset_init:
-                        or_queryset |= UniversalAwardView.objects.filter(
-                            total_obligation__gt=v["lower_bound"])
-                    else:
-                        queryset_init = True
-                        or_queryset = UniversalAwardView.objects.filter(
-                            total_obligation__gt=v["lower_bound"])
-                elif v.get("upper_bound") is not None:
-                    if queryset_init:
-                        or_queryset |= UniversalAwardView.objects.filter(
-                            total_obligation__lt=v["upper_bound"])
-                    else:
-                        queryset_init = True
-                        or_queryset = UniversalAwardView.objects.filter(
-                            total_obligation__lt=v["upper_bound"])
-                else:
-                    raise InvalidParameterException('Invalid filter: award amount has incorrect object.')
-            if queryset_init:
+            success, or_queryset = total_obligation_queryset(value, UniversalAwardView)
+            if success:
                 queryset &= or_queryset
 
         elif key == "award_ids":


### PR DESCRIPTION
- Updating award_filter to use total_obl_bin for preset monetary ranges
- Updating non-preset ranges to include the lower and upper bounds instead of ignoring them