### PR TITLE
Removed Django's inefficient icontains from recipient_name

### DIFF
--- a/usaspending_api/awards/v2/filters/matview_award.py
+++ b/usaspending_api/awards/v2/filters/matview_award.py
@@ -45,7 +45,7 @@ def award_filter(filters, model):
         if key == "keyword":
             keyword = value
 
-            compound_or = Q(recipient_name__icontains=keyword) | \
+            compound_or = Q(recipient_name__contains=keyword.upper()) | \
                 Q(piid=keyword) | \
                 Q(fain=keyword) | \
                 Q(recipient_unique_id=keyword) | \
@@ -140,7 +140,7 @@ def award_filter(filters, model):
                 raise InvalidParameterException('Invalid filter: recipient_search_text must have exactly one value.')
             recipient_string = str(value[0])
 
-            filter_obj = Q(recipient_name__icontains=recipient_string)
+            filter_obj = Q(recipient_name__contains=recipient_string.upper())
 
             if len(recipient_string) == 9:
                 filter_obj |= Q(recipient_unique_id__iexact=recipient_string)

--- a/usaspending_api/awards/v2/filters/matview_transaction.py
+++ b/usaspending_api/awards/v2/filters/matview_transaction.py
@@ -45,7 +45,7 @@ def transaction_filter(filters, model):
         if key == "keyword":
             keyword = value
 
-            compound_or = Q(recipient_name__icontains=keyword) | \
+            compound_or = Q(recipient_name__contains=keyword.upper()) | \
                 Q(piid=keyword) | \
                 Q(fain=keyword) | \
                 Q(recipient_unique_id=keyword) | \
@@ -139,7 +139,7 @@ def transaction_filter(filters, model):
                 raise InvalidParameterException('Invalid filter: recipient_search_text must have exactly one value.')
             recipient_string = str(value[0])
 
-            filter_obj = Q(recipient_name__icontains=recipient_string)
+            filter_obj = Q(recipient_name__contains=recipient_string.upper())
 
             if len(recipient_string) == 9:
                 filter_obj |= Q(recipient_unique_id__iexact=recipient_string)


### PR DESCRIPTION
Recipient_name is already upper-case in the matviews

### Example Performance Diff
FY2018, FY2017, FY2016, FY2015, Recipient Lockheed Martin - Table Count
Original: (35.6s, 19.2s, 17.8s)
New: 1.6s
