### PR TITLE
Hotfix fix subaward mappings

### DIFF
--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -758,8 +758,8 @@ query_paths = {
             'prime_awardee_name': 'award__latest_transaction__contract_data__awardee_or_recipient_legal',
             'subawardee_duns': 'recipient__recipient_unique_id',
             'subawardee_name': 'recipient__recipient_name',
-            'subawardee_parent_duns': 'award__latest_transaction__contract_data__ultimate_parent_unique_ide',
-            'subawardee_parent_name': 'award__latest_transaction__contract_data__ultimate_parent_legal_enti',
+            'subawardee_parent_duns': 'recipient__parent_recipient_unique_id',
+            # 'subawardee_parent_name': 'recipient__parent_recipient_name', -- need to add this column
             'subawardee_address_line_1': 'recipient__location__address_line1',
             'subawardee_city_name': 'recipient__location__city_name',
             'subawardee_state_code': 'recipient__location__state_code',


### PR DESCRIPTION
**High level description:**
Fixing parent DUNS mappings in subaward download

**Technical details:**
The parent DUNS and parent DUNS name were pointing to the wrong columns. We do not currently store the name so that has been commented out and the parent DUNS itself has been fixed

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [ ] Matview impact assessment completed (N/A)
- [ ] Frontend impact assessment completed (N/A)
- [ ] Data validation completed
- [ ] API Performance evaluation completed and present (N/A)