### PR TITLE
Autocomplete searches subtier abbrev

### DIFF
--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -1,4 +1,4 @@
-from django.db.models import F
+from django.db.models import F, Q
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_extensions.cache.decorators import cache_response
@@ -40,11 +40,13 @@ class BaseAutocompleteViewSet(APIView):
     # Shared autocomplete...
     def agency_autocomplete(self, request):
         """Search by subtier agencies, return all, with toptiers first"""
+
         search_text, limit = self.get_request_payload(request)
 
         queryset = Agency.objects.filter(
-            subtier_agency__name__icontains=search_text). \
-            order_by('-toptier_flag')
+            Q(subtier_agency__name__icontains=search_text)
+            | Q(subtier_agency__abbreviation__icontains=search_text)
+            ).order_by('-toptier_flag')
 
         return Response(
             {'results': AgencySerializer(queryset[:limit], many=True).data}


### PR DESCRIPTION
Per bug DS-1708: 

> As identified in the PMO team's QA review: When searching in Funding Agency or Awarding Agency, "USDA" will not bring up Department of Agriculture, HHS does not bring up Health and Human Services, etc. If you put a space between each letter in the acronym it does work, but that is not intuitive to do.

https://federal-spending-transparency.atlassian.net/browse/DS-1708

```
url = 'http://localhost:8000/api/v2/autocomplete/awarding_agency'
payload = json.loads('''{"search_text":"usda","limit":20}''')
import requests
resp = requests.post(url, payload)
resp.json()
```
result 

```
{'results': [{'id': 112,
   'office_agency': None,
   'subtier_agency': {'abbreviation': 'USDA',
    'name': 'Department of Agriculture',
    'subtier_code': '1200'},
   'toptier_agency': {'abbreviation': 'USDA',
    'cgac_code': '012',
    'fpds_code': '1200',
    'name': 'Department of Agriculture'},
   'toptier_flag': True}]}
```

## Performance impact 

(testing on the chunk of code above with %timeit):

Without change, 667 ms ± 18 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

With change, 843 ms ± 112 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

