### PR TITLE
Hotfix: Remove cfda_popular_name from Elasticsearch ETL

### DIFF
--- a/usaspending_api/database_scripts/etl/transaction_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/transaction_delta_view.sql
@@ -60,7 +60,7 @@ SELECT
   UTM.funding_subtier_agency_abbreviation,
 
   UTM.cfda_title,
-  UTM.cfda_popular_name,
+  '' AS cfda_popular_name,
   UTM.type_of_contract_pricing,
   UTM.type_set_aside,
   UTM.extent_competed,


### PR DESCRIPTION
**High level description:**
Removed `cfda_popular_name` from matviews, but failed to remove from Elasticsearch ETL

**Technical details:**
While `cfda_popular_name` is not used by any API endpoints it is included in the Elasticsearch ETL view. Instead of removing the column, or modifying the view to join to `references_cfda`, simply changed to inserting an empty string value. Elasticsearch isn't even indexing the values in the documents.

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed (N/A)
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)