### PR TITLE
Hotfix: updating total funding queries to improve performance

### DIFF
--- a/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
+++ b/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     TRANSACTION_FABS_TFA = """
         UPDATE transaction_normalized AS txn
         SET non_federal_funding_amount = txf.non_federal_funding_amount,
-        funding_amount = federal_action_obligation + txf.non_federal_funding_amount
+        funding_amount = txf.federal_action_obligation + txf.non_federal_funding_amount
         FROM transaction_fabs AS txf
         WHERE txf.transaction_id = txn.id;
     """

--- a/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
+++ b/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
@@ -19,39 +19,26 @@ class Command(BaseCommand):
 
         with connection.cursor() as curs:
             curs.execute(self.TRANSACTION_FABS_TFA)
-            logger.info('total_funding_amount recalculated. {} successful updates'.format(curs.rowcount))
-
-            curs.execute(self.TRANSACTION_NORMALIZED_TFA)
-            logger.info('total_funding_amount moved to the transaction normalized table. {} successful updates'.format(
-                curs.rowcount))
+            logger.info('Updated FABS non_federal_funding_amount, funding_amount in transaction_normalized. '
+                        '{} successful updates'.format(curs.rowcount))
 
             curs.execute(self.SUM_TRANSACTION_TFA)
-            logger.info('New sum for total_funding_amount. {} successful updates'.format(curs.rowcount))
+            logger.info('Updated FABS total_funding_amount in awards. {} successful updates'.format(curs.rowcount))
 
     TRANSACTION_FABS_TFA = """
-        update transaction_normalized as tn
-        set non_federal_funding_amount=tf.non_federal_funding_amount
-        from transaction_fabs as tf
-            where tf.transaction_id=tn.id;
-    """
-
-    TRANSACTION_NORMALIZED_TFA = """
-        update transaction_normalized as tn
-        set funding_amount= federal_action_obligation + non_federal_funding_amount;
+        UPDATE transaction_normalized AS txn
+        SET non_federal_funding_amount = txf.non_federal_funding_amount,
+        funding_amount = federal_action_obligation + txf.non_federal_funding_amount
+        FROM transaction_fabs AS txf
+        WHERE txf.transaction_id = txn.id;
     """
 
     SUM_TRANSACTION_TFA = """
-        With sum_table as (
-            SELECT award_id, SUM(tn.funding_amount) sum_val
-            FROM transaction_normalized as tn
-            join awards a
-            on tn.award_id = a.id
-            where a.is_fpds = false
-            and tn.funding_amount is not null
-            GROUP BY award_id
+        UPDATE awards AS aw
+        SET total_funding_amount = (
+            SELECT SUM(funding_amount)
+            FROM transaction_normalized AS txn
+            WHERE txn.award_id = aw.id
         )
-        update awards as a
-        set total_funding_amount=sum_table.sum_val
-        from sum_table
-        where a.id = sum_table.award_id;
+        WHERE category IS NOT NULL AND category != 'contract';
     """


### PR DESCRIPTION
**High level description:**
Made improvements to queries used to update existing data to recalculate `total_funding_amount`

**Technical details:**
Limited SQL queries to operate only on Assistance data (aka FABS), thus cutting the data volume down to ~36 million rows from ~90 million.

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed and present (N/A)