### PR TITLE
Feature sum summary loans include

### DIFF
--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -145,7 +145,6 @@ def get_sum_aggregation_results(keyword, field='transaction_amount'):
                 }
             }
         }
-        
     }
 
     response = es_client_query(index=index_name, body=query, retries=10)
@@ -224,7 +223,7 @@ def get_sum_and_count_aggregation_results(keyword):
                 "sum": {
                     "field": "original_loan_subsidy_cost"
                 }
-            }         
+            }
         },
         "size": 0}
     response = es_client_query(index=index_name, body=query, retries=10)
@@ -233,7 +232,8 @@ def get_sum_and_count_aggregation_results(keyword):
             results = {}
             results["prime_awards_count"] = response['aggregations']["prime_awards_count"]["value"]
             results["prime_awards_obligation_amount"] = \
-                round((response['aggregations']["prime_awards_obligation_amount"]["value"] + response['aggregations']["original_loan_subsidy_cost_sum"]["value"]), 2)
+                round((response['aggregations']["prime_awards_obligation_amount"]["value"] +
+                       response['aggregations']["original_loan_subsidy_cost_sum"]["value"]), 2)
             return results
         except KeyError:
             logger.error('Unexpected Response')

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -206,8 +206,7 @@ def get_download_ids(keyword, field, size=10000):
 
 
 def get_sum_and_count_aggregation_results(keyword):
-    #index_name = '{}-*'.format(TRANSACTIONS_INDEX_ROOT)
-    index_name = "test_index"
+    index_name = '{}-*'.format(TRANSACTIONS_INDEX_ROOT)
     query = {
         "query": base_query(keyword),
         "aggs": {
@@ -219,11 +218,6 @@ def get_sum_and_count_aggregation_results(keyword):
             "prime_awards_count": {
                 "value_count": {
                     "field": "transaction_id"
-                }
-            },
-            "face_value_loan_guarantee_sum": {
-                "sum": {
-                    "field": "face_value_loan_guarantee"
                 }
             },
             "original_loan_subsidy_cost_sum": {
@@ -239,16 +233,7 @@ def get_sum_and_count_aggregation_results(keyword):
             results = {}
             results["prime_awards_count"] = response['aggregations']["prime_awards_count"]["value"]
             results["prime_awards_obligation_amount"] = \
-                round(response['aggregations']["prime_awards_obligation_amount"]["value"] + \
-                response['aggregations']["face_value_loan_guarantee_sum"]["value"] + \
-                response['aggregations']["original_loan_subsidy_cost_sum"]["value"], 2)
-            
-            #this is just for testing, remove these later.
-            results["face_value_loan_guarantee_sum"] = \
-                round(response['aggregations']["face_value_loan_guarantee_sum"]["value"], 2)
-            results["original_loan_subsidy_cost_sum"] = \
-                round(response['aggregations']["original_loan_subsidy_cost_sum"]["value"], 2)
-            
+                round((response['aggregations']["prime_awards_obligation_amount"]["value"] + response['aggregations']["original_loan_subsidy_cost_sum"]["value"]), 2)
             return results
         except KeyError:
             logger.error('Unexpected Response')


### PR DESCRIPTION
High level description:
Adding loan subsidies to the total of transaction sums.

Technical details:

Since the original_loan_subsidies do not have values greater than 0 (below is the main elasticsearch index), I do not need to filter for only loans to get the subsidy costs then add them. Other award types do not have subsidy costs, nor do loans have transaction amounts.

See below:

`curl 52.222.76.101:9200/2018-03-21-transactions/_search?q=original_loan_subsidy_cost:>0 AND transaction_amount:>0`

Simply having 2 aggregations then adding them in the code to get the total is sufficient for the problem.

Link to JIRA Ticket:
DEV-669

The following are ALL required for the PR to be merged:

[ ] - Backend review completed
[ ] - Matview impact assessment completed
[ ] - Frontend impact assessment completed
[X] - Data validation completed
[X] - API Performance evaluation completed and present:

Timing changes:
    Before = X seconds
    After = Y seconds

Data volume changes:
    Before = X rows
    After = Y rows