### PR TITLE
Bugfix: Corrected column name in SQL function

### DIFF
--- a/usaspending_api/database_scripts/matviews/functions_and_enums.sql
+++ b/usaspending_api/database_scripts/matviews/functions_and_enums.sql
@@ -28,7 +28,7 @@ CREATE OR REPLACE FUNCTION public.recipient_normalization_pair(original_name TEX
     DECLARE result text;
   BEGIN
     IF search_duns IS NULL THEN result = original_name;
-    ELSE result = (SELECT legal_business_name FROM recipient_lookup_view WHERE awardee_or_recipient_uniqu = search_duns);
+    ELSE result = (SELECT legal_business_name FROM recipient_lookup_view WHERE duns = search_duns);
     END IF;
   RETURN (result, search_duns)::RECORD;
   END;


### PR DESCRIPTION
**High level description:**
PR #1331 switched the DB relation used in a function to lookup the recipient name by DUNS (from the `duns` table to the `recipient_lookup_view` matview) . The original DUNS column name was "awardee_or_recipient_uniqu" the new relation column name is "duns"

**Technical details:**
See above.

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed (N/A)
- [X] API Performance evaluation completed (N/A)