### PR TITLE
DEV-1552: Adding federal account code to the v2/federal_obligations endpoint

### DIFF
--- a/usaspending_api/accounts/serializers.py
+++ b/usaspending_api/accounts/serializers.py
@@ -147,4 +147,5 @@ class FederalAccountByObligationSerializer(serializers.Serializer):
 
     id = serializers.CharField()
     account_title = serializers.CharField()
+    account_number = serializers.CharField()
     obligated_amount = serializers.DecimalField(None, 2)

--- a/usaspending_api/accounts/tests/test_federal_obligations.py
+++ b/usaspending_api/accounts/tests/test_federal_obligations.py
@@ -9,8 +9,10 @@ def financial_obligations_models():
     fiscal_year = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2016)
     top_tier_id = mommy.make('references.Agency', id=654, toptier_agency_id=987).toptier_agency_id
     top_tier = mommy.make('references.ToptierAgency', toptier_agency_id=top_tier_id)
-    federal_id_awesome = mommy.make('accounts.FederalAccount', id=6969, agency_identifier="867", main_account_code="5309", account_title='Turtlenecks and Chains')
-    federal_id_lame = mommy.make('accounts.FederalAccount', id=1234, agency_identifier="314", main_account_code="1592", account_title='Suits and Ties')
+    federal_id_awesome = mommy.make('accounts.FederalAccount', id=6969, agency_identifier="867",
+                                    main_account_code="5309", account_title='Turtlenecks and Chains')
+    federal_id_lame = mommy.make('accounts.FederalAccount', id=1234, agency_identifier="314",
+                                 main_account_code="1592", account_title='Suits and Ties')
     """
         Until this gets updated with mock.Mock(),
         the following cascade of variables applied to parameters,

--- a/usaspending_api/accounts/tests/test_federal_obligations.py
+++ b/usaspending_api/accounts/tests/test_federal_obligations.py
@@ -9,8 +9,8 @@ def financial_obligations_models():
     fiscal_year = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2016)
     top_tier_id = mommy.make('references.Agency', id=654, toptier_agency_id=987).toptier_agency_id
     top_tier = mommy.make('references.ToptierAgency', toptier_agency_id=top_tier_id)
-    federal_id_awesome = mommy.make('accounts.FederalAccount', id=6969, account_title='Turtlenecks and Chains')
-    federal_id_lame = mommy.make('accounts.FederalAccount', id=1234, account_title='Suits and Ties')
+    federal_id_awesome = mommy.make('accounts.FederalAccount', id=6969, agency_identifier="867", main_account_code="5309", account_title='Turtlenecks and Chains')
+    federal_id_lame = mommy.make('accounts.FederalAccount', id=1234, agency_identifier="314", main_account_code="1592", account_title='Suits and Ties')
     """
         Until this gets updated with mock.Mock(),
         the following cascade of variables applied to parameters,
@@ -106,10 +106,12 @@ def test_financial_obligations(client, financial_obligations_models):
     assert len(resp.data['results']) == 2
     res_awesome = resp.data['results'][0]
     assert res_awesome['id'] == '1234'
+    assert res_awesome['account_number'] == '314-1592'
     assert res_awesome['account_title'] == 'Suits and Ties'
     assert res_awesome['obligated_amount'] == '400.00'
     res_lame = resp.data['results'][1]
     assert res_lame['id'] == '6969'
+    assert res_lame['account_number'] == '867-5309'
     assert res_lame['account_title'] == 'Turtlenecks and Chains'
     assert res_lame['obligated_amount'] == '100.00'
 

--- a/usaspending_api/accounts/views/federal_obligations.py
+++ b/usaspending_api/accounts/views/federal_obligations.py
@@ -51,13 +51,13 @@ class FederalAccountByObligationViewSet(CachedDetailViewSet):
         queryset = queryset.annotate(
             account_title=F('treasury_account_identifier__federal_account__account_title'),
             id=F('treasury_account_identifier__federal_account')
-
         )
         # Sum and sort descending obligations_incurred by account
         queryset = queryset.values(
             'id',
-            'account_title'
+            'account_title',
         ).annotate(
+            account_number=F('treasury_account_identifier__federal_account__federal_account_code'),
             obligated_amount=Sum('obligations_incurred_total_by_tas_cpe')
         ).order_by('-obligated_amount')
         # Return minor object class vars

--- a/usaspending_api/api_docs/api_documentation/federal_obligations.md
+++ b/usaspending_api/api_docs/api_documentation/federal_obligations.md
@@ -1,5 +1,5 @@
 ## Federal Obligations
-**Route:** `v2/federal_obligations?fiscal_year=[year]&federal_account_id=[id]`
+**Route:** `v2/federal_obligations?fiscal_year=[year]&funding_agency_id=[id]`
 
 **Example:** `v2/federal_obligations?fiscal_year=2017&funding_agency_id=1068`
 
@@ -11,7 +11,7 @@ This route sends a request to the backend to retrieve federal obligations.
 ### Query Parameters Description
 
 * `year` - **REQUIRED** - Required parameter indicating what fiscal year to retrieve federal obligations.
-* `id` - **REQUIRED** - Required parameter indicating what Agency to retrieve federal obligations for.
+* `funding_agency_id` - **REQUIRED** - Required parameter indicating what Agency to retrieve federal obligations for.
 * `limit` - **OPTIONAL** - How many results are returned.
 * `page` - **OPTIONAL** - What page of results are returned.
 
@@ -31,21 +31,25 @@ This route sends a request to the backend to retrieve federal obligations.
     "results": [
         {
             "id": "2497",
+            "account_number":"020-1234",
             "account_title": "Federal Direct Student Loan Program, Education",
             "obligated_amount": "45538408088.64"
         },
         {
             "id": "2484",
+            "account_number":"020-1534",
             "account_title": "Student Financial Assistance, Education",
             "obligated_amount": "33796974073.25"
         },
         {
             "id": "2509",
+            "account_number":"070-1234",
             "account_title": "Education for the Disadvantaged, Education",
             "obligated_amount": "16789619206.31"
         },
         {
             "id": "2500",
+            "account_number":"070-1534",
             "account_title": "Special Education, Education",
             "obligated_amount": "13063113992.31"
         },...


### PR DESCRIPTION
**Description:**
Adds the federal account code to the response from v2/federal_obligations

**Technical details:**
Adds the account code as an annotation to the queryset. 

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [NA] API documentation updated 
3. [x] Necessary PR reviewers:
	- [x] Backend
	- [x] Frontend (Lizzie)
4. [NA] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
8. [X] Jira Ticket [DEV-1552](https://federal-spending-transparency.atlassian.net/browse/DEV-1552):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Frontend will be updating the API Contract
```

Performance:
Before:
1248 ms
1337 ms
1283 ms
1278 ms
1316 ms
1298 ms
1249 ms


After
1275 ms
1293 ms
1260 ms
1296 ms
1286 ms
1281 ms
1279 ms

No Significant Change
