### PR TITLE
Hotfix: Federal account loan value field update

### DIFF
--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -266,7 +266,6 @@ class AwardSerializer(LimitableSerializer):
             "total_obligation",
             "total_outlay",
             "total_subsidy_cost",
-            "latest_transaction__original_loan_subsidy_cost",
             "date_signed",
             "description",
             "piid",
@@ -281,7 +280,9 @@ class AwardSerializer(LimitableSerializer):
             "recipient",
             "date_signed__fy",
             "subaward_count",
-            "total_subaward_amount"
+            "total_subaward_amount",
+            "latest_transaction__assistance_data",
+            "latest_transaction__contract_data"
         ]
         nested_serializers = {
             "recipient": {


### PR DESCRIPTION
**High level description:**
Fixing API response to include necessary loans values

**Technical details:**
Replacing original_loan_subsidy_cost in award serializer with contract_data and assistance_data to provide necessary fields to display `face_value_loan_guarantee` for the spending by award table for loans on the federal account page

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed:
  - `original_loan_subsidy_cost` will no longer be used by frontend. new fields have been communicated to @mab6bf for frontend updates.
- [x] Data validation completed:
  - Value mappings discussed & confirmed with relevant stakeholders. Necessary fields are now part of the API response.
- [x] API Performance evaluation completed and present (N/A)