### PR TITLE
DEV-1495/1496: Create list_budget_functions and list_budget_subfunctions endpoints

### DIFF
--- a/usaspending_api/accounts/tests/integration/test_budget_function.py
+++ b/usaspending_api/accounts/tests/integration/test_budget_function.py
@@ -1,0 +1,96 @@
+import json
+import pytest
+
+from model_mommy import mommy
+from rest_framework import status
+
+
+@pytest.fixture
+def model_instances():
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='050', budget_function_title='National Defense',
+        budget_subfunction_code='051', budget_subfunction_title='Department of Defense-Military'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='050', budget_function_title='National Defense',
+        budget_subfunction_code='054', budget_subfunction_title='Defense-related activities'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='050', budget_function_title='National Defense',
+        budget_subfunction_code='053', budget_subfunction_title='Atomic energy defense activities'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='276', budget_subfunction_title='Energy information, policy, and regulation'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='271', budget_subfunction_title='Energy supply'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='272', budget_subfunction_title='Energy conservation'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='274', budget_subfunction_title='Emergency energy preparedness'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='276', budget_subfunction_title='Energy information, policy, and regulation'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='271', budget_subfunction_title='Energy supply'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='272', budget_subfunction_title='Energy conservation'
+    )
+    mommy.make(
+        'accounts.TreasuryAppropriationAccount',
+        budget_function_code='270', budget_function_title='Energy',
+        budget_subfunction_code='274', budget_subfunction_title='Emergency energy preparedness'
+    )
+
+
+@pytest.mark.django_db
+def test_list_budget_functions_unique(model_instances, client):
+    """ Ensure the list_budget_functions endpoint returns unique values """
+    response = client.get('/api/v2/budget_functions/list_budget_functions/')
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'results' in response.json()
+    assert len(response.json()['results']) == 2
+
+
+@pytest.mark.django_db
+def test_list_budget_subfunctions_unique(model_instances, client):
+    """ Ensure the list_budget_subfunctions endpoint returns unique values """
+    response = client.post('/api/v2/budget_functions/list_budget_subfunctions/',
+                           content_type='application/json', data=json.dumps({}))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'results' in response.json()
+    assert len(response.json()['results']) == 7
+
+
+@pytest.mark.django_db
+def test_list_budget_subfunctions_filter(model_instances, client):
+    """ Ensure the list_budget_subfunctions endpoint filters by the budget_function_code """
+    response = client.post('/api/v2/budget_functions/list_budget_subfunctions/',
+                           content_type='application/json', data=json.dumps({"budget_function": "050"}))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'results' in response.json()
+    assert len(response.json()['results']) == 3

--- a/usaspending_api/accounts/v2/urls_budget_functions.py
+++ b/usaspending_api/accounts/v2/urls_budget_functions.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from usaspending_api.accounts.v2.views import budget_function
+
+urlpatterns = [
+    url(r'^list_budget_functions/$', budget_function.BudgetFunctionViewSet.as_view()),
+    url(r'^list_budget_subfunctions/$', budget_function.BudgetSubfunctionViewSet.as_view())
+]

--- a/usaspending_api/accounts/v2/urls_budget_functions.py
+++ b/usaspending_api/accounts/v2/urls_budget_functions.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from usaspending_api.accounts.v2.views import budget_function
 
 urlpatterns = [
-    url(r'^list_budget_functions/$', budget_function.BudgetFunctionViewSet.as_view()),
-    url(r'^list_budget_subfunctions/$', budget_function.BudgetSubfunctionViewSet.as_view())
+    url(r'^list_budget_functions/$', budget_function.ListBudgetFunctionViewSet.as_view()),
+    url(r'^list_budget_subfunctions/$', budget_function.ListBudgetSubfunctionViewSet.as_view())
 ]

--- a/usaspending_api/accounts/v2/views/budget_function.py
+++ b/usaspending_api/accounts/v2/views/budget_function.py
@@ -6,7 +6,7 @@ from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.views import APIDocumentationView
 
 
-class BudgetFunctionViewSet(APIDocumentationView):
+class ListBudgetFunctionViewSet(APIDocumentationView):
     """
     This route sends a request to the backend to retrieve all Budget Functions associated with a TAS, ordered by Budget
         Function code.
@@ -17,14 +17,13 @@ class BudgetFunctionViewSet(APIDocumentationView):
         # Retrieve all Budget Functions, grouped by code and title, ordered by code
         results = TreasuryAppropriationAccount.objects \
             .filter(~Q(budget_function_code=''), ~Q(budget_function_code=None)) \
-            .filter(budget_function_code='050') \
             .values('budget_function_code', 'budget_function_title') \
             .order_by('budget_function_code').distinct()
 
         return Response({'results': results})
 
 
-class BudgetSubfunctionViewSet(APIDocumentationView):
+class ListBudgetSubfunctionViewSet(APIDocumentationView):
     """
     This route sends a request to the backend to retrieve all Budget Subfunctions associated with a TAS, ordered by
         Budget Subfunction code. Can be filtered by Budget Function.

--- a/usaspending_api/accounts/v2/views/budget_function.py
+++ b/usaspending_api/accounts/v2/views/budget_function.py
@@ -1,0 +1,49 @@
+from django.db.models import Q
+from rest_framework.response import Response
+
+from usaspending_api.accounts.models import TreasuryAppropriationAccount
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.common.views import APIDocumentationView
+
+
+class BudgetFunctionViewSet(APIDocumentationView):
+    """
+    This route sends a request to the backend to retrieve all Budget Functions associated with a TAS, ordered by Budget
+        Function code.
+    endpoint_doc: /budget_function.md
+    """
+    @cache_response()
+    def get(self, request):
+        # Retrieve all Budget Functions, grouped by code and title, ordered by code
+        results = TreasuryAppropriationAccount.objects \
+            .filter(~Q(budget_function_code=''), ~Q(budget_function_code=None)) \
+            .filter(budget_function_code='050') \
+            .values('budget_function_code', 'budget_function_title') \
+            .order_by('budget_function_code').distinct()
+
+        return Response({'results': results})
+
+
+class BudgetSubfunctionViewSet(APIDocumentationView):
+    """
+    This route sends a request to the backend to retrieve all Budget Subfunctions associated with a TAS, ordered by
+        Budget Subfunction code. Can be filtered by Budget Function.
+    endpoint_doc: /budget_subfunction.md
+    """
+    @cache_response()
+    def post(self, request):
+        # Retrieve all Budget Subfunctions
+        queryset = TreasuryAppropriationAccount.objects \
+            .filter(~Q(budget_subfunction_code=''), ~Q(budget_subfunction_code=None))
+
+        # Filter by Budget Function, if provided
+        budget_function = request.data.get('budget_function', None)
+        if budget_function:
+            queryset = queryset.filter(budget_function_code=budget_function)
+
+        # Group by code and title, order by code
+        results = queryset \
+            .values('budget_subfunction_code', 'budget_subfunction_title') \
+            .order_by('budget_subfunction_code').distinct()
+
+        return Response({'results': results})

--- a/usaspending_api/urls.py
+++ b/usaspending_api/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     url(r'^api/v2/subawards/', include('usaspending_api.awards.v2.urls_subawards')),
     url(r'^api/v2/budget_authority/', include('usaspending_api.accounts.urls_budget_authority')),
     url(r'^api/v2/download/', include('usaspending_api.download.v2.urls')),
+    url(r'^api/v2/budget_functions/', include('usaspending_api.accounts.v2.urls_budget_functions')),
     url(r'^api/v2/bulk_download/', include('usaspending_api.bulk_download.v2.urls')),
     url(r'^api/v2/federal_accounts/', include('usaspending_api.accounts.urls_federal_accounts_v2')),
     url(r'^api/v2/federal_obligations/', include('usaspending_api.accounts.urls_federal_obligations')),


### PR DESCRIPTION
**High level description:**
Create a `list_budget_functions` endpoint for the Budget Functions dropdown, and create a filterable `list_budget_subfunctions` endpoint for the Budget Subfunctions dropdown.

**Technical details:**
Budget functions are pulled from all unique budget function code/title combinations in the TAS table. Budget subfunctions are similarly pulled, and able to be filtered by a budget function code.

**Link to JIRA Ticket:**
[DEV-1495](https://federal-spending-transparency.atlassian.net/browse/DEV-1495)
[DEV-1496](https://federal-spending-transparency.atlassian.net/browse/DEV-1496)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Matview impact assessment completed N/A
- [x] Frontend impact assessment completed
- [x] Data validation completed
- [x] API documentation updated
- [x] Performance evaluation completed and present (`list_budget_functions`):
    ```
    Timing: 996 ms
    Data volume: 20 rows
    ```
- [x] Performance evaluation completed and present (`list_budget_subfunctions`):
    ```
    Timing: 1066 ms
    Data volume: 69 rows
    ```