### PR TITLE
Feature: Make the SpendingByGeography geo_layer_filters parameter optional

### DIFF
--- a/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_geography.md
+++ b/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_geography.md
@@ -12,11 +12,11 @@ subawards (**OPTIONAL**): boolean value.  True when you want to group by Subawar
 
 geo_layer: Defines which geographical level should be returned in the request. Options include: "state", "county", "district"
 
-geo_layer_filter: Defines a filter for a specific geographic area correlating to the geo_layer. It is a list of strings that are the unique identifiers for the geographic location.
+geo_layer_filter (**OPTIONAL**): Defines a filter for a specific geographic area correlating to the geo_layer. It is a list of strings that are the unique identifiers for the geographic location.
 
 - When `geo_layer` is `"state"` then the `geo_layer_filters` should be an array of state codes ex: `["MN", "WA", "DC"]`.
 - When `geo_layer` is `"county"` then the `geo_layer_filters` should be an array of county codes. County codes are the county's state FIPS code concatenated with the county's FIPS code. ex: `["51041", "51117", "51179"]`.
-- When `geo_layer` is `"district"` then  the geo_layer filters should be an array of congressional district codes. The congressional district code is a concatenation of the state FIPS code + the Congressional District code including any leading zeros. ex: `["5109", "5109", "5109"]`.
+- When `geo_layer` is `"district"` then the `geo_layer_filters` should be an array of congressional district codes. The congressional district code is a concatenation of the state FIPS code + the Congressional District code including any leading zeros. ex: `["5109", "5109", "5109"]`.
 
 filters: how the awards are filtered.  The filter object is defined here: [Filter Object](../search_filters.md)
 

--- a/usaspending_api/search/tests/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/test_spending_by_geography.py
@@ -7,8 +7,7 @@ from usaspending_api.search.tests.test_mock_data_search import all_filters
 
 
 @pytest.mark.django_db
-def test_spending_by_geography_success(client, refresh_matviews):
-
+def test_spending_by_geography_state_success(client, refresh_matviews):
     # test for required filters
     resp = client.post(
         '/api/v2/search/spending_by_geography',
@@ -16,7 +15,6 @@ def test_spending_by_geography_success(client, refresh_matviews):
         data=json.dumps({
             "scope": "place_of_performance",
             "geo_layer": "state",
-            "geo_layer_filters": ["01"],
             "filters": {
                 'recipient_locations': [{'country': 'ABC'}]
             }
@@ -30,6 +28,62 @@ def test_spending_by_geography_success(client, refresh_matviews):
         data=json.dumps({
             "scope": "recipient_location",
             "geo_layer": "county",
+            "geo_layer_filters": ["WA"],
+            "filters": all_filters()
+        }))
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_spending_by_geography_county_success(client, refresh_matviews):
+    # test for required filters
+    resp = client.post(
+        '/api/v2/search/spending_by_geography',
+        content_type='application/json',
+        data=json.dumps({
+            "scope": "place_of_performance",
+            "geo_layer": "county",
+            "filters": {
+                'recipient_locations': [{'country': 'ABC'}]
+            }
+        }))
+    assert resp.status_code == status.HTTP_200_OK
+
+    # test all filters
+    resp = client.post(
+        '/api/v2/search/spending_by_geography',
+        content_type='application/json',
+        data=json.dumps({
+            "scope": "recipient_location",
+            "geo_layer": "county",
+            "geo_layer_filters": ["01"],
+            "filters": all_filters()
+        }))
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_spending_by_geography_congressional_success(client, refresh_matviews):
+    # test for required filters
+    resp = client.post(
+        '/api/v2/search/spending_by_geography',
+        content_type='application/json',
+        data=json.dumps({
+            "scope": "place_of_performance",
+            "geo_layer": "district",
+            "filters": {
+                'recipient_locations': [{'country': 'ABC'}]
+            }
+        }))
+    assert resp.status_code == status.HTTP_200_OK
+
+    # test all filters
+    resp = client.post(
+        '/api/v2/search/spending_by_geography',
+        content_type='application/json',
+        data=json.dumps({
+            "scope": "recipient_location",
+            "geo_layer": "district",
             "geo_layer_filters": ["01"],
             "filters": all_filters()
         }))

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -425,8 +425,8 @@ class SpendingByGeographyVisualizationViewSet(APIView):
              'enum_values': ['place_of_performance', 'recipient_location']},
             {'name': 'geo_layer', 'key': 'geo_layer', 'type': 'enum', 'optional': False,
              'enum_values': ['state', 'county', 'district']},
-            {'name': 'geo_layer_filters', 'key': 'geo_layer_filters', 'optional': False,
-             'type': 'array', 'array_type': 'text', 'text_type': 'search'}
+            {'name': 'geo_layer_filters', 'key': 'geo_layer_filters', 'type': 'array', 'array_type': 'text',
+             'text_type': 'search'}
         ]
         models.extend(copy.deepcopy(AWARD_FILTER))
         models.extend(copy.deepcopy(PAGINATION))
@@ -436,7 +436,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         self.scope = json_request["scope"]
         self.filters = json_request.get("filters", None)
         self.geo_layer = json_request["geo_layer"]
-        self.geo_layer_filters = json_request["geo_layer_filters"]
+        self.geo_layer_filters = json_request.get("geo_layer_filters", None)
 
         fields_list = []  # fields to include in the aggregate query
 


### PR DESCRIPTION
**High level description:**
The frontend uses the `geo_layer_filters` parameter for the advanced search map, but does not want to use it for the map on the new state profile pages.

**Technical details:**
Updated TinyShield and how the JSONRequest retrieves the `geo_layer_filters` param. We already check if the `geo_layer_filters` exist before applying the filters, and set "not null" defaults. Updated tests to test when `geo_layer` is `"state"`, `"county"`, or `"district"`.

**Link to JIRA Ticket:**
[DEV-1043](https://federal-spending-transparency.atlassian.net/browse/DEV-1043)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Matview impact assessment completed N/A
- [x] Frontend impact assessment completed
- Data validation completed N/A
- API Performance evaluation completed and present N/A