### PR TITLE
Allow bulk download logic to be used for Advanced Search w/ keyword

### DIFF
--- a/usaspending_api/download/v2/views.py
+++ b/usaspending_api/download/v2/views.py
@@ -225,7 +225,8 @@ class YearLimitedDownloadViewSet(BaseDownloadViewSet):
             raise InvalidParameterException('Missing one or more required query parameters: filters')
 
         # Validate keyword search first, remove all other filters
-        if len(filters.keys()) == 1 and 'keyword' in filters:
+        if 'keyword' in filters and len(filters.keys()) == 1:
+
             request_data['filters'] = {'elasticsearch_keyword': filters['keyword']}
             return
 

--- a/usaspending_api/download/v2/views.py
+++ b/usaspending_api/download/v2/views.py
@@ -225,7 +225,7 @@ class YearLimitedDownloadViewSet(BaseDownloadViewSet):
             raise InvalidParameterException('Missing one or more required query parameters: filters')
 
         # Validate keyword search first, remove all other filters
-        if 'keyword' in filters:
+        if len(filters.keys()) == 1 and 'keyword' in filters:
             request_data['filters'] = {'elasticsearch_keyword': filters['keyword']}
             return
 


### PR DESCRIPTION
**High level description:**
Ensures that a search filter which includes `keyword` will not drop the additional filters and route the queries to Elasticsearch. 

**Technical details:**
Adds additional check to ensure there is only one filter field before routing keyword download queries to Elasticsearch.

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Matview impact assessment completed
- [X] Frontend impact assessment completed (Kevin confirmed no other filters are passed by frontend)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed and present (N/A)