### PR TITLE
Hotfix dev 300 agency filter

### DIFF
--- a/usaspending_api/awards/v2/filters/award.py
+++ b/usaspending_api/awards/v2/filters/award.py
@@ -138,39 +138,45 @@ def award_filter(filters):
 
         elif key == "agencies":
             # TODO: Make function to match agencies in award filter throwing dupe error
-            or_queryset = None
-            funding_toptier = []
-            funding_subtier = []
-            awarding_toptier = []
-            awarding_subtier = []
+            funding_toptier = Q()
+            funding_subtier = Q()
+            awarding_toptier = Q()
+            awarding_subtier = Q()
             for v in value:
                 type = v["type"]
                 tier = v["tier"]
                 name = v["name"]
                 if type == "funding":
                     if tier == "toptier":
-                        funding_toptier.append(name)
+                        funding_toptier |= Q(funding_agency__toptier_agency__name=name)
                     elif tier == "subtier":
-                        funding_subtier.append(name)
+                        funding_subtier |= Q(funding_agency__subtier_agency__name=name)
                     else:
                         raise InvalidParameterException('Invalid filter: agencies ' + tier + ' tier is invalid.')
                 elif type == "awarding":
                     if tier == "toptier":
-                        awarding_toptier.append(name)
+                        awarding_toptier |= Q(awarding_agency__toptier_agency__name=name)
                     elif tier == "subtier":
-                        awarding_subtier.append(name)
+                        awarding_subtier |= Q(awarding_agency__subtier_agency__name=name)
                     else:
                         raise InvalidParameterException('Invalid filter: agencies ' + tier + ' tier is invalid.')
                 else:
                     raise InvalidParameterException('Invalid filter: agencies ' + type + ' type is invalid.')
-            if len(funding_toptier) != 0:
-                queryset &= Award.objects.filter(funding_agency__toptier_agency__name__in=funding_toptier)
-            if len(funding_subtier) != 0:
-                queryset &= Award.objects.filter(funding_agency__subtier_agency__name__in=funding_subtier)
-            if len(awarding_toptier) != 0:
-                queryset &= Award.objects.filter(awarding_agency__toptier_agency__name__in=awarding_toptier)
-            if len(awarding_subtier) != 0:
-                queryset &= Award.objects.filter(awarding_agency__subtier_agency__name__in=awarding_subtier)
+
+            awarding_queryfilter = Q()
+            funding_queryfilter = Q()
+
+            # Since these are Q filters, no DB hits for boolean checks
+            if funding_toptier:
+                funding_queryfilter |= funding_toptier
+            if funding_subtier:
+                funding_queryfilter |= funding_subtier
+            if awarding_toptier:
+                awarding_queryfilter |= awarding_toptier
+            if awarding_subtier:
+                awarding_queryfilter |= awarding_subtier
+
+            queryset = queryset.filter(funding_queryfilter & awarding_queryfilter)
 
         elif key == "legal_entities":
             or_queryset = []

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -103,13 +103,13 @@ def matview_search_filter(filters, model):
 
             # Since these are Q filters, no DB hits for boolean checks
             if funding_toptier:
-                award_queryfilter |= funding_toptier
+                award_queryfilter &= funding_toptier
             if funding_subtier:
-                award_queryfilter |= funding_subtier
+                award_queryfilter &= funding_subtier
             if awarding_toptier:
-                award_queryfilter |= awarding_toptier
+                award_queryfilter &= awarding_toptier
             if awarding_subtier:
-                award_queryfilter |= awarding_subtier
+                award_queryfilter &= awarding_subtier
 
             queryset = queryset.filter(award_queryfilter)
 

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -99,19 +99,20 @@ def matview_search_filter(filters, model):
                 else:
                     raise InvalidParameterException('Invalid filter: agencies ' + type + ' type is invalid.')
 
-            award_queryfilter = Q()
+            awarding_queryfilter = Q()
+            funding_queryfilter = Q()
 
             # Since these are Q filters, no DB hits for boolean checks
             if funding_toptier:
-                award_queryfilter &= funding_toptier
+                funding_queryfilter |= funding_toptier
             if funding_subtier:
-                award_queryfilter &= funding_subtier
+                funding_queryfilter |= funding_subtier
             if awarding_toptier:
-                award_queryfilter &= awarding_toptier
+                awarding_queryfilter |= awarding_toptier
             if awarding_subtier:
-                award_queryfilter &= awarding_subtier
+                awarding_queryfilter |= awarding_subtier
 
-            queryset = queryset.filter(award_queryfilter)
+            queryset = queryset.filter(funding_queryfilter & awarding_queryfilter)
 
         elif key == "legal_entities":
             in_query = [v for v in value]

--- a/usaspending_api/awards/v2/filters/transaction.py
+++ b/usaspending_api/awards/v2/filters/transaction.py
@@ -139,46 +139,45 @@ def transaction_filter(filters):
         # agencies
         elif key == "agencies":
             # TODO: Make function to match agencies in award filter throwing dupe error
-            funding_toptier = []
-            funding_subtier = []
-            awarding_toptier = []
-            awarding_subtier = []
+            funding_toptier = Q()
+            funding_subtier = Q()
+            awarding_toptier = Q()
+            awarding_subtier = Q()
             for v in value:
                 type = v["type"]
                 tier = v["tier"]
                 name = v["name"]
                 if type == "funding":
                     if tier == "toptier":
-                        funding_toptier.append(name)
+                        funding_toptier |= Q(funding_agency__toptier_agency__name=name)
                     elif tier == "subtier":
-                        funding_subtier.append(name)
+                        funding_subtier |= Q(funding_agency__subtier_agency__name=name)
                     else:
                         raise InvalidParameterException('Invalid filter: agencies ' + tier + ' tier is invalid.')
                 elif type == "awarding":
                     if tier == "toptier":
-                        awarding_toptier.append(name)
+                        awarding_toptier |= Q(awarding_agency__toptier_agency__name=name)
                     elif tier == "subtier":
-                        awarding_subtier.append(name)
+                        awarding_subtier |= Q(awarding_agency__subtier_agency__name=name)
                     else:
                         raise InvalidParameterException('Invalid filter: agencies ' + tier + ' tier is invalid.')
                 else:
                     raise InvalidParameterException('Invalid filter: agencies ' + type + ' type is invalid.')
-            if len(funding_toptier) != 0:
-                queryset &= TransactionNormalized.objects.filter(
-                    funding_agency__toptier_agency__name__in=funding_toptier
-                )
-            if len(funding_subtier) != 0:
-                queryset &= TransactionNormalized.objects.filter(
-                    funding_agency__subtier_agency__name__in=funding_subtier
-                )
-            if len(awarding_toptier) != 0:
-                queryset &= TransactionNormalized.objects.filter(
-                    awarding_agency__toptier_agency__name__in=awarding_toptier
-                )
-            if len(awarding_subtier) != 0:
-                queryset &= TransactionNormalized.objects.filter(
-                    awarding_agency__subtier_agency__name__in=awarding_subtier
-                )
+
+            awarding_queryfilter = Q()
+            funding_queryfilter = Q()
+
+            # Since these are Q filters, no DB hits for boolean checks
+            if funding_toptier:
+                funding_queryfilter |= funding_toptier
+            if funding_subtier:
+                funding_queryfilter |= funding_subtier
+            if awarding_toptier:
+                awarding_queryfilter |= awarding_toptier
+            if awarding_subtier:
+                awarding_queryfilter |= awarding_subtier
+
+            queryset = queryset.filter(funding_queryfilter & awarding_queryfilter)
 
         elif key == "legal_entities":
             or_queryset = []


### PR DESCRIPTION
Related Bug - DEV-300: https://federal-spending-transparency.atlassian.net/browse/DEV-300

1. Fixing matview agency filter to use `and` when filtering funding and awarding agencies
2. Fixing agency filter for download (awards.py & transactions.py) to use `or` when filtering between toptier and subtier agencies for awarding agency and funding agency and match matview filter

## Example
**URL** `/api/v2/search/spending_over_time/`
**Post Body**
```{"group":"fiscal_year","filters":{"time_period":[{"start_date":"2017-10-01","end_date":"2018-09-30"},{"start_date":"2016-10-01","end_date":"2017-09-30"},{"start_date":"2015-10-01","end_date":"2016-09-30"}],"agencies":[{"type":"funding","tier":"toptier","name":"Department` of Health and Human Services"},{"type":"awarding","tier":"toptier","name":"Department of Energy"}]},"auditTrail":"Spending Over Time Visualization"}```

- [x] Backend review

### JSON Response
**OLD**
`{
    "group": "fiscal_year",
    "results": [
        {
            "time_period": {
                "fiscal_year": "2016"
            },
            "aggregated_amount": 55128610527.77
        },
        {
            "time_period": {
                "fiscal_year": "2017"
            },
            "aggregated_amount": 57419112361.06
        },
        {
            "time_period": {
                "fiscal_year": "2018"
            },
            "aggregated_amount": 6411673226.17
        }
    ]
}`

**NEW**
`{
    "group": "fiscal_year",
    "results": [
        {
            "time_period": {
                "fiscal_year": "2016"
            },
            "aggregated_amount": 6981081.84
        }
    ]
}`

### SQL
**OLD**
`SELECT "summary_view"."fiscal_year", SUM("summary_view"."federal_action_obligation") AS "federal_action_obligation" FROM "summary_view" WHERE ("summary_view"."fiscal_year" IN (2016, 2017, 2018) AND ("summary_view"."funding_toptier_agency_name" = 'Department of Health and Human Services' OR "summary_view"."awarding_toptier_agency_name" = 'Department of Energy')) GROUP BY "summary_view"."fiscal_year";`

**NEW**
`SELECT "summary_view"."fiscal_year", SUM("summary_view"."federal_action_obligation") AS "federal_action_obligation" FROM "summary_view" WHERE ("summary_view"."fiscal_year" IN (2016, 2017, 2018) AND "summary_view"."funding_toptier_agency_name" = 'Department of Health and Human Services' AND "summary_view"."awarding_toptier_agency_name" = 'Department of Energy') GROUP BY "summary_view"."fiscal_year";`