### PR TITLE
Fix: Award Download IDV Contracts

### DIFF
--- a/usaspending_api/awards/v2/filters/award.py
+++ b/usaspending_api/awards/v2/filters/award.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # TODO: Performance when multiple false values are initially provided
 def award_filter(filters):
 
-    queryset = Award.objects.filter(latest_transaction_id__isnull=False, category__isnull=False)
+    queryset = Award.objects.filter(latest_transaction_id__isnull=False)
 
     faba_flag = False
     faba_queryset = FinancialAccountsByAwards.objects.filter(award_id__isnull=False)


### PR DESCRIPTION
**High level description:**
When testing baby download, we found that the award table counts weren't matching the row counts in the download awards file. We then found out the universal award filter used for downloads excludes awards where category is null. This then removes that restraint to include the IDV contracts missing beforehand.

**Technical details:**
See High level description.

**Link to JIRA Ticket:**
[DEV-532](https://federal-spending-transparency.atlassian.net/projects/DEV/issues/DEV-532)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed *NA*
- [x] Frontend impact assessment completed *NA*
- [x] Data validation completed 
    ```
    Award Search, Dev Database, All Fiscal Years, Contracts and Loans, 200k+
    Before changes:
        Award Count: 291
        Download Count: 285
    After changes:
        Award Count: 291
        Download Count: 291
    
   ```
- [ ] API Performance evaluation completed and present *NA*