### PR TITLE
Hotfix: OPS-257 missed qualifying schema on table used within function

### DIFF
--- a/usaspending_api/database_scripts/matviews/functions_and_enums.sql
+++ b/usaspending_api/database_scripts/matviews/functions_and_enums.sql
@@ -32,7 +32,7 @@ CREATE OR REPLACE FUNCTION public.recipient_normalization_pair(original_name TEX
     ELSIF original_name ILIKE 'multiple foreign recipients' THEN result = ARRAY['MULTIPLE FOREIGN RECIPIENTS', '-3'];
     ELSIF original_name ILIKE 'private individual' THEN result = ARRAY['PRIVATE INDIVIDUAL', '-4'];
     ELSIF original_name ILIKE 'individual recipient' THEN result = ARRAY['INDIVIDUAL RECIPIENT', '-5'];
-    ELSE result = ARRAY[(SELECT legal_business_name FROM duns WHERE awardee_or_recipient_uniqu = search_duns), search_duns];
+    ELSE result = ARRAY[(SELECT legal_business_name FROM public.duns WHERE awardee_or_recipient_uniqu = search_duns), search_duns];
     END IF;
   RETURN (COALESCE(result[1], ' '), result[2])::RECORD;
   END;


### PR DESCRIPTION
**High level description:**
Cannot restore dumped databases without qualifying where (what schema) pg_restore or psql should find the `duns` table, which is used as a lookup in this function. This adds that schema-qualification

**Technical details:**
See: See this postgres bug report for details: https://www.postgresql.org/message-id/flat/153184074037.1405.15097715315257989847%40wrigleys.postgresql.org

**Link to JIRA Ticket:**
[OPS-257](https://federal-spending-transparency.atlassian.net/browse/OPS-257) discovered during working through this Operations Epic

**Links to Dependent/Related PRs**
- A continuation of: https://github.com/fedspendingtransparency/usaspending-api/pull/1336

**Special Deployment Steps**

1. Will need to explicitly run this sql script on each database. Note, if not run, it will run as part of the nightly pipeline where that jenkins job is run

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases N/A
- [x] Matview impact assessment completed
- [x] Frontend impact assessment completed N/A
- [x] Data validation completed N/A
- [x] API Performance evaluation completed and present: N/A

