### PR TITLE
Hotfix: delta file generations multiple scripts at the same time

### DIFF
--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -171,13 +171,15 @@ def parse_source(source, columns, download_job, working_dir, start_time, message
         os.remove(temp_file_path)
 
 
-def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job):
+def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None):
     try:
         # Split CSV into separate files
         log_time = time.time()
         split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
                                output_name_template='{}_%s.csv'.format(source_name))
-        write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time), download_job=download_job)
+        if download_job:
+            write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
+                         download_job=download_job)
 
         # Zip the split CSVs into one zipfile
         log_time = time.time()
@@ -185,8 +187,9 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job):
         for split_csv_part in split_csvs:
             zipped_csvs.write(split_csv_part, os.path.basename(split_csv_part))
 
-        write_to_log(message='Writing to zipfile took {} seconds'.format(time.time() - log_time),
-                     download_job=download_job)
+        if download_job:
+            write_to_log(message='Writing to zipfile took {} seconds'.format(time.time() - log_time),
+                         download_job=download_job)
     except Exception as e:
         logger.error(e)
         raise e

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -158,7 +158,7 @@ class Command(BaseCommand):
             if match_date:
                 # Create a local copy of the deletion file
                 delete_filepath = '{}{}'.format(working_dir, key.name)
-                open(x, delete_filepath).close()
+                open(delete_filepath, 'a').close()
                 key.get_contents_to_filename(delete_filepath)
                 df = pd.read_csv(delete_filepath)
                 os.remove(delete_filepath)

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -130,6 +130,7 @@ class Command(BaseCommand):
             # Split the CSV into multiple files and zip it up
             zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
                                                          datetime.strftime(date.today(), '%Y%m%d'))
+            logger.info('Creating compressed file: {}'.format(os.path.basename(zipfile_path)))
             split_and_zip_csvs(zipfile_path, source_path, source_name)
         else:
             zipfile_path = None

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pandas as pd
 import re
+import shutil
 import subprocess
 import tempfile
 
@@ -106,12 +107,12 @@ class Command(BaseCommand):
         logger.info('Generating CSV file with creations and modifications')
 
         # Create file paths and working directory
-        working_dir = settings.CSV_LOCAL_PATH + 'delta_gen/'
+        timestamp = datetime.strftime(datetime.now(), '%Y%m%d%H%M%S%f')
+        working_dir = '{}_{}_delta_gen_{}/'.format(settings.CSV_LOCAL_PATH, agency_code, timestamp)
         if not os.path.exists(working_dir):
             os.mkdir(working_dir)
         source_name = '{}_{}_delta'.format(award_type, VALUE_MAPPINGS['transactions']['download_name'])
-        timestamp = datetime.strftime(datetime.now(), '%Y%m%d%H%M%S%f')
-        source_path = os.path.join(working_dir, '{}_{}.csv'.format(source_name, timestamp))
+        source_path = os.path.join(working_dir, '{}_{}.csv'.format(source_name))
 
         # Create a unique temporary file with the raw query
         raw_quoted_query = generate_raw_quoted_query(source.row_emitter(None))  # None requests all headers
@@ -138,7 +139,7 @@ class Command(BaseCommand):
 
         os.close(temp_sql_file)
         os.remove(temp_sql_file_path)
-        os.remove(source_path)
+        shutil.rmtree(working_dir)
 
         return zipfile_path
 

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -3,7 +3,6 @@ import logging
 import os
 import pandas as pd
 import re
-import shutil
 import subprocess
 import tempfile
 
@@ -126,7 +125,7 @@ class Command(BaseCommand):
                                  'ON_ERROR_STOP=1'], stdin=cat_command.stdout, stderr=subprocess.STDOUT)
 
         # Append deleted rows to the end of the file
-        self.add_deletion_records(source_path, award_type, agency_code, source, generate_since)
+        self.add_deletion_records(source_path, working_dir, award_type, agency_code, source, generate_since)
         if csv_row_count(source_path, has_header=True) > 0:
             # Split the CSV into multiple files and zip it up
             zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
@@ -141,7 +140,7 @@ class Command(BaseCommand):
 
         return zipfile_path
 
-    def add_deletion_records(self, source_path, award_type, agency_code, source, generate_since):
+    def add_deletion_records(self, source_path, working_dir, award_type, agency_code, source, generate_since):
         """ Retrieve deletion files from S3 and append necessary records to the end of the the file """
         logger.info('Retrieving deletion records from S3 files and appending to the CSV')
 

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -126,7 +126,7 @@ class Command(BaseCommand):
                                  'ON_ERROR_STOP=1'], stdin=cat_command.stdout, stderr=subprocess.STDOUT)
 
         # Append deleted rows to the end of the file
-        self.add_deletion_records(source_path, working_dir, award_type, agency_code, source, generate_since)
+        self.add_deletion_records(source_path, award_type, agency_code, source, generate_since)
         if csv_row_count(source_path, has_header=True) > 0:
             # Split the CSV into multiple files and zip it up
             zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
@@ -137,11 +137,11 @@ class Command(BaseCommand):
 
         os.close(temp_sql_file)
         os.remove(temp_sql_file_path)
-        shutil.rmtree(working_dir)
+        os.remove(source_path)
 
         return zipfile_path
 
-    def add_deletion_records(self, source_path, working_dir, award_type, agency_code, source, generate_since):
+    def add_deletion_records(self, source_path, award_type, agency_code, source, generate_since):
         """ Retrieve deletion files from S3 and append necessary records to the end of the the file """
         logger.info('Retrieving deletion records from S3 files and appending to the CSV')
 
@@ -158,7 +158,6 @@ class Command(BaseCommand):
             if match_date:
                 # Create a local copy of the deletion file
                 delete_filepath = '{}{}'.format(working_dir, key.name)
-                open(delete_filepath, 'a').close()
                 key.get_contents_to_filename(delete_filepath)
                 df = pd.read_csv(delete_filepath)
                 os.remove(delete_filepath)

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -6,7 +6,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-import zipfile
 
 from collections import OrderedDict
 from datetime import datetime, date
@@ -16,9 +15,9 @@ from django.db.models import Case, When, Value, CharField
 
 from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings as all_ats_mappings
 from usaspending_api.common.helpers.generic_helper import generate_raw_quoted_query
-from usaspending_api.download.filestreaming.csv_generation import EXCEL_ROW_LIMIT
+from usaspending_api.download.filestreaming.csv_generation import split_and_zip_csvs
 from usaspending_api.download.filestreaming.csv_source import CsvSource
-from usaspending_api.download.helpers import split_csv, pull_modified_agencies_cgacs, multipart_upload
+from usaspending_api.download.helpers import pull_modified_agencies_cgacs, multipart_upload
 from usaspending_api.download.lookups import VALUE_MAPPINGS
 from usaspending_api.etl.es_etl_helpers import csv_row_count
 from usaspending_api.references.models import ToptierAgency, SubtierAgency
@@ -129,17 +128,10 @@ class Command(BaseCommand):
         # Append deleted rows to the end of the file
         self.add_deletion_records(source_path, working_dir, award_type, agency_code, source, generate_since)
         if csv_row_count(source_path, has_header=True) > 0:
-            # Split CSV into separate files
-            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
-                                   output_name_template='{}_%s.csv'.format(source_name))
-
-            # Zip the split CSVs into one zipfile
+            # Split the CSV into multiple files and zip it up
             zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
                                                          datetime.strftime(date.today(), '%Y%m%d'))
-            logger.info('Creating compressed file: {}'.format(os.path.basename(zipfile_path)))
-            zipped_csvs = zipfile.ZipFile(zipfile_path, 'a', compression=zipfile.ZIP_DEFLATED, allowZip64=True)
-            for split_csv_part in split_csvs:
-                zipped_csvs.write(split_csv_part, os.path.basename(split_csv_part))
+            split_and_zip_csvs(zipfile_path, source_path, source_name)
         else:
             zipfile_path = None
 

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -158,6 +158,7 @@ class Command(BaseCommand):
             if match_date:
                 # Create a local copy of the deletion file
                 delete_filepath = '{}{}'.format(working_dir, key.name)
+                open(x, delete_filepath).close()
                 key.get_contents_to_filename(delete_filepath)
                 df = pd.read_csv(delete_filepath)
                 os.remove(delete_filepath)

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -110,7 +110,8 @@ class Command(BaseCommand):
         if not os.path.exists(working_dir):
             os.mkdir(working_dir)
         source_name = '{}_{}_delta'.format(award_type, VALUE_MAPPINGS['transactions']['download_name'])
-        source_path = os.path.join(working_dir, '{}.csv'.format(source_name))
+        timestamp = datetime.strftime(datetime.now(), '%Y%m%d%H%M%S%f')
+        source_path = os.path.join(working_dir, '{}_{}.csv'.format(source_name, timestamp))
 
         # Create a unique temporary file with the raw query
         raw_quoted_query = generate_raw_quoted_query(source.row_emitter(None))  # None requests all headers

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -112,7 +112,7 @@ class Command(BaseCommand):
         if not os.path.exists(working_dir):
             os.mkdir(working_dir)
         source_name = '{}_{}_delta'.format(award_type, VALUE_MAPPINGS['transactions']['download_name'])
-        source_path = os.path.join(working_dir, '{}_{}.csv'.format(source_name))
+        source_path = os.path.join(working_dir, '{}.csv'.format(source_name))
 
         # Create a unique temporary file with the raw query
         raw_quoted_query = generate_raw_quoted_query(source.row_emitter(None))  # None requests all headers


### PR DESCRIPTION
- Reuse the `split_and_zip_csvs` from `csv_generation.py`.
- Add a timestamp to the `working_dir` to ensure that we don't delete files being accessed by another version of the script running on the same box.