### PR TITLE
Feature: Locations in Custom Award Search

### DIFF
--- a/usaspending_api/api_docs/api_documentation/download/custom_award_data_download.md
+++ b/usaspending_api/api_docs/api_documentation/download/custom_award_data_download.md
@@ -18,7 +18,21 @@ This route sends a request to the backend to begin generating a zipfile of award
         "date_range": {
             "start_date": "2016-10-01",
             "end_date": "2017-09-30"
-        }
+        },
+        "recipient_locations": [
+            {
+        	"country": "USA",
+            "state": "VA",
+            "county": "059"
+            }
+        ],
+        "place_of_performance_locations": [
+            {
+        	"country": "USA",
+            "state": "VA",
+            "county": "059"
+            }
+       ]
     },
     "columns": [],
     "file_format": "csv"
@@ -45,6 +59,8 @@ This route sends a request to the backend to begin generating a zipfile of award
     * `sub_agency` - *optional* - sub-agency name to include (based on the agency filter)
     * `date_type` - *optional* - choice between two types: "action_date", "last_modified_date"
     * `date_range` - *optional* - object with start and end dates
+    * `recipient_locations` - *optional* - see the same filter from the [Universal Filters](https://github.com/fedspendingtransparency/usaspending-api/wiki/Search-Filters-v2-Documentation#award-id)
+    * `place_of_performance_locations` - *optional* - see the same filter from the [Universal Filters](https://github.com/fedspendingtransparency/usaspending-api/wiki/Search-Filters-v2-Documentation#award-id)
 * `columns` - *optional* - columns to select
 * `file_format` - *optional* - must be `csv`
 

--- a/usaspending_api/api_docs/api_documentation/download/custom_award_data_download.md
+++ b/usaspending_api/api_docs/api_documentation/download/custom_award_data_download.md
@@ -21,14 +21,14 @@ This route sends a request to the backend to begin generating a zipfile of award
         },
         "recipient_locations": [
             {
-        	"country": "USA",
+            "country": "USA",
             "state": "VA",
             "county": "059"
             }
         ],
         "place_of_performance_locations": [
             {
-        	"country": "USA",
+            "country": "USA",
             "state": "VA",
             "county": "059"
             }

--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -84,7 +84,6 @@ def location_error_handling(fields):
     # Request must have country, and can only have 3 fields,
     # and must have state if there is county or district
     if 'country' not in fields:
-
         raise InvalidParameterException(
             'Invalid filter:  Missing necessary location field: country.'
         )

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -56,7 +56,9 @@ VALUE_MAPPINGS['prime_awards'] = VALUE_MAPPINGS['transactions']
 SHARED_FILTER_DEFAULTS = {
     'award_type_codes': list(award_type_mapping.keys()),
     'agencies': [],
-    'time_period': []
+    'time_period': [],
+    'place_of_performance_locations': [],
+    'recipient_locations': []
 }
 YEAR_CONSTRAINT_FILTER_DEFAULTS = {'elasticsearch_keyword': ''}
 ROW_CONSTRAINT_FILTER_DEFAULTS = {
@@ -64,10 +66,8 @@ ROW_CONSTRAINT_FILTER_DEFAULTS = {
     'legal_entities': [],
     'recipient_search_text': [],
     'recipient_scope': '',
-    'recipient_locations': [],
     'recipient_type_names': [],
     'place_of_performance_scope': '',
-    'place_of_performance_locations': [],
     'award_amounts': [],
     'award_ids': [],
     'program_numbers': [],

--- a/usaspending_api/download/v2/views.py
+++ b/usaspending_api/download/v2/views.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import NotFound
 from usaspending_api.accounts.models import FederalAccount
 from usaspending_api.awards.models import Agency
 from usaspending_api.awards.v2.filters.view_selector import download_transaction_count
+from usaspending_api.awards.v2.filters.location_filter_geocode import location_error_handling
 from usaspending_api.awards.v2.lookups.lookups import award_type_mapping, all_award_types_mappings
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.csv_helpers import sqs_queue
@@ -112,6 +113,15 @@ class BaseDownloadViewSet(APIDocumentationView):
             if award_type_code not in award_type_mapping:
                 raise InvalidParameterException('Invalid award_type: {}'.format(award_type_code))
         json_request['filters']['award_type_codes'] = filters['award_type_codes']
+
+        # Validate locations
+        for location_filter in ['place_of_performance_locations', 'recipient_locations']:
+            if filters.get(location_filter):
+                for location_dict in filters[location_filter]:
+                    if not isinstance(location_dict, dict):
+                        raise InvalidParameterException('Location is not a dictionary: {}'.format(location_dict))
+                    location_error_handling(location_dict.keys())
+                json_request['filters'][location_filter] = filters[location_filter]
 
         # Validate time periods
         total_range_count = validate_time_periods(filters, json_request)
@@ -226,7 +236,6 @@ class YearLimitedDownloadViewSet(BaseDownloadViewSet):
 
         # Validate keyword search first, remove all other filters
         if 'keyword' in filters and len(filters.keys()) == 1:
-
             request_data['filters'] = {'elasticsearch_keyword': filters['keyword']}
             return
 
@@ -268,7 +277,6 @@ class YearLimitedDownloadViewSet(BaseDownloadViewSet):
                 del filters['sub_agency']
             else:
                 filters['agencies'] = [{'type': 'awarding', 'tier': 'toptier', 'name': toptier_name}]
-
         del filters['agency']
 
         request_data['filters'] = filters


### PR DESCRIPTION
**High level description:**
Allows Custom Award Data downloads to be filtered by recipient or place of performance locations.

**Technical details:**
* Simply allowing the `recipient_locations` and `place_of_performance_locations` universal filters to be sent to the Custom Award Data download endpoint and validating it before generating the files.

**Link to JIRA Ticket:**
[DEV-653](https://federal-spending-transparency.atlassian.net/browse/DEV-653)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Frontend impact assessment completed
    * [Custom Award Data Endpoint](https://github.com/fedspendingtransparency/usaspending-api/blob/feature-location-custom-award-download/usaspending_api/api_docs/api_documentation/download/custom_award_data_download.md)
- [x] Data validation completed
- [x] API Performance evaluation completed and present N/A