### PR TITLE
Hotfix dev 293 fabs records not deleting

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         # Iterate through the result dict and determine what needs to be deleted and what needs to be added
         for row in db_rows:
             if row['correction_late_delete_ind'] and row['correction_late_delete_ind'].upper() == 'D':
-                ids_to_delete += [row['published_award_financial_assistance_id']]
+                ids_to_delete += [row['afa_generated_unique']]
                 # remove the row from the list of rows from the Broker since once we delete it, we don't care about it.
                 # all that'll be left in db_rows are rows we want to insert
                 db_rows.remove(row)
@@ -80,7 +80,7 @@ class Command(BaseCommand):
 
         # This cascades deletes for TransactionFABS & Awards in addition to deleting TransactionNormalized records
         TransactionNormalized.objects.\
-            filter(assistance_data__published_award_financial_assistance_id__in=ids_to_delete).delete()
+            filter(assistance_data__afa_generated_unique__in=ids_to_delete).delete()
 
     @staticmethod
     def insert_new_fabs(to_insert, total_rows):


### PR DESCRIPTION
Fixing how we delete old FABS records. We now delete using the afa_generated_unique, which carries over, as opposed to the ID which would never point to the right one.