### PR TITLE
MatView now accounts for IDV Contracts

### DIFF
--- a/usaspending_api/database_scripts/matviews/universal_award_matview.sql
+++ b/usaspending_api/database_scripts/matviews/universal_award_matview.sql
@@ -128,7 +128,7 @@ LEFT OUTER JOIN
     ON (FA."office_agency_id" = FAO."office_agency_id")
 WHERE
   "awards"."latest_transaction_id" IS NOT NULL AND
-  "awards"."category" IS NOT NULL AND
+  ("awards"."category" IS NOT NULL or ("contract_data"."pulled_from"='IDV')AND
   latest_transaction."action_date" >= '2007-10-01';
 
 

--- a/usaspending_api/database_scripts/matviews/universal_award_matview.sql
+++ b/usaspending_api/database_scripts/matviews/universal_award_matview.sql
@@ -128,7 +128,7 @@ LEFT OUTER JOIN
     ON (FA."office_agency_id" = FAO."office_agency_id")
 WHERE
   "awards"."latest_transaction_id" IS NOT NULL AND
-  ("awards"."category" IS NOT NULL or ("contract_data"."pulled_from"='IDV')AND
+  ("awards"."category" IS NOT NULL or "contract_data"."pulled_from"='IDV')AND
   latest_transaction."action_date" >= '2007-10-01';
 
 


### PR DESCRIPTION
IDV contracts where not focused because their category would be null.  This change will surface IDV contracts the next time the mat view is run.