### PR TITLE
DEV-1053: Remapping "XX-90" to "XX-MULTIPLE DISTRICTS"

### DIFF
--- a/usaspending_api/search/tests/unit/test_spending_by_category.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_category.py
@@ -911,6 +911,46 @@ def test_category_district_awards(mock_matviews_qs):
     assert expected_response == spending_by_category_logic
 
 
+def test_category_district_awards_multiple_districts(mock_matviews_qs):
+    mock_model_1 = MockModel(pop_congressional_code='90', pop_state_code='XY',
+                             generated_pragmatic_obligation=1)
+    mock_model_2 = MockModel(pop_congressional_code='90', pop_state_code='XY',
+                             generated_pragmatic_obligation=1)
+
+    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
+
+    test_payload = {
+        'category': 'district',
+        'subawards': False,
+        'page': 1,
+        'limit': 50
+    }
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        'category': 'district',
+        'limit': 50,
+        'page_metadata': {
+            'page': 1,
+            'next': None,
+            'previous': None,
+            'hasNext': False,
+            'hasPrevious': False
+        },
+        'results': [
+            {
+                'amount': 2,
+                'code': '90',
+                'name': 'XY-MULTIPLE DISTRICTS',
+                'id': None
+            }
+        ]
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
 def test_category_district_subawards(mock_matviews_qs):
     mock_model_1 = MockModel(pop_congressional_code='06', pop_state_code='XY',
                              amount=1)

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -2,7 +2,7 @@ import copy
 import logging
 
 from django.conf import settings
-from django.db.models import Case, F, Sum, TextField, Value, When
+from django.db.models import Sum
 from rest_framework.response import Response
 from rest_framework.views import APIView
 


### PR DESCRIPTION
**High level description:**
Updating API response to display "XX-90" congressional districts as "XX-MULTIPLE DISTRICTS".

**Technical details:**
Updating API response to display "XX-90" congressional districts as "XX-MULTIPLE DISTRICTS". This update happens in the business logic only and does not affect any underlying data in the database.

**Link to JIRA Ticket:**
[DEV-1053](https://federal-spending-transparency.atlassian.net/browse/DEV-1053)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [ ] Unit & integration tests updated with relevant test cases
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [ ] Data validation completed
  - Data is returned "XX-MULTIPLE DISTRICTS". For example: 
    ```
    {
        "amount": 20611513026.06,
        "code": "90",
        "id": null,
        "name": "AL-MULTIPLE DISTRICTS"
    }
    ```
- [x] API Performance evaluation completed and present (N/A)