### PR TITLE
Hotfix: Adding certified_date to response

### DIFF
--- a/usaspending_api/awards/serializers.py
+++ b/usaspending_api/awards/serializers.py
@@ -267,6 +267,7 @@ class AwardSerializer(LimitableSerializer):
             "total_outlay",
             "total_subsidy_cost",
             "date_signed",
+            "certified_date",
             "description",
             "piid",
             "fain",


### PR DESCRIPTION
**High level description:**
Adding field to populate the Issue Date on the spending by award table, loans tab on the federal account profile page

**Technical details:**
Adding certified_date to the award serializer

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed:
  - new field needed by frontend. Communicated to @mab6bf 
- [x] Data validation completed:
  - Value mappings discussed & confirmed with relevant stakeholders. Necessary fields are now part of the API response.
- [x] API Performance evaluation completed and present (N/A)