### PR TITLE
Hotfix: Update spending explorer to group recipients by name

### DIFF
--- a/usaspending_api/spending_explorer/v2/filters/explorer.py
+++ b/usaspending_api/spending_explorer/v2/filters/explorer.py
@@ -81,8 +81,8 @@ class Explorer(object):
     def recipient(self):
         # Recipients Queryset
         alt_set = self.alt_set.filter(~Q(transaction_obligated_amount=Decimal('NaN')), award__recipient__isnull=False).\
-            annotate(id=F('award__recipient__legal_entity_id'), type=Value('recipient', output_field=CharField()),
-                     name=F('award__recipient__recipient_name'), code=F('award__recipient__recipient_unique_id')).\
+            annotate(id=F('award__recipient__recipient_name'), type=Value('recipient', output_field=CharField()),
+                     name=F('award__recipient__recipient_name'), code=F('award__recipient__recipient_name')).\
             values('id', 'type', 'name', 'code', 'amount').\
             annotate(total=Sum('transaction_obligated_amount')).\
             order_by('-total')

--- a/usaspending_api/spending_explorer/v2/filters/spending_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/spending_filter.py
@@ -1,6 +1,5 @@
 import logging
 
-from usaspending_api.awards.models import Award
 from usaspending_api.references.models import Agency
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.references.constants import DOD_ARMED_FORCES_CGAC, DOD_CGAC
@@ -113,8 +112,7 @@ def spending_filter(alt_set, queryset, filters, _type):
             # recipient
             elif key == 'recipient':
                 and_queryset = queryset.\
-                    filter(treasury_account__in=alt_set.
-                             filter(award__recipient__recipient_name=value).
+                    filter(treasury_account__in=alt_set.filter(award__recipient__recipient_name=value).
                            values_list('treasury_account_id', flat=True))
                 queryset &= and_queryset
 

--- a/usaspending_api/spending_explorer/v2/filters/spending_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/spending_filter.py
@@ -56,7 +56,7 @@ def spending_filter(alt_set, queryset, filters, _type):
 
             # recipient
             elif key == 'recipient':
-                and_alt_set = alt_set.filter(award__recipient_id=value)
+                and_alt_set = alt_set.filter(award__recipient__recipient_name=value)
                 alt_set &= and_alt_set
 
             # award, award_category
@@ -114,8 +114,7 @@ def spending_filter(alt_set, queryset, filters, _type):
             elif key == 'recipient':
                 and_queryset = queryset.\
                     filter(treasury_account__in=alt_set.
-                           filter(award__in=Award.objects.all().
-                                  filter(recipient_id=value)).
+                             filter(award__recipient__recipient_name=value).
                            values_list('treasury_account_id', flat=True))
                 queryset &= and_queryset
 

--- a/usaspending_api/spending_explorer/v2/views/spending_explorer.py
+++ b/usaspending_api/spending_explorer/v2/views/spending_explorer.py
@@ -17,6 +17,6 @@ class SpendingExplorerViewSet(APIView):
         filters = json_request.get('filters', None)
 
         # Returned filtered queryset results
-        results = type_filter(_type, filters, limit=SPENDING_EXPLORER_LIMIT)
+        results = type_filter(_type, filters)
 
         return Response(results)


### PR DESCRIPTION
**High level description:**
Updating spending explorer to group recipients by name and return any awards that match that recipient name when drilling down from recipients to awards.

**Technical details:**
Updating spending explorer logic to group by recipient name and to return awards based on the recipient name instead of ID. Also removing the "limit" since the grouping should handle the large amount of duplication previously present.

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed:
  - No frontend impact as confirmed by @kevinli-work 
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed and present:
    ```
    Timing changes (example of going from FY 18, Q1 Budget Function -> Social Security -> Recipient):
        Before =  11.7 seconds & 5.3 mb response (500 error b/c of cache size limit)
        After = ~7.8 seconds & 269.1 kb response
    ```