### PR TITLE
[Hotfix] Fixed AppropriationAccountBalances to list the correct submissions as the latest for FY

### DIFF
--- a/usaspending_api/accounts/models.py
+++ b/usaspending_api/accounts/models.py
@@ -249,22 +249,28 @@ class AppropriationAccountBalances(DataSourceTrackedModel):
     final_objects = AppropriationAccountBalancesManager()
 
     FINAL_OF_FY_SQL = """
-        UPDATE appropriation_account_balances
-        SET final_of_fy = submission_id in
-        ( SELECT DISTINCT ON
-            (aab.treasury_account_identifier,
-             FY(s.reporting_period_start))
-          s.submission_id
-          FROM submission_attributes s
-          JOIN appropriation_account_balances aab
-              ON (s.submission_id = aab.submission_id)
-          ORDER BY aab.treasury_account_identifier,
-                   FY(s.reporting_period_start),
-                   s.reporting_period_start DESC)"""
+        WITH submission_and_tai AS (
+            SELECT
+                DISTINCT ON (aab.treasury_account_identifier, FY(s.reporting_period_start))
+                aab.treasury_account_identifier,
+                s.submission_id
+            FROM submission_attributes s
+            JOIN appropriation_account_balances aab
+                  ON (s.submission_id = aab.submission_id)
+            ORDER BY aab.treasury_account_identifier,
+                       FY(s.reporting_period_start),
+                       s.reporting_period_start DESC
+        )
+        UPDATE appropriation_account_balances aab
+            SET final_of_fy = true
+            FROM submission_and_tai sat
+            WHERE aab.treasury_account_identifier = sat.treasury_account_identifier AND
+            aab.submission_id = sat.submission_id"""
 
     @classmethod
     def populate_final_of_fy(cls):
         with connection.cursor() as cursor:
+            cursor.execute("UPDATE appropriation_account_balances SET final_of_fy = false")
             cursor.execute(cls.FINAL_OF_FY_SQL)
 
     # TODO: is the self-joining SQL below do-able via the ORM?

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -5,17 +5,13 @@ from django.db.models import F, Func, OuterRef, Q, Subquery, Sum, Value
 from django.db.models.functions import Concat
 from django.utils.dateparse import parse_date
 from rest_framework.response import Response
-from usaspending_api.common.views import APIDocumentationView
 
+from usaspending_api.accounts.models import AppropriationAccountBalances, FederalAccount, TreasuryAppropriationAccount
 from usaspending_api.common.cache_decorator import cache_response
-
-from usaspending_api.accounts.models import (AppropriationAccountBalances,
-                                             FederalAccount,
-                                             TreasuryAppropriationAccount)
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.generic_helper import get_simple_pagination_metadata
-from usaspending_api.financial_activities.models import \
-    FinancialAccountsByProgramActivityObjectClass
+from usaspending_api.common.views import APIDocumentationView
+from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 from usaspending_api.references.models import ToptierAgency
 from usaspending_api.submissions.models import SubmissionAttributes
 
@@ -69,29 +65,42 @@ class FiscalYearSnapshotFederalAccountsViewSet(APIDocumentationView):
 
     endpoint_doc: /federal_account/fiscal_year_snapshot.md
     """
+
     @cache_response()
     def get(self, request, pk, fy=0, format=None):
         fy = int(fy) or SubmissionAttributes.last_certified_fy()
-        queryset = AppropriationAccountBalances.objects.all() \
-            .filter(treasury_account_identifier__federal_account_id=int(pk), submission__reporting_fiscal_year=fy) \
+        queryset = (
+            AppropriationAccountBalances.objects.all()
+            .filter(treasury_account_identifier__federal_account_id=int(pk), submission__reporting_fiscal_year=fy)
             .annotate(
-                outlay=F('gross_outlay_amount_by_tas_cpe'),
-                budget_authority=F('total_budgetary_resources_amount_cpe'),
-                obligated=F('obligations_incurred_total_by_tas_cpe'),
-                unobligated=F('unobligated_balance_cpe'),
+                outlay=F("gross_outlay_amount_by_tas_cpe"),
+                budget_authority=F("total_budgetary_resources_amount_cpe"),
+                obligated=F("obligations_incurred_total_by_tas_cpe"),
+                unobligated=F("unobligated_balance_cpe"),
                 balance_brought_forward=Sum(
-                    F('budget_authority_unobligated_balance_brought_forward_fyb') +
-                    F('adjustments_to_unobligated_balance_brought_forward_cpe')),
-                other_budgetary_resources=F('other_budgetary_resources_amount_cpe'),
-                appropriations=F('budget_authority_appropriated_amount_cpe')) \
-            .values('outlay', 'budget_authority', 'obligated', 'unobligated',
-                    'balance_brought_forward', 'other_budgetary_resources', 'appropriations') \
-            .order_by('-reporting_period_end').first()
+                    F("budget_authority_unobligated_balance_brought_forward_fyb") +
+                    F("adjustments_to_unobligated_balance_brought_forward_cpe")
+                ),
+                other_budgetary_resources=F("other_budgetary_resources_amount_cpe"),
+                appropriations=F("budget_authority_appropriated_amount_cpe"),
+            )
+            .values(
+                "outlay",
+                "budget_authority",
+                "obligated",
+                "unobligated",
+                "balance_brought_forward",
+                "other_budgetary_resources",
+                "appropriations",
+            )
+            .order_by("-reporting_period_end")
+            .first()
+        )
 
-        if queryset and queryset['outlay'] is not None:
-            name = FederalAccount.objects.filter(id=int(pk)).values('account_title').first()['account_title']
-            queryset['name'] = name
-            return Response({'results': queryset})
+        if queryset and queryset["outlay"] is not None:
+            name = FederalAccount.objects.filter(id=int(pk)).values("account_title").first()["account_title"]
+            queryset["name"] = name
+            return Response({"results": queryset})
         else:
             return Response({})
 

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -86,24 +86,9 @@ class FiscalYearSnapshotFederalAccountsViewSet(APIDocumentationView):
                 appropriations=F('budget_authority_appropriated_amount_cpe')) \
             .values('outlay', 'budget_authority', 'obligated', 'unobligated',
                     'balance_brought_forward', 'other_budgetary_resources', 'appropriations') \
-            .order_by('-reporting_period_end')
+            .order_by('-reporting_period_end').first()
 
-        from usaspending_api.common.helpers.generic_helper import generate_raw_quoted_query
-        print('=======================================')
-        print(request.path)
-        print(generate_raw_quoted_query(queryset))
-        # queryset = queryset.aggregate(
-        #     outlay=Sum('gross_outlay_amount_by_tas_cpe'),
-        #     budget_authority=Sum('total_budgetary_resources_amount_cpe'),
-        #     obligated=Sum('obligations_incurred_total_by_tas_cpe'),
-        #     unobligated=Sum('unobligated_balance_cpe'),
-        #     balance_brought_forward=Sum(
-        #         F('budget_authority_unobligated_balance_brought_forward_fyb') +
-        #         F('adjustments_to_unobligated_balance_brought_forward_cpe')),
-        #     other_budgetary_resources=Sum('other_budgetary_resources_amount_cpe'),
-        #     appropriations=Sum('budget_authority_appropriated_amount_cpe'))
-        queryset = queryset[0]
-        if queryset['outlay'] is not None:
+        if queryset and queryset['outlay'] is not None:
             name = FederalAccount.objects.filter(id=int(pk)).values('account_title').first()['account_title']
             queryset['name'] = name
             return Response({'results': queryset})

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -69,42 +69,24 @@ class FiscalYearSnapshotFederalAccountsViewSet(APIDocumentationView):
     @cache_response()
     def get(self, request, pk, fy=0, format=None):
         fy = int(fy) or SubmissionAttributes.last_certified_fy()
-        queryset = (
-            AppropriationAccountBalances.objects.all()
-            .filter(treasury_account_identifier__federal_account_id=int(pk), submission__reporting_fiscal_year=fy)
-            .annotate(
-                outlay=F("gross_outlay_amount_by_tas_cpe"),
-                budget_authority=F("total_budgetary_resources_amount_cpe"),
-                obligated=F("obligations_incurred_total_by_tas_cpe"),
-                unobligated=F("unobligated_balance_cpe"),
-                balance_brought_forward=(F("budget_authority_unobligated_balance_brought_forward_fyb") +
-                    F("adjustments_to_unobligated_balance_brought_forward_cpe")),
-                other_budgetary_resources=F("other_budgetary_resources_amount_cpe"),
-                appropriations=F("budget_authority_appropriated_amount_cpe"),
-            )
-            .values(
-                "outlay",
-                "budget_authority",
-                "obligated",
-                "unobligated",
-                "balance_brought_forward",
-                "other_budgetary_resources",
-                "appropriations",
-            )
-            .order_by("-reporting_period_end")
-        )
+        queryset = AppropriationAccountBalances.final_objects.filter(
+            treasury_account_identifier__federal_account_id=int(pk)).filter(submission__reporting_fiscal_year=fy)
+        queryset = queryset \
+            .aggregate(
+                outlay=Sum('gross_outlay_amount_by_tas_cpe'),
+                budget_authority=Sum('total_budgetary_resources_amount_cpe'),
+                obligated=Sum('obligations_incurred_total_by_tas_cpe'),
+                unobligated=Sum('unobligated_balance_cpe'),
+                balance_brought_forward=Sum(
+                    F('budget_authority_unobligated_balance_brought_forward_fyb') +
+                    F('adjustments_to_unobligated_balance_brought_forward_cpe')),
+                other_budgetary_resources=Sum('other_budgetary_resources_amount_cpe'),
+                appropriations=Sum('budget_authority_appropriated_amount_cpe'))
 
-        from usaspending_api.common.helpers.generic_helper import generate_raw_quoted_query
-        print('=======================================')
-        print(request.path)
-        print(generate_raw_quoted_query(queryset))
-
-        results = queryset.first()
-
-        if results and results["outlay"] is not None:
-            name = FederalAccount.objects.filter(id=int(pk)).values("account_title").first()["account_title"]
-            results["name"] = name
-            return Response({"results": results})
+        if queryset['outlay'] is not None:
+            name = FederalAccount.objects.filter(id=int(pk)).values('account_title').first()['account_title']
+            queryset['name'] = name
+            return Response({'results': queryset})
         else:
             return Response({})
 

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -77,10 +77,8 @@ class FiscalYearSnapshotFederalAccountsViewSet(APIDocumentationView):
                 budget_authority=F("total_budgetary_resources_amount_cpe"),
                 obligated=F("obligations_incurred_total_by_tas_cpe"),
                 unobligated=F("unobligated_balance_cpe"),
-                balance_brought_forward=Sum(
-                    F("budget_authority_unobligated_balance_brought_forward_fyb") +
-                    F("adjustments_to_unobligated_balance_brought_forward_cpe")
-                ),
+                balance_brought_forward=(F("budget_authority_unobligated_balance_brought_forward_fyb") +
+                    F("adjustments_to_unobligated_balance_brought_forward_cpe")),
                 other_budgetary_resources=F("other_budgetary_resources_amount_cpe"),
                 appropriations=F("budget_authority_appropriated_amount_cpe"),
             )
@@ -94,13 +92,19 @@ class FiscalYearSnapshotFederalAccountsViewSet(APIDocumentationView):
                 "appropriations",
             )
             .order_by("-reporting_period_end")
-            .first()
         )
 
-        if queryset and queryset["outlay"] is not None:
+        from usaspending_api.common.helpers.generic_helper import generate_raw_quoted_query
+        print('=======================================')
+        print(request.path)
+        print(generate_raw_quoted_query(queryset))
+
+        results = queryset.first()
+
+        if results and results["outlay"] is not None:
             name = FederalAccount.objects.filter(id=int(pk)).values("account_title").first()["account_title"]
-            queryset["name"] = name
-            return Response({"results": queryset})
+            results["name"] = name
+            return Response({"results": results})
         else:
             return Response({})
 

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -72,18 +72,37 @@ class FiscalYearSnapshotFederalAccountsViewSet(APIDocumentationView):
     @cache_response()
     def get(self, request, pk, fy=0, format=None):
         fy = int(fy) or SubmissionAttributes.last_certified_fy()
-        queryset = AppropriationAccountBalances.final_objects.filter(
-            treasury_account_identifier__federal_account_id=int(pk)).filter(submission__reporting_fiscal_year=fy)
-        queryset = queryset.aggregate(
-            outlay=Sum('gross_outlay_amount_by_tas_cpe'),
-            budget_authority=Sum('total_budgetary_resources_amount_cpe'),
-            obligated=Sum('obligations_incurred_total_by_tas_cpe'),
-            unobligated=Sum('unobligated_balance_cpe'),
-            balance_brought_forward=Sum(
-                F('budget_authority_unobligated_balance_brought_forward_fyb') +
-                F('adjustments_to_unobligated_balance_brought_forward_cpe')),
-            other_budgetary_resources=Sum('other_budgetary_resources_amount_cpe'),
-            appropriations=Sum('budget_authority_appropriated_amount_cpe'))
+        queryset = AppropriationAccountBalances.objects.all() \
+            .filter(treasury_account_identifier__federal_account_id=int(pk), submission__reporting_fiscal_year=fy) \
+            .annotate(
+                outlay=F('gross_outlay_amount_by_tas_cpe'),
+                budget_authority=F('total_budgetary_resources_amount_cpe'),
+                obligated=F('obligations_incurred_total_by_tas_cpe'),
+                unobligated=F('unobligated_balance_cpe'),
+                balance_brought_forward=Sum(
+                    F('budget_authority_unobligated_balance_brought_forward_fyb') +
+                    F('adjustments_to_unobligated_balance_brought_forward_cpe')),
+                other_budgetary_resources=F('other_budgetary_resources_amount_cpe'),
+                appropriations=F('budget_authority_appropriated_amount_cpe')) \
+            .values('outlay', 'budget_authority', 'obligated', 'unobligated',
+                    'balance_brought_forward', 'other_budgetary_resources', 'appropriations') \
+            .order_by('-reporting_period_end')
+
+        from usaspending_api.common.helpers.generic_helper import generate_raw_quoted_query
+        print('=======================================')
+        print(request.path)
+        print(generate_raw_quoted_query(queryset))
+        # queryset = queryset.aggregate(
+        #     outlay=Sum('gross_outlay_amount_by_tas_cpe'),
+        #     budget_authority=Sum('total_budgetary_resources_amount_cpe'),
+        #     obligated=Sum('obligations_incurred_total_by_tas_cpe'),
+        #     unobligated=Sum('unobligated_balance_cpe'),
+        #     balance_brought_forward=Sum(
+        #         F('budget_authority_unobligated_balance_brought_forward_fyb') +
+        #         F('adjustments_to_unobligated_balance_brought_forward_cpe')),
+        #     other_budgetary_resources=Sum('other_budgetary_resources_amount_cpe'),
+        #     appropriations=Sum('budget_authority_appropriated_amount_cpe'))
+        queryset = queryset[0]
         if queryset['outlay'] is not None:
             name = FederalAccount.objects.filter(id=int(pk)).values('account_title').first()['account_title']
             queryset['name'] = name

--- a/usaspending_api/references/management/commands/load_tas.py
+++ b/usaspending_api/references/management/commands/load_tas.py
@@ -10,44 +10,48 @@ from usaspending_api.references.models import ToptierAgency
 from usaspending_api.references.reference_helpers import (insert_federal_accounts, update_federal_accounts,
                                                           remove_empty_federal_accounts)
 
-logger = logging.getLogger('console')
+logger = logging.getLogger("console")
 
-TAS_SQL_PATH = 'usaspending_api/references/management/sql/restock_tas.sql'
+TAS_SQL_PATH = "usaspending_api/references/management/sql/restock_tas.sql"
 
 
 class Command(BaseCommand):
-    help = 'Update TAS records from the DATA Broker'
+    help = "Update TAS records from the DATA Broker"
 
     @transaction.atomic()
     def handle(self, *args, **options):
         try:
-            call_command('run_sql', '-f', TAS_SQL_PATH)
+            call_command("run_sql", "-f", TAS_SQL_PATH)
 
             # Match funding toptiers by FREC if they didn't match by AID
             unmapped_funding_agencies = TreasuryAppropriationAccount.objects.filter(funding_toptier_agency=None)
             match_count = 0
-            logger.info('Found {} unmatched funding agencies across all TAS objects. Attempting to match on FREC.'.
-                        format(unmapped_funding_agencies.count()))
+            msg_str = "\n=== Found {} unmatched funding agencies across all TAS objects. ==="
+            logger.info(msg_str.format(unmapped_funding_agencies.count()))
             for next_tas in unmapped_funding_agencies:
                 # CGAC code is a combination of FRECs and CGACs. It will never be empty and it will always
                 # be unique in ToptierAgencies; this should be safe to do.
                 frec_match = ToptierAgency.objects.filter(cgac_code=next_tas.fr_entity_code).first()
                 if frec_match:
                     match_count += 1
-                    logger.info('Matched unknown funding agency for TAS {} with FREC {}'.format(
+                    logger.info("   Matched unknown funding agency for TAS {} with FREC {}".format(
                         next_tas.tas_rendering_label, next_tas.fr_entity_code))
                     next_tas.funding_toptier_agency = frec_match
                     next_tas.save()
 
-            logger.info('Updated {} funding toptiers with a FREC agency.'.format(match_count))
+            logger.info("\n=== Updated {} funding toptiers with a FREC agency. ===".format(match_count))
 
             # update TAS fk relationships to federal accounts
-            logger.info('Updating TAS FK relationships to Federal Accounts')
-            remove_empty_federal_accounts()
-            update_federal_accounts()
-            insert_federal_accounts()
+            logger.info("\n=== Updating TAS FK relationships to Federal Accounts ===")
+            updates = update_federal_accounts()
+            logger.info("   Updated {} Federal Account Rows".format(updates))
+            inserts = insert_federal_accounts()
+            logger.info("   Created {} Federal Account Rows".format(inserts))
+            deletes = remove_empty_federal_accounts()
+            logger.info("   Removed {} Federal Account Rows".format(deletes))
 
-            logger.info('TAS loader finished successfully!')
+            logger.info("\n=== TAS loader finished successfully! ===")
         except Exception as e:
             logger.error(e)
+            logger.error("\n=== TAS loader failed ===")
             sys.exit(1)

--- a/usaspending_api/references/reference_helpers.py
+++ b/usaspending_api/references/reference_helpers.py
@@ -41,8 +41,6 @@ def update_federal_accounts(tas_tuple=None):
         "AND t.main_account_code = fa.main_account_code",
         "AND t.treasury_account_identifier IN %s" if tas_tuple is not None else "",
     ])
-    # if tas_tuple is not None:
-    #     tas_fk_sql += " AND t.treasury_account_identifier IN %s "
 
     with connection.cursor() as cursor:
         cursor.execute(tas_fk_sql, [tas_tuple])

--- a/usaspending_api/references/reference_helpers.py
+++ b/usaspending_api/references/reference_helpers.py
@@ -9,7 +9,8 @@ def remove_empty_federal_accounts(tas_tuple=None):
     """
     Removes federal accounts who are no longer attached to a TAS
     """
-    FederalAccount.objects.filter(treasuryappropriationaccount__isnull=True).distinct().delete()
+    returns = FederalAccount.objects.filter(treasuryappropriationaccount__isnull=True).distinct().delete()
+    return returns[0]
 
 
 def update_federal_accounts(tas_tuple=None):
@@ -32,15 +33,16 @@ def update_federal_accounts(tas_tuple=None):
 
     # Because orm doesn't support join updates, dropping down to raw SQL
     # to update existing federal_account FK relationships on the tas table.
-    tas_fk_sql = '''
-        update treasury_appropriation_account t
-        set federal_account_id = fa.id
-        from federal_account fa
-        where t.agency_id = fa.agency_identifier
-        and t.main_account_code = fa.main_account_code
-        '''
-    if tas_tuple is not None:
-        tas_fk_sql += 'AND t.treasury_account_identifier IN %s '
+    tas_fk_sql = " ".join([
+        "UPDATE treasury_appropriation_account t",
+        "SET federal_account_id = fa.id",
+        "FROM federal_account fa",
+        "WHERE t.agency_id = fa.agency_identifier",
+        "AND t.main_account_code = fa.main_account_code",
+        "AND t.treasury_account_identifier IN %s" if tas_tuple is not None else "",
+    ])
+    # if tas_tuple is not None:
+    #     tas_fk_sql += " AND t.treasury_account_identifier IN %s "
 
     with connection.cursor() as cursor:
         cursor.execute(tas_fk_sql, [tas_tuple])
@@ -86,3 +88,6 @@ def insert_federal_accounts():
         # FKs to their corresponding treasury_appropriation_account records
         tas_update_list = [t.treasury_account_identifier for t in tas_no_federal_account]
         update_federal_accounts(tuple(tas_update_list))
+        return len(fa_objects)
+    else:
+        return 0


### PR DESCRIPTION
**High level description:**
In AppropriationAccountBalances, submissions which were marked as "final_of_fy" were not always correct. Some submission_id values were duplicated across different TAS. So if a submission was correctly listed as "latest" for one TAS might not be the latest for another TAS.

**Technical details:**
In AppropriationAccountBalances, there is a class method `populate_final_of_fy` which is run after each submission load. The SQL was modified to appropriately only update `final_of_fy` by linking submission ids to TASs using `treasury_account_identifier`.

Also, as a followup of the TAS reloader script, the federal_account rows were being deleted and recreated by `load_tas` management command every night. Minor edits were made with the command ordering and logging to prevent this behavior.

**Link to JIRA Ticket:**
[DEV-517](https://federal-spending-transparency.atlassian.net/browse/DEV-517)
[DEV-1451](https://federal-spending-transparency.atlassian.net/browse/DEV-1451)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed
- [x] API Performance evaluation completed (N/A)