### PR TITLE
Bugfix: Display 'All' Agency Name monthly downloads

### DIFF
--- a/usaspending_api/bulk_download/v2/views.py
+++ b/usaspending_api/bulk_download/v2/views.py
@@ -394,6 +394,8 @@ class ListMonthylDownloadsViewset(APIView):
                 if agency:
                     agency_name = agency[0]['name']
                     agency_abbr = agency[0]['abbreviation']
+            else:
+                agency_name = 'All'
             # Simply adds dashes for the date, 20180101 -> 2018-01-01, could also use strftime
             updated_date = '-'.join([name_data[3][:4], name_data[3][4:6], name_data[3][6:]])
             downloads.append({'fiscal_year': name_data[0],


### PR DESCRIPTION
Previously it was blank, this sets it to 'All'. Tested with local dev frontend.