### PR TITLE
Added new GIN index on business categories

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
@@ -213,6 +213,10 @@
       "name": "type_set_aside",
       "where": "\"type_set_aside\" IS NOT NULL",
       "columns": [{"name": "\"type_set_aside\""}]
+    }, {
+      "name": "business_categories",
+      "method": "GIN",
+      "columns": [{"name": "\"business_categories\""}]
     }
   ]
 }

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
@@ -201,6 +201,10 @@
         "name": "type_set_aside",
         "where": "\"type_set_aside\" IS NOT NULL",
         "columns": [{"name": "\"type_set_aside\""}]
+    }, {
+      "name": "business_categories",
+      "method": "GIN",
+      "columns": [{"name": "\"business_categories\""}]
     }
   ]
 }

--- a/usaspending_api/database_scripts/matview_generator/universal_award_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/universal_award_matview.json
@@ -305,6 +305,10 @@
       "name": "naics_description",
       "method": "GIN",
       "columns": [{"name": "UPPER(\"naics_description\")", "opclass": "gin_trgm_ops"}]
+    }, {
+      "name": "business_categories",
+      "method": "GIN",
+      "columns": [{"name": "\"business_categories\""}]
     }
   ]
 }

--- a/usaspending_api/database_scripts/matview_generator/universal_transaction_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/universal_transaction_matview.json
@@ -358,6 +358,10 @@
       "name": "original_loan_subsidy_cost",
       "where": "\"original_loan_subsidy_cost\" IS NOT NULL",
       "columns": [{"name": "\"original_loan_subsidy_cost\""}]
+    }, {
+      "name": "business_categories",
+      "method": "GIN",
+      "columns": [{"name": "\"business_categories\""}]
     }
   ]
 }

--- a/usaspending_api/database_scripts/matviews/summary_transaction_month_view.sql
+++ b/usaspending_api/database_scripts/matviews/summary_transaction_month_view.sql
@@ -145,6 +145,7 @@ CREATE INDEX idx_9e65a28f__type_of_contract_temp ON summary_transaction_month_vi
 CREATE INDEX idx_9e65a28f__fy_set_aside_temp ON summary_transaction_month_view_temp USING BTREE("fiscal_year" DESC NULLS LAST, "type_set_aside") WITH (fillfactor = 100);
 CREATE INDEX idx_9e65a28f__extent_competed_temp ON summary_transaction_month_view_temp USING BTREE("extent_competed") WITH (fillfactor = 100);
 CREATE INDEX idx_9e65a28f__type_set_aside_temp ON summary_transaction_month_view_temp USING BTREE("type_set_aside") WITH (fillfactor = 100) WHERE "type_set_aside" IS NOT NULL;
+CREATE INDEX idx_9e65a28f__business_categories_temp ON summary_transaction_month_view_temp USING GIN("business_categories");
 
 CLUSTER VERBOSE summary_transaction_month_view_temp USING idx_9e65a28f__date_temp;
 
@@ -175,6 +176,7 @@ ALTER INDEX IF EXISTS idx_9e65a28f__type_of_contract RENAME TO idx_9e65a28f__typ
 ALTER INDEX IF EXISTS idx_9e65a28f__fy_set_aside RENAME TO idx_9e65a28f__fy_set_aside_old;
 ALTER INDEX IF EXISTS idx_9e65a28f__extent_competed RENAME TO idx_9e65a28f__extent_competed_old;
 ALTER INDEX IF EXISTS idx_9e65a28f__type_set_aside RENAME TO idx_9e65a28f__type_set_aside_old;
+ALTER INDEX IF EXISTS idx_9e65a28f__business_categories RENAME TO idx_9e65a28f__business_categories_old;
 
 ALTER MATERIALIZED VIEW summary_transaction_month_view_temp RENAME TO summary_transaction_month_view;
 ALTER INDEX idx_9e65a28f__date_temp RENAME TO idx_9e65a28f__date;
@@ -201,3 +203,4 @@ ALTER INDEX idx_9e65a28f__type_of_contract_temp RENAME TO idx_9e65a28f__type_of_
 ALTER INDEX idx_9e65a28f__fy_set_aside_temp RENAME TO idx_9e65a28f__fy_set_aside;
 ALTER INDEX idx_9e65a28f__extent_competed_temp RENAME TO idx_9e65a28f__extent_competed;
 ALTER INDEX idx_9e65a28f__type_set_aside_temp RENAME TO idx_9e65a28f__type_set_aside;
+ALTER INDEX idx_9e65a28f__business_categories_temp RENAME TO idx_9e65a28f__business_categories;

--- a/usaspending_api/database_scripts/matviews/summary_transaction_view.sql
+++ b/usaspending_api/database_scripts/matviews/summary_transaction_view.sql
@@ -145,6 +145,7 @@ CREATE INDEX idx_d625130a__type_of_contract_temp ON summary_transaction_view_tem
 CREATE INDEX idx_d625130a__ordered_fy_set_aside_temp ON summary_transaction_view_temp USING BTREE("fiscal_year" DESC NULLS LAST, "type_set_aside") WITH (fillfactor = 100);
 CREATE INDEX idx_d625130a__extent_competed_temp ON summary_transaction_view_temp USING BTREE("extent_competed") WITH (fillfactor = 100);
 CREATE INDEX idx_d625130a__type_set_aside_temp ON summary_transaction_view_temp USING BTREE("type_set_aside") WITH (fillfactor = 100) WHERE "type_set_aside" IS NOT NULL;
+CREATE INDEX idx_d625130a__business_categories_temp ON summary_transaction_view_temp USING GIN("business_categories");
 
 VACUUM ANALYZE VERBOSE summary_transaction_view_temp;
 
@@ -173,6 +174,7 @@ ALTER INDEX IF EXISTS idx_d625130a__type_of_contract RENAME TO idx_d625130a__typ
 ALTER INDEX IF EXISTS idx_d625130a__ordered_fy_set_aside RENAME TO idx_d625130a__ordered_fy_set_aside_old;
 ALTER INDEX IF EXISTS idx_d625130a__extent_competed RENAME TO idx_d625130a__extent_competed_old;
 ALTER INDEX IF EXISTS idx_d625130a__type_set_aside RENAME TO idx_d625130a__type_set_aside_old;
+ALTER INDEX IF EXISTS idx_d625130a__business_categories RENAME TO idx_d625130a__business_categories_old;
 
 ALTER MATERIALIZED VIEW summary_transaction_view_temp RENAME TO summary_transaction_view;
 ALTER INDEX idx_d625130a__ordered_action_date_temp RENAME TO idx_d625130a__ordered_action_date;
@@ -199,3 +201,4 @@ ALTER INDEX idx_d625130a__type_of_contract_temp RENAME TO idx_d625130a__type_of_
 ALTER INDEX idx_d625130a__ordered_fy_set_aside_temp RENAME TO idx_d625130a__ordered_fy_set_aside;
 ALTER INDEX idx_d625130a__extent_competed_temp RENAME TO idx_d625130a__extent_competed;
 ALTER INDEX idx_d625130a__type_set_aside_temp RENAME TO idx_d625130a__type_set_aside;
+ALTER INDEX idx_d625130a__business_categories_temp RENAME TO idx_d625130a__business_categories;

--- a/usaspending_api/database_scripts/matviews/universal_award_matview.sql
+++ b/usaspending_api/database_scripts/matviews/universal_award_matview.sql
@@ -177,6 +177,7 @@ CREATE INDEX idx_fdbd0c97__product_or_service_code_temp ON universal_award_matvi
 CREATE INDEX idx_fdbd0c97__gin_product_or_service_description_temp ON universal_award_matview_temp USING GIN(("product_or_service_description") gin_trgm_ops);
 CREATE INDEX idx_fdbd0c97__naics_code_temp ON universal_award_matview_temp USING GIN("naics_code" gin_trgm_ops);
 CREATE INDEX idx_fdbd0c97__naics_description_temp ON universal_award_matview_temp USING GIN(UPPER("naics_description") gin_trgm_ops);
+CREATE INDEX idx_fdbd0c97__business_categories_temp ON universal_award_matview_temp USING GIN("business_categories");
 
 CLUSTER VERBOSE universal_award_matview_temp USING idx_fdbd0c97__action_date_temp;
 
@@ -231,6 +232,7 @@ ALTER INDEX IF EXISTS idx_fdbd0c97__product_or_service_code RENAME TO idx_fdbd0c
 ALTER INDEX IF EXISTS idx_fdbd0c97__gin_product_or_service_description RENAME TO idx_fdbd0c97__gin_product_or_service_description_old;
 ALTER INDEX IF EXISTS idx_fdbd0c97__naics_code RENAME TO idx_fdbd0c97__naics_code_old;
 ALTER INDEX IF EXISTS idx_fdbd0c97__naics_description RENAME TO idx_fdbd0c97__naics_description_old;
+ALTER INDEX IF EXISTS idx_fdbd0c97__business_categories RENAME TO idx_fdbd0c97__business_categories_old;
 
 ALTER MATERIALIZED VIEW universal_award_matview_temp RENAME TO universal_award_matview;
 ALTER INDEX idx_fdbd0c97__id_temp RENAME TO idx_fdbd0c97__id;
@@ -281,3 +283,4 @@ ALTER INDEX idx_fdbd0c97__product_or_service_code_temp RENAME TO idx_fdbd0c97__p
 ALTER INDEX idx_fdbd0c97__gin_product_or_service_description_temp RENAME TO idx_fdbd0c97__gin_product_or_service_description;
 ALTER INDEX idx_fdbd0c97__naics_code_temp RENAME TO idx_fdbd0c97__naics_code;
 ALTER INDEX idx_fdbd0c97__naics_description_temp RENAME TO idx_fdbd0c97__naics_description;
+ALTER INDEX idx_fdbd0c97__business_categories_temp RENAME TO idx_fdbd0c97__business_categories;

--- a/usaspending_api/database_scripts/matviews/universal_transaction_matview.sql
+++ b/usaspending_api/database_scripts/matviews/universal_transaction_matview.sql
@@ -178,6 +178,7 @@ CREATE INDEX idx_09492a43__naics_code_temp ON universal_transaction_matview_temp
 CREATE INDEX idx_09492a43__naics_description_temp ON universal_transaction_matview_temp USING GIN(UPPER("naics_description") gin_trgm_ops);
 CREATE INDEX idx_09492a43__face_value_loan_guarantee_temp ON universal_transaction_matview_temp USING BTREE("face_value_loan_guarantee") WITH (fillfactor = 100) WHERE "face_value_loan_guarantee" IS NOT NULL;
 CREATE INDEX idx_09492a43__original_loan_subsidy_cost_temp ON universal_transaction_matview_temp USING BTREE("original_loan_subsidy_cost") WITH (fillfactor = 100) WHERE "original_loan_subsidy_cost" IS NOT NULL;
+CREATE INDEX idx_09492a43__business_categories_temp ON universal_transaction_matview_temp USING GIN("business_categories");
 
 CLUSTER VERBOSE universal_transaction_matview_temp USING idx_09492a43__action_date_temp;
 
@@ -249,6 +250,7 @@ ALTER INDEX IF EXISTS idx_09492a43__naics_code RENAME TO idx_09492a43__naics_cod
 ALTER INDEX IF EXISTS idx_09492a43__naics_description RENAME TO idx_09492a43__naics_description_old;
 ALTER INDEX IF EXISTS idx_09492a43__face_value_loan_guarantee RENAME TO idx_09492a43__face_value_loan_guarantee_old;
 ALTER INDEX IF EXISTS idx_09492a43__original_loan_subsidy_cost RENAME TO idx_09492a43__original_loan_subsidy_cost_old;
+ALTER INDEX IF EXISTS idx_09492a43__business_categories RENAME TO idx_09492a43__business_categories_old;
 
 ALTER MATERIALIZED VIEW universal_transaction_matview_temp RENAME TO universal_transaction_matview;
 ALTER INDEX idx_09492a43__transaction_id_temp RENAME TO idx_09492a43__transaction_id;
@@ -316,3 +318,4 @@ ALTER INDEX idx_09492a43__naics_code_temp RENAME TO idx_09492a43__naics_code;
 ALTER INDEX idx_09492a43__naics_description_temp RENAME TO idx_09492a43__naics_description;
 ALTER INDEX idx_09492a43__face_value_loan_guarantee_temp RENAME TO idx_09492a43__face_value_loan_guarantee;
 ALTER INDEX idx_09492a43__original_loan_subsidy_cost_temp RENAME TO idx_09492a43__original_loan_subsidy_cost;
+ALTER INDEX idx_09492a43__business_categories_temp RENAME TO idx_09492a43__business_categories;


### PR DESCRIPTION
The `business_categories` column wasn't properly indexed. It is used for "Recipient Type" searches

### Example Performance Diff
Endpoint: `/api/v2/search/spending_by_award_count/`
JSON: `{"filters":{"time_period":[{"start_date":"2012-10-01","end_date":"2013-09-30"},{"start_date":"2013-10-01","end_date":"2014-09-30"},{"start_date":"2014-10-01","end_date":"2015-09-30"},{"start_date":"2015-10-01","end_date":"2016-09-30"},{"start_date":"2016-10-01","end_date":"2017-09-30"},{"start_date":"2017-10-01","end_date":"2018-09-30"},{"start_date":"2007-10-01","end_date":"2008-09-30"},{"start_date":"2008-10-01","end_date":"2009-09-30"},{"start_date":"2009-10-01","end_date":"2010-09-30"},{"start_date":"2010-10-01","end_date":"2011-09-30"},{"start_date":"2011-10-01","end_date":"2012-09-30"}],"recipient_type_names":["nonprofit"]},"auditTrail":"Award Table - Tab Counts"}`

Original: timeout
New: 7s