### PR TITLE
Fixed typo (county vs country col name)

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
@@ -16,7 +16,7 @@
     "  recipient_location.\"zip5\" AS \"recipient_location_zip5\",",
 
     "  place_of_performance.\"location_country_code\" AS \"pop_country_code\",",
-    "  place_of_performance.\"county_name\" AS \"pop_country_name\",",
+    "  place_of_performance.\"country_name\" AS \"pop_country_name\",",
     "  place_of_performance.\"state_code\" AS \"pop_state_code\",",
     "  place_of_performance.\"county_code\" AS \"pop_county_code\",",
     "  place_of_performance.\"county_name\" AS \"pop_county_name\",",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
@@ -14,7 +14,7 @@
     "  recipient_location.\"congressional_code\" AS \"recipient_location_congressional_code\",",
     "  recipient_location.\"zip5\" AS \"recipient_location_zip5\",",
     "  place_of_performance.\"location_country_code\" AS \"pop_country_code\",",
-    "  place_of_performance.\"county_name\" AS \"pop_country_name\",",
+    "  place_of_performance.\"country_name\" AS \"pop_country_name\",",
     "  place_of_performance.\"state_code\" AS \"pop_state_code\",",
     "  place_of_performance.\"county_code\" AS \"pop_county_code\",",
     "  place_of_performance.\"county_name\" AS \"pop_county_name\",",

--- a/usaspending_api/database_scripts/matviews/summary_transaction_month_view.sql
+++ b/usaspending_api/database_scripts/matviews/summary_transaction_month_view.sql
@@ -22,7 +22,7 @@ SELECT
   recipient_location."congressional_code" AS "recipient_location_congressional_code",
   recipient_location."zip5" AS "recipient_location_zip5",
   place_of_performance."location_country_code" AS "pop_country_code",
-  place_of_performance."county_name" AS "pop_country_name",
+  place_of_performance."country_name" AS "pop_country_name",
   place_of_performance."state_code" AS "pop_state_code",
   place_of_performance."county_code" AS "pop_county_code",
   place_of_performance."county_name" AS "pop_county_name",

--- a/usaspending_api/database_scripts/matviews/summary_transaction_view.sql
+++ b/usaspending_api/database_scripts/matviews/summary_transaction_view.sql
@@ -22,7 +22,7 @@ SELECT
   recipient_location."congressional_code" AS "recipient_location_congressional_code",
   recipient_location."zip5" AS "recipient_location_zip5",
   place_of_performance."location_country_code" AS "pop_country_code",
-  place_of_performance."county_name" AS "pop_country_name",
+  place_of_performance."country_name" AS "pop_country_name",
   place_of_performance."state_code" AS "pop_state_code",
   place_of_performance."county_code" AS "pop_county_code",
   place_of_performance."county_name" AS "pop_county_name",


### PR DESCRIPTION
small typo with large consequences. incorrectly mapped `county_name` instead of desired `country_name`