### PR TITLE
Removing string literal f with regards to Python 3.5 string formatting

### DIFF
--- a/usaspending_api/broker/management/commands/update_agency_code_999_fpds.py
+++ b/usaspending_api/broker/management/commands/update_agency_code_999_fpds.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def get_broker_data(fiscal_year, fy_start, fy_end):
-        sql_statment = f"""
+        sql_statment = """
         CREATE TEMPORARY TABlE fpds_agencies_to_update_{fiscal_year} AS
         SELECT * FROM dblink('broker_server',
         '
@@ -50,7 +50,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def update_website(fiscal_year):
-        sql_statement = f"""
+        sql_statement = """
         -- Updating awarding agency code
         UPDATE transaction_fpds
         SET


### PR DESCRIPTION
Fixing syntax error for running script
