### PR TITLE
Added nice print statements to SQL during index creation

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
@@ -21,18 +21,18 @@ EXAMPLE SQL DESCRIPTION JSON FILE:
 {   "final_name": "example_matview",
     "matview_sql": [
     "SELECT",
-    "  \"transaction_normalized\".\"action_date\",",
-    "  \"transaction_normalized\".\"fiscal_year\",",
-    "  \"awards\".\"type\",",
-    "  \"awards\".\"category\",",
+    "  action_date,",
+    "  fiscal_year,",
+    "  awards.type,",
+    "  awards.category,",
     "FROM",
-    "  \"awards\"",
+    "  awards",
     "LEFT OUTER JOIN",
-    "  \"transaction_normalized\" ON (\"awards\".\"latest_transaction_id\" = \"transaction_normalized\".\"id\")",
+    "  transaction_normalized ON (awards.latest_transaction_id = id)",
     "WHERE",
-    "  \"transaction_normalized\".action_date >= '2000-10-01'",
+    "  action_date >= '2000-10-01'",
     "ORDER BY",
-    "  \"action_date\" DESC"
+    "  action_date DESC"
 
     ],
     "index": {
@@ -63,6 +63,7 @@ TEMPLATE = {
     'create_index': 'CREATE {}INDEX {} ON {} USING {}({}){}{};',
     'rename_index': 'ALTER INDEX {}{} RENAME TO {};',
     'grant_select': 'GRANT SELECT ON {} TO {};',
+    'sql_print_output': 'DO $$ BEGIN RAISE NOTICE \'{}\'; END $$;',
 }
 
 CLUSTERING_INDEX = None
@@ -184,9 +185,16 @@ def make_indexes_sql(sql_json, matview_name):
 
     if len(unique_name_list) != len(set(unique_name_list)):
         raise Exception('Name collision detected. Examine JSON file')
-    print_debug('There are {} index creations'.format(len(create_indexes)))
+    total = len(create_indexes)
+    print_debug('There are {} index creations'.format(total))
+    indexes_and_msg = []
+    for n, index in enumerate(create_indexes):
+        if n % 10 == 0 and n > 0:
+            console_output = TEMPLATE['sql_print_output'].format('{} indexes created, {} remaining'.format(n, total - n))
+            indexes_and_msg.append(console_output)
+        indexes_and_msg.append(index)
 
-    return create_indexes, rename_old_indexes, rename_new_indexes
+    return indexes_and_msg, rename_old_indexes, rename_new_indexes
 
 
 def make_modification_sql(matview_name):


### PR DESCRIPTION
**High level description:**
Adding an print statement to the SQL files for notifying how many indexes are left to create on a materialized view during index creation.

**Technical details:**
Using the `RAISE NOTICE` expression in PL/pgSQL

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed (N/A)
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)