### PR TITLE
README.md instruct venv in dot dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,15 +5,15 @@
 .coverage
 .DS_Store
 
-pip-selfcheck.json
+# JetBrains IDEs
+**/.idea/
+
+# Temporary and generated files
 log/*
-csv_downloads/*
-tmp/*
 usaspending_api/logs/*
-usaspending_api/.idea/*
-usaspending_api/references/.idea/*
-usaspending_api/financial_activities/.idea/*
-.idea/*
+csv_downloads/*
+bulk_downloads/*
+tmp/*
 
 # pyenv ignores
 .python-version
@@ -30,5 +30,4 @@ pyvenv.cfg
 .ipynb
 .lprof
 .pytest_cache/*
-
-
+pip-selfcheck.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .DS_Store
 
 pip-selfcheck.json
-pyvenv.cfg
 log/*
 csv_downloads/*
 tmp/*
@@ -16,10 +15,20 @@ usaspending_api/references/.idea/*
 usaspending_api/financial_activities/.idea/*
 .idea/*
 
+# pyenv ignores
+.python-version
+pyvenv.cfg
+
+# for a project-local (rather than home-dir based) virtual environment directory
+.venv/ 
+
+# direnv ignores
 .direnv/
+.envrc
+
 .pgdump
 .ipynb
 .lprof
-.envrc
 .pytest_cache/*
-.python-version
+
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Create and activate the virtual environment using `venv`, and ensure the right v
     $ source .venv/usaspending-api/bin/activate
 
 
+Your prompt should then look as below to show you are _in_ the virtual environment named `usaspending-api` (_to exit that virtual environment, simply type `deactivate` at the prompt_).
+
+    (usaspending-api) $ 
 
 [`pip`](https://pip.pypa.io/en/stable/installing/) `install` application dependencies
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Navigate to the base file directory for the USAspending repositories
 
 Create and activate the virtual environment using `venv`, and ensure the right version of Python 3.5.x is being used (the latest RHEL package available for `python35u`, currently 3.5.5)
 
-    (usaspending-api) $ pyenv install 3.5.5
-    (usaspending-api) $ pyenv local 3.5.5
-    $ python -m venv .
-    $ source bin/activate
+    $ pyenv install 3.5.5
+    $ pyenv local 3.5.5
+    $ python -m venv .venv/usaspending-api
+    $ source .venv/usaspending-api/bin/activate
 
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 DJANGO_SETTINGS_MODULE=usaspending_api.settings
 
 [flake8]
-exclude=.git,.venv,usaspending_api/*/migrations/*
+exclude=.venv,usaspending_api/*/migrations/*
 max-line-length=120

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 DJANGO_SETTINGS_MODULE=usaspending_api.settings
 
 [flake8]
-exclude=usaspending_api/*/migrations/*
+exclude=.git,.venv,usaspending_api/*/migrations/*
 max-line-length=120


### PR DESCRIPTION
Changing instructions in the `README.md` so that it embeds the project-local virtual environemnt directory into a 'hidden' dot directory (`.venv`).

Also adding an exclude in flake8 config in `setup.cfg` to not have `flake8` analyze python files in this dot directory. 

Without these, these extra subfolders under the project directory were interfering with local execution of `pytest` and `flake8`.