### PR TITLE
Update spending explorer unreported data to only be displayed at top level entry points

### DIFF
--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -11,9 +11,10 @@ from usaspending_api.spending_explorer.v2.filters.spending_filter import spendin
 
 UNREPORTED_DATA_NAME = 'Unreported Data'
 VALID_UNREPORTED_DATA_TYPES = ['agency', 'budget_function', 'object_class']
+VALID_UNREPORTED_FILTERS = ['fy', 'quarter']
 
 
-def get_unreported_data_obj(queryset, limit, spending_type, actual_total, fiscal_year, fiscal_quarter) -> \
+def get_unreported_data_obj(queryset, filters, limit, spending_type, actual_total, fiscal_year, fiscal_quarter) -> \
         (list, float):
     """ Returns the modified list of result objects including the object corresponding to the unreported amount, only
         if applicable. If the unreported amount does not fit within the limit of results provided, it will not be added.
@@ -45,7 +46,7 @@ def get_unreported_data_obj(queryset, limit, spending_type, actual_total, fiscal
         values_list('total_obligation', flat=True). \
         first()
 
-    if spending_type in VALID_UNREPORTED_DATA_TYPES:
+    if spending_type in VALID_UNREPORTED_DATA_TYPES and list(filters.keys()) == VALID_UNREPORTED_FILTERS:
         unreported_obj = {
             'id': None,
             'code': None,
@@ -62,6 +63,8 @@ def get_unreported_data_obj(queryset, limit, spending_type, actual_total, fiscal
             result_set.append(unreported_obj)
 
         result_set = sorted(result_set, key=lambda k: k['amount'], reverse=True)
+    else:
+        expected_total = actual_total
 
     return result_set, expected_total
 
@@ -180,9 +183,9 @@ def type_filter(_type, filters, limit=None):
         # Actual total value of filtered results
         actual_total = queryset.aggregate(total=Sum('obligations_incurred_by_program_object_class_cpe'))['total']
 
-        result_set, expected_total = get_unreported_data_obj(queryset=queryset, limit=limit, spending_type=_type,
-                                                             actual_total=actual_total, fiscal_year=fiscal_year,
-                                                             fiscal_quarter=fiscal_quarter)
+        result_set, expected_total = get_unreported_data_obj(queryset=queryset, filters=filters, limit=limit,
+                                                             spending_type=_type, actual_total=actual_total,
+                                                             fiscal_year=fiscal_year, fiscal_quarter=fiscal_quarter)
 
         results = {
             'total': expected_total,


### PR DESCRIPTION
**High level description:**
Updating to only show unreported data if at the top level of the spending explorer, therefore had to check that the type wasn't used again with additional filters.

**Technical details:**
Updating to only show unreported data if at the top level of the spending explorer. Had to check that the type wasn't used again with additional filters and then set the `expected_total` to the `actual_total` if unreported data wasn't being utilized.

**Link to JIRA Ticket:**
(PENDING ACTUAL TICKET, WILL BE UPDATED)
[DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases (N/A)
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed
  - Data validated to no longer show unreported data at nested levels even if the `type` matches one of the top entry points
- [x] API Performance evaluation completed and present (N/A)