### PR TITLE
DEV-918: Importing Specific Transaction to Website

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -37,9 +37,8 @@ class Command(BaseCommand):
         # by the Broker's PK since every modification is a new row
         db_query = 'SELECT * ' \
                    'FROM published_award_financial_assistance ' \
-                   'WHERE created_at >= %s ' \
-                   'AND (is_active IS True OR UPPER(correction_delete_indicatr) = \'D\')'
-        db_args = [date]
+                   'WHERE published_award_financial_assistance_id=81494538'
+        db_args = []
 
         db_cursor.execute(db_query, db_args)
         db_rows = dictfetchall(db_cursor)  # this returns an OrderedDict


### PR DESCRIPTION
**Description:**
Hotfix to manually import a single transaction from the broker.

**Technical details:**
Uses the `fabs_nightly_load` but pulls transaction with a specific id (81494538), the transaction that was missing.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
	- [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created: [OPS-350](https://federal-spending-transparency.atlassian.net/browse/OPS-350)
8. [x] Jira Ticket [DEV-916](https://federal-spending-transparency.atlassian.net/browse/DEV-916):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison
Row was added in fabs

**Area for explaining above N/A when needed:**
```
Should never be merged into the code but rather this should be used for a data fix akin to https://github.com/fedspendingtransparency/usaspending-api/pull/1119
```
