### PR TITLE
Adding pyup file so pyup.io stops making PRs

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,51 @@
+# configure updates globally
+# default: all
+# allowed: all, insecure, False
+update: False
+
+# configure dependency pinning globally
+# default: True
+# allowed: True, False
+pin: True
+
+# set the default branch
+# default: empty, the default branch on GitHub
+branch: dev
+
+# update schedule
+# default: empty
+# allowed: "every day", "every week", ..
+schedule: "every month"
+
+# search for requirement files
+# default: True
+# allowed: True, False
+search: False
+
+# Specify requirement files by hand, default is empty
+# default: empty
+# allowed: list
+requirements:
+  - requirements/requirements.txt:
+
+# add a label to pull requests, default is not set
+# requires private repo permissions, even on public repos
+# default: empty
+label_prs: pyup.io
+
+# assign users to pull requests, default is not set
+# requires private repo permissions, even on public repos
+# default: empty
+# assignees:
+
+# configure the branch prefix the bot is using
+# default: pyup-
+branch_prefix: pyup/
+
+# set a global prefix for PRs
+# default: empty
+# pr_prefix:
+
+# allow to close stale PRs
+# default: True
+close_prs: False


### PR DESCRIPTION
**High level description:**
For questionable reasons pyup.io does not allow users to edit global settings in the web app. To stop pyup.io from creating PRs this config file needs to be present 

**Technical details:**
https://pyup.io/docs/configuration/

**Link to JIRA Ticket:**
(N/A)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases (N/A)
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed (N/A)