### PR TITLE
Fix nightly loader last update

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -202,6 +202,7 @@ class Command(BaseCommand):
             unique_fabs = TransactionFABS.objects.filter(afa_generated_unique=afa_generated_unique)
 
             if unique_fabs.first():
+                transaction_normalized_dict["update_date"] = datetime.utcnow()
                 # Update TransactionNormalized
                 TransactionNormalized.objects.filter(id=unique_fabs.first().transaction.id).\
                     update(**transaction_normalized_dict)
@@ -262,9 +263,10 @@ class Command(BaseCommand):
             data_load_date_obj = ExternalDataLoadDate.objects. \
                 filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']).first()
             if not data_load_date_obj:
-                date = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
+                date = (datetime.utcnow() - timedelta(days=1)).strftime('%Y-%m-%d')
             else:
                 date = data_load_date_obj.last_load_date
+        start_date = datetime.utcnow().strftime('%Y-%m-%d')
 
         logger.info('Processing data for FABS starting from %s' % date)
 
@@ -317,7 +319,7 @@ class Command(BaseCommand):
 
         # Update the date for the last time the data load was run
         ExternalDataLoadDate.objects.filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']).delete()
-        ExternalDataLoadDate(last_load_date=datetime.now().strftime('%Y-%m-%d'),
+        ExternalDataLoadDate(last_load_date=start_date,
                              external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']).save()
 
         logger.info('FABS NIGHTLY UPDATE FINISHED!')

--- a/usaspending_api/broker/management/commands/fpds_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fpds_nightly_loader.py
@@ -239,6 +239,8 @@ class Command(BaseCommand):
             unique_fpds = TransactionFPDS.objects.filter(detached_award_proc_unique=detached_award_proc_unique)
 
             if unique_fpds.first():
+                transaction_normalized_dict["update_date"] = datetime.utcnow()
+
                 # update TransactionNormalized
                 TransactionNormalized.objects.filter(id=unique_fpds.first().transaction.id).\
                     update(**transaction_normalized_dict)
@@ -274,9 +276,10 @@ class Command(BaseCommand):
             data_load_date_obj = ExternalDataLoadDate.objects. \
                 filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fpds']).first()
             if not data_load_date_obj:
-                date = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
+                date = (datetime.utcnow() - timedelta(days=1)).strftime('%Y-%m-%d')
             else:
                 date = data_load_date_obj.last_load_date
+        start_date = datetime.utcnow().strftime('%Y-%m-%d')
 
         logger.info('Processing data for FPDS starting from %s' % date)
 
@@ -327,7 +330,7 @@ class Command(BaseCommand):
 
         # Update the date for the last time the data load was run
         ExternalDataLoadDate.objects.filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fpds']).delete()
-        ExternalDataLoadDate(last_load_date=datetime.now().strftime('%Y-%m-%d'),
+        ExternalDataLoadDate(last_load_date=start_date,
                              external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fpds']).save()
 
         logger.info('FPDS NIGHTLY UPDATE FINISHED!')

--- a/usaspending_api/etl/executive_compensation_etl.py
+++ b/usaspending_api/etl/executive_compensation_etl.py
@@ -34,7 +34,7 @@ TRIM(high_comp_officer5_amount) != '')
 
 
 # Updates all executive compensation data
-def load_executive_compensation(db_cursor, date):
+def load_executive_compensation(db_cursor, date, start_date):
     logger.info("Getting DUNS/Exec Comp data from broker based on the last pull date of %s..." % str(date))
 
     # Get first page
@@ -92,5 +92,5 @@ def load_executive_compensation(db_cursor, date):
 
     # Update the date for the last time the data load was run
     ExternalDataLoadDate.objects.filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['exec_comp']).delete()
-    ExternalDataLoadDate(last_load_date=datetime.now().strftime('%Y-%m-%d'),
+    ExternalDataLoadDate(last_load_date=start_date,
                          external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['exec_comp']).save()

--- a/usaspending_api/etl/management/commands/load_executive_compensation.py
+++ b/usaspending_api/etl/management/commands/load_executive_compensation.py
@@ -66,5 +66,6 @@ class Command(BaseCommand):
                 date = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
             else:
                 date = data_load_date_obj.last_load_date
+        start_date = datetime.utcnow().strftime('%Y-%m-%d')
 
-        load_executive_compensation(db_cursor, date)
+        load_executive_compensation(db_cursor, date, start_date)


### PR DESCRIPTION
**High level description:**
Fix dates we associate with last run date for the loader.

**Technical details:**
Using the date the script started running (in UTC) instead of the date it finished (not in utc) for the last run date.
Making sure transaction_normalized actually updates the `update_date` when we run the loaders

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed - Verified that update_date properly updates in UTC format
- [x] API Performance evaluation completed and present (N/A)