### PR TITLE
Hotfix download smart open issue

### DIFF
--- a/usaspending_api/download/filestreaming/csv_selection.py
+++ b/usaspending_api/download/filestreaming/csv_selection.py
@@ -11,8 +11,8 @@ from django.conf import settings
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.download.lookups import JOB_STATUS_DICT
 from usaspending_api.download.v2 import download_column_historical_lookups
-
-logger = logging.getLogger(__name__)
+import traceback
+logger = logging.getLogger('console')
 
 
 def update_number_of_columns(row, download_job):
@@ -132,6 +132,8 @@ def write_csvs(download_job, file_name, columns, sources):
     except Exception as e:
         download_job.job_status_id = JOB_STATUS_DICT['failed']
         download_job.error_message = 'An exception was raised while attempting to write the CSV'
+        logger.error(traceback.format_exc())
+
         if settings.DEBUG:
             download_job.error_message += '\n' + str(e)
     else:

--- a/usaspending_api/download/filestreaming/csv_selection.py
+++ b/usaspending_api/download/filestreaming/csv_selection.py
@@ -127,7 +127,7 @@ def write_csvs(download_job, file_name, columns, sources):
                 # Adding timeout to break the stream if exceeding time limit, closes out thread
                 if time.time() > timeout:
                     raise Exception('Stream exceeded time of {} minutes.'.format(minutes))
-            download_job.file_size = stream.total_size
+            download_job.file_size = stream.tell()
 
     except Exception as e:
         download_job.job_status_id = JOB_STATUS_DICT['failed']

--- a/usaspending_api/download/filestreaming/csv_selection.py
+++ b/usaspending_api/download/filestreaming/csv_selection.py
@@ -121,7 +121,7 @@ def write_csvs(download_job, file_name, columns, sources):
             s3_bucket = boto.s3.connect_to_region(region).get_bucket(bucket)
             conn = s3_bucket.new_key(file_name)
             stream = smart_open.smart_open(
-                's3://{}/{}'.format(bucket,file_name), 'wb', region_name=region)
+                's3://{}/{}'.format(bucket, file_name), 'wb', region_name=region)
             for chunk in zstream:
                 stream.write(chunk)
                 # Adding timeout to break the stream if exceeding time limit, closes out thread

--- a/usaspending_api/download/filestreaming/csv_selection.py
+++ b/usaspending_api/download/filestreaming/csv_selection.py
@@ -121,7 +121,7 @@ def write_csvs(download_job, file_name, columns, sources):
             s3_bucket = boto.s3.connect_to_region(region).get_bucket(bucket)
             conn = s3_bucket.new_key(file_name)
             stream = smart_open.smart_open(
-                conn, 'w')
+                's3://{}/{}'.format(bucket,file_name), 'w', region_name=region)
             for chunk in zstream:
                 stream.write(chunk)
                 # Adding timeout to break the stream if exceeding time limit, closes out thread

--- a/usaspending_api/download/filestreaming/csv_selection.py
+++ b/usaspending_api/download/filestreaming/csv_selection.py
@@ -121,7 +121,7 @@ def write_csvs(download_job, file_name, columns, sources):
             s3_bucket = boto.s3.connect_to_region(region).get_bucket(bucket)
             conn = s3_bucket.new_key(file_name)
             stream = smart_open.smart_open(
-                's3://{}/{}'.format(bucket,file_name), 'w', region_name=region)
+                's3://{}/{}'.format(bucket,file_name), 'wb', region_name=region)
             for chunk in zstream:
                 stream.write(chunk)
                 # Adding timeout to break the stream if exceeding time limit, closes out thread

--- a/usaspending_api/download/filestreaming/csv_selection.py
+++ b/usaspending_api/download/filestreaming/csv_selection.py
@@ -12,8 +12,6 @@ from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.download.lookups import JOB_STATUS_DICT
 from usaspending_api.download.v2 import download_column_historical_lookups
 
-BUFFER_SIZE = (5 * 1024 ** 2)
-
 logger = logging.getLogger(__name__)
 
 
@@ -123,7 +121,7 @@ def write_csvs(download_job, file_name, columns, sources):
             s3_bucket = boto.s3.connect_to_region(region).get_bucket(bucket)
             conn = s3_bucket.new_key(file_name)
             stream = smart_open.smart_open(
-                conn, 'w', min_part_size=BUFFER_SIZE)
+                conn, 'w')
             for chunk in zstream:
                 stream.write(chunk)
                 # Adding timeout to break the stream if exceeding time limit, closes out thread


### PR DESCRIPTION
Smart Open package was upgraded since the last deploy. It was causing the award search download to fail on Dev and Staging. Updated the zipfile writer to match the new library standards.  Additionally added logging to debug  future issues. 

- [x] Backend Code Review
- [x]  Testing on sandbox

