### PR TITLE
Hotfix: Business Categories, allow Nones in Legal Entity

### DIFF
--- a/usaspending_api/broker/helpers.py
+++ b/usaspending_api/broker/helpers.py
@@ -91,7 +91,7 @@ def build_legal_entity_booleans_dict(row):
         'other_not_for_profit_organ',
         'us_local_government'
     ]
-    return {le_col: bool(strtobool(row.get(le_col, 'false'))) for le_col in le_cols}
+    return {le_col: bool(strtobool(row.get(le_col, 'false') or 'false')) for le_col in le_cols}
 
 
 def get_award_category(award_type_code):


### PR DESCRIPTION
**High level description:**
Simply account for a legal entity column to be `None` instead of `True` and `False` when recreating the business categories.

**Technical details:**
(see above)

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases (N/A)
- Matview impact assessment completed (N/A)
- Frontend impact assessment completed (N/A)
- Data validation completed (N/A)
- API Performance evaluation completed (N/A)