### PR TITLE
Fixed issue of splitting up a filepath with spaces in Python SQL script 

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
@@ -89,7 +89,11 @@ def ingest_json(path):
 
 
 def generate_uid(characters=8, filename=None):
-    git_hash = get_git_commit(characters - 1, filename)
+    git_hash = None
+    try:
+        git_hash = get_git_commit(characters - 1, filename)
+    except Exception as e:
+        print('Error: [{}]. Continuing...'.format(e))
     if git_hash is None:
         return str(uuid4())[:characters]
     else:
@@ -98,9 +102,10 @@ def generate_uid(characters=8, filename=None):
 
 def get_git_commit(characters=8, filename=None):
     cmd = 'git log -n 1 --pretty=format:"%H"'
-    if filename and os.path.isfile(filename):
-        cmd += ' -- {}'.format(filename)
     args = cmd.split(' ')
+    if filename and os.path.isfile(filename):
+        args.append(filename)
+
     shell = subprocess.run(args, stdout=subprocess.PIPE, check=True)
     if shell.stdout:
         # First character is a '#' so skip it


### PR DESCRIPTION
**High level description:**
Fix has the script properly handle file paths with spaces. Currently our Jenkins workspace directories contain spaces. PR'ed as hotfix so it can reach `master` branch quicker

**Technical details:**
Split the argument string by spaces before adding the filepath to the command list. Also added a try-except 

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Matview impact assessment completed (N/A)
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)