### PR TITLE
Changed mapping for Prime-Recipient Names in SpendingByAward

### DIFF
--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1098,7 +1098,7 @@ contract_subaward_mapping = {
     "Awarding Agency": "awarding_toptier_agency_name",
     "Awarding Sub Agency": "awarding_subtier_agency_name",
     "Prime Award ID": "piid",
-    "Prime Recipient Name": "recipient_name"
+    "Prime Recipient Name": "prime_recipient_name"
 }
 
 grant_subaward_mapping = {
@@ -1110,7 +1110,7 @@ grant_subaward_mapping = {
     "Awarding Agency": "awarding_toptier_agency_name",
     "Awarding Sub Agency": "awarding_subtier_agency_name",
     "Prime Award ID": "fain",
-    "Prime Recipient Name": "recipient_name"
+    "Prime Recipient Name": "prime_recipient_name"
 }
 
 award_assistance_mapping = {**grant_award_mapping, **loan_award_mapping, **direct_payment_award_mapping,


### PR DESCRIPTION
**High level description:**
Changed mapping for the Prime Recipient in SpendingByAward for Subawards

**Technical details:**
Incorrectly mapped to `recipient_name` instead of  `prime_recipient_name`

**Link to JIRA Ticket:**
[DEV-1473](https://federal-spending-transparency.atlassian.net/browse/DEV-1473)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases (N/A)
- [x] Matview impact assessment completed (N/A)
- [x] Frontend impact assessment completed (N/A)
- [x] Data validation completed
- [x] API Performance evaluation completed (N/A)