### PR TITLE
Changed agency filter to be more restrictive

### DIFF
--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -110,19 +110,20 @@ def matview_search_filter(filters, model):
                 else:
                     raise InvalidParameterException('Invalid filter: agencies ' + type + ' type is invalid.')
 
-            award_queryfilter = Q()
+            awarding_queryfilter = Q()
+            funding_queryfilter = Q()
 
             # Since these are Q filters, no DB hits for boolean checks
             if funding_toptier:
-                award_queryfilter &= funding_toptier
+                funding_queryfilter |= funding_toptier
             if funding_subtier:
-                award_queryfilter &= funding_subtier
+                funding_queryfilter |= funding_subtier
             if awarding_toptier:
-                award_queryfilter &= awarding_toptier
+                awarding_queryfilter |= awarding_toptier
             if awarding_subtier:
-                award_queryfilter &= awarding_subtier
+                awarding_queryfilter |= awarding_subtier
 
-            queryset = queryset.filter(award_queryfilter)
+            queryset = queryset.filter(funding_queryfilter & awarding_queryfilter)
 
         elif key == "legal_entities":
             in_query = [v for v in value]

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -114,13 +114,13 @@ def matview_search_filter(filters, model):
 
             # Since these are Q filters, no DB hits for boolean checks
             if funding_toptier:
-                award_queryfilter |= funding_toptier
+                award_queryfilter &= funding_toptier
             if funding_subtier:
-                award_queryfilter |= funding_subtier
+                award_queryfilter &= funding_subtier
             if awarding_toptier:
-                award_queryfilter |= awarding_toptier
+                award_queryfilter &= awarding_toptier
             if awarding_subtier:
-                award_queryfilter |= awarding_subtier
+                award_queryfilter &= awarding_subtier
 
             queryset = queryset.filter(award_queryfilter)
 


### PR DESCRIPTION
Changed Django queryset to `and` the agency types instead of `or`

- [ ] Bug Team Review

## Example
**URL** `/api/v2/search/spending_over_time/`
**Post Body**
`{"group":"fiscal_year","filters":{"time_period":[{"start_date":"2017-10-01","end_date":"2018-09-30"},{"start_date":"2016-10-01","end_date":"2017-09-30"},{"start_date":"2015-10-01","end_date":"2016-09-30"}],"agencies":[{"type":"funding","tier":"toptier","name":"Department` of Health and Human Services"},{"type":"awarding","tier":"toptier","name":"Department of Energy"}]},"auditTrail":"Spending Over Time Visualization"}`


### JSON Response
**OLD**
`{
    "group": "fiscal_year",
    "results": [
        {
            "time_period": {
                "fiscal_year": "2016"
            },
            "aggregated_amount": 55128610527.77
        },
        {
            "time_period": {
                "fiscal_year": "2017"
            },
            "aggregated_amount": 57419112361.06
        },
        {
            "time_period": {
                "fiscal_year": "2018"
            },
            "aggregated_amount": 6411673226.17
        }
    ]
}`

**NEW**
`{
    "group": "fiscal_year",
    "results": [
        {
            "time_period": {
                "fiscal_year": "2016"
            },
            "aggregated_amount": 6981081.84
        }
    ]
}`

### SQL
**OLD**
`SELECT "summary_view"."fiscal_year", SUM("summary_view"."federal_action_obligation") AS "federal_action_obligation" FROM "summary_view" WHERE ("summary_view"."fiscal_year" IN (2016, 2017, 2018) AND ("summary_view"."funding_toptier_agency_name" = 'Department of Health and Human Services' OR "summary_view"."awarding_toptier_agency_name" = 'Department of Energy')) GROUP BY "summary_view"."fiscal_year";`

**NEW**
`SELECT "summary_view"."fiscal_year", SUM("summary_view"."federal_action_obligation") AS "federal_action_obligation" FROM "summary_view" WHERE ("summary_view"."fiscal_year" IN (2016, 2017, 2018) AND "summary_view"."funding_toptier_agency_name" = 'Department of Health and Human Services' AND "summary_view"."awarding_toptier_agency_name" = 'Department of Energy') GROUP BY "summary_view"."fiscal_year";`