### PR TITLE
Bugfix: altered subward_view Matview and edited API docs for Spending By Category

### DIFF
--- a/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_category.md
+++ b/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_category.md
@@ -6,16 +6,13 @@
 These endpoints return data that is grouped in preset units to support the various data visualizations on USAspending.gov's Advanced Search page.
 ### Request
 
-filters (**REQUIRED**): The filters to find with said category. The filter object is defined here: [Filter Object](../search_filters.md). 
+filters (**REQUIRED**): The filters to find with said category. The filter object is defined here: [Filter Object](../search_filters.md).
 
 category (**REQUIRED**): String value. Parameter indicating which category to aggregate and return. Below are the following categories available.
 
 * `awarding_agency`
 * `awarding_subagency`
-* `funding_agency`
-* `funding_subagency`
 * `recipient_duns`
-* `recipient_parent_duns`
 * `cfda`
 * `psc`
 * `naics`
@@ -31,7 +28,7 @@ page (**OPTIONAL**): The page number that is currently returned. Default is 1.
 ```
 {
   "category": "awarding_agency",
-  "filters": {	
+  "filters": {
     "time_period": [
       {
         "start_date": "2016-10-01",

--- a/usaspending_api/database_scripts/matview_generator/subaward_view.json
+++ b/usaspending_api/database_scripts/matview_generator/subaward_view.json
@@ -114,7 +114,7 @@
     "  subtier_agency AS SAA",
     "    ON (AA.subtier_agency_id = SAA.subtier_agency_id)",
     "LEFT OUTER JOIN",
-    "  agency AS FA ON (awards.funding_agency_id = FA.id)",
+    "  agency AS FA ON (sub.funding_agency_id = FA.id)",
     "LEFT OUTER JOIN",
     "  toptier_agency AS TFA",
     "    ON (FA.toptier_agency_id = TFA.toptier_agency_id)",

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -179,6 +179,12 @@ class BusinessLogic:
         return results
 
     def funding_agency(self) -> list:
+        """
+        NOTICE: These categories were originally included for both Prime and Sub awards.
+        However, there are concerns with the data sparsity so it is unlikely to be used immediately.
+        So this category will be "dark" for now (removed from API doc). If undesired long-term they should be
+        removed from code and API contract.
+        """
         if self.category == 'funding_agency':
             filters = {'funding_toptier_agency_name__isnull': False}
             values = ['funding_agency_id', 'funding_toptier_agency_name', 'funding_toptier_agency_abbreviation']
@@ -224,7 +230,7 @@ class BusinessLogic:
             values = ['cfda_number']
         elif self.category == 'psc':
             if self.subawards:
-                # Not available until it's available in the broker
+                # N/A for subawards
                 self.raise_not_implemented()
             filters = {'product_or_service_code__isnull': False}
             values = ['product_or_service_code']


### PR DESCRIPTION
**High level description:**
The subward matview has inconsistent joins to obtain the funding and awarding agency columns.

Removed these categories from API docs: `funding_agency`, `funding_subagency`, and `recipient_parent_duns` as they are either not ready or undesired. The two funding_agency categories can possibly be completely removed from the code and API contract if it is decided there isn't much benefit.

**Technical details:**
Switched to use `funding_agency_id` from the awards_subaward table instead of from the awards table. Technically there should be no difference to the resulting view as the subaward table is populated with awards data.

**Link to JIRA Ticket:**
[DEV-805](https://federal-spending-transparency.atlassian.net/browse/DEV-805)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed (N/A)
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)