### PR TITLE
USASPENDING_AWS_REGION env var consolidation

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -304,7 +304,7 @@ class Command(BaseCommand):
                     writer.write(row + '\n')
         else:
             # Write to file in S3 bucket directly
-            aws_region = os.environ.get('AWS_REGION')
+            aws_region = os.environ.get('USASPENDING_AWS_REGION')
             elasticsearch_bucket_name = os.environ.get('FPDS_BUCKET_NAME')
             s3_bucket = boto.s3.connect_to_region(aws_region).get_bucket(elasticsearch_bucket_name)
             conn = s3_bucket.new_key(file_name)

--- a/usaspending_api/broker/management/commands/fpds_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fpds_nightly_loader.py
@@ -62,11 +62,11 @@ class Command(BaseCommand):
                         ids_to_delete += unique_key_list
         else:
             # Connect to AWS
-            aws_region = os.environ.get('AWS_REGION')
+            aws_region = os.environ.get('USASPENDING_AWS_REGION')
             fpds_bucket_name = os.environ.get('FPDS_BUCKET_NAME')
 
             if not (aws_region or fpds_bucket_name):
-                raise Exception('Missing required environment variables: AWS_REGION, FPDS_BUCKET_NAME')
+                raise Exception('Missing required environment variables: USASPENDING_AWS_REGION, FPDS_BUCKET_NAME')
 
             s3client = boto3.client('s3', region_name=aws_region)
             s3resource = boto3.resource('s3', region_name=aws_region)

--- a/usaspending_api/common/csv_helpers.py
+++ b/usaspending_api/common/csv_helpers.py
@@ -4,7 +4,7 @@ import boto3
 
 
 # Used by bulk and baby download
-def sqs_queue(region_name=settings.CSV_AWS_REGION, QueueName=settings.CSV_SQS_QUEUE_NAME):
+def sqs_queue(region_name=settings.USASPENDING_AWS_REGION, QueueName=settings.CSV_SQS_QUEUE_NAME):
     # stuff that's in get_queue
     sqs = boto3.resource('sqs', region_name=region_name)
     queue = sqs.get_queue_by_name(QueueName=QueueName)

--- a/usaspending_api/common/threaded_data_loader.py
+++ b/usaspending_api/common/threaded_data_loader.py
@@ -90,7 +90,7 @@ class ThreadedDataLoader():
             process.start()
 
         if remote_file:
-            aws_region = os.environ.get('AWS_REGION')
+            aws_region = os.environ.get('USASPENDING_AWS_REGION')
             with smart_open.smart_open(filepath, 'r', encoding=encoding, region_name=aws_region) as csv_file:
                 row_queue = self.csv_file_to_queue(csv_file, row_queue)
         else:

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -67,7 +67,7 @@ def generate_csvs(download_job, sqs_message=None):
         # push file to S3 bucket, if not local
         if not settings.IS_LOCAL:
             bucket = settings.BULK_DOWNLOAD_S3_BUCKET_NAME
-            region = settings.BULK_DOWNLOAD_AWS_REGION
+            region = settings.USASPENDING_API_REGION
             start_uploading = time.time()
             multipart_upload(bucket, region, file_path, os.path.basename(file_path), acl='public-read',
                              parallel_processes=multiprocessing.cpu_count())

--- a/usaspending_api/download/filestreaming/s3_handler.py
+++ b/usaspending_api/download/filestreaming/s3_handler.py
@@ -13,7 +13,7 @@ class S3Handler:
     This class acts a wrapper for S3 URL Signing
     """
 
-    def __init__(self, name=settings.CSV_S3_BUCKET_NAME, region=settings.CSV_AWS_REGION):
+    def __init__(self, name=settings.CSV_S3_BUCKET_NAME, region=settings.USASPENDING_AWS_REGION):
         """
         Creates the object for signing URLS
 

--- a/usaspending_api/download/management/commands/generate_zip.py
+++ b/usaspending_api/download/management/commands/generate_zip.py
@@ -19,8 +19,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Run the application."""
-        queue = sqs_queue(region_name=settings.BULK_DOWNLOAD_AWS_REGION,
-                          QueueName=settings.BULK_DOWNLOAD_SQS_QUEUE_NAME)
+        queue = sqs_queue(QueueName=settings.BULK_DOWNLOAD_SQS_QUEUE_NAME)
 
         write_to_log(message='Starting SQS polling')
         while True:

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
         elif not settings.IS_LOCAL:
             # Upload file to S3 and delete local version
             logger.info('Uploading file to S3 bucket and deleting local copy')
-            multipart_upload(settings.MONTHLY_DOWNLOAD_S3_BUCKET_NAME, settings.BULK_DOWNLOAD_AWS_REGION, file_path,
+            multipart_upload(settings.MONTHLY_DOWNLOAD_S3_BUCKET_NAME, settings.USASPENDING_AWS_REGION, file_path,
                              os.path.basename(file_path))
             os.remove(file_path)
 
@@ -157,7 +157,7 @@ class Command(BaseCommand):
                                 values_list('subtier_code', flat=True))
 
         # Create a list of keys in the bucket that match the date range we want
-        bucket = boto.s3.connect_to_region(settings.BULK_DOWNLOAD_AWS_REGION).get_bucket(settings.FPDS_BUCKET_NAME)
+        bucket = boto.s3.connect_to_region(settings.USASPENDING_AWS_REGION).get_bucket(settings.FPDS_BUCKET_NAME)
 
         all_deletions = pd.DataFrame()
         for key in bucket.list():

--- a/usaspending_api/download/management/commands/populate_monthly_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_files.py
@@ -70,13 +70,12 @@ class Command(BaseCommand):
         else:
             # Send a SQS message that will be processed by another server, which will eventually run
             # csv_generation.generate_csvs(download_job, message) (see generate_zip.py)
-            queue = sqs_queue(region_name=settings.BULK_DOWNLOAD_AWS_REGION,
-                              QueueName=settings.BULK_DOWNLOAD_SQS_QUEUE_NAME)
+            queue = sqs_queue(QueueName=settings.BULK_DOWNLOAD_SQS_QUEUE_NAME)
             queue.send_message(MessageBody=str(download_job.download_job_id))
 
     def upload_placeholder(self, file_name, empty_file):
         bucket = settings.BULK_DOWNLOAD_S3_BUCKET_NAME
-        region = settings.BULK_DOWNLOAD_AWS_REGION
+        region = settings.USASPENDING_AWS_REGION
 
         logger.info('Uploading {}'.format(file_name))
         multipart_upload(bucket, region, empty_file, file_name, acl='public-read',
@@ -164,7 +163,7 @@ class Command(BaseCommand):
         # Make sure
         #   settings.BULK_DOWNLOAD_S3_BUCKET_NAME
         #   settings.BULK_DOWNLOAD_SQS_QUEUE_NAME
-        #   settings.BULK_DOWNLOAD_AWS_REGION
+        #   settings.USASPENDING_AWS_REGION
         # are properly configured!
 
         local = options['local']
@@ -206,7 +205,7 @@ class Command(BaseCommand):
 
         # moving it to self.bucket as it may be used in different cases
         bucket_name = settings.MONTHLY_DOWNLOAD_S3_BUCKET_NAME
-        region_name = settings.BULK_DOWNLOAD_AWS_REGION
+        region_name = settings.USASPENDING_AWS_REGION
         self.bucket = boto.s3.connect_to_region(region_name).get_bucket(bucket_name)
 
         if not clobber:

--- a/usaspending_api/download/v2/views.py
+++ b/usaspending_api/download/v2/views.py
@@ -41,7 +41,7 @@ from usaspending_api.references.models import ToptierAgency
 
 @api_transformations(api_version=settings.API_VERSION, function_list=API_TRANSFORM_FUNCTIONS)
 class BaseDownloadViewSet(APIDocumentationView):
-    s3_handler = S3Handler(name=settings.BULK_DOWNLOAD_S3_BUCKET_NAME, region=settings.BULK_DOWNLOAD_AWS_REGION)
+    s3_handler = S3Handler(name=settings.BULK_DOWNLOAD_S3_BUCKET_NAME)
 
     def post(self, request, request_type='award'):
         """Push a message to SQS with the validated request JSON"""
@@ -219,8 +219,7 @@ class BaseDownloadViewSet(APIDocumentationView):
             # csv_generation.write_csvs(**kwargs) (see generate_zip.py)
             write_to_log(message='Passing download_job {} to SQS'.format(download_job.download_job_id),
                          download_job=download_job)
-            queue = sqs_queue(region_name=settings.BULK_DOWNLOAD_AWS_REGION,
-                              QueueName=settings.BULK_DOWNLOAD_SQS_QUEUE_NAME)
+            queue = sqs_queue(QueueName=settings.BULK_DOWNLOAD_SQS_QUEUE_NAME)
             queue.send_message(MessageBody=str(download_job.download_job_id))
 
     def get_download_response(self, file_name):
@@ -519,7 +518,7 @@ class ListMonthlyDownloadsViewset(APIDocumentationView):
 
     endpoint_doc: /download/list_downloads.md
     """
-    s3_handler = S3Handler(name=settings.MONTHLY_DOWNLOAD_S3_BUCKET_NAME, region=settings.BULK_DOWNLOAD_AWS_REGION)
+    s3_handler = S3Handler(name=settings.MONTHLY_DOWNLOAD_S3_BUCKET_NAME)
 
     # This is intentionally not cached so that the latest updates to these monthly generated files are always returned
     def post(self, request):

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -409,8 +409,8 @@ def gather_deleted_ids(config):
         bucket_objects = list(bucket.objects.all())
     except Exception as e:
         print('\n[ERROR]\n')
-        print('Verify settings.CSV_AWS_REGION and settings.DELETED_TRANSACTIONS_S3_BUCKET_NAME are correct')
-        print('  or is using env variables: CSV_AWS_REGION and DELETED_TRANSACTIONS_S3_BUCKET_NAME')
+        print('Verify settings.USASPENDING_AWS_REGION and settings.DELETED_TRANSACTIONS_S3_BUCKET_NAME are correct')
+        print('  or is using env variables: USASPENDING_AWS_REGION and DELETED_TRANSACTIONS_S3_BUCKET_NAME')
         print('\n {} \n'.format(e))
         raise SystemExit(1)
 

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -225,7 +225,7 @@ class Command(BaseCommand):
 
 def set_config():
     return {
-        'aws_region': os.environ.get('CSV_AWS_REGION'),
+        'aws_region': os.environ.get('USASPENDING_AWS_REGION'),
         's3_bucket': os.environ.get('DELETED_TRANSACTIONS_S3_BUCKET_NAME'),
         'root_index': settings.TRANSACTIONS_INDEX_ROOT,
         'formatted_now': datetime.utcnow().strftime('%Y%m%dT%H%M%SZ'),  # ISO8601

--- a/usaspending_api/etl/management/commands/fetch_transactions.py
+++ b/usaspending_api/etl/management/commands/fetch_transactions.py
@@ -158,8 +158,8 @@ class Command(BaseCommand):
 
 def set_config():
 
-    if not os.environ.get('CSV_AWS_REGION'):
-        print('Missing environment variable `CSV_AWS_REGION`')
+    if not os.environ.get('USASPENDING_AWS_REGION'):
+        print('Missing environment variable `USASPENDING_AWS_REGION`')
         raise SystemExit
 
     if not os.environ.get('DELETED_TRANSACTIONS_S3_BUCKET_NAME'):
@@ -171,7 +171,7 @@ def set_config():
         raise SystemExit
 
     config = {
-        'aws_region': os.environ.get('CSV_AWS_REGION'),
+        'aws_region': os.environ.get('USASPENDING_AWS_REGION'),
         's3_bucket': os.environ.get('DELETED_TRANSACTIONS_S3_BUCKET_NAME')
     }
 

--- a/usaspending_api/recipient/management/commands/load_state_data.py
+++ b/usaspending_api/recipient/management/commands/load_state_data.py
@@ -43,8 +43,8 @@ class Command(BaseCommand):
             elif os.path.splitext(csv_file)[1] != '.csv':
                 raise Exception('Wrong filetype provided, expecting csv')
             file_path = csv_file
-        elif not settings.IS_LOCAL and os.environ.get('AWS_REGION') and os.environ.get('STATE_DATA_BUCKET'):
-            s3connection = boto.s3.connect_to_region(os.environ.get('AWS_REGION'))
+        elif not settings.IS_LOCAL and os.environ.get('USASPENDING_AWS_REGION') and os.environ.get('STATE_DATA_BUCKET'):
+            s3connection = boto.s3.connect_to_region(os.environ.get('USASPENDING_AWS_REGION'))
             s3bucket = s3connection.lookup(os.environ.get('STATE_DATA_BUCKET'))
             key = s3bucket.get_key(LOCAL_STATE_DATA_FILENAME)
             file_path = os.path.join('/', 'tmp', LOCAL_STATE_DATA_FILENAME)

--- a/usaspending_api/references/management/commands/generate_broker_agency_list.py
+++ b/usaspending_api/references/management/commands/generate_broker_agency_list.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
         self.logger.info('Connecting to S3 bucked to retrive broker agency list')
 
-        s3connection = boto.s3.connect_to_region(settings.BULK_DOWNLOAD_AWS_REGION)
+        s3connection = boto.s3.connect_to_region(settings.USASPENDING_AWS_REGION)
         s3bucket = s3connection.lookup(settings.BROKER_AGENCY_BUCKET_NAME)
         agency_list = s3bucket.get_key("agency_list.csv").generate_url(expires_in=600)
         broker_agency_list = pd.read_csv(agency_list, dtype=str)

--- a/usaspending_api/references/management/commands/loadtas.py
+++ b/usaspending_api/references/management/commands/loadtas.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         is_remote_file = len(options['location'][0].split('.')) == 1
         if is_remote_file:
-            s3connection = boto.s3.connect_to_region(os.environ.get('AWS_REGION'))
+            s3connection = boto.s3.connect_to_region(os.environ.get('USASPENDING_AWS_REGION'))
             s3bucket = s3connection.lookup(options['location'][0])
             file_path = s3bucket.get_key('cars_tas.csv')
         else:

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -41,16 +41,17 @@ ALLOWED_HOSTS = ['*']
 # Define local flag to affect location of downloads
 IS_LOCAL = True
 
+# AWS Region for USAspending Infrastructure
+USASPENDING_AWS_REGION = ""
+
 # AWS locations for CSV files
 CSV_LOCAL_PATH = os.path.join(BASE_DIR, 'csv_downloads', '')
 CSV_S3_BUCKET_NAME = ""
 CSV_SQS_QUEUE_NAME = ""
-CSV_AWS_REGION = ""
 
 BULK_DOWNLOAD_LOCAL_PATH = os.path.join(BASE_DIR, 'bulk_downloads', '')
 BULK_DOWNLOAD_S3_BUCKET_NAME = ""
 BULK_DOWNLOAD_SQS_QUEUE_NAME = ""
-BULK_DOWNLOAD_AWS_REGION = ""
 MONTHLY_DOWNLOAD_S3_BUCKET_NAME = ""
 BROKER_AGENCY_BUCKET_NAME = ""
 FPDS_BUCKET_NAME = ""


### PR DESCRIPTION
**High level description:**
Over the history of this API, many environment variable names have been used. Formerly, this repo used:
`CSV_AWS_REGION `
`BULK_DOWNLOAD_AWS_REGION`
and in many ETL scripts:
`AWS_REGION`

(There is also `CFDA_REGION`, which needs to exist separately as it comes from a different source).

This consolidates all of these into one environment variable, `USASPENDING_AWS_REGION`.

**Link to JIRA Ticket:**
[link not provided]

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [ ] Operations review completed (for scripts/jobs that use these env vars)