### PR TITLE
Fixed new bug in /v2/download/count/ when there are no rows

### DIFF
--- a/usaspending_api/download/v2/views.py
+++ b/usaspending_api/download/v2/views.py
@@ -180,7 +180,7 @@ class DownloadTransactionCountViewSet(APIView):
             # "summary" materialized views are pre-aggregated and contain a counts col
             total_count = queryset.aggregate(total_count=Sum('counts'))['total_count']
 
-        if total_count > settings.MAX_DOWNLOAD_LIMIT:
+        if total_count and total_count > settings.MAX_DOWNLOAD_LIMIT:
             is_over_limit = True
 
         result = {


### PR DESCRIPTION
Due to different django functions returning different values (None vs 0)