### PR TITLE
Bugfix: Referenced incorrect column for uniqueness

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/summary_award_recipient_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_award_recipient_view.json
@@ -3,6 +3,7 @@
   "refresh": true,
   "matview_sql": [
     "SELECT",
+    "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
     "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
     "  awards.date_signed,",
     "  transaction_normalized.action_date,",

--- a/usaspending_api/database_scripts/matview_generator/summary_state_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_state_view.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_geo_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_geo_view.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  cast(date_trunc('month', transaction_normalized.action_date) as date) as action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_month_view.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  cast(date_trunc('month', transaction_normalized.action_date) as date) as action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_recipient_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_recipient_view.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_transaction_view.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  awards.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view_cfda_number.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view_cfda_number.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view_naics_codes.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view_naics_codes.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",

--- a/usaspending_api/database_scripts/matview_generator/summary_view_psc_codes.json
+++ b/usaspending_api/database_scripts/matview_generator/summary_view_psc_codes.json
@@ -4,7 +4,7 @@
   "matview_sql": [
     "SELECT",
     "  -- Deterministic Unique Hash (DUH) created for view concurrent refresh",
-    "  MD5(array_to_string(sort(array_agg(awards.id::int)), ' '))::uuid AS duh,",
+    "  MD5(array_to_string(sort(array_agg(transaction_normalized.id::int)), ' '))::uuid AS duh,",
     "  transaction_normalized.action_date,",
     "  transaction_normalized.fiscal_year,",
     "  transaction_normalized.type,",


### PR DESCRIPTION
**High level description:**
A previous PR introduced bugs to a number of materialized views by breaking the unique column necessary for having a unique index which is used for concurrent refreshing of the matviews.

**Technical details:**
The column `duh` is only present to add a unique column to pre-aggregated materialized view. Incorrectly copy-pasted using awards.id instead of transaction_normalized.id

**Link to JIRA Ticket:**
N/A

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases (N/A)
- [x] Matview impact assessment completed
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed (N/A)
- [x] API Performance evaluation completed (N/A)