### PR TITLE
Hotfix: Fix for location country code between matview and normal filters

### DIFF
--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -72,13 +72,11 @@ def get_fields_list(scope, field_value, loc_dict):
 
 def return_query_strings(use_matview):
     # Returns query strings according based on mat view or database
-    loc_dict = LOCATION_MAPPING
+    loc_dict = LOCATION_MAPPING.copy()
     q_str = '{0}__{1}__in'
 
     if use_matview:
         q_str = '{0}_{1}__in'
         loc_dict['country'] = 'country_code'
-    else:
-        loc_dict['country'] = 'location_country_code'
 
     return q_str, loc_dict

--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -78,5 +78,7 @@ def return_query_strings(use_matview):
     if use_matview:
         q_str = '{0}_{1}__in'
         loc_dict['country'] = 'country_code'
+    else:
+        loc_dict['country'] = 'location_country_code'
 
     return q_str, loc_dict


### PR DESCRIPTION
For baby download, the matviews are not used and thus the `loc_dict` should use the `location_country_code` instead of the `country_code`