### PR TITLE
Bugfix: Distinct Subagencies for Award Search

### DIFF
--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -46,7 +46,8 @@ class BaseAutocompleteViewSet(APIView):
         queryset = Agency.objects.filter(
             Q(subtier_agency__name__icontains=search_text)
             | Q(subtier_agency__abbreviation__icontains=search_text)
-            ).order_by('-toptier_flag')
+            ).order_by('-toptier_flag', 'toptier_agency_id', 'subtier_agency__name').distinct(
+                'toptier_flag', 'toptier_agency_id', 'subtier_agency__name')
 
         return Response(
             {'results': AgencySerializer(queryset[:limit], many=True).data}


### PR DESCRIPTION
Removes duplicate subtier agencies (funding and awarding) on the Award Search page