### PR TITLE
Hotfix: Spending by Category (Agency and Recipient Rollup logic)

### DIFF
--- a/usaspending_api/search/tests/unit/test_spending_by_category.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_category.py
@@ -11,14 +11,17 @@ from usaspending_api.search.v2.views.spending_by_category import BusinessLogic
 
 
 def test_category_awarding_agency_awards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, toptier_agency_id=1)
+    mock_toptier = MockModel(toptier_agency_id=1, name='Department of Pizza', abbreviation='DOP')
+    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
+    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
     mock_model_1 = MockModel(awarding_agency_id=2, awarding_toptier_agency_name='Department of Pizza',
                              awarding_toptier_agency_abbreviation='DOP', generated_pragmatic_obligation=5)
-    mock_model_2 = MockModel(awarding_agency_id=2, awarding_toptier_agency_name='Department of Pizza',
+    mock_model_2 = MockModel(awarding_agency_id=3, awarding_toptier_agency_name='Department of Pizza',
                              awarding_toptier_agency_abbreviation='DOP', generated_pragmatic_obligation=10)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
+    add_to_mock_objects(mock_agencies['toptier_agency'], [mock_toptier])
 
     test_payload = {
         'category': 'awarding_agency',
@@ -44,7 +47,7 @@ def test_category_awarding_agency_awards(mock_matviews_qs, mock_agencies):
                 'amount': 15,
                 'name': 'Department of Pizza',
                 'code': 'DOP',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -53,14 +56,16 @@ def test_category_awarding_agency_awards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_awarding_agency_subawards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, toptier_agency_id=1)
+    mock_toptier = MockModel(toptier_agency_id=1, name='Department of Pizza', abbreviation='DOP')
+    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
+    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
     mock_model_1 = MockModel(awarding_agency_id=2, awarding_toptier_agency_name='Department of Pizza',
                              awarding_toptier_agency_abbreviation='DOP', amount=5)
-    mock_model_2 = MockModel(awarding_agency_id=2, awarding_toptier_agency_name='Department of Pizza',
+    mock_model_2 = MockModel(awarding_agency_id=3, awarding_toptier_agency_name='Department of Pizza',
                              awarding_toptier_agency_abbreviation='DOP', amount=10)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'awarding_agency',
@@ -86,7 +91,7 @@ def test_category_awarding_agency_subawards(mock_matviews_qs, mock_agencies):
                 'amount': 15,
                 'name': 'Department of Pizza',
                 'code': 'DOP',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -95,14 +100,16 @@ def test_category_awarding_agency_subawards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_awarding_subagency_awards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, subtier_agency_id=1)
+    mock_subtier = MockModel(subtier_agency_id=1, name='Department of Sub-pizza', abbreviation='DOSP')
+    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
+    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
     mock_model_1 = MockModel(awarding_agency_id=2, awarding_subtier_agency_name='Department of Sub-pizza',
                              awarding_subtier_agency_abbreviation='DOSP', generated_pragmatic_obligation=10)
-    mock_model_2 = MockModel(awarding_agency_id=2, awarding_subtier_agency_name='Department of Sub-pizza',
+    mock_model_2 = MockModel(awarding_agency_id=3, awarding_subtier_agency_name='Department of Sub-pizza',
                              awarding_subtier_agency_abbreviation='DOSP', generated_pragmatic_obligation=10)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'awarding_subagency',
@@ -128,7 +135,7 @@ def test_category_awarding_subagency_awards(mock_matviews_qs, mock_agencies):
                 'amount': 20,
                 'name': 'Department of Sub-pizza',
                 'code': 'DOSP',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -137,14 +144,16 @@ def test_category_awarding_subagency_awards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_awarding_subagency_subawards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, subtier_agency_id=1)
+    mock_subtier = MockModel(subtier_agency_id=1, name='Department of Sub-pizza', abbreviation='DOSP')
+    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
+    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
     mock_model_1 = MockModel(awarding_agency_id=2, awarding_subtier_agency_name='Department of Sub-pizza',
                              awarding_subtier_agency_abbreviation='DOSP', amount=10)
-    mock_model_2 = MockModel(awarding_agency_id=2, awarding_subtier_agency_name='Department of Sub-pizza',
+    mock_model_2 = MockModel(awarding_agency_id=3, awarding_subtier_agency_name='Department of Sub-pizza',
                              awarding_subtier_agency_abbreviation='DOSP', amount=10)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'awarding_subagency',
@@ -170,7 +179,7 @@ def test_category_awarding_subagency_subawards(mock_matviews_qs, mock_agencies):
                 'amount': 20,
                 'name': 'Department of Sub-pizza',
                 'code': 'DOSP',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -179,14 +188,16 @@ def test_category_awarding_subagency_subawards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_funding_agency_awards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, toptier_agency_id=1)
+    mock_toptier = MockModel(toptier_agency_id=1, name='Department of Calzone', abbreviation='DOC')
+    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
+    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
     mock_model_1 = MockModel(funding_agency_id=2, funding_toptier_agency_name='Department of Calzone',
                              funding_toptier_agency_abbreviation='DOC', generated_pragmatic_obligation=50)
-    mock_model_2 = MockModel(funding_agency_id=2, funding_toptier_agency_name='Department of Calzone',
+    mock_model_2 = MockModel(funding_agency_id=3, funding_toptier_agency_name='Department of Calzone',
                              funding_toptier_agency_abbreviation='DOC', generated_pragmatic_obligation=50)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'funding_agency',
@@ -212,7 +223,7 @@ def test_category_funding_agency_awards(mock_matviews_qs, mock_agencies):
                 'amount': 100,
                 'name': 'Department of Calzone',
                 'code': 'DOC',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -221,14 +232,16 @@ def test_category_funding_agency_awards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_funding_agency_subawards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, toptier_agency_id=1)
+    mock_toptier = MockModel(toptier_agency_id=1, name='Department of Calzone', abbreviation='DOC')
+    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
+    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
     mock_model_1 = MockModel(funding_agency_id=2, funding_toptier_agency_name='Department of Calzone',
                              funding_toptier_agency_abbreviation='DOC', amount=50)
-    mock_model_2 = MockModel(funding_agency_id=2, funding_toptier_agency_name='Department of Calzone',
+    mock_model_2 = MockModel(funding_agency_id=3, funding_toptier_agency_name='Department of Calzone',
                              funding_toptier_agency_abbreviation='DOC', amount=50)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'funding_agency',
@@ -254,7 +267,7 @@ def test_category_funding_agency_subawards(mock_matviews_qs, mock_agencies):
                 'amount': 100,
                 'name': 'Department of Calzone',
                 'code': 'DOC',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -263,14 +276,16 @@ def test_category_funding_agency_subawards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_funding_subagency_awards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, subtier_agency_id=1)
+    mock_subtier = MockModel(subtier_agency_id=1, name='Department of Sub-calzone', abbreviation='DOSC')
+    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
+    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
     mock_model_1 = MockModel(funding_agency_id=2, funding_subtier_agency_name='Department of Sub-calzone',
                              funding_subtier_agency_abbreviation='DOSC', generated_pragmatic_obligation=5)
-    mock_model_2 = MockModel(funding_agency_id=2, funding_subtier_agency_name='Department of Sub-calzone',
+    mock_model_2 = MockModel(funding_agency_id=3, funding_subtier_agency_name='Department of Sub-calzone',
                              funding_subtier_agency_abbreviation='DOSC', generated_pragmatic_obligation=-5)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'funding_subagency',
@@ -296,7 +311,7 @@ def test_category_funding_subagency_awards(mock_matviews_qs, mock_agencies):
                 'amount': 0,
                 'name': 'Department of Sub-calzone',
                 'code': 'DOSC',
-                'id': 1
+                'id': 2
             }
         ]
     }
@@ -305,14 +320,16 @@ def test_category_funding_subagency_awards(mock_matviews_qs, mock_agencies):
 
 
 def test_category_funding_subagency_subawards(mock_matviews_qs, mock_agencies):
-    mock_agency = MockModel(id=2, subtier_agency_id=1)
+    mock_subtier = MockModel(subtier_agency_id=1, name='Department of Sub-calzone', abbreviation='DOSC')
+    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
+    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
     mock_model_1 = MockModel(funding_agency_id=2, funding_subtier_agency_name='Department of Sub-calzone',
                              funding_subtier_agency_abbreviation='DOSC', amount=5)
-    mock_model_2 = MockModel(funding_agency_id=2, funding_subtier_agency_name='Department of Sub-calzone',
+    mock_model_2 = MockModel(funding_agency_id=3, funding_subtier_agency_name='Department of Sub-calzone',
                              funding_subtier_agency_abbreviation='DOSC', amount=-5)
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies['agency'], [mock_agency])
+    add_to_mock_objects(mock_agencies['agency'], [mock_agency, mock_agency_1])
 
     test_payload = {
         'category': 'funding_subagency',
@@ -338,7 +355,7 @@ def test_category_funding_subagency_subawards(mock_matviews_qs, mock_agencies):
                 'amount': 0,
                 'name': 'Department of Sub-calzone',
                 'code': 'DOSC',
-                'id': 1
+                'id': 2
             }
         ]
     }

--- a/usaspending_api/search/tests/unit/test_spending_by_category.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_category.py
@@ -349,6 +349,7 @@ def test_category_funding_subagency_subawards(mock_matviews_qs, mock_agencies):
 def test_category_recipient_duns_awards(mock_matviews_qs, mock_recipients):
     mock_recipient_1 = MockModel(recipient_unique_id='00UOP00', legal_entity_id=1)
     mock_recipient_2 = MockModel(recipient_unique_id='1234JD4321', legal_entity_id=2)
+    mock_recipient_3 = MockModel(recipient_name='MULTIPLE RECIPIENTS', recipient_unique_id=None, legal_entity_id=3)
     mock_model_1 = MockModel(recipient_name='University of Pawnee',
                              recipient_unique_id='00UOP00', generated_pragmatic_obligation=1)
     mock_model_2 = MockModel(recipient_name='University of Pawnee',
@@ -357,9 +358,11 @@ def test_category_recipient_duns_awards(mock_matviews_qs, mock_recipients):
                              recipient_unique_id='1234JD4321', generated_pragmatic_obligation=1)
     mock_model_4 = MockModel(recipient_name='John Doe',
                              recipient_unique_id='1234JD4321', generated_pragmatic_obligation=10)
+    mock_model_5 = MockModel(recipient_name='MULTIPLE RECIPIENTS',
+                             recipient_unique_id=None, generated_pragmatic_obligation=15)
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_recipients, [mock_recipient_1, mock_recipient_2])
+    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4, mock_model_5])
+    add_to_mock_objects(mock_recipients, [mock_recipient_1, mock_recipient_2, mock_recipient_3])
 
     test_payload = {
         'category': 'recipient_duns',
@@ -382,6 +385,12 @@ def test_category_recipient_duns_awards(mock_matviews_qs, mock_recipients):
         },
         'results': [
             {
+                'amount': 15,
+                'name': 'MULTIPLE RECIPIENTS',
+                'code': None,
+                'id': 3
+            },
+            {
                 'amount': 11,
                 'name': 'John Doe',
                 'code': '1234JD4321',
@@ -402,6 +411,7 @@ def test_category_recipient_duns_awards(mock_matviews_qs, mock_recipients):
 def test_category_recipient_duns_subawards(mock_matviews_qs, mock_recipients):
     mock_recipient_1 = MockModel(recipient_unique_id='00UOP00', legal_entity_id=1)
     mock_recipient_2 = MockModel(recipient_unique_id='1234JD4321', legal_entity_id=2)
+    mock_recipient_3 = MockModel(recipient_name='MULTIPLE RECIPIENTS', recipient_unique_id=None, legal_entity_id=3)
     mock_model_1 = MockModel(recipient_name='University of Pawnee',
                              recipient_unique_id='00UOP00', amount=1)
     mock_model_2 = MockModel(recipient_name='University of Pawnee',
@@ -410,9 +420,11 @@ def test_category_recipient_duns_subawards(mock_matviews_qs, mock_recipients):
                              recipient_unique_id='1234JD4321', amount=1)
     mock_model_4 = MockModel(recipient_name='John Doe',
                              recipient_unique_id='1234JD4321', amount=10)
+    mock_model_5 = MockModel(recipient_name='MULTIPLE RECIPIENTS',
+                             recipient_unique_id=None, amount=15)
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_recipients, [mock_recipient_1, mock_recipient_2])
+    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4, mock_model_5])
+    add_to_mock_objects(mock_recipients, [mock_recipient_1, mock_recipient_2, mock_recipient_3])
 
     test_payload = {
         'category': 'recipient_duns',
@@ -434,6 +446,12 @@ def test_category_recipient_duns_subawards(mock_matviews_qs, mock_recipients):
             'hasPrevious': False
         },
         'results': [
+            {
+                'amount': 15,
+                'name': 'MULTIPLE RECIPIENTS',
+                'code': None,
+                'id': 3
+            },
             {
                 'amount': 11,
                 'name': 'John Doe',

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -278,7 +278,10 @@ class BusinessLogic:
 def fetch_agency_tier_id_by_agency(agency_name, is_subtier=False):
     agency_type = 'subtier_agency' if is_subtier else 'toptier_agency'
     columns = ['id']
-    filters = {'{}__name'.format(agency_type): agency_name, 'toptier_flag': not is_subtier}
+    filters = {'{}__name'.format(agency_type): agency_name}
+    if not is_subtier:
+        # Note: The awarded/funded subagency can be a toptier agency, so we don't filter only subtiers in that case.
+        filters['toptier_flag'] = True
     result = Agency.objects.filter(**filters).values(*columns).first()
     if not result:
         logger.warning('{} not found for agency_name: {}'.format(','.join(columns), agency_name))

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -164,18 +164,17 @@ class BusinessLogic:
     def awarding_agency(self) -> list:
         if self.category == 'awarding_agency':
             filters = {'awarding_toptier_agency_name__isnull': False}
-            values = ['awarding_agency_id', 'awarding_toptier_agency_name', 'awarding_toptier_agency_abbreviation']
+            values = ['awarding_toptier_agency_name', 'awarding_toptier_agency_abbreviation']
         elif self.category == 'awarding_subagency':
             filters = {'awarding_subtier_agency_name__isnull': False}
-            values = ['awarding_agency_id', 'awarding_subtier_agency_name', 'awarding_subtier_agency_abbreviation']
+            values = ['awarding_subtier_agency_name', 'awarding_subtier_agency_abbreviation']
 
         self.queryset = self.common_db_query(filters, values)
         # DB hit here
         query_results = list(self.queryset[self.lower_limit:self.upper_limit])
         results = alias_response(ALIAS_DICT[self.category], query_results)
         for row in results:
-            row['id'] = fetch_agency_tier_id_by_agency(row['awarding_agency_id'], self.category == 'awarding_subagency')
-            del row['awarding_agency_id']
+            row['id'] = fetch_agency_tier_id_by_agency(row['name'], self.category == 'awarding_subagency')
         return results
 
     def funding_agency(self) -> list:
@@ -187,10 +186,10 @@ class BusinessLogic:
         """
         if self.category == 'funding_agency':
             filters = {'funding_toptier_agency_name__isnull': False}
-            values = ['funding_agency_id', 'funding_toptier_agency_name', 'funding_toptier_agency_abbreviation']
+            values = ['funding_toptier_agency_name', 'funding_toptier_agency_abbreviation']
         elif self.category == 'funding_subagency':
             filters = {'funding_subtier_agency_name__isnull': False}
-            values = ['funding_agency_id', 'funding_subtier_agency_name', 'funding_subtier_agency_abbreviation']
+            values = ['funding_subtier_agency_name', 'funding_subtier_agency_abbreviation']
 
         self.queryset = self.common_db_query(filters, values)
         # DB hit here
@@ -198,8 +197,7 @@ class BusinessLogic:
 
         results = alias_response(ALIAS_DICT[self.category], query_results)
         for row in results:
-            row['id'] = fetch_agency_tier_id_by_agency(row['funding_agency_id'], self.category == 'funding_subagency')
-            del row['funding_agency_id']
+            row['id'] = fetch_agency_tier_id_by_agency(row['name'], self.category == 'funding_subagency')
         return results
 
     def recipient(self) -> list:
@@ -277,14 +275,13 @@ class BusinessLogic:
         return results
 
 
-def fetch_agency_tier_id_by_agency(agency_id, is_subtier=False):
-    columns = ['toptier_agency_id']
-    if is_subtier:
-        # filters = {'subtier_agency__isnull': False}
-        columns = ['subtier_agency_id']
-    result = Agency.objects.filter(id=agency_id).values(*columns).first()
+def fetch_agency_tier_id_by_agency(agency_name, is_subtier=False):
+    agency_type = 'subtier_agency' if is_subtier else 'toptier_agency'
+    columns = ['id']
+    filters = {'{}__name'.format(agency_type): agency_name, 'toptier_flag': not is_subtier}
+    result = Agency.objects.filter(**filters).values(*columns).first()
     if not result:
-        logger.warning('{} not found for agency_id: {}'.format(','.join(columns), agency_id))
+        logger.warning('{} not found for agency_name: {}'.format(','.join(columns), agency_name))
         return None
     return result[columns[0]]
 

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -202,7 +202,7 @@ class BusinessLogic:
 
     def recipient(self) -> list:
         if self.category == 'recipient_duns':
-            filters = {'recipient_unique_id__isnull': False}
+            filters = {}
             values = ['recipient_name', 'recipient_unique_id']
 
         elif self.category == 'recipient_parent_duns':


### PR DESCRIPTION
**High level description:**
Hotfixes some of the aggregate logic for the agency and recipient categories in Spending by Category.

**Technical details:**
* Agency categories are rolled up based on name and not their agency ids (led to duplicate results)
* The database IDS returned from the agency categories are the `agency` id and not the `toptier`/`subtier` ids in preparation for possible linking to agency pages. **Note: when grouping toptier agencies, the agency ID returned will be the single agency with `toptier_flag` is set to True. For subtier agencies, it may return a top or subtier agency depending on what agency listing the award links to**
* Recipient groups allows blank duns (allows `MULTIPLE RECIPIENTS`)

**Link to JIRA Ticket:**
[DEV-1108](https://federal-spending-transparency.atlassian.net/browse/DEV-1108)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Matview impact assessment completed (N/A)
- Frontend impact assessment completed (N/A)
- [x] Data validation completed
- API Performance evaluation completed (N/A)
```