### PR TITLE
Bugfix: PK in models

### DIFF
--- a/usaspending_api/awards/models_matviews.py
+++ b/usaspending_api/awards/models_matviews.py
@@ -89,7 +89,6 @@ class UniversalTransactionView(models.Model):
 
 
 class SummaryTransactionView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField(blank=True, null=False)
     fiscal_year = models.IntegerField()
     type = models.TextField(blank=True, null=True)
@@ -233,7 +232,6 @@ class UniversalAwardView(models.Model):
 
 
 class SummaryAwardView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField(blank=True, null=True)
     fiscal_year = models.IntegerField()
     type = models.TextField(blank=True, null=True)
@@ -261,7 +259,6 @@ class SummaryAwardView(models.Model):
 
 
 class SummaryView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField(blank=True, null=True)
     fiscal_year = models.IntegerField()
     type = models.TextField(blank=True, null=True)
@@ -289,7 +286,6 @@ class SummaryView(models.Model):
 
 
 class SummaryNaicsCodesView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField(blank=True, null=True)
     fiscal_year = models.IntegerField()
     type = models.TextField(blank=True, null=True)
@@ -309,7 +305,6 @@ class SummaryNaicsCodesView(models.Model):
 
 
 class SummaryPscCodesView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField(blank=True, null=True)
     fiscal_year = models.IntegerField()
     type = models.TextField(blank=True, null=True)
@@ -327,7 +322,6 @@ class SummaryPscCodesView(models.Model):
 
 
 class SummaryCfdaNumbersView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField(blank=True, null=True)
     fiscal_year = models.IntegerField()
     type = models.TextField(blank=True, null=True)
@@ -346,7 +340,6 @@ class SummaryCfdaNumbersView(models.Model):
 
 
 class SummaryTransactionMonthView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField()
     fiscal_year = models.IntegerField()
     type = models.TextField()
@@ -409,7 +402,6 @@ class SummaryTransactionMonthView(models.Model):
 
 
 class SummaryTransactionGeoView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField()
     fiscal_year = models.IntegerField()
     type = models.TextField()
@@ -455,7 +447,6 @@ class SummaryTransactionGeoView(models.Model):
 
 
 class SummaryStateView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField()
     fiscal_year = models.IntegerField()
     type = models.TextField()
@@ -828,7 +819,6 @@ class SubawardView(models.Model):
 
 
 class SummaryTransactionRecipientView(models.Model):
-    pk = models.UUIDField(primary_key=True)
     action_date = models.DateField()
     fiscal_year = models.IntegerField()
     type = models.TextField()


### PR DESCRIPTION
* Removing the PK Django fields, keeping them in results in the failure of `generate_zip` to start which processes all the downloads