### PR TITLE
Hotfix spending explorer limiting for awards

### DIFF
--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -94,7 +94,7 @@ def type_filter(_type, filters, limit=None):
                     award["name"] = code
             total += award['total']
 
-        alt_set = results[:limit]
+        alt_set = results[:limit] if _type == 'award' else results
 
         results = {
             'total': total,
@@ -124,7 +124,7 @@ def type_filter(_type, filters, limit=None):
         for key, value in total.items():
             total = value
 
-        queryset = queryset[:limit]
+        queryset = queryset[:limit] if _type == 'award' else queryset
 
         results = {
             'total': total,

--- a/usaspending_api/spending_explorer/v2/views/spending_explorer.py
+++ b/usaspending_api/spending_explorer/v2/views/spending_explorer.py
@@ -4,7 +4,7 @@ from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.spending_explorer.v2.filters.type_filter import type_filter
 
 # Limits the amount of results the spending explorer returns
-SPENDING_EXPLORER_LIMIT = 5000
+SPENDING_EXPLORER_LIMIT = 500
 
 
 class SpendingExplorerViewSet(APIView):
@@ -21,6 +21,6 @@ class SpendingExplorerViewSet(APIView):
         filters = json_request.get('filters', None)
 
         # Returned filtered queryset results
-        results = type_filter(_type, filters)
+        results = type_filter(_type, filters, SPENDING_EXPLORER_LIMIT)
 
         return Response(results)


### PR DESCRIPTION
**High level description:**
Limiting award results in spending explorer to 500 records.

**Technical details:**
Changing global limit variable for spending explorer to 500 and only utilizing the limit if the type requested is "award".

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed:
  - Frontend will include text to indicate result set is limited.
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed and present:
    ```
    Timing changes (going down budget function path for SSA and selecting first option until you get to awards):
        Before = Timeout
        After = ~17.6 seconds
    ```