### PR TITLE
Adding original_loan_subsidy_cost to the top level award serializer

### DIFF
--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -266,6 +266,7 @@ class AwardSerializer(LimitableSerializer):
             "total_obligation",
             "total_outlay",
             "total_subsidy_cost",
+            "latest_transaction__original_loan_subsidy_cost",
             "date_signed",
             "description",
             "piid",


### PR DESCRIPTION
**High level description:**
Added original loan subsidy cost field in the response

**Technical details:**
Adding original_loan_subsidy_cost to the top level award serializer

**Link to JIRA Ticket:**
[DEV-552](https://federal-spending-transparency.atlassian.net/browse/DEV-552)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed and present (N/A)