### PR TITLE
Corrected method of adding timezone info to datetime in Python 3.5

### DIFF
--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -3,7 +3,6 @@ import csv
 import os
 import json
 import pandas as pd
-import pytz
 import subprocess
 import tempfile
 
@@ -325,13 +324,12 @@ def gather_deleted_ids(config):
     if config['verbose']:
         printf({'msg': 'CSV data from {} to now'.format(config['starting_date'])})
 
-    to_datetime = datetime.combine(config['starting_date'], datetime.min.time(), tzinfo=pytz.UTC)
     filtered_csv_list = [
         x for x in bucket_objects
         if (
             x.key.endswith('.csv') and
             not x.key.startswith('staging') and
-            x.last_modified >= to_datetime
+            x.last_modified >= config['starting_date']
         )
     ]
 

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -227,8 +227,8 @@ def es_data_loader(client, fetch_jobs, done_jobs, config):
             if os.path.exists(job.csv) and not config['keep']:
                 os.remove(job.csv)
         else:
-            printf({'msg': 'No Job :-( Sleeping 15s', 'f': 'ES Ingest'})
-            sleep(15)
+            printf({'msg': 'No Job. Sleeping 45s', 'f': 'ES Ingest'})
+            sleep(45)
 
     printf({'msg': 'Completed Elasticsearch data load', 'f': 'ES Ingest'})
     return

--- a/usaspending_api/etl/management/commands/es_loader.py
+++ b/usaspending_api/etl/management/commands/es_loader.py
@@ -1,5 +1,4 @@
 import os
-import pytz
 
 from datetime import datetime
 from django.core.management.base import BaseCommand
@@ -69,8 +68,7 @@ class Command(BaseCommand):
         self.config['directory'] = options['dir'] + os.sep
         self.config['provide_deleted'] = options['deleted']
         self.config['recreate'] = options['recreate']
-        self.config['starting_date'] = datetime.strptime(options['since'], '%Y-%m-%d')
-        self.config['starting_date'] = datetime.combine(self.config['starting_date'], datetime.min.time(), tzinfo=pytz.UTC)
+        self.config['starting_date'] = datetime.strptime(options['since'] + '+0000', '%Y-%m-%d%z')
 
         if self.config['recreate'] and self.config['starting_date'] > datetime(2007, 1, 1):
             print('Bad mix of parameters! An index should not be dropped if only a subset of data will be loaded')

--- a/usaspending_api/etl/management/commands/es_loader.py
+++ b/usaspending_api/etl/management/commands/es_loader.py
@@ -1,4 +1,5 @@
 import os
+import pytz
 
 from datetime import datetime
 from django.core.management.base import BaseCommand
@@ -68,9 +69,10 @@ class Command(BaseCommand):
         self.config['directory'] = options['dir'] + os.sep
         self.config['provide_deleted'] = options['deleted']
         self.config['recreate'] = options['recreate']
-        self.config['starting_date'] = datetime.strptime(options['since'], "%Y-%m-%d")
+        self.config['starting_date'] = datetime.strptime(options['since'], '%Y-%m-%d')
+        self.config['starting_date'] = datetime.combine(self.config['starting_date'], datetime.min.time(), tzinfo=pytz.UTC)
 
-        if self.config['recreate'] and self.config['starting_date'] != datetime(2001, 1, 1):
+        if self.config['recreate'] and self.config['starting_date'] > datetime(2007, 1, 1):
             print('Bad mix of parameters! An index should not be dropped if only a subset of data will be loaded')
             raise SystemExit
 

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -1,5 +1,4 @@
 import os
-import pytz
 
 from datetime import datetime
 from django.core.management.base import BaseCommand
@@ -86,8 +85,7 @@ class Command(BaseCommand):
         self.config['recreate'] = options['recreate']
         self.config['stale'] = options['stale']
         self.config['keep'] = options['keep']
-        self.config['starting_date'] = datetime.strptime(options['since'], '%Y-%m-%d')
-        self.config['starting_date'] = datetime.combine(self.config['starting_date'], datetime.min.time(), tzinfo=pytz.UTC)
+        self.config['starting_date'] = datetime.strptime(options['since'] + '+0000', '%Y-%m-%d%z')
 
         if self.config['recreate'] and self.config['starting_date'] > datetime(2007, 1, 1):
             print('Bad mix of parameters! An index should not be dropped if only a subset of data will be loaded')

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             type=int)
         parser.add_argument(
             '--since',
-            default='2001-01-01',
+            default=None,
             type=str,
             help='Start date for computing the delta of changed transactions [YYYY-MM-DD]')
         parser.add_argument(
@@ -85,11 +85,17 @@ class Command(BaseCommand):
         self.config['recreate'] = options['recreate']
         self.config['stale'] = options['stale']
         self.config['keep'] = options['keep']
-        self.config['starting_date'] = datetime.strptime(options['since'] + '+0000', '%Y-%m-%d%z')
 
-        if self.config['recreate'] and self.config['starting_date'] > datetime(2007, 1, 1):
-            print('Bad mix of parameters! An index should not be dropped if only a subset of data will be loaded')
-            raise SystemExit
+        if not options['since']:
+            # Due to the queries used for fetching postgres data, `starting_date` needs to be present and a date
+            #   before the earliest records in S3 and when Postgres records were updated.
+            #   Choose the beginning of FY2008, and made it timezone-award for S3
+            self.config['starting_date'] = datetime.strptime('2007-10-01+0000', '%Y-%m-%d%z')
+        else:
+            if self.config['recreate']:
+                print('Bad mix of parameters! An index should not be dropped if only a subset of data will be loaded')
+                raise SystemExit
+            self.config['starting_date'] = datetime.strptime(options['since'] + '+0000', '%Y-%m-%d%z')
 
         if not os.path.isdir(self.config['directory']):
             printf({'msg': 'Provided directory does not exist'})

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -1,12 +1,14 @@
 import os
+import pytz
 
 from datetime import datetime
 from django.core.management.base import BaseCommand
 from elasticsearch import Elasticsearch
 from multiprocessing import Process, Queue
-from time import perf_counter, sleep
-from usaspending_api import settings
+from time import perf_counter
+from time import sleep
 
+from usaspending_api import settings
 from usaspending_api.etl.es_etl_helpers import AWARD_DESC_CATEGORIES
 from usaspending_api.etl.es_etl_helpers import csv_row_count
 from usaspending_api.etl.es_etl_helpers import DataJob
@@ -84,9 +86,10 @@ class Command(BaseCommand):
         self.config['recreate'] = options['recreate']
         self.config['stale'] = options['stale']
         self.config['keep'] = options['keep']
-        self.config['starting_date'] = datetime.strptime(options['since'], "%Y-%m-%d")
+        self.config['starting_date'] = datetime.strptime(options['since'], '%Y-%m-%d')
+        self.config['starting_date'] = datetime.combine(self.config['starting_date'], datetime.min.time(), tzinfo=pytz.UTC)
 
-        if self.config['recreate'] and self.config['starting_date'] != datetime(2001, 1, 1):
+        if self.config['recreate'] and self.config['starting_date'] > datetime(2007, 1, 1):
             print('Bad mix of parameters! An index should not be dropped if only a subset of data will be loaded')
             raise SystemExit
 


### PR DESCRIPTION
Original code works for Python 3.6. Unfortunately Jenkins runs Python 3.5.