### PR TITLE
DEV-1314: Federal Account landing page TinyShield update

### DIFF
--- a/usaspending_api/accounts/tests/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/test_federal_account_v2.py
@@ -60,7 +60,7 @@ def test_federal_accounts_endpoint_exists(client, fixture_data):
     """ Verify the federal accounts endpoint returns a status of 200 """
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'filters': {'fy': 2017}}))
+                       data=json.dumps({'filters': {'fy': '2017'}}))
     assert resp.status_code == status.HTTP_200_OK
 
 
@@ -69,7 +69,7 @@ def test_federal_accounts_endpoint_correct_form(client, fixture_data):
     """ Verify the correct keys exist within the response """
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'filters': {'fy': 2017}}))
+                       data=json.dumps({'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['page'] == 1
     assert 'limit' in response_data
@@ -84,9 +84,8 @@ def test_federal_accounts_endpoint_correct_data(client, fixture_data):
     """ Verify federal accounts endpoint returns the correct data """
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'managing_agency',
-                                                 'direction': 'asc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'managing_agency', 'direction': 'asc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['budgetary_resources'] == 3000
     assert response_data['results'][0]['managing_agency'] == 'Dept. of Depts'
@@ -94,7 +93,7 @@ def test_federal_accounts_endpoint_correct_data(client, fixture_data):
 
     assert response_data['results'][1]['managing_agency_acronym'] == 'EFGH'
     assert response_data['results'][1]['budgetary_resources'] == 9000
-    assert response_data['fy'] == 2017
+    assert response_data['fy'] == '2017'
 
 
 @pytest.mark.django_db
@@ -104,18 +103,16 @@ def test_federal_accounts_endpoint_sorting_managing_agency(client, fixture_data)
     # sort by managing agency, asc
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'managing_agency',
-                                                 'direction': 'asc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'managing_agency', 'direction': 'asc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['managing_agency'] < response_data['results'][1]['managing_agency']
 
     # sort by managing agency, desc
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'managing_agency',
-                                                 'direction': 'desc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'managing_agency', 'direction': 'desc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['managing_agency'] > response_data['results'][1]['managing_agency']
 
@@ -127,18 +124,16 @@ def test_federal_accounts_endpoint_sorting_account_number(client, fixture_data):
     # sort by account number, asc
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'account_number',
-                                                 'direction': 'asc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'account_number', 'direction': 'asc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['account_number'] < response_data['results'][1]['account_number']
 
     # sort by account number, desc
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'account_number',
-                                                 'direction': 'desc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'account_number', 'direction': 'desc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['account_number'] > response_data['results'][1]['account_number']
 
@@ -150,18 +145,16 @@ def test_federal_accounts_endpoint_sorting_budgetary_resources(client, fixture_d
     # sort by budgetary resources, asc
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'budgetary_resources',
-                                                 'direction': 'asc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'budgetary_resources', 'direction': 'asc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['budgetary_resources'] < response_data['results'][1]['budgetary_resources']
 
     # sort by budgetary resources, desc
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'budgetary_resources',
-                                                 'direction': 'desc'},
-                                        'filters': {'fy': 2017}}))
+                       data=json.dumps({'sort': {'field': 'budgetary_resources', 'direction': 'desc'},
+                                        'filters': {'fy': '2017'}}))
     response_data = resp.json()
     assert response_data['results'][0]['budgetary_resources'] > response_data['results'][1]['budgetary_resources']
 
@@ -173,8 +166,7 @@ def test_federal_accounts_endpoint_keyword_filter_account_number(client, fixture
     # filter by the "Bureau" keyword
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'filters': {'fy': 2017},
-                                        'keyword': '001-000'}))
+                       data=json.dumps({'filters': {'fy': '2017'}, 'keyword': '001-000'}))
     response_data = resp.json()
     assert len(response_data['results']) == 1
     assert response_data['results'][0]['account_number'] == '001-0005'
@@ -187,8 +179,7 @@ def test_federal_accounts_endpoint_keyword_filter_account_name(client, fixture_d
     # filter by the "Bureau" keyword
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'filters': {'fy': 2017},
-                                        'keyword': 'someth'}))
+                       data=json.dumps({'filters': {'fy': '2017'}, 'keyword': 'someth'}))
     response_data = resp.json()
     assert len(response_data['results']) == 1
     assert response_data['results'][0]['account_name'] == 'Something'
@@ -201,8 +192,7 @@ def test_federal_accounts_endpoint_keyword_filter_agency_name(client, fixture_da
     # filter by the "Bureau" keyword
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'filters': {'fy': 2017},
-                                        'keyword': 'burea'}))
+                       data=json.dumps({'filters': {'fy': '2017'}, 'keyword': 'burea'}))
     response_data = resp.json()
     assert len(response_data['results']) == 1
     assert response_data['results'][0]['managing_agency'] == 'The Bureau'
@@ -215,8 +205,7 @@ def test_federal_accounts_endpoint_keyword_filter_agency_acronym(client, fixture
     # filter by the "Bureau" keyword
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'filters': {'fy': 2017},
-                                        'keyword': 'efgh'}))
+                       data=json.dumps({'filters': {'fy': '2017'}, 'keyword': 'efgh'}))
     response_data = resp.json()
     assert len(response_data['results']) == 1
     assert response_data['results'][0]['managing_agency_acronym'] == 'EFGH'
@@ -227,8 +216,7 @@ def test_federal_accounts_uses_corrected_cgac(client, fixture_data):
     """Verify that CGAC reported as 1600 in FederalAccount will map to ToptierAgency 1601"""
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'field': 'managing_agency',
-                                                 'direction': 'asc'},
-                                        'filters': {'fy': 2015}}))
+                       data=json.dumps({'sort': {'field': 'managing_agency', 'direction': 'asc'},
+                                        'filters': {'fy': '2015'}}))
     response_data = resp.json()
     response_data['results'][0]['managing_agency_acronym'] == 'DOL'

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -384,8 +384,8 @@ class FederalAccountsViewSet(APIDocumentationView):
     """
     def _parse_and_validate_request(self, request_dict):
         """ Validate the Request object includes the required fields """
-        fy_range = [i for i in range(2001, FiscalDateTime.today().year + 1)]
-        last_fy = SubmissionAttributes.last_certified_fy()
+        fy_range = [str(i) for i in range(2001, FiscalDateTime.today().year + 1)]
+        last_fy = str(SubmissionAttributes.last_certified_fy()) or str(FiscalDateTime.today().year)
         request_settings = [
             {'key': 'sort', 'name': 'sort', 'type': 'object', 'optional': True, 'object_keys': {
                 'field': {'type': 'enum', 'enum_values': ['budgetary_resources', 'managing_agency', 'account_name',

--- a/usaspending_api/api_docs/api_documentation/federal_account/federal_account.md
+++ b/usaspending_api/api_docs/api_documentation/federal_account/federal_account.md
@@ -12,7 +12,7 @@ This route sends a request to the backend to retrieve a list of federal accounts
     "count": 786,
     "limit": 10,
     "page": 1,
-    "fy": 2017,
+    "fy": "2017",
     "next": 2,
     "previous": null,
     "hasNext": true,


### PR DESCRIPTION
**High level description:**
`/v2/federal_accounts/` endpoint should enforce the `fy` parameter as a String.

**Technical details:**
Correcting a mismatch between the API contract and the implementation of TinyShield.

**Link to JIRA Ticket:**
[DEV-1314](https://federal-spending-transparency.atlassian.net/browse/DEV-1314)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Matview impact assessment completed N/A
- [ ] Frontend impact assessment completed
- Data validation completed N/A
- [x] API documentation updated
- Performance evaluation completed and present (API | Script | Download) N/A