### PR TITLE
Hotfix nightly pipeline: adding missing refresh flag to summary_state_view

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/summary_state_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_state_view.json
@@ -1,5 +1,6 @@
 {
   "final_name": "summary_state_view",
+  "refresh": true,
   "matview_sql": [
     "SELECT",
     "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' ')) AS pk,",


### PR DESCRIPTION
**High level description:**
`summary_state_view` materialized view description JSON file was surprisingly missing a necessary flag to trigger the sql generator script to create the necessary SQL file for matview refreshes.

**Technical details:**
(N/A)

**Link to JIRA Ticket:**
[DEV-1135](https://federal-spending-transparency.atlassian.net/browse/DEV-1135)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)