### PR TITLE
Revert "Hotfix: Moving c to d linkage call to end of the submission load"

### DIFF
--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -4,7 +4,6 @@ import logging
 
 # Core Django imports
 from django.conf import settings
-from django.db import connections
 
 # Third-party app imports
 import pytest
@@ -20,7 +19,6 @@ VALID_DB_CURSORS = ['default', 'data_broker']
 
 
 @pytest.fixture()
-@pytest.mark.django_db
 def mock_db_cursor(monkeypatch, request):
     db_cursor_dict = request.param
 
@@ -34,8 +32,6 @@ def mock_db_cursor(monkeypatch, request):
 
             db_cursor_dict[cursor].cursor.return_value = PhonyCursor(db_cursor_dict[data_file_key])
             del db_cursor_dict[data_file_key]
-        else:
-            db_cursor_dict[cursor] = connections[cursor]
 
     monkeypatch.setattr('django.db.connections', db_cursor_dict)
 

--- a/usaspending_api/etl/management/commands/load_multiple_submissions.py
+++ b/usaspending_api/etl/management/commands/load_multiple_submissions.py
@@ -88,15 +88,9 @@ class Command(BaseCommand):
         # Stuff happens here, if you don't flag '--safe'
         # The submission loader is atomic, so one of these failing should not affect subsequent submissions
         if not options["safe"]:
-            load_executed_flag = False
             for next_missing_sub in missing_submissions:
                 try:
                     call_command('load_submission', '--noclean', '--nosubawards', next_missing_sub[0])
-                    load_executed_flag = True
                 except CommandError:
                     logger.info('Skipping submission ID {} due to CommandError (bad ID)'.format(next_missing_sub[0]))
                     continue
-
-            if load_executed_flag:
-                # update C to D linkage using SQL scripts
-                call_command('update_file_c_linkages')

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -7,6 +7,7 @@ from django.core.management.base import CommandError
 from django.core.management import call_command
 from django.db import connections, transaction
 from django.db.models import Q
+from django.core.cache import caches
 import pandas as pd
 import numpy as np
 
@@ -21,6 +22,7 @@ from usaspending_api.submissions.models import SubmissionAttributes
 from usaspending_api.etl.award_helpers import get_award_financial_transaction, get_awarding_agency
 from usaspending_api.etl.helpers import get_fiscal_quarter, get_previous_submission
 from usaspending_api.etl.broker_etl_helpers import dictfetchall, PhonyCursor
+from usaspending_api.etl.subaward_etl import load_subawards
 
 from usaspending_api.etl.management import load_base
 from usaspending_api.etl.management.load_base import load_data_into_model
@@ -32,6 +34,7 @@ TAS_ID_TO_ACCOUNT = {}
 # Lists to store for update_awards and update_contract_awards
 AWARD_UPDATE_ID_LIST = []
 
+awards_cache = caches['awards']
 logger = logging.getLogger('console')
 
 
@@ -116,11 +119,17 @@ class Command(load_base.Command):
                     .format(submission_id, award_financial_frame.shape[0]))
         logger.info('Loading File C data')
         start_time = datetime.now()
-        load_file_c(submission_attributes, db_cursor, award_financial_frame)
+        awards_touched = load_file_c(submission_attributes, db_cursor, award_financial_frame)
         logger.info('Finished loading File C data, took {}'.format(datetime.now() - start_time))
 
         if not options['nosubawards']:
-            logger.warning("Loading subaward during a submission load is no longer supported")
+            try:
+                start_time = datetime.now()
+                logger.info('Loading subaward data...')
+                load_subawards(submission_attributes, awards_touched, db_cursor)
+                logger.info('Finshed loading subaward data, took {}'.format(datetime.now() - start_time))
+            except Exception:
+                logger.warning("Error loading subawards for this submission")
         else:
             logger.info('Skipping subawards due to flags...')
 
@@ -630,6 +639,7 @@ def load_file_c(submission_attributes, db_cursor, award_financial_frame):
 
     total_rows = award_financial_frame.shape[0]
     start_time = datetime.now()
+    awards_touched = []
 
     # format award_financial_frame
     float_cols = ['transaction_obligated_amou']
@@ -651,10 +661,32 @@ def load_file_c(submission_attributes, db_cursor, award_financial_frame):
             update_skipped_tas(row, skipped_tas)
             continue
 
+        # Find a matching transaction record, so we can use its subtier agency information to match to (or create) an
+        # Award record.
+
+        # Find the award that this award transaction belongs to. If it doesn't exist, create it.
+        filters = {}
+        if row.get('piid'):
+            filters['piid'] = row.get('piid')
+            filters['parent_piid'] = row.get('parent_award_id')
+        else:
+            if row.get('fain') and not row.get('uri'):
+                filters['fain'] = row.get('fain')
+            elif row.get('uri') and not row.get('fain'):
+                filters['uri'] = row.get('uri')
+            else:
+                filters['fain'] = row.get('fain')
+                filters['uri'] = row.get('uri')
+
+        award = find_matching_award(**filters)
+
+        if award:
+            awards_touched += [award]
+
         award_financial_data = FinancialAccountsByAwards()
 
         value_map_faba = {
-            'award': None,
+            'award': award,
             'submission': submission_attributes,
             'reporting_period_start': submission_attributes.reporting_period_start,
             'reporting_period_end': submission_attributes.reporting_period_end,
@@ -666,6 +698,8 @@ def load_file_c(submission_attributes, db_cursor, award_financial_frame):
         # Still using the cpe|fyb regex compiled above for reverse
         load_data_into_model(award_financial_data, row, value_map=value_map_faba, save=True, reverse=reverse)
 
+    awards_cache.clear()
+
     for key in skipped_tas:
         logger.info('Skipped %d rows due to missing TAS: %s', skipped_tas[key]['count'], key)
 
@@ -674,3 +708,5 @@ def load_file_c(submission_attributes, db_cursor, award_financial_frame):
         total_tas_skipped += skipped_tas[key]['count']
 
     logger.info('Skipped a total of {} TAS rows for File C'.format(total_tas_skipped))
+
+    return [award.id for award in awards_touched if award]

--- a/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
+++ b/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
@@ -10,13 +10,318 @@ from model_mommy import mommy
 from unittest.mock import MagicMock
 
 # Imports from your apps
-from usaspending_api.awards.models import FinancialAccountsByAwards, TreasuryAppropriationAccount
+from usaspending_api.awards.models import (Award, FinancialAccountsByAwards, TransactionNormalized,
+                                           TreasuryAppropriationAccount)
 
 
 DB_CURSOR_PARAMS = {
+    'default': MagicMock(),
     'data_broker': MagicMock(),
     'data_broker_data_file': 'usaspending_api/etl/tests/data/submission_data.json'
 }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('mock_db_cursor', [DB_CURSOR_PARAMS.copy()], indirect=True)
+def test_load_submission_file_c_no_d_linkage(mock_db_cursor):
+    """
+    Test load submission management command for File C records that are not expected to be linked to Award data
+    """
+
+    models_to_mock = [
+        {
+            'model': TreasuryAppropriationAccount,
+            'treasury_account_identifier': -1111,
+            'allocation_transfer_agency_id': '999',
+            'agency_id': '999',
+            'beginning_period_of_availability': '1700-01-01',
+            'ending_period_of_availability': '1700-12-31',
+            'availability_type_code': '000',
+            'main_account_code': '0000',
+            'sub_account_code': '0000'
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -999
+        },
+        {
+            'model': Award,
+            'id': -999,
+            'piid': 'RANDOM_LOAD_SUB_PIID',
+            'parent_award_piid': 'PARENT_LOAD_SUB_PIID_DNE',
+            'latest_transaction_id': -999
+        }
+    ]
+
+    for entry in models_to_mock:
+        mommy.make(entry.pop('model'), **entry)
+
+    call_command('load_submission', '--noclean', '--nosubawards', '-9999')
+
+    expected_results = {
+        'award_ids': [],
+    }
+
+    actual_results = {
+        'award_ids': list(FinancialAccountsByAwards.objects.
+                          filter(award_id__isnull=False).values_list('award_id', flat=True))
+    }
+
+    assert expected_results == actual_results
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('mock_db_cursor', [DB_CURSOR_PARAMS.copy()], indirect=True)
+def test_load_submission_file_c_piid_with_no_parent_piid(mock_db_cursor):
+    """
+    Test load submission management command for File C records with only a piid and no parent piid
+    """
+
+    models_to_mock = [
+        {
+            'model': TreasuryAppropriationAccount,
+            'treasury_account_identifier': -1111,
+            'allocation_transfer_agency_id': '999',
+            'agency_id': '999',
+            'beginning_period_of_availability': '1700-01-01',
+            'ending_period_of_availability': '1700-12-31',
+            'availability_type_code': '000',
+            'main_account_code': '0000',
+            'sub_account_code': '0000'
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -998
+        },
+        {
+            'model': Award,
+            'id': -998,
+            'piid': 'RANDOM_LOAD_SUB_PIID',
+            'parent_award_piid': None,
+            'latest_transaction_id': -998
+        }
+    ]
+
+    for entry in models_to_mock:
+        mommy.make(entry.pop('model'), **entry)
+
+        call_command('load_submission', '--noclean', '--nosubawards', '-9999')
+
+    expected_results = {
+        'award_ids': [-998],
+    }
+
+    actual_results = {
+        'award_ids': list(FinancialAccountsByAwards.objects.
+                          filter(award_id__isnull=False).values_list('award_id', flat=True))
+    }
+
+    assert expected_results == actual_results
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('mock_db_cursor', [DB_CURSOR_PARAMS.copy()], indirect=True)
+def test_load_submission_file_c_piid_with_parent_piid(mock_db_cursor):
+    """
+    Test load submission management command for File C records with only a piid and parent piid
+    """
+
+    models_to_mock = [
+        {
+            'model': TreasuryAppropriationAccount,
+            'treasury_account_identifier': -1111,
+            'allocation_transfer_agency_id': '999',
+            'agency_id': '999',
+            'beginning_period_of_availability': '1700-01-01',
+            'ending_period_of_availability': '1700-12-31',
+            'availability_type_code': '000',
+            'main_account_code': '0000',
+            'sub_account_code': '0000'
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -997
+        },
+        {
+            'model': Award,
+            'id': -997,
+            'piid': 'RANDOM_LOAD_SUB_PIID',
+            'parent_award_piid': 'RANDOM_LOAD_SUB_PARENT_PIID',
+            'latest_transaction_id': -997
+        }
+    ]
+
+    for entry in models_to_mock:
+        mommy.make(entry.pop('model'), **entry)
+
+        call_command('load_submission', '--noclean', '--nosubawards', '-9999')
+
+    expected_results = {
+        'award_ids': [-997],
+    }
+
+    actual_results = {
+        'award_ids': list(FinancialAccountsByAwards.objects.
+                          filter(award_id__isnull=False).values_list('award_id', flat=True))
+    }
+
+    assert expected_results == actual_results
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('mock_db_cursor', [DB_CURSOR_PARAMS.copy()], indirect=True)
+def test_load_submission_file_c_fain(mock_db_cursor):
+    """
+    Test load submission management command for File C records with only a FAIN
+    """
+
+    models_to_mock = [
+        {
+            'model': TreasuryAppropriationAccount,
+            'treasury_account_identifier': -1111,
+            'allocation_transfer_agency_id': '999',
+            'agency_id': '999',
+            'beginning_period_of_availability': '1700-01-01',
+            'ending_period_of_availability': '1700-12-31',
+            'availability_type_code': '000',
+            'main_account_code': '0000',
+            'sub_account_code': '0000'
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -997
+        },
+        {
+            'model': Award,
+            'id': -997,
+            'fain': 'RANDOM_LOAD_SUB_FAIN',
+            'latest_transaction_id': -997
+        }
+    ]
+
+    for entry in models_to_mock:
+        mommy.make(entry.pop('model'), **entry)
+
+        call_command('load_submission', '--noclean', '--nosubawards', '-9999')
+
+    expected_results = {
+        'award_ids': [-997],
+    }
+
+    actual_results = {
+        'award_ids': list(FinancialAccountsByAwards.objects.
+                          filter(award_id__isnull=False).values_list('award_id', flat=True))
+    }
+
+    assert expected_results == actual_results
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('mock_db_cursor', [DB_CURSOR_PARAMS.copy()], indirect=True)
+def test_load_submission_file_c_uri(mock_db_cursor):
+    """
+    Test load submission management command for File C records with only a URI
+    """
+
+    models_to_mock = [
+        {
+            'model': TreasuryAppropriationAccount,
+            'treasury_account_identifier': -1111,
+            'allocation_transfer_agency_id': '999',
+            'agency_id': '999',
+            'beginning_period_of_availability': '1700-01-01',
+            'ending_period_of_availability': '1700-12-31',
+            'availability_type_code': '000',
+            'main_account_code': '0000',
+            'sub_account_code': '0000'
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -997
+        },
+        {
+            'model': Award,
+            'id': -997,
+            'uri': 'RANDOM_LOAD_SUB_URI',
+            'latest_transaction_id': -997
+        }
+    ]
+
+    for entry in models_to_mock:
+        mommy.make(entry.pop('model'), **entry)
+
+        call_command('load_submission', '--noclean', '--nosubawards', '-9999')
+
+    expected_results = {
+        'award_ids': [-997],
+    }
+
+    actual_results = {
+        'award_ids': list(FinancialAccountsByAwards.objects.
+                          filter(award_id__isnull=False).values_list('award_id', flat=True))
+    }
+
+    assert expected_results == actual_results
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('mock_db_cursor', [DB_CURSOR_PARAMS.copy()], indirect=True)
+def test_load_submission_file_c_fain_and_uri(mock_db_cursor):
+    """
+    Test load submission management command for File C records with FAIN and URI
+    """
+
+    models_to_mock = [
+        {
+            'model': TreasuryAppropriationAccount,
+            'treasury_account_identifier': -1111,
+            'allocation_transfer_agency_id': '999',
+            'agency_id': '999',
+            'beginning_period_of_availability': '1700-01-01',
+            'ending_period_of_availability': '1700-12-31',
+            'availability_type_code': '000',
+            'main_account_code': '0000',
+            'sub_account_code': '0000'
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -999
+        },
+        {
+            'model': TransactionNormalized,
+            'id': -1999
+        },
+        {
+            'model': Award,
+            'id': -999,
+            'fain': 'RANDOM_LOAD_SUB_FAIN_999',
+            'uri': 'RANDOM_LOAD_SUB_URI_999',
+            'latest_transaction_id': -999
+        },
+        {
+            'model': Award,
+            'id': -1999,
+            'fain': 'RANDOM_LOAD_SUB_FAIN_1999',
+            'uri': 'RANDOM_LOAD_SUB_URI_1999',
+            'latest_transaction_id': -1999
+        }
+    ]
+
+    for entry in models_to_mock:
+        mommy.make(entry.pop('model'), **entry)
+
+        call_command('load_submission', '--noclean', '--nosubawards', '-9999')
+
+    expected_results = {
+        'award_ids': [-1999, -999],
+    }
+
+    actual_results = {
+        'award_ids': sorted(list(FinancialAccountsByAwards.objects.
+                                 filter(award_id__isnull=False).values_list('award_id', flat=True)))
+    }
+
+    assert expected_results == actual_results
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Reverts fedspendingtransparency/usaspending-api#1431