### PR TITLE
DEV-1291: Custom Account download FREC agency filter

### DIFF
--- a/usaspending_api/accounts/tests/unit/test_account_download_filter.py
+++ b/usaspending_api/accounts/tests/unit/test_account_download_filter.py
@@ -2,11 +2,10 @@ import pytest
 
 from model_mommy import mommy
 
-from usaspending_api.accounts.models import AppropriationAccountBalances, TreasuryAppropriationAccount
+from usaspending_api.accounts.models import AppropriationAccountBalances
 from usaspending_api.accounts.v2.filters.account_download import account_download_filter
 from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
-from usaspending_api.references.models import ToptierAgency
 
 
 @pytest.mark.django_db
@@ -62,14 +61,16 @@ def test_cgac_agency_filter():
     tas2 = mommy.make('accounts.TreasuryAppropriationAccount', agency_id='CGC')
 
     # Create file B models
-    mommy.make(FinancialAccountsByProgramActivityObjectClass, treasury_account_id=tas1.treasury_account_identifier,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
-    mommy.make(FinancialAccountsByProgramActivityObjectClass, treasury_account_id=tas2.treasury_account_identifier,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+    mommy.make('financial_activities.FinancialAccountsByProgramActivityObjectClass',
+               treasury_account_id=tas1.treasury_account_identifier, reporting_period_start='1699-10-01',
+               reporting_period_end='1699-12-31')
+    mommy.make('financial_activities.FinancialAccountsByProgramActivityObjectClass',
+               treasury_account_id=tas2.treasury_account_identifier, reporting_period_start='1699-10-01',
+               reporting_period_end='1699-12-31')
 
     # Create ToptierAgency models
-    mommy.make(ToptierAgency, toptier_agency_id=-9999, cgac_code='CGC')
-    mommy.make(ToptierAgency, toptier_agency_id=-9998, cgac_code='NOT')
+    mommy.make('references.ToptierAgency', toptier_agency_id=-9999, cgac_code='CGC')
+    mommy.make('references.ToptierAgency', toptier_agency_id=-9998, cgac_code='NOT')
 
     # Filter by ToptierAgency (CGAC)
     queryset = account_download_filter('program_activity_object_class', FinancialAccountsByProgramActivityObjectClass, {
@@ -88,15 +89,15 @@ def test_frec_agency_filter():
     tas2 = mommy.make('accounts.TreasuryAppropriationAccount', agency_id='CGC', fr_entity_code='FREC')
 
     # Create file C models
-    mommy.make(FinancialAccountsByAwards, treasury_account_id=tas1.treasury_account_identifier,
+    mommy.make('awards.FinancialAccountsByAwards', treasury_account_id=tas1.treasury_account_identifier,
                reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
-    mommy.make(FinancialAccountsByAwards, treasury_account_id=tas2.treasury_account_identifier,
+    mommy.make('awards.FinancialAccountsByAwards', treasury_account_id=tas2.treasury_account_identifier,
                reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
 
     # Create ToptierAgency models
-    mommy.make(ToptierAgency, toptier_agency_id=-9999, cgac_code='FREC')
-    mommy.make(ToptierAgency, toptier_agency_id=-9998, cgac_code='FAKE')
-    mommy.make(ToptierAgency, toptier_agency_id=-9997, cgac_code='CGC')
+    mommy.make('references.ToptierAgency', toptier_agency_id=-9999, cgac_code='FREC')
+    mommy.make('references.ToptierAgency', toptier_agency_id=-9998, cgac_code='FAKE')
+    mommy.make('references.ToptierAgency', toptier_agency_id=-9997, cgac_code='CGC')
 
     # Filter by ToptierAgency (FREC)
     queryset = account_download_filter('award_financial', FinancialAccountsByAwards, {

--- a/usaspending_api/accounts/tests/unit/test_account_download_filter.py
+++ b/usaspending_api/accounts/tests/unit/test_account_download_filter.py
@@ -1,0 +1,107 @@
+import pytest
+
+from model_mommy import mommy
+
+from usaspending_api.accounts.models import AppropriationAccountBalances, TreasuryAppropriationAccount
+from usaspending_api.accounts.v2.filters.account_download import account_download_filter
+from usaspending_api.awards.models import FinancialAccountsByAwards
+from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
+from usaspending_api.references.models import ToptierAgency
+
+
+@pytest.mark.django_db
+def test_fyq_filter():
+    """ Ensure the fiscal year and quarter filter is working """
+    # Create TAS models
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount')
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount')
+
+    # Create file A models
+    mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+    mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas2,
+               reporting_period_start='1700-01-01', reporting_period_end='1700-03-31')
+
+    queryset = account_download_filter('account_balances', AppropriationAccountBalances, {
+        'fy': 1700,
+        'quarter': 1
+    })
+    assert queryset.count() == 1
+
+
+@pytest.mark.django_db
+def test_federal_account_filter():
+    """ Ensure the fiscal year and quarter filter is working """
+    # Create FederalAccount models
+    fed_acct1 = mommy.make('accounts.FederalAccount')
+    fed_acct2 = mommy.make('accounts.FederalAccount')
+
+    # Create TAS models
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1)
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2)
+
+    # Create file A models
+    mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+    mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas2,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+
+    queryset = account_download_filter('account_balances', AppropriationAccountBalances, {
+        'federal_account': fed_acct1.id,
+        'fy': 1700,
+        'quarter': 1
+    })
+    assert queryset.count() == 1
+
+
+@pytest.mark.django_db
+def test_cgac_agency_filter():
+    """ Ensure the CGAC agency filter is working """
+    # Create TAS models
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', agency_id='NOT')
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', agency_id='CGC')
+
+    # Create file B models
+    mommy.make(FinancialAccountsByProgramActivityObjectClass, treasury_account_id=tas1.treasury_account_identifier,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+    mommy.make(FinancialAccountsByProgramActivityObjectClass, treasury_account_id=tas2.treasury_account_identifier,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+
+    # Create ToptierAgency models
+    mommy.make(ToptierAgency, toptier_agency_id=-9999, cgac_code='CGC')
+    mommy.make(ToptierAgency, toptier_agency_id=-9998, cgac_code='NOT')
+
+    # Filter by ToptierAgency (CGAC)
+    queryset = account_download_filter('program_activity_object_class', FinancialAccountsByProgramActivityObjectClass, {
+        'agency': '-9999',
+        'fy': 1700,
+        'quarter': 1
+    })
+    assert queryset.count() == 1
+
+
+@pytest.mark.django_db
+def test_frec_agency_filter():
+    """ Ensure the FREC agency filter is working """
+    # Create TAS models
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', agency_id='CGC', fr_entity_code='FAKE')
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', agency_id='CGC', fr_entity_code='FREC')
+
+    # Create file C models
+    mommy.make(FinancialAccountsByAwards, treasury_account_id=tas1.treasury_account_identifier,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+    mommy.make(FinancialAccountsByAwards, treasury_account_id=tas2.treasury_account_identifier,
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+
+    # Create ToptierAgency models
+    mommy.make(ToptierAgency, toptier_agency_id=-9999, cgac_code='FREC')
+    mommy.make(ToptierAgency, toptier_agency_id=-9998, cgac_code='FAKE')
+    mommy.make(ToptierAgency, toptier_agency_id=-9997, cgac_code='CGC')
+
+    # Filter by ToptierAgency (FREC)
+    queryset = account_download_filter('award_financial', FinancialAccountsByAwards, {
+        'agency': '-9999',
+        'fy': 1700,
+        'quarter': 1
+    })
+    assert queryset.count() == 1

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -19,7 +19,9 @@ def account_download_filter(account_type, download_table, filters, account_level
     if filters.get('agency', False) and filters['agency'] != 'all':
         agency = ToptierAgency.objects.filter(toptier_agency_id=filters['agency']).first()
         if agency:
-            query_filters['{}__agency_id'.format(tas_id)] = agency.cgac_code
+            # Agency is FREC if the cgac_code is 4 digits, CGAC otherwise
+            agency_filter_type = "fr_entity_code" if len(agency.cgac_code) == 4 else "agency_id"
+            query_filters['{}__{}'.format(tas_id, agency_filter_type)] = agency.cgac_code
         else:
             raise InvalidParameterException('Agency with that ID does not exist')
 

--- a/usaspending_api/api_docs/api_documentation/download/custom_account_data_download.md
+++ b/usaspending_api/api_docs/api_documentation/download/custom_account_data_download.md
@@ -12,6 +12,7 @@ This route sends a request to the backend to begin generating a zipfile of accou
     "account_level": "treasury_account",
     "filters": {
         "agency": "3",
+        "federal_account": "15",
         "submission_type": "object_class_program_activity",
         "fy": "2018",
         "quarter": "2"
@@ -21,14 +22,14 @@ This route sends a request to the backend to begin generating a zipfile of accou
 ```
 
 ### Request Parameters Description
-* `account_level` - *required* - the account level: `tresury_account` or `federal_account` (must be `treasury_account` for Beta)
+* `account_level` - *required* - the account level: `tresury_account` or `federal_account`
 * `filters` - *required* - a JSON filter object with the following fields
-        * `agency` - *optional* - agency database id to include, `all` is also an option to include all agencies
-        * `federal_account` - *optional* - federal account id to include (based on the agency filter), out of scope for Beta
-        * `submission_type` - *required* - the file type requested: `account_balances` (File A) or `program_activity_object_class` (File B)
+        * `agency` - *optional* - agency database id, `all` is also an option to include all agencies
+        * `federal_account` - *optional* - federal account id
+        * `submission_type` - *required* - the file type requested: `account_balances` (File A), `program_activity_object_class` (File B), or `award_financial` (File C)
         * `fy` - *required* - fiscal year
         * `quarter` - *required*
-* `file_format` - *optional* - must be `csv` for Beta
+* `file_format` - *optional* - must be `csv`
 
 ### Response (JSON)
 


### PR DESCRIPTION
**High level description:**
Update the Custom Account download filter to filter by the `fr_entity_code` column instead of the `agency_id` column when a FREC agency is selected.

**Technical details:**
If the passed in `agency` filter is 4 digits, filter by the `fr_entity_code` column instead of the `agency_id`. Add unit tests for the `account_download_filter`. Update Custom Account download documentation.

**Link to JIRA Ticket:**
[DEV-1291](https://federal-spending-transparency.atlassian.net/browse/DEV-1291)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Matview impact assessment completed N/A
- Frontend impact assessment completed N/A
- Data validation completed
    ```
    Successfully created a file filtered by FREC agency.
    ```
- API Performance evaluation completed and present N/A