### PR TITLE
Adding PR template for Github

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,27 @@
+**Description:**
+High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances
+
+**Technical details:**
+The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.
+
+**Requirements for PR merge:**
+
+1. [ ] Unit & integration tests updated
+2. [ ] API documentation updated
+3. [ ] Necessary PR reviewers:
+	- [ ] Backend
+	- [ ] Frontend <OPTIONAL>
+	- [ ] Operations <OPTIONAL>
+	- [ ] Domain Expert <OPTIONAL>
+4. [ ] Matview impact assessment completed
+5. [ ] Frontend impact assessment completed
+6. [ ] Data validation completed
+7. [ ] Appropriate Operations ticket(s) created
+8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
+	- [ ] Link to this Pull-Request
+	- [ ] Performance evaluation of affected (API | Script | Download)
+	- [ ] Before / After data comparison
+
+**Area for explaining above N/A when needed:**
+```
+```


### PR DESCRIPTION
**Description:**
Adding a markdown file to auto-populate Github PR descriptions

**Technical details:**
https://tommcfarlin.com/github-pr-templates/
https://help.github.com/articles/about-issue-and-pull-request-templates/#pull-request-templates

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Almost everything in N/A as this is a "mod" branch, only adding a single markdown file
```