### PR TITLE
Altering loader to handle NULL for `business_types_codes`

### DIFF
--- a/usaspending_api/broker/management/sql/reload_duns.sql
+++ b/usaspending_api/broker/management/sql/reload_duns.sql
@@ -35,7 +35,7 @@ INSERT INTO duns (
                     duns.zip4,
                     duns.country_code,
                     duns.congressional_district,
-                    duns.business_types_codes,
+                    COALESCE(duns.business_types_codes, ''{}''::text[]) AS business_types_codes,
                     duns.duns_id
             FROM
                 duns


### PR DESCRIPTION
**High level description:**
After reloading SAM data in the Broker's `duns` table, the production nightly pipeline failed on the `reload_duns` stage due to default values now NULL instead of an empty text array. This changes the script to COALESCE NULLs to text arrays

**Technical details:**
(N/A)

**Link to JIRA Ticket:**
[DEV-1449](https://federal-spending-transparency.atlassian.net/browse/DEV-1449)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases (N/A)
- [X] Matview impact assessment completed (N/A)
- [X] Frontend impact assessment completed (N/A)
- [X] Data validation completed
- [X] API Performance evaluation completed (N/A)