### PR TITLE
OPS-257 qualifying the schema in which the enum type is declared for pg_dump restore

### DIFF
--- a/usaspending_api/database_scripts/matviews/functions_and_enums.sql
+++ b/usaspending_api/database_scripts/matviews/functions_and_enums.sql
@@ -5,10 +5,10 @@ CREATE EXTENSION IF NOT EXISTS intarray;
 
 -- The function(s) and enum(s) below were originally created for the materialized views
 
-CREATE TYPE total_obligation_bins AS ENUM ('<1M', '1M..25M', '25M..100M', '100M..500M', '>500M');
+CREATE TYPE public.total_obligation_bins AS ENUM ('<1M', '1M..25M', '25M..100M', '100M..500M', '>500M');
 
 
-CREATE OR REPLACE FUNCTION obligation_to_enum(award NUMERIC) RETURNS total_obligation_bins AS $$
+CREATE OR REPLACE FUNCTION obligation_to_enum(award NUMERIC) RETURNS public.total_obligation_bins AS $$
   DECLARE
     DECLARE result text;
   BEGIN
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION obligation_to_enum(award NUMERIC) RETURNS total_oblig
     ELSIF award < 500000000.0 THEN result='100M..500M';  -- under $500 million
     ELSE result='>500M';                                 --  over $500 million
     END IF;
-  RETURN result::total_obligation_bins;
+  RETURN result::public.total_obligation_bins;
   END;
 $$ LANGUAGE plpgsql;
 

--- a/usaspending_api/database_scripts/matviews/functions_and_enums.sql
+++ b/usaspending_api/database_scripts/matviews/functions_and_enums.sql
@@ -8,7 +8,7 @@ CREATE EXTENSION IF NOT EXISTS intarray;
 CREATE TYPE public.total_obligation_bins AS ENUM ('<1M', '1M..25M', '25M..100M', '100M..500M', '>500M');
 
 
-CREATE OR REPLACE FUNCTION obligation_to_enum(award NUMERIC) RETURNS public.total_obligation_bins AS $$
+CREATE OR REPLACE FUNCTION public.obligation_to_enum(award NUMERIC) RETURNS public.total_obligation_bins AS $$
   DECLARE
     DECLARE result text;
   BEGIN
@@ -23,7 +23,7 @@ CREATE OR REPLACE FUNCTION obligation_to_enum(award NUMERIC) RETURNS public.tota
 $$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION recipient_normalization_pair(original_name TEXT, search_duns TEXT) RETURNS RECORD AS $$
+CREATE OR REPLACE FUNCTION public.recipient_normalization_pair(original_name TEXT, search_duns TEXT) RETURNS RECORD AS $$
   DECLARE
     DECLARE result text[];
   BEGIN


### PR DESCRIPTION
**High level description:**
Cannot restore dumped databases without qualifying where (what schema) pg_restore or psql should find the `total_obligation_bins` enum type. This adds that schema-qualification

**Technical details:**
See: See this postgres bug report for details: https://www.postgresql.org/message-id/flat/153184074037.1405.15097715315257989847%40wrigleys.postgresql.org

**Link to JIRA Ticket:**
[OPS-257](https://federal-spending-transparency.atlassian.net/browse/OPS-257) discovered during working through this Operations Epic

**Links to Dependent/Related PRs**
N/A

**Special Deployment Steps**

1. Will need to explicitly run this sql script on each database. Note, if not run, it will run as part of the nightly pipeline where that jenkins job is run

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [ ] Unit & integration tests updated with relevant test cases N/A
- [x] Matview impact assessment completed
- [ ] Frontend impact assessment completed N/A
- [ ] Data validation completed N/A
- [ ] API Performance evaluation completed and present: N/A

