### PR TITLE
Hotfix: Updating matviews to generate FY 2001 and newer

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
@@ -30,7 +30,7 @@ EXAMPLE SQL DESCRIPTION JSON FILE:
     "LEFT OUTER JOIN",
     "  \"transaction_normalized\" ON (\"awards\".\"latest_transaction_id\" = \"transaction_normalized\".\"id\")",
     "WHERE",
-    "  \"transaction_normalized\".action_date >= '2007-10-01'",
+    "  \"transaction_normalized\".action_date >= '2000-10-01'",
     "ORDER BY",
     "  \"action_date\" DESC"
 

--- a/usaspending_api/database_scripts/matview_generator/summary_award_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_award_view.json
@@ -44,7 +44,7 @@
     "LEFT OUTER JOIN",
     "  subtier_agency AS SFA ON (FA.subtier_agency_id = SFA.subtier_agency_id)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_geo_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_geo_view.json
@@ -73,7 +73,7 @@
     "LEFT OUTER JOIN",
     "  subtier_agency AS SFA ON (FA.subtier_agency_id = SFA.subtier_agency_id)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  cast(date_trunc('month', transaction_normalized.action_date) as date),",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
@@ -91,7 +91,7 @@
     "LEFT OUTER JOIN",
     "  psc ON (transaction_fpds.product_or_service_code = psc.code)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  cast(date_trunc('month', transaction_normalized.action_date) as date),",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
@@ -91,7 +91,7 @@
     "LEFT OUTER JOIN",
     "  psc ON (transaction_fpds.product_or_service_code = psc.code)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view.json
@@ -47,7 +47,7 @@
     "LEFT OUTER JOIN",
     "  subtier_agency AS SFA ON (FA.subtier_agency_id = SFA.subtier_agency_id)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view_cfda_number.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view_cfda_number.json
@@ -28,7 +28,7 @@
     "LEFT OUTER JOIN",
     "  transaction_fpds ON (transaction_normalized.id = transaction_fpds.transaction_id)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view_naics_codes.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view_naics_codes.json
@@ -26,7 +26,7 @@
     "INNER JOIN",
     "  transaction_fpds ON (transaction_normalized.id = transaction_fpds.transaction_id)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view_psc_codes.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view_psc_codes.json
@@ -25,7 +25,7 @@
     "INNER JOIN",
     "  transaction_fpds ON (transaction_normalized.id = transaction_fpds.transaction_id)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "GROUP BY",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",

--- a/usaspending_api/database_scripts/matview_generator/universal_award_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/universal_award_matview.json
@@ -129,7 +129,7 @@
     "WHERE",
     "  awards.latest_transaction_id IS NOT NULL AND",
     "  (awards.category IS NOT NULL or contract_data.pulled_from='IDV') AND",
-    "  latest_transaction.action_date >= '2007-10-01'",
+    "  latest_transaction.action_date >= '2000-10-01'",
     "ORDER BY",
     "  latest_transaction.action_date DESC"
   ],

--- a/usaspending_api/database_scripts/matview_generator/universal_transaction_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/universal_transaction_matview.json
@@ -113,7 +113,7 @@
     "LEFT OUTER JOIN",
     "  psc ON (transaction_fpds.product_or_service_code = psc.code)",
     "WHERE",
-    "  transaction_normalized.action_date >= '2007-10-01'",
+    "  transaction_normalized.action_date >= '2000-10-01'",
     "ORDER BY",
     "  transaction_normalized.action_date DESC"
   ],


### PR DESCRIPTION
**High level description:**
Bulk download has moved to using matviews to support performance, as a result matviews need to be updated to go as far back as FY 2001 instead of the current limit of 2008.

**Technical details:**
Updated matview generator JSON to alter the action date condition to be `>= '2000-10-01'`

**Link to JIRA Ticket:**
[DEV-882](https://federal-spending-transparency.atlassian.net/browse/DEV-882)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Matview impact assessment completed
- [x] Frontend impact assessment completed
- [x] Data validation completed
- [x] API Performance evaluation completed and present:
    ```
    Timing changes (newman tests on staging):
        Before = Ranged from 8-20 failures due to timeouts
        After = Run after matview recreate resulted in 15 failures due to timeouts (no worse than before)
    
    Data volume changes (comparison of prod `universal_transaction_matview` to that of staging):
        Before = 75,163,632
        After = 93,971,212 (~25% increase)
    ```