### PR TITLE
DEV-679: Removing all traces of fabs marked as deleted

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -293,8 +293,8 @@ class Command(BaseCommand):
             legal_entity.save()
 
     @staticmethod
-    def send_deletes_to_elasticsearch(ids_to_delete):
-        logger.info('Uploading FABS delete data to Elasticsearch bucket')
+    def send_deletes_to_s3(ids_to_delete):
+        logger.info('Uploading FABS delete data to FPDS bucket')
 
         # Make timestamp
         seconds = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
@@ -310,8 +310,8 @@ class Command(BaseCommand):
         else:
             # Write to file in S3 bucket directly
             aws_region = os.environ.get('USASPENDING_AWS_REGION')
-            elasticsearch_bucket_name = os.environ.get('FPDS_BUCKET_NAME')
-            s3_bucket = boto.s3.connect_to_region(aws_region).get_bucket(elasticsearch_bucket_name)
+            fpds_bucket_name = os.environ.get('FPDS_BUCKET_NAME')
+            s3_bucket = boto.s3.connect_to_region(aws_region).get_bucket(fpds_bucket_name)
             conn = s3_bucket.new_key(file_name)
             with smart_open.smart_open(conn, 'w') as writer:
                 for row in file_with_headers:
@@ -352,7 +352,7 @@ class Command(BaseCommand):
 
         if total_rows_delete > 0:
             # Create a file with the deletion IDs and place in a bucket for ElasticSearch
-            self.send_deletes_to_elasticsearch(ids_to_delete)
+            self.send_deletes_to_s3(ids_to_delete)
 
             # Delete FABS records by ID
             with timer('deleting stale FABS data', logger.info):

--- a/usaspending_api/broker/management/commands/fix_deleted_fabs.py
+++ b/usaspending_api/broker/management/commands/fix_deleted_fabs.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                 return
             delete_ids = [r[0] for r in rows]
             with timer('deleting rows', logger.info):
-                fabs_cmd.send_deletes_to_elasticsearch(delete_ids)
+                fabs_cmd.send_deletes_to_s3(delete_ids)
                 fabs_cmd().delete_stale_fabs(delete_ids)
             batch_no += 1
         logger.info('{} batches finished, complete'.format(batch_no - 1))

--- a/usaspending_api/broker/management/commands/fix_deleted_fabs.py
+++ b/usaspending_api/broker/management/commands/fix_deleted_fabs.py
@@ -5,6 +5,7 @@ Before running, must set up foreign data broker by running
 usaspending_api/database_scripts/broker_matviews/broker_server.sql
 through psql, after editing to add conneciton specifics
 """
+
 import logging
 
 from django.core.management.base import BaseCommand

--- a/usaspending_api/broker/management/commands/fix_deleted_fabs.py
+++ b/usaspending_api/broker/management/commands/fix_deleted_fabs.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
                 SELECT *
                 FROM    dblink('broker_server',
                 '
-                SELECT 
+                SELECT
                     afa_generated_unique,
                     bool_or(is_active) AS is_active,
                     bool_or(correction_delete_indicatr in (''d'', ''D'')) AS deleted

--- a/usaspending_api/broker/management/commands/fix_deleted_fabs.py
+++ b/usaspending_api/broker/management/commands/fix_deleted_fabs.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
     help = "Deletes FABS rows that have been deactivated in the broker"
 
     def add_arguments(self, parser):
-        parser.add_argument('-b', '--batchsize', type=int, default=1000, help='Fetch rows for deletion in batches of N')
+        parser.add_argument('-b', '--batchsize', type=int, default=10000, help='Fetch rows for deletion in batches of N')
         parser.add_argument('--batches', type=int, default=0, help='Stop after N batches (deletes all by default)')
 
     @staticmethod

--- a/usaspending_api/broker/management/commands/fix_deleted_fabs.py
+++ b/usaspending_api/broker/management/commands/fix_deleted_fabs.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
     help = "Deletes FABS rows that have been deactivated in the broker"
 
     def add_arguments(self, parser):
-        parser.add_argument('-b', '--batchsize', type=int, default=10000, help='Fetch rows for deletion in batches of N')
+        parser.add_argument('-b', '--batchsize', type=int, default=10000,
+                            help='Fetch rows for deletion in batches of N')
         parser.add_argument('--batches', type=int, default=0, help='Stop after N batches (deletes all by default)')
 
     @staticmethod


### PR DESCRIPTION
**High level description:**
DEV-679 reports of a deleted FABS record appearing on website. This updated script deletes all traces of it and any other FABS record marked as delete from the website.

**Technical details:**
* The issue was that the delete process from nightly FABS load didn't remove *all* traces of the FABS record from the website until mid-late April 2018 when it was fixed. However, we didn't run the same deletion process for all the previous records.
* Importing the same delete process as the FABS nightly loader
* Updating script to use db_link

**Link to JIRA Ticket:**
[DEV-679](https://federal-spending-transparency.atlassian.net/browse/DEV-679)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Matview impact assessment completed (N/A)
-  Frontend impact assessment completed (N/A)
- [x] Data validation completed
Deleted necessary row from `TransactionFABS` on dev
- [x] Ops ticket created
- [x] ~API~ Performance evaluation completed:
```
ERROR:root:ES_HOSTNAME is not specified!!!
18:51:29 - Starting row deletion...
INFO:console:Starting row deletion...
18:51:29 - Beginning executing query...
INFO:console:Beginning executing query...
18:57:47 - ... finished executing query in 377.8954143419978 sec
INFO:console:... finished executing query in 377.8954143419978 sec
18:57:47 - Beginning deleting rows...
INFO:console:Beginning deleting rows...
18:57:47 - Uploading FABS delete data to Elasticsearch bucket
INFO:console:Uploading FABS delete data to Elasticsearch bucket
18:57:47 - Starting deletion of stale FABS data
INFO:console:Starting deletion of stale FABS data
18:58:04 - ... finished deleting rows in 17.06035723601235 sec
INFO:console:... finished deleting rows in 17.06035723601235 sec
18:58:04 - Beginning deleting rows...
INFO:console:Beginning deleting rows...
18:58:04 - Uploading FABS delete data to Elasticsearch bucket
INFO:console:Uploading FABS delete data to Elasticsearch bucket
18:58:04 - Starting deletion of stale FABS data
INFO:console:Starting deletion of stale FABS data
18:58:15 - ... finished deleting rows in 11.533235892013181 sec
INFO:console:... finished deleting rows in 11.533235892013181 sec
18:58:15 - Beginning deleting rows...
INFO:console:Beginning deleting rows...
18:58:15 - Uploading FABS delete data to Elasticsearch bucket
INFO:console:Uploading FABS delete data to Elasticsearch bucket
18:58:15 - Starting deletion of stale FABS data
INFO:console:Starting deletion of stale FABS data
18:58:20 - ... finished deleting rows in 5.164470762014389 sec
INFO:console:... finished deleting rows in 5.164470762014389 sec
18:58:20 - Beginning deleting rows...
INFO:console:Beginning deleting rows...
18:58:20 - Uploading FABS delete data to Elasticsearch bucket
INFO:console:Uploading FABS delete data to Elasticsearch bucket
18:58:20 - Starting deletion of stale FABS data
INFO:console:Starting deletion of stale FABS data
18:58:28 - ... finished deleting rows in 7.5048733439762145 sec
INFO:console:... finished deleting rows in 7.5048733439762145 sec
18:58:28 - Beginning deleting rows...
INFO:console:Beginning deleting rows...
18:58:28 - Uploading FABS delete data to Elasticsearch bucket
INFO:console:Uploading FABS delete data to Elasticsearch bucket
18:58:28 - Starting deletion of stale FABS data
INFO:console:Starting deletion of stale FABS data
18:58:52 - ... finished deleting rows in 24.423911572957877 sec
INFO:console:... finished deleting rows in 24.423911572957877 sec
18:58:52 - No further rows; finished
INFO:console:No further rows; finished
```