### PR TITLE
Fixing loans SQL queries

### DIFF
--- a/usaspending_api/broker/management/sql/update_subsidy_cost_awards.sql
+++ b/usaspending_api/broker/management/sql/update_subsidy_cost_awards.sql
@@ -4,4 +4,5 @@ SET total_subsidy_cost = (
         SELECT SUM(original_loan_subsidy_cost)
         FROM transaction_normalized AS tx_norm
         WHERE tx_norm.award_id = aw.id
-    );
+    )
+WHERE category='loans';

--- a/usaspending_api/broker/management/sql/update_subsidy_cost_tx_normalized.sql
+++ b/usaspending_api/broker/management/sql/update_subsidy_cost_tx_normalized.sql
@@ -1,5 +1,5 @@
 -- Update FABS records since they're the only ones that could use original_loan_subsidy_cost
 UPDATE transaction_normalized AS tx_norm
 SET original_loan_subsidy_cost = tx_fabs.original_loan_subsidy_cost
-FROM transaction_fabs as tx_fabs
-WHERE tx_norm.id = tx_fabs.transaction_id;
+FROM transaction_fabs AS tx_fabs
+WHERE tx_norm.id = tx_fabs.transaction_id AND tx_norm.type IN ('07', '08');


### PR DESCRIPTION
**High level description:** 
Limiting SQL queries that propagate loans values to only operate on loan type transactions and awards.

**Technical details:** 
Added `WHERE` clauses to limit queries only to operate on loans. Updated queries have already been run on staging.

**Link to JIRA Ticket:** 
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed and present: (N/A)