### PR TITLE
Re-enable api/v2/search/spending_by_category

### DIFF
--- a/usaspending_api/awards/models_matviews.py
+++ b/usaspending_api/awards/models_matviews.py
@@ -123,6 +123,9 @@ class SummaryTransactionView(models.Model):
     awarding_subtier_agency_abbreviation = models.TextField()
     funding_subtier_agency_abbreviation = models.TextField()
 
+    recipient_name = models.TextField()
+    recipient_unique_id = models.TextField()
+    parent_recipient_unique_id = models.TextField()
     business_categories = ArrayField(models.TextField(), default=list)
     cfda_number = models.TextField()
     cfda_title = models.TextField()
@@ -364,6 +367,9 @@ class SummaryTransactionMonthView(models.Model):
     awarding_subtier_agency_abbreviation = models.TextField()
     funding_subtier_agency_abbreviation = models.TextField()
 
+    recipient_name = models.TextField()
+    recipient_unique_id = models.TextField()
+    parent_recipient_unique_id = models.TextField()
     business_categories = ArrayField(models.TextField(), default=list)
     cfda_number = models.TextField(blank=True, null=True)
     cfda_title = models.TextField(blank=True, null=True)

--- a/usaspending_api/awards/v2/filters/view_selector.py
+++ b/usaspending_api/awards/v2/filters/view_selector.py
@@ -294,3 +294,29 @@ def transaction_spending_summary(filters):
         raise InvalidParameterException
 
     return queryset, model
+
+
+def spending_by_category(category, filters):
+    view_chain = []
+    if category in ['awarding_agency', 'funding_agency']:
+        view_chain = ['SummaryView']
+    elif category == 'industry_codes':
+        view_chain = ['SummaryPscCodesView']
+    elif category == 'cfda_programs':
+        view_chain = ['SummaryCfdaNumbersView']
+    elif category == 'naics':
+        view_chain = ['SummaryNaicsCodesView']
+    view_chain.extend([
+        'SummaryTransactionMonthView',
+        'SummaryTransactionView',
+        'UniversalTransactionView'
+    ])
+    for view in view_chain:
+        if can_use_view(filters, view):
+            queryset = get_view_queryset(filters, view)
+            print('spending_by_category using {}'.format(view))
+            break
+    else:
+        raise InvalidParameterException
+
+    return queryset

--- a/usaspending_api/awards/v2/filters/view_selector.py
+++ b/usaspending_api/awards/v2/filters/view_selector.py
@@ -316,6 +316,8 @@ def spending_by_category(category_scope, filters):
         view_chain = ['SummaryNaicsCodesView']
     elif category_scope == 'cfda_programs-':
         view_chain = ['SummaryCfdaNumbersView']
+
+    # All of these category/scope combinations can use the following:
     view_chain.extend([
         'SummaryTransactionMonthView',
         'SummaryTransactionView',
@@ -326,7 +328,6 @@ def spending_by_category(category_scope, filters):
         if can_use_view(filters, view):
             queryset = get_view_queryset(filters, view)
             model = view
-            print('spending_by_category using {}'.format(view))
             break
     else:
         raise InvalidParameterException

--- a/usaspending_api/awards/v2/filters/view_selector.py
+++ b/usaspending_api/awards/v2/filters/view_selector.py
@@ -319,8 +319,8 @@ def spending_by_category(category, filters):
         'SummaryTransactionView',
         'UniversalTransactionView'
     ])
-    if category in ['recipient-duns', 'recipient-parent_duns']:
-        view_chain = ['UniversalTransactionView']
+    # if category in ['recipient-duns', 'recipient-parent_duns']:
+    #     view_chain = ['SummaryTransactionView', 'UniversalTransactionView']
     for view in view_chain:
         if can_use_view(filters, view):
             queryset = get_view_queryset(filters, view)

--- a/usaspending_api/awards/v2/filters/view_selector.py
+++ b/usaspending_api/awards/v2/filters/view_selector.py
@@ -299,28 +299,29 @@ def transaction_spending_summary(filters):
     return queryset, model
 
 
-def spending_by_category(category, filters):
+def spending_by_category(category_scope, filters):
+    # category_scope is a string of <category>-<scope>.
+    # It isn't elegant but it works enough until we can refactor this endpoint into individual endpoints
     view_chain = []
-    if category in [
+    if category_scope in [
         'awarding_agency-agency',
         'funding_agency-agency',
         'awarding_agency-subagency',
         'funding_agency-subagency',
     ]:
         view_chain = ['SummaryView']
-    elif category == 'industry_codes-psc':
+    elif category_scope == 'industry_codes-psc':
         view_chain = ['SummaryPscCodesView']
-    elif category == 'industry_codes-naics':
+    elif category_scope == 'industry_codes-naics':
         view_chain = ['SummaryNaicsCodesView']
-    elif category == 'cfda_programs-':
+    elif category_scope == 'cfda_programs-':
         view_chain = ['SummaryCfdaNumbersView']
     view_chain.extend([
         'SummaryTransactionMonthView',
         'SummaryTransactionView',
         'UniversalTransactionView'
     ])
-    # if category in ['recipient-duns', 'recipient-parent_duns']:
-    #     view_chain = ['SummaryTransactionView', 'UniversalTransactionView']
+
     for view in view_chain:
         if can_use_view(filters, view):
             queryset = get_view_queryset(filters, view)

--- a/usaspending_api/awards/v2/filters/view_selector.py
+++ b/usaspending_api/awards/v2/filters/view_selector.py
@@ -319,6 +319,8 @@ def spending_by_category(category, filters):
         'SummaryTransactionView',
         'UniversalTransactionView'
     ])
+    if category in ['recipient-duns', 'recipient-parent_duns']:
+        view_chain = ['UniversalTransactionView']
     for view in view_chain:
         if can_use_view(filters, view):
             queryset = get_view_queryset(filters, view)

--- a/usaspending_api/awards/v2/filters/view_selector.py
+++ b/usaspending_api/awards/v2/filters/view_selector.py
@@ -77,7 +77,8 @@ MATVIEW_SELECTOR = {
             'psc_codes',
             'contract_pricing_type_codes',
             'set_aside_type_codes',
-            'extent_competed_type_codes'],
+            'extent_competed_type_codes',
+        ],
         'prevent_values': {},
         'examine_values': {},
         'model': SummaryTransactionView,
@@ -97,7 +98,8 @@ MATVIEW_SELECTOR = {
             'psc_codes',
             'contract_pricing_type_codes',
             'set_aside_type_codes',
-            'extent_competed_type_codes'],
+            'extent_competed_type_codes',
+        ],
         'prevent_values': {},
         'examine_values': {
             'time_period': can_use_month_aggregation,
@@ -124,7 +126,8 @@ MATVIEW_SELECTOR = {
             'psc_codes',
             'contract_pricing_type_codes',
             'set_aside_type_codes',
-            'extent_competed_type_codes'],
+            'extent_competed_type_codes',
+        ],
         'prevent_values': {},
         'examine_values': {},
         'model': UniversalTransactionView,
@@ -152,8 +155,8 @@ MATVIEW_SELECTOR = {
             'extent_competed_type_codes',
             'federal_account_ids',
             'object_class',
-            'program_activity'
-            ],
+            'program_activity',
+        ],
         'prevent_values': {},
         'examine_values': {},
         'model': UniversalAwardView,
@@ -298,14 +301,19 @@ def transaction_spending_summary(filters):
 
 def spending_by_category(category, filters):
     view_chain = []
-    if category in ['awarding_agency', 'funding_agency']:
+    if category in [
+        'awarding_agency-agency',
+        'funding_agency-agency',
+        'awarding_agency-subagency',
+        'funding_agency-subagency',
+    ]:
         view_chain = ['SummaryView']
-    elif category == 'industry_codes':
+    elif category == 'industry_codes-psc':
         view_chain = ['SummaryPscCodesView']
-    elif category == 'cfda_programs':
-        view_chain = ['SummaryCfdaNumbersView']
-    elif category == 'naics':
+    elif category == 'industry_codes-naics':
         view_chain = ['SummaryNaicsCodesView']
+    elif category == 'cfda_programs-':
+        view_chain = ['SummaryCfdaNumbersView']
     view_chain.extend([
         'SummaryTransactionMonthView',
         'SummaryTransactionView',
@@ -314,9 +322,10 @@ def spending_by_category(category, filters):
     for view in view_chain:
         if can_use_view(filters, view):
             queryset = get_view_queryset(filters, view)
+            model = view
             print('spending_by_category using {}'.format(view))
             break
     else:
         raise InvalidParameterException
 
-    return queryset
+    return queryset, model

--- a/usaspending_api/core/validator/tinyshield.py
+++ b/usaspending_api/core/validator/tinyshield.py
@@ -195,11 +195,16 @@ class TinyShield():
                     if 'optional' in v and v['optional'] is False:
                         raise Exception('Object {} is missing required key {}'.format(provided_object, k))
                 else:
+                    # copy the parent rules, then overwrite any with the child's rules
                     child_rule = copy.copy(rule)
-                    child_rule['type'] = v['type']
+                    child_rule.update(v)
+                    # Delete parent fields we know exist and aren't useful for the child
+                    del child_rule['object_keys']
+                    del child_rule['array_type']
                     child_rule['value'] = provided_object[k]
-                    child_rule['min'] = rule.get('object_min', None)
-                    child_rule['max'] = rule.get('object_max', None)
+                    # If defined, use the child rules, else if defined use the parent rules, else None
+                    child_rule['min'] = rule.get('object_min', None) or child_rule.get('min', None)
+                    child_rule['max'] = rule.get('object_max', None) or child_rule.get('max', None)
 
                     object_result[k] = self.apply_rule(child_rule)
 

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
@@ -36,6 +36,9 @@
     "  SAA.abbreviation AS awarding_subtier_agency_abbreviation,",
     "  SFA.abbreviation AS funding_subtier_agency_abbreviation,",
     "",
+    "  UPPER(legal_entity.recipient_name) AS recipient_name,",
+    "  legal_entity.recipient_unique_id,",
+    "  legal_entity.parent_recipient_unique_id,",
     "  legal_entity.business_categories,",
     "  transaction_fabs.cfda_number,",
     "  references_cfda.program_title AS cfda_title,",
@@ -125,6 +128,9 @@
     "  SAA.abbreviation,",
     "  SFA.abbreviation,",
     "",
+    "  legal_entity.recipient_name,",
+    "  legal_entity.recipient_unique_id,",
+    "  legal_entity.parent_recipient_unique_id,",
     "  legal_entity.business_categories,",
     "  transaction_fabs.cfda_number,",
     "  references_cfda.program_title,",
@@ -166,6 +172,14 @@
       "name": "pulled_from",
       "where": "pulled_from IS NOT NULL",
       "columns": [{"name": "pulled_from", "order": "DESC NULLS LAST"}]
+    }, {
+      "name": "recipient_unique_id",
+      "where": "recipient_unique_id IS NOT NULL",
+      "columns": [{"name": "recipient_unique_id"}]
+    }, {
+      "name": "parent_recipient_unique_id",
+      "where": "parent_recipient_unique_id IS NOT NULL",
+      "columns": [{"name": "parent_recipient_unique_id"}]
     }, {
     "name": "recipient_country_code",
         "where": "recipient_location_country_code IS NOT NULL",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
@@ -36,6 +36,9 @@
     "  SAA.abbreviation AS awarding_subtier_agency_abbreviation,",
     "  SFA.abbreviation AS funding_subtier_agency_abbreviation,",
     "",
+    "  UPPER(legal_entity.recipient_name) AS recipient_name,",
+    "  legal_entity.recipient_unique_id,",
+    "  legal_entity.parent_recipient_unique_id,",
     "  legal_entity.business_categories,",
     "  transaction_fabs.cfda_number,",
     "  references_cfda.program_title AS cfda_title,",
@@ -123,6 +126,9 @@
     "  SAA.abbreviation,",
     "  SFA.abbreviation,",
     "",
+    "  legal_entity.recipient_name,",
+    "  legal_entity.recipient_unique_id,",
+    "  legal_entity.parent_recipient_unique_id,",
     "  legal_entity.business_categories,",
     "  transaction_fabs.cfda_number,",
     "  references_cfda.program_title,",
@@ -161,6 +167,14 @@
         "name": "pulled_from",
         "where": "pulled_from IS NOT NULL",
         "columns": [{"name": "pulled_from", "order": "DESC NULLS LAST"}]
+    }, {
+      "name": "recipient_unique_id",
+      "where": "recipient_unique_id IS NOT NULL",
+      "columns": [{"name": "recipient_unique_id"}]
+    }, {
+      "name": "parent_recipient_unique_id",
+      "where": "parent_recipient_unique_id IS NOT NULL",
+      "columns": [{"name": "parent_recipient_unique_id"}]
     }, {
         "name": "recipient_country_code",
         "where": "recipient_location_country_code IS NOT NULL",

--- a/usaspending_api/search/v2/urls_search.py
+++ b/usaspending_api/search/v2/urls_search.py
@@ -3,7 +3,7 @@ from usaspending_api.search.v2.views import search
 
 urlpatterns = [
     url(r'^spending_over_time', search.SpendingOverTimeVisualizationViewSet.as_view()),
-    # url(r'^spending_by_category', search.SpendingByCategoryVisualizationViewSet.as_view()), # will be used in future
+    url(r'^spending_by_category', search.SpendingByCategoryVisualizationViewSet.as_view()),
     url(r'^spending_by_geography', search.SpendingByGeographyVisualizationViewSet.as_view()),
     url(r'^spending_by_award_count', search.SpendingByAwardCountVisualizationViewSet.as_view()),
     url(r'^spending_by_award', search.SpendingByAwardVisualizationViewSet.as_view()),

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -159,7 +159,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
         print('============================================')
         print(validated_payload)
 
-        response = spending_by_category_logic(validated_payload).logic()
+        response = spending_by_category_logic(validated_payload)
         return Response(response)
 
 

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -146,7 +146,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
         # TODO: check logic in name_dict[x]["aggregated_amount"] statements
 
         categories = ["awarding_agency", "funding_agency", "recipient", "cfda_programs", "industry_codes"]
-        scopes = ["agency", "subagency", "psc", "naics"]
+        scopes = ["agency", "subagency", "psc", "naics", "duns", "parent_duns"]
 
         models = [
             # {'name': '_filters', 'key': 'filters', 'type': 'schema', 'optional': False},

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -143,24 +143,19 @@ class SpendingByCategoryVisualizationViewSet(APIView):
     @cache_response()
     def post(self, request):
         """Return all budget function/subfunction titles matching the provided search text"""
-        # TODO: check logic in name_dict[x]["aggregated_amount"] statements
 
         categories = ["awarding_agency", "funding_agency", "recipient", "cfda_programs", "industry_codes"]
         scopes = ["agency", "subagency", "psc", "naics", "duns", "parent_duns"]
 
         models = [
-            # {'name': '_filters', 'key': 'filters', 'type': 'schema', 'optional': False},
             {'name': 'category', 'key': 'category', 'type': 'enum', 'enum_values': categories, 'optional': False},
             {'name': 'scope', 'key': 'scope', 'type': 'enum', 'enum_values': scopes},
         ]
         models.extend(AWARD_FILTER)
         models.extend(PAGINATION)
         validated_payload = TinyShield(models).block(request.data)
-        print('============================================')
-        print(validated_payload)
 
-        response = spending_by_category_logic(validated_payload)
-        return Response(response)
+        return Response(spending_by_category_logic(validated_payload))
 
 
 class SpendingByGeographyVisualizationViewSet(APIView):

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -10,17 +10,17 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from usaspending_api.common.cache_decorator import cache_response
-from django.db.models import Sum, Count, F, Value, FloatField
+from django.db.models import Sum, Count, Value, FloatField
 from django.db.models.functions import ExtractMonth, ExtractYear, Cast, Coalesce
 
 from usaspending_api.awards.models import Subaward
-from usaspending_api.awards.models_matviews import UniversalAwardView, UniversalTransactionView
+from usaspending_api.awards.models_matviews import UniversalAwardView
 from usaspending_api.awards.v2.filters.filter_helpers import sum_transaction_amount
 from usaspending_api.awards.v2.filters.location_filter_geocode import geocode_filter_locations
 from usaspending_api.awards.v2.filters.matview_filters import matview_search_filter
 from usaspending_api.awards.v2.filters.sub_award import subaward_filter
-from usaspending_api.awards.v2.filters.view_selector import (can_use_view, get_view_queryset, spending_by_award_count,
-                                                             spending_by_geography, spending_over_time)
+from usaspending_api.awards.v2.filters.view_selector import (spending_by_award_count, spending_by_geography,
+                                                             spending_over_time)
 from usaspending_api.awards.v2.lookups.lookups import (award_type_mapping, contract_type_mapping, loan_type_mapping,
                                                        non_loan_assistance_type_mapping, grant_type_mapping,
                                                        contract_subaward_mapping, grant_subaward_mapping)
@@ -32,7 +32,6 @@ from usaspending_api.core.validator.award_filter import AWARD_FILTER
 from usaspending_api.core.validator.pagination import PAGINATION
 from usaspending_api.core.validator.tinyshield import TinyShield
 from usaspending_api.references.abbreviations import code_to_state, fips_to_code, pad_codes
-from usaspending_api.references.models import Cfda
 from usaspending_api.search.v2.elasticsearch_helper import (search_transactions, spending_by_transaction_count,
                                                             spending_by_transaction_sum_and_count)
 from usaspending_api.search.v2.views.spending_by_category import business_logic as spending_by_category_logic
@@ -147,7 +146,7 @@ class SpendingByCategoryVisualizationViewSet(APIView):
         # TODO: check logic in name_dict[x]["aggregated_amount"] statements
 
         categories = ["awarding_agency", "funding_agency", "recipient", "cfda_programs", "industry_codes"]
-        scopes = ["agency", "subagency"]
+        scopes = ["agency", "subagency", "psc", "naics"]
 
         models = [
             # {'name': '_filters', 'key': 'filters', 'type': 'schema', 'optional': False},
@@ -592,7 +591,7 @@ class SpendingByTransactionVisualizationViewSet(APIView):
     def post(self, request):
 
         models = [
-            {'name': 'fields', 'key': 'fields', 'type': 'array', 'array_type': 'text', 'text_type': 'search', 'dependencies': [{'sort': 'contains'}]},
+            {'name': 'fields', 'key': 'fields', 'type': 'array', 'array_type': 'text', 'text_type': 'search'},
         ]
         models.extend(AWARD_FILTER)
         models.extend(PAGINATION)

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -1,32 +1,17 @@
 import logging
 
-from rest_framework.response import Response
-from rest_framework.views import APIView
+from django.db.models import F
 
-from usaspending_api.common.cache_decorator import cache_response
-from django.db.models import Sum, Count, F, Value, FloatField
-from django.db.models.functions import ExtractMonth, ExtractYear, Cast, Coalesce
-
-from usaspending_api.awards.models_matviews import UniversalAwardView, UniversalTransactionView
 from usaspending_api.awards.v2.filters.filter_helpers import sum_transaction_amount
-from usaspending_api.awards.v2.filters.location_filter_geocode import geocode_filter_locations
-from usaspending_api.awards.v2.filters.matview_filters import matview_search_filter
-from usaspending_api.awards.v2.filters.sub_award import subaward_filter
+
+# from usaspending_api.awards.v2.filters.sub_award import subaward_filter
 from usaspending_api.awards.v2.filters.view_selector import spending_by_category as sbc_view_queryset
-from usaspending_api.awards.v2.lookups.lookups import (award_type_mapping, contract_type_mapping, loan_type_mapping,
-                                                       non_loan_assistance_type_mapping, grant_type_mapping,
-                                                       contract_subaward_mapping, grant_subaward_mapping)
-from usaspending_api.awards.v2.lookups.matview_lookups import (award_contracts_mapping, loan_award_mapping,
-                                                               non_loan_assistance_award_mapping)
-from usaspending_api.common.exceptions import ElasticsearchConnectionException, InvalidParameterException
-from usaspending_api.common.helpers import generate_fiscal_month, generate_fiscal_year, get_simple_pagination_metadata
+from usaspending_api.awards.v2.lookups.lookups import award_type_mapping
+
+from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.common.helpers import get_simple_pagination_metadata
 from usaspending_api.core.validator.award_filter import AWARD_FILTER
-from usaspending_api.core.validator.pagination import PAGINATION
-from usaspending_api.core.validator.tinyshield import TinyShield
-from usaspending_api.references.abbreviations import code_to_state, fips_to_code, pad_codes
 from usaspending_api.references.models import Cfda
-from usaspending_api.search.v2.elasticsearch_helper import (search_transactions, spending_by_transaction_count,
-                                                            spending_by_transaction_sum_and_count)
 
 logger = logging.getLogger(__name__)
 
@@ -46,17 +31,24 @@ class business_logic:
         if (self.scope is None) and (self.category != "cfda_programs"):
             raise InvalidParameterException("Missing one or more required request parameters: scope")
 
-        self.filter_types = self.filters['award_type_codes'] if 'award_type_codes' in self.filters else award_type_mapping
+        if 'award_type_codes' in self.filters:
+            self.filter_types = self.filters['award_type_codes']
+        else:
+            self.filter_types = award_type_mapping
+        self.queryset, self.model = sbc_view_queryset('{}-{}'.format(self.category, self.scope or ''), self.filters)
 
     def logic(self):
-        # filter queryset
-        # queryset = matview_search_filter(self.filters, UniversalTransactionView)
-
         # filter the transactions by category
         if self.category == "awarding_agency":
             results = self.awarding_agency()
         elif self.category == "funding_agency":
-            results = []
+            results = self.funding_agency()
+        elif self.category == 'recipient':
+            results = self.recipient()
+        elif self.category == 'cfda_programs':
+            results = self.cfda_programs()
+        elif self.category == 'industry_codes':
+            results = self.industry_codes()
         else:  # recipient_type
             raise InvalidParameterException("Category \"{}\" is not yet implemented".format(self.category))
 
@@ -71,198 +63,17 @@ class business_logic:
         }
         return response
 
-        # elif self.category == "funding_agency":
-        #     if self.scope == "agency":
-        #         queryset = queryset \
-        #             .filter(funding_toptier_agency_name__isnull=False) \
-        #             .values(
-        #                 agency_name=F('funding_toptier_agency_name'),
-        #                 agency_abbreviation=F('funding_toptier_agency_abbreviation'))
-
-        #     elif self.scope == "subagency":
-        #         queryset = queryset \
-        #             .filter(
-        #                 funding_subtier_agency_name__isnull=False) \
-        #             .values(
-        #                 agency_name=F('funding_subtier_agency_name'),
-        #                 agency_abbreviation=F('funding_subtier_agency_abbreviation'))
-
-        #     elif self.scope == "office":
-        #         # NOT IMPLEMENTED IN UI
-        #         raise NotImplementedError
-
-        #     queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=self.filter_types) \
-        #         .order_by('-aggregated_amount')
-        #     results = list(queryset[self.lower_limit:self.upper_limit + 1])
-
-        #     page_metadata = get_simple_pagination_metadata(len(results), self.limit, self.page)
-        #     results = results[:self.limit]
-
-        #     response = {"category": category, "scope": scope, "limit": limit, "results": results,
-        #                 "page_metadata": page_metadata}
-        #     return response
-
-        # elif category == "recipient":
-        #     if scope == "duns":
-        #         queryset = queryset \
-        #             .values(legal_entity_id=F("recipient_id"))
-        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
-        #             .order_by('-aggregated_amount') \
-        #             .values("aggregated_amount", "legal_entity_id", "recipient_name") \
-        #             .order_by("-aggregated_amount")
-
-        #         # Begin DB hits here
-        #         results = list(queryset[lower_limit:upper_limit + 1])
-
-        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
-        #         results = results[:limit]
-
-        #     elif scope == "parent_duns":
-        #         queryset = queryset \
-        #             .filter(parent_recipient_unique_id__isnull=False)
-        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types,
-        #                                           calculate_totals=False) \
-        #             .values(
-        #                 'aggregated_amount',
-        #                 'recipient_name',
-        #                 'parent_recipient_unique_id') \
-        #             .order_by('-aggregated_amount')
-
-        #         # Begin DB hits here
-        #         results = list(queryset[lower_limit:upper_limit + 1])
-        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
-        #         results = results[:limit]
-
-        #     else:  # recipient_type
-        #         raise InvalidParameterException("recipient type is not yet implemented")
-
-        #     response = {"category": category, "scope": scope, "limit": limit, "results": results,
-        #                 "page_metadata": page_metadata}
-        #     return response
-
-        # elif category == "cfda_programs":
-        #     if can_use_view(filters, 'SummaryCfdaNumbersView'):
-        #         queryset = get_view_queryset(filters, 'SummaryCfdaNumbersView')
-        #         queryset = queryset \
-        #             .filter(
-        #                 federal_action_obligation__isnull=False,
-        #                 cfda_number__isnull=False) \
-        #             .values(cfda_program_number=F("cfda_number"))
-        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
-        #             .values(
-        #                 "aggregated_amount",
-        #                 "cfda_program_number",
-        #                 program_title=F("cfda_title")) \
-        #             .order_by('-aggregated_amount')
-
-        #         # Begin DB hits here
-        #         results = list(queryset[lower_limit:upper_limit + 1])
-        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
-        #         results = results[:limit]
-        #         for trans in results:
-        #             trans['popular_name'] = None
-        #             # small DB hit every loop here
-        #             cfda = Cfda.objects \
-        #                 .filter(
-        #                     program_title=trans['program_title'],
-        #                     program_number=trans['cfda_program_number']) \
-        #                 .values('popular_name').first()
-
-        #             if cfda:
-        #                 trans['popular_name'] = cfda['popular_name']
-
-        #     else:
-        #         queryset = queryset \
-        #             .filter(
-        #                 cfda_number__isnull=False) \
-        #             .values(cfda_program_number=F("cfda_number"))
-        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
-        #             .values(
-        #                 "aggregated_amount",
-        #                 "cfda_program_number",
-        #                 popular_name=F("cfda_popular_name"),
-        #                 program_title=F("cfda_title")) \
-        #             .order_by('-aggregated_amount')
-
-        #         # Begin DB hits here
-        #         results = list(queryset[lower_limit:upper_limit + 1])
-        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
-        #         results = results[:limit]
-
-        #     response = {"category": category, "limit": limit, "results": results, "page_metadata": page_metadata}
-        #     return response
-
-        # elif category == "industry_codes":  # industry_codes
-        #     if scope == "psc":
-        #         if can_use_view(filters, 'SummaryPscCodesView'):
-        #             queryset = get_view_queryset(filters, 'SummaryPscCodesView')
-        #             queryset = queryset \
-        #                 .filter(product_or_service_code__isnull=False) \
-        #                 .values(psc_code=F("product_or_service_code"))
-        #         else:
-        #             queryset = queryset \
-        #                 .filter(psc_code__isnull=False) \
-        #                 .values("psc_code")
-
-        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
-        #             .order_by('-aggregated_amount')
-        #         # Begin DB hits here
-        #         results = list(queryset[lower_limit:upper_limit + 1])
-
-        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
-        #         results = results[:limit]
-
-        #         response = {"category": category, "scope": scope, "limit": limit, "results": results,
-        #                     "page_metadata": page_metadata}
-        #         return response
-
-        #     elif scope == "naics":
-        #         if can_use_view(filters, 'SummaryNaicsCodesView'):
-        #             queryset = get_view_queryset(filters, 'SummaryNaicsCodesView')
-        #             queryset = queryset \
-        #                 .filter(naics_code__isnull=False) \
-        #                 .values('naics_code')
-        #             queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
-        #                 .order_by('-aggregated_amount') \
-        #                 .values(
-        #                     'naics_code',
-        #                     'aggregated_amount',
-        #                     'naics_description')
-        #         else:
-        #             queryset = queryset \
-        #                 .filter(naics_code__isnull=False) \
-        #                 .values("naics_code")
-        #             queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
-        #                 .order_by('-aggregated_amount') \
-        #                 .values(
-        #                     'naics_code',
-        #                     'aggregated_amount',
-        #                     'naics_description')
-
-        #         # Begin DB hits here
-        #         results = list(queryset[lower_limit:upper_limit + 1])
-
-        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
-        #         results = results[:limit]
-
-        #         response = {"category": category, "scope": scope, "limit": limit, "results": results,
-        #                     "page_metadata": page_metadata}
-        #     else:  # recipient_type
-        #         raise InvalidParameterException("recipient type is not yet implemented")
-        # return response
-
     def awarding_agency(self):
-        # filter queryset
-        queryset = sbc_view_queryset(self.category, self.filters)
+        # filter self.queryset
         if self.scope == "agency":
-            queryset = queryset \
+            self.queryset = self.queryset \
                 .filter(awarding_toptier_agency_name__isnull=False) \
                 .values(
                     agency_name=F('awarding_toptier_agency_name'),
                     agency_abbreviation=F('awarding_toptier_agency_abbreviation'))
 
         elif self.scope == "subagency":
-            queryset = queryset \
+            self.queryset = self.queryset \
                 .filter(
                     awarding_subtier_agency_name__isnull=False) \
                 .values(
@@ -271,10 +82,131 @@ class business_logic:
 
         elif self.scope == "office":
                 # NOT IMPLEMENTED IN UI
-                raise NotImplementedError
+                raise InvalidParameterException("office scope is not yet implemented")
 
-        queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=self.filter_types)\
+        self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types)\
             .order_by('-aggregated_amount')
-        results = list(queryset[self.lower_limit:self.upper_limit + 1])
+        return list(self.queryset[self.lower_limit:self.upper_limit + 1])
+
+    def funding_agency(self):
+        if self.scope == "agency":
+            self.queryset = self.queryset \
+                .filter(funding_toptier_agency_name__isnull=False) \
+                .values(
+                    agency_name=F('funding_toptier_agency_name'),
+                    agency_abbreviation=F('funding_toptier_agency_abbreviation'))
+
+        elif self.scope == "subagency":
+            self.queryset = self.queryset \
+                .filter(
+                    funding_subtier_agency_name__isnull=False) \
+                .values(
+                    agency_name=F('funding_subtier_agency_name'),
+                    agency_abbreviation=F('funding_subtier_agency_abbreviation'))
+
+        elif self.scope == "office":
+            # NOT IMPLEMENTED IN UI
+            raise NotImplementedError
+
+        self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types) \
+            .order_by('-aggregated_amount')
+
+        return list(self.queryset[self.lower_limit:self.upper_limit + 1])
+
+    def recipient(self):
+        if self.scope == "duns":
+            self.queryset = self.queryset \
+                .values(legal_entity_id=F("recipient_id"))
+            self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types) \
+                .order_by('-aggregated_amount') \
+                .values("aggregated_amount", "legal_entity_id", "recipient_name") \
+                .order_by("-aggregated_amount")
+
+        elif self.scope == "parent_duns":
+            self.queryset = self.queryset \
+                .filter(parent_recipient_unique_id__isnull=False)
+            self.queryset = sum_transaction_amount(
+                self.queryset,
+                'aggregated_amount',
+                filter_types=self.filter_types,
+                calculate_totals=False) \
+                .values(
+                    'aggregated_amount',
+                    'recipient_name',
+                    'parent_recipient_unique_id') \
+                .order_by('-aggregated_amount')
+
+        else:  # recipient_type
+            raise InvalidParameterException("recipient type is not yet implemented")
+
+        return list(self.queryset[self.lower_limit:self.upper_limit + 1])
+
+    def cfda_programs(self):
+        if self.model == 'SummaryCfdaNumbersView':
+            self.queryset = self.queryset \
+                .filter(
+                    federal_action_obligation__isnull=False,
+                    cfda_number__isnull=False) \
+                .values(cfda_program_number=F("cfda_number"))
+            self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types) \
+                .values(
+                    "aggregated_amount",
+                    "cfda_program_number",
+                    program_title=F("cfda_title")) \
+                .order_by('-aggregated_amount')
+
+            # Begin DB hits here
+            results = list(self.queryset[self.lower_limit:self.upper_limit + 1])
+
+            for trans in results:
+                trans['popular_name'] = None
+                # small DB hit every loop here
+                cfda = Cfda.objects \
+                    .filter(
+                        program_title=trans['program_title'],
+                        program_number=trans['cfda_program_number']) \
+                    .values('popular_name').first()
+
+                if cfda:
+                    trans['popular_name'] = cfda['popular_name']
+
+        else:
+            self.queryset = self.queryset \
+                .filter(
+                    cfda_number__isnull=False) \
+                .values(cfda_program_number=F("cfda_number"))
+            self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types) \
+                .values(
+                    "aggregated_amount",
+                    "cfda_program_number",
+                    popular_name=F("cfda_popular_name"),
+                    program_title=F("cfda_title")) \
+                .order_by('-aggregated_amount')
+
+            # Begin DB hits here
+            results = list(self.queryset[self.lower_limit:self.upper_limit + 1])
 
         return results
+
+    def industry_codes(self):
+        if self.scope == "psc":
+            self.queryset = self.queryset \
+                .filter(product_or_service_code__isnull=False) \
+                .values(psc_code=F("product_or_service_code"))
+
+            self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types) \
+                .order_by('-aggregated_amount')
+
+        elif self.scope == "naics":
+            self.queryset = self.queryset \
+                .filter(naics_code__isnull=False) \
+                .values('naics_code')
+            self.queryset = sum_transaction_amount(self.queryset, 'aggregated_amount', filter_types=self.filter_types) \
+                .order_by('-aggregated_amount') \
+                .values(
+                    'naics_code',
+                    'aggregated_amount',
+                    'naics_description')
+        else:  # recipient_type
+            raise InvalidParameterException("recipient type is not yet implemented")
+        return list(self.queryset[self.lower_limit:self.upper_limit + 1])

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -1,0 +1,280 @@
+import logging
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from usaspending_api.common.cache_decorator import cache_response
+from django.db.models import Sum, Count, F, Value, FloatField
+from django.db.models.functions import ExtractMonth, ExtractYear, Cast, Coalesce
+
+from usaspending_api.awards.models_matviews import UniversalAwardView, UniversalTransactionView
+from usaspending_api.awards.v2.filters.filter_helpers import sum_transaction_amount
+from usaspending_api.awards.v2.filters.location_filter_geocode import geocode_filter_locations
+from usaspending_api.awards.v2.filters.matview_filters import matview_search_filter
+from usaspending_api.awards.v2.filters.sub_award import subaward_filter
+from usaspending_api.awards.v2.filters.view_selector import spending_by_category as sbc_view_queryset
+from usaspending_api.awards.v2.lookups.lookups import (award_type_mapping, contract_type_mapping, loan_type_mapping,
+                                                       non_loan_assistance_type_mapping, grant_type_mapping,
+                                                       contract_subaward_mapping, grant_subaward_mapping)
+from usaspending_api.awards.v2.lookups.matview_lookups import (award_contracts_mapping, loan_award_mapping,
+                                                               non_loan_assistance_award_mapping)
+from usaspending_api.common.exceptions import ElasticsearchConnectionException, InvalidParameterException
+from usaspending_api.common.helpers import generate_fiscal_month, generate_fiscal_year, get_simple_pagination_metadata
+from usaspending_api.core.validator.award_filter import AWARD_FILTER
+from usaspending_api.core.validator.pagination import PAGINATION
+from usaspending_api.core.validator.tinyshield import TinyShield
+from usaspending_api.references.abbreviations import code_to_state, fips_to_code, pad_codes
+from usaspending_api.references.models import Cfda
+from usaspending_api.search.v2.elasticsearch_helper import (search_transactions, spending_by_transaction_count,
+                                                            spending_by_transaction_sum_and_count)
+
+logger = logging.getLogger(__name__)
+
+
+class business_logic:
+    def __init__(self, payload):
+        self.category = payload['category']
+        self.scope = payload['scope']
+        self.page = payload['page']
+        self.limit = payload['limit']
+        self.filters = {
+            item['name']: payload[item['name']] for item in AWARD_FILTER if item['name'] in payload}
+
+        self.lower_limit = (self.page - 1) * self.limit
+        self.upper_limit = self.page * self.limit
+
+        if (self.scope is None) and (self.category != "cfda_programs"):
+            raise InvalidParameterException("Missing one or more required request parameters: scope")
+
+        self.filter_types = self.filters['award_type_codes'] if 'award_type_codes' in self.filters else award_type_mapping
+
+    def logic(self):
+        # filter queryset
+        # queryset = matview_search_filter(self.filters, UniversalTransactionView)
+
+        # filter the transactions by category
+        if self.category == "awarding_agency":
+            results = self.awarding_agency()
+        elif self.category == "funding_agency":
+            results = []
+        else:  # recipient_type
+            raise InvalidParameterException("Category \"{}\" is not yet implemented".format(self.category))
+
+        page_metadata = get_simple_pagination_metadata(len(results), self.limit, self.page)
+
+        response = {
+            "category": self.category,
+            "limit": self.limit,
+            "page_metadata": page_metadata,
+            "results": results[:self.limit],
+            "scope": self.scope,
+        }
+        return response
+
+        # elif self.category == "funding_agency":
+        #     if self.scope == "agency":
+        #         queryset = queryset \
+        #             .filter(funding_toptier_agency_name__isnull=False) \
+        #             .values(
+        #                 agency_name=F('funding_toptier_agency_name'),
+        #                 agency_abbreviation=F('funding_toptier_agency_abbreviation'))
+
+        #     elif self.scope == "subagency":
+        #         queryset = queryset \
+        #             .filter(
+        #                 funding_subtier_agency_name__isnull=False) \
+        #             .values(
+        #                 agency_name=F('funding_subtier_agency_name'),
+        #                 agency_abbreviation=F('funding_subtier_agency_abbreviation'))
+
+        #     elif self.scope == "office":
+        #         # NOT IMPLEMENTED IN UI
+        #         raise NotImplementedError
+
+        #     queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=self.filter_types) \
+        #         .order_by('-aggregated_amount')
+        #     results = list(queryset[self.lower_limit:self.upper_limit + 1])
+
+        #     page_metadata = get_simple_pagination_metadata(len(results), self.limit, self.page)
+        #     results = results[:self.limit]
+
+        #     response = {"category": category, "scope": scope, "limit": limit, "results": results,
+        #                 "page_metadata": page_metadata}
+        #     return response
+
+        # elif category == "recipient":
+        #     if scope == "duns":
+        #         queryset = queryset \
+        #             .values(legal_entity_id=F("recipient_id"))
+        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
+        #             .order_by('-aggregated_amount') \
+        #             .values("aggregated_amount", "legal_entity_id", "recipient_name") \
+        #             .order_by("-aggregated_amount")
+
+        #         # Begin DB hits here
+        #         results = list(queryset[lower_limit:upper_limit + 1])
+
+        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
+        #         results = results[:limit]
+
+        #     elif scope == "parent_duns":
+        #         queryset = queryset \
+        #             .filter(parent_recipient_unique_id__isnull=False)
+        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types,
+        #                                           calculate_totals=False) \
+        #             .values(
+        #                 'aggregated_amount',
+        #                 'recipient_name',
+        #                 'parent_recipient_unique_id') \
+        #             .order_by('-aggregated_amount')
+
+        #         # Begin DB hits here
+        #         results = list(queryset[lower_limit:upper_limit + 1])
+        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
+        #         results = results[:limit]
+
+        #     else:  # recipient_type
+        #         raise InvalidParameterException("recipient type is not yet implemented")
+
+        #     response = {"category": category, "scope": scope, "limit": limit, "results": results,
+        #                 "page_metadata": page_metadata}
+        #     return response
+
+        # elif category == "cfda_programs":
+        #     if can_use_view(filters, 'SummaryCfdaNumbersView'):
+        #         queryset = get_view_queryset(filters, 'SummaryCfdaNumbersView')
+        #         queryset = queryset \
+        #             .filter(
+        #                 federal_action_obligation__isnull=False,
+        #                 cfda_number__isnull=False) \
+        #             .values(cfda_program_number=F("cfda_number"))
+        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
+        #             .values(
+        #                 "aggregated_amount",
+        #                 "cfda_program_number",
+        #                 program_title=F("cfda_title")) \
+        #             .order_by('-aggregated_amount')
+
+        #         # Begin DB hits here
+        #         results = list(queryset[lower_limit:upper_limit + 1])
+        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
+        #         results = results[:limit]
+        #         for trans in results:
+        #             trans['popular_name'] = None
+        #             # small DB hit every loop here
+        #             cfda = Cfda.objects \
+        #                 .filter(
+        #                     program_title=trans['program_title'],
+        #                     program_number=trans['cfda_program_number']) \
+        #                 .values('popular_name').first()
+
+        #             if cfda:
+        #                 trans['popular_name'] = cfda['popular_name']
+
+        #     else:
+        #         queryset = queryset \
+        #             .filter(
+        #                 cfda_number__isnull=False) \
+        #             .values(cfda_program_number=F("cfda_number"))
+        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
+        #             .values(
+        #                 "aggregated_amount",
+        #                 "cfda_program_number",
+        #                 popular_name=F("cfda_popular_name"),
+        #                 program_title=F("cfda_title")) \
+        #             .order_by('-aggregated_amount')
+
+        #         # Begin DB hits here
+        #         results = list(queryset[lower_limit:upper_limit + 1])
+        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
+        #         results = results[:limit]
+
+        #     response = {"category": category, "limit": limit, "results": results, "page_metadata": page_metadata}
+        #     return response
+
+        # elif category == "industry_codes":  # industry_codes
+        #     if scope == "psc":
+        #         if can_use_view(filters, 'SummaryPscCodesView'):
+        #             queryset = get_view_queryset(filters, 'SummaryPscCodesView')
+        #             queryset = queryset \
+        #                 .filter(product_or_service_code__isnull=False) \
+        #                 .values(psc_code=F("product_or_service_code"))
+        #         else:
+        #             queryset = queryset \
+        #                 .filter(psc_code__isnull=False) \
+        #                 .values("psc_code")
+
+        #         queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
+        #             .order_by('-aggregated_amount')
+        #         # Begin DB hits here
+        #         results = list(queryset[lower_limit:upper_limit + 1])
+
+        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
+        #         results = results[:limit]
+
+        #         response = {"category": category, "scope": scope, "limit": limit, "results": results,
+        #                     "page_metadata": page_metadata}
+        #         return response
+
+        #     elif scope == "naics":
+        #         if can_use_view(filters, 'SummaryNaicsCodesView'):
+        #             queryset = get_view_queryset(filters, 'SummaryNaicsCodesView')
+        #             queryset = queryset \
+        #                 .filter(naics_code__isnull=False) \
+        #                 .values('naics_code')
+        #             queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
+        #                 .order_by('-aggregated_amount') \
+        #                 .values(
+        #                     'naics_code',
+        #                     'aggregated_amount',
+        #                     'naics_description')
+        #         else:
+        #             queryset = queryset \
+        #                 .filter(naics_code__isnull=False) \
+        #                 .values("naics_code")
+        #             queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=filter_types) \
+        #                 .order_by('-aggregated_amount') \
+        #                 .values(
+        #                     'naics_code',
+        #                     'aggregated_amount',
+        #                     'naics_description')
+
+        #         # Begin DB hits here
+        #         results = list(queryset[lower_limit:upper_limit + 1])
+
+        #         page_metadata = get_simple_pagination_metadata(len(results), limit, page)
+        #         results = results[:limit]
+
+        #         response = {"category": category, "scope": scope, "limit": limit, "results": results,
+        #                     "page_metadata": page_metadata}
+        #     else:  # recipient_type
+        #         raise InvalidParameterException("recipient type is not yet implemented")
+        # return response
+
+    def awarding_agency(self):
+        # filter queryset
+        queryset = sbc_view_queryset(self.category, self.filters)
+        if self.scope == "agency":
+            queryset = queryset \
+                .filter(awarding_toptier_agency_name__isnull=False) \
+                .values(
+                    agency_name=F('awarding_toptier_agency_name'),
+                    agency_abbreviation=F('awarding_toptier_agency_abbreviation'))
+
+        elif self.scope == "subagency":
+            queryset = queryset \
+                .filter(
+                    awarding_subtier_agency_name__isnull=False) \
+                .values(
+                    agency_name=F('awarding_subtier_agency_name'),
+                    agency_abbreviation=F('awarding_subtier_agency_abbreviation'))
+
+        elif self.scope == "office":
+                # NOT IMPLEMENTED IN UI
+                raise NotImplementedError
+
+        queryset = sum_transaction_amount(queryset, 'aggregated_amount', filter_types=self.filter_types)\
+            .order_by('-aggregated_amount')
+        results = list(queryset[self.lower_limit:self.upper_limit + 1])
+
+        return results


### PR DESCRIPTION
## High level description
This PR is the foundation to get core functionality of `spending_by_category` back into the API. It is missing tests and other desired functionality mostly to chop PRs up into more manageable pieces. The Story ticket in Jira is [DEV-805](https://federal-spending-transparency.atlassian.net/browse/DEV-805). This PR completes the first four scope items and two sub-tasks.

### Technical details
- Re-enabled the spending_by_category endpoint URL
- Moved the business logic into its own file to make the code more modular
- Added additional columns (DUNS) to several matviews for the _recipient_ category
- First pass at using TinyShield for this endpoint
- Using new `generated_pragmatic_obligation` column for loan+obligation aggregations

### Link to JIRA Ticket
[DEV-834](https://federal-spending-transparency.atlassian.net/browse/DEV-834)
[DEV-835](https://federal-spending-transparency.atlassian.net/browse/DEV-835)

### The following are ALL required for the PR to be merged
- [ ] Backend review completed
- [ ] Matview impact assessment completed
- [X] Frontend impact assessment completed **(N/A)**
- [ ] Data validation completed
- [ ] API Performance evaluation completed and present **(Shall be added as additional comments once staging has the new materialized views)**

### Matview Impact
`SummaryTransactionView` and `SummaryTransactionMonthView` were modified to contain DUNS and parent DUNS. Final appraisal still needs to be completed of how many rows it expands these aggregation views.

### Data Validation
Once the matviews are in staging, @geoffgeiling @IsaacRay please work together to compare the API responses with the data records.