### PR TITLE
Added reload_duns script for nightly updates

### DIFF
--- a/usaspending_api/broker/management/sql/reload_duns.sql
+++ b/usaspending_api/broker/management/sql/reload_duns.sql
@@ -1,0 +1,36 @@
+BEGIN;
+DROP INDEX IF EXISTS duns_awardee_idx;
+TRUNCATE TABLE duns;
+INSERT INTO duns (
+    SELECT
+        broker_duns.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
+        broker_duns.legal_business_name AS legal_business_name,
+        broker_duns.ultimate_parent_unique_ide AS ultimate_parent_unique_ide,
+        broker_duns.ultimate_parent_legal_enti AS ultimate_parent_legal_enti,
+        broker_duns.duns_id AS broker_duns_id,
+        NOW()::DATE AS update_date
+    FROM
+        dblink ('broker_server', '(
+            SELECT
+                DISTINCT
+                    ON (duns.awardee_or_recipient_uniqu)
+                    duns.awardee_or_recipient_uniqu,
+                    duns.legal_business_name,
+                    duns.ultimate_parent_unique_ide,
+                    duns.ultimate_parent_legal_enti,
+                    duns.duns_id
+            FROM
+                duns
+            ORDER BY
+                duns.awardee_or_recipient_uniqu,
+                duns.activation_date DESC NULLS LAST)') AS broker_duns
+            (
+                awardee_or_recipient_uniqu text,
+                legal_business_name text,
+                ultimate_parent_unique_ide text,
+                ultimate_parent_legal_enti text,
+                duns_id text
+            )
+);
+CREATE UNIQUE INDEX duns_awardee_idx ON duns USING btree (awardee_or_recipient_uniqu);
+COMMIT;


### PR DESCRIPTION
**High level description:**
Created a new script to reload the `duns` table with data from the Broker's `duns` table. The original `load_duns` script would cascade drop and recreate the table which is detrimental to the matviews as a number of them rely on that table and would be dropped.

**Technical details:**
New sql file is wrapped as a single transactions. It will truncate the table and reload from the broker using the same dblink SQL as the original load script.

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)