### PR TITLE
Fixed the temporary_restock_recipient_profile row creation

### DIFF
--- a/usaspending_api/recipient/management/sql/restock_recipient_profile.sql
+++ b/usaspending_api/recipient/management/sql/restock_recipient_profile.sql
@@ -21,7 +21,7 @@ CREATE MATERIALIZED VIEW public.temporary_recipients_from_transactions_view AS (
   FROM
     universal_transaction_matview
   WHERE action_date >= '2007-10-01' AND
-    (award_category IS NOT NULL OR award_category IS NULL AND pulled_from = 'IDV')
+    (award_category IS NOT NULL OR (award_category IS NULL AND pulled_from = 'IDV'))
 );
 
 CREATE INDEX idx_recipients_in_transactions_view ON public.temporary_recipients_from_transactions_view USING BTREE(recipient_hash, recipient_level);
@@ -55,33 +55,29 @@ INSERT INTO public.temporary_restock_recipient_profile (
   recipient_unique_id,
   recipient_name
 )
-SELECT
-  'P' as recipient_level,
-  recipient_hash,
-  duns AS recipient_unique_id,
-  legal_business_name AS recipient_name
-FROM
-  public.recipient_lookup
-WHERE
-  recipient_lookup.duns IS NOT NULL
+  SELECT
+    'P' as recipient_level,
+    recipient_hash,
+    duns AS recipient_unique_id,
+    legal_business_name AS recipient_name
+  FROM
+    public.recipient_lookup
 UNION ALL
-SELECT
-  'C' as recipient_level,
-  recipient_hash,
-  duns AS recipient_unique_id,
-  legal_business_name AS recipient_name
-FROM
-  public.recipient_lookup
+  SELECT
+    'C' as recipient_level,
+    recipient_hash,
+    duns AS recipient_unique_id,
+    legal_business_name AS recipient_name
+  FROM
+    public.recipient_lookup
 UNION ALL
-SELECT
-  'R' as recipient_level,
-  recipient_hash,
-  duns AS recipient_unique_id,
-  legal_business_name AS recipient_name
-FROM
-  public.recipient_lookup
-WHERE
-  recipient_lookup.duns IS NULL;
+  SELECT
+    'R' as recipient_level,
+    recipient_hash,
+    duns AS recipient_unique_id,
+    legal_business_name AS recipient_name
+  FROM
+    public.recipient_lookup;
 
 
 CREATE UNIQUE INDEX idx_recipient_profile_uniq_new ON public.temporary_restock_recipient_profile USING BTREE(recipient_hash, recipient_level);


### PR DESCRIPTION
**High level description:**
There was unnecessary filters which reduced some recipient DUNS/type combinations for the Recipient Profile page.

**Technical details:**
Removed all of the predicates from the SQL insert command which creates all potential Recipient + type combinations before the data are populated for the last 12 months.

**Link to JIRA Ticket:**
[DEV-1454](https://federal-spending-transparency.atlassian.net/browse/DEV-1454)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [X] Unit & integration tests updated with relevant test cases
- [X] Matview impact assessment completed
- [X] Frontend impact assessment completed
- [X] Data validation completed
- [X] API Performance evaluation completed and present:

Rows before: 1,452,991
Rows after: 2,171,516
Diff: +718,525

No detectable performance changes. Responses still consistently under 2s for most requests, upper bounds of 5s max