### PR TITLE
Update logging error message for 400 errors

### DIFF
--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -97,7 +97,12 @@ class LoggingMiddleware(MiddlewareMixin):
         elif 400 <= status_code < 500:
             # Logged at an WARNING level: 4xx (Client error)
             self.log["status"] = 'WARNING'
-            self.server_logger.warning(self.get_message_string(), extra=self.log)
+            self.log["error_msg"] = response.getvalue().decode('ASCII')
+
+            # Adding separate error message to message field for user to view error on Kibana default view
+            error_msg_str = '['+self.log["error_msg"]+']'
+
+            self.server_logger.warning('{} {}'.format(self.get_message_string(), error_msg_str), extra=self.log)
         else:
             # 500 or greater messages will be processed by the process_exception function
             pass

--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -97,7 +97,14 @@ class LoggingMiddleware(MiddlewareMixin):
         elif 400 <= status_code < 500:
             # Logged at an WARNING level: 4xx (Client error)
             self.log["status"] = 'WARNING'
-            self.log["error_msg"] = response.getvalue().decode('ASCII')
+
+            # Get response message
+            try:
+                # If API returns error message
+                self.log["error_msg"] = str(response.data)
+            except AttributeError:
+                # For cases when Django responds with an error template, get the response content (byte string)
+                self.log["error_msg"] = response.getvalue().decode('ASCII')
 
             # Adding separate error message to message field for user to view error on Kibana default view
             error_msg_str = '['+self.log["error_msg"]+']'

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -211,7 +211,7 @@ LOGGING = {
         'user_readable': {
             '()': "pythonjsonlogger.jsonlogger.JsonFormatter",
             'format': "%(timestamp)s %(status)s %(method)s %(path)s %(status_code)s %(remote_addr)s %(host)s " +
-                      "%(response_ms)d %(message)s %(request)s %(traceback)s"
+                      "%(response_ms)d %(message)s %(request)s %(traceback)s %(error_msg)s"
         }
     },
     'handlers': {
@@ -237,7 +237,7 @@ LOGGING = {
         'server': {
             'handlers': ['server'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
         'console': {
             'handlers': ['console', 'console_file'],


### PR DESCRIPTION
**High level description:**
Updating the `server.log` to display the error message when it is a 400-499 status code on Kibana.

**Technical details:**
- Added `error_msg` to the logger format so that it adds it to the log as a field that Kibana can pick up for filtering
- Additionally added the error `message` to the message field to make as requested by the Ops team, to make it easy to spot the error
- Common 400 error codes include:
    1. 400 - Bad request (invalid parameter)
    2. 404 -  Not Found ( endpoint is missing)
    3. 405 -  Method is not allowed 
    4. 422 - Unprocessable Entity ( For elasticsearch)
- Took out propagation so that the server.log would not logged in the console.

**Link to JIRA Ticket:**
N/A - Requested by Ops

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed N/A
- [x] Frontend impact assessment completed N/A
- [x] Data validation completed N/A
- [x] API Performance evaluation completed and present N/A

**Testing Notes**
Pushed code to sandbox and was verified by Hitesh.