### PR TITLE
add speedup to update_total_funding_amount

### DIFF
--- a/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
+++ b/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
             join awards a
             on tn.award_id = a.id
             where a.is_fpds = false
-            and tn.funding_amount is not null 
+            and tn.funding_amount is not null
             GROUP BY award_id
         )
         update awards as a

--- a/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
+++ b/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
@@ -42,8 +42,13 @@ class Command(BaseCommand):
 
     SUM_TRANSACTION_TFA = """
         With sum_table as (
-        SELECT award_id, SUM(tn.funding_amount) sum_val
-        FROM transaction_normalized as tn join awards a on tn.award_id = a.id WHERE a.id = tn.award_id GROUP BY award_id
+            SELECT award_id, SUM(tn.funding_amount) sum_val
+            FROM transaction_normalized as tn
+            join awards a
+            on tn.award_id = a.id
+            where a.is_fpds = false
+            and tn.funding_amount is not null 
+            GROUP BY award_id
         )
         update awards as a
         set total_funding_amount=sum_table.sum_val


### PR DESCRIPTION
**High level description:**
total funding amount sql script was too slow.  Added a simple optimization.

**Technical details:**
total funding amount is only influenced by fabs data, so removing all contracts provides huge speedups. 60% speedup on dev, and the speedup should be exponential because of the group by.

**Link to JIRA Ticket:**
NA

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed NA
- [x] Frontend impact assessment completed NA
- [x] Data validation completed NA
- [x] API Performance evaluation completed and present:
    ```
    Timing changes:
        Before = 800 ms
        After = 290 ms
    

