### PR TITLE
Bugfix: datetime.date's in validate_date()

### DIFF
--- a/usaspending_api/common/helpers.py
+++ b/usaspending_api/common/helpers.py
@@ -18,7 +18,7 @@ QUOTABLE_TYPES = (str, datetime.date)
 
 
 def validate_date(date):
-    if not isinstance(date, datetime.datetime):
+    if not isinstance(date, (datetime.datetime, datetime.date)):
         raise TypeError('Incorrect parameter type provided')
 
     if not (date.day or date.month or date.year):


### PR DESCRIPTION
**High level description:**
`validate_date()` was only checking against `datetime.datetime`'s and not `datetime.date`'s

**Technical details:**
(see high level description)

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- Matview impact assessment completed (N/A)
- Frontend impact assessment completed (N/A)
- Data validation completed (N/A)
- API Performance evaluation completed and present (N/A)