### PR TITLE
NAICS duplicate code fix (branched from Staging)

### DIFF
--- a/usaspending_api/references/management/commands/load_naics.py
+++ b/usaspending_api/references/management/commands/load_naics.py
@@ -4,7 +4,7 @@ import re
 import glob
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from openpyxl import load_workbook
 from django.db import transaction
 
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         load_naics(path=options['path'], append=options['append'])
 
 
-def populate_naics_fields(ws, naics_year):
+def populate_naics_fields(ws, naics_year, path):
     for current_row, row in enumerate(ws.rows):
         if current_row == 0:
             continue
@@ -43,7 +43,7 @@ def populate_naics_fields(ws, naics_year):
         try:
             naics_code = int(row[0].value)
         except ValueError:
-            logging.warning('could not parse to string: %s', row[0].value)
+            raise CommandError('Invalid NAICS code: {0}. Please review file {1}'.format(naics_code, path))
 
         naics_desc = row[1].value.strip()
 
@@ -76,4 +76,4 @@ def load_naics(path, append):
         ws = wb.active
 
         naics_year = p_year.search(ws["A1"].value).group()
-        populate_naics_fields(ws, naics_year)
+        populate_naics_fields(ws, naics_year, path)

--- a/usaspending_api/references/management/commands/load_naics.py
+++ b/usaspending_api/references/management/commands/load_naics.py
@@ -40,8 +40,12 @@ def populate_naics_fields(ws, naics_year):
         if not row[0].value:
             break  # Reads file only until a blank line
 
-        naics_code = row[0].value
-        naics_desc = row[1].value
+        try:
+            naics_code = int(row[0].value)
+        except:
+            logging.warning('could not parse to string: %s', row[0].value)
+
+        naics_desc = row[1].value.strip()
 
         obj, created = NAICS.objects.get_or_create(pk=naics_code,
                                                    defaults={'description': naics_desc,

--- a/usaspending_api/references/management/commands/load_naics.py
+++ b/usaspending_api/references/management/commands/load_naics.py
@@ -42,7 +42,7 @@ def populate_naics_fields(ws, naics_year):
 
         try:
             naics_code = int(row[0].value)
-        except:
+        except ValueError:
             logging.warning('could not parse to string: %s', row[0].value)
 
         naics_desc = row[1].value.strip()

--- a/usaspending_api/references/tests/test_load_naics.py
+++ b/usaspending_api/references/tests/test_load_naics.py
@@ -14,12 +14,14 @@ def test_naics_existing_and_new_files():
 
     call_command('load_naics')
 
-    naics_cascade_count = (NAICS.objects.all().filter(year=2017).count()
-                           + NAICS.objects.all().filter(year=2012).count()
-                           + NAICS.objects.all().filter(year=2007).count()
-                           + NAICS.objects.all().filter(year=2002).count())
+    naics = NAICS.objects.all()
+    naics_count_2017 = naics.filter(year=2017).count()
+    naics_count_2002 = naics.filter(year=2002).count()
+    naics_count_all = naics.count()
 
     naics_2012_named_entry = NAICS.objects.get(pk=541712)
 
     assert naics_2012_named_entry is not None
-    assert naics_cascade_count == 1283
+    assert naics_count_2002 == 12
+    assert naics_count_2017 == 1057
+    assert naics_count_all == 1256

--- a/usaspending_api/references/tests/test_load_naics.py
+++ b/usaspending_api/references/tests/test_load_naics.py
@@ -14,8 +14,12 @@ def test_naics_existing_and_new_files():
 
     call_command('load_naics')
 
-    naics_2002_data_total = NAICS.objects.all().filter(year=2002).count()
+    naics_cascade_count = (NAICS.objects.all().filter(year=2017).count()
+                           + NAICS.objects.all().filter(year=2012).count()
+                           + NAICS.objects.all().filter(year=2007).count()
+                           + NAICS.objects.all().filter(year=2002).count())
+
     naics_2012_named_entry = NAICS.objects.get(pk=541712)
 
     assert naics_2012_named_entry is not None
-    assert naics_2002_data_total == 36
+    assert naics_cascade_count == 1283

--- a/usaspending_api/references/tests/test_load_naics.py
+++ b/usaspending_api/references/tests/test_load_naics.py
@@ -24,4 +24,4 @@ def test_naics_existing_and_new_files():
     assert naics_2012_named_entry is not None
     assert naics_count_2002 == 12
     assert naics_count_2017 == 1057
-    assert naics_count_all == 1256
+    assert naics_count_all == 1283


### PR DESCRIPTION
**Description:**
Fix for the duplicate NAICS codes

**Technical details:**
Found when NAICS codes appeared multiple times in auto-complete. This was caused by NAICS codes with trailing spaces. Issue resolved by importing NAICS codes as integers.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [ ] Necessary PR reviewers:
	- [ ] Backend
3. [X] Data validation completed

