### PR TITLE
DEV-1549: Adding account_number to v2/spending response for federal_account type

### DIFF
--- a/usaspending_api/api_docs/api_documentation/spending_explorer.md
+++ b/usaspending_api/api_docs/api_documentation/spending_explorer.md
@@ -84,7 +84,7 @@ This route sends a request to the backend to retrieve spending data information 
 {
     "amount": 141781627513.91,
     "id": 577,
-    "type": "agency",
+    "type": "federal_account",
     "name": "Department of Veterans Affairs",
     "code": "036",
     "total": 141781627513.91

--- a/usaspending_api/api_docs/api_documentation/spending_explorer.md
+++ b/usaspending_api/api_docs/api_documentation/spending_explorer.md
@@ -78,6 +78,20 @@ This route sends a request to the backend to retrieve spending data information 
 }
 ```
 
+**NOTE**: For `type: federal_account` responses, the response object will also contain an `account_number` field containing the federal account code,. i.e.,
+
+```
+{
+    "amount": 141781627513.91,
+    "id": 577,
+    "type": "agency",
+    "name": "Department of Veterans Affairs",
+    "code": "036",
+    "total": 141781627513.91
+    "account_number": "123-4567"
+}
+```
+
 **Response Key Descriptions**
 
 **id** - The Database Id for the requested *type*

--- a/usaspending_api/spending_explorer/v2/filters/explorer.py
+++ b/usaspending_api/spending_explorer/v2/filters/explorer.py
@@ -43,11 +43,12 @@ class Explorer(object):
         # Federal Account Queryset
         queryset = self.queryset.annotate(
             id=F('treasury_account__federal_account'),
+            account_number=F('treasury_account__federal_account__federal_account_code'),
             type=Value('federal_account', output_field=CharField()),
             name=F('treasury_account__federal_account__account_title'),
             code=F('treasury_account__federal_account__main_account_code')
         ).values(
-            'id', 'type', 'name', 'code', 'amount').annotate(
+            'id', 'account_number', 'type', 'name', 'code', 'amount').annotate(
             total=Sum('obligations_incurred_by_program_object_class_cpe')).order_by('-total')
 
         return queryset

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -42,7 +42,6 @@ def get_unreported_data_obj(queryset, filters, limit, spending_type, actual_tota
     for entry in queryset:
         condensed_entry = {}
         for key in result_keys:
-            #front-end specifically requested that id be a string for all types
             condensed_entry[key] = entry[key] if key != 'id' else str(entry[key])
         result_set.append(condensed_entry)
 
@@ -146,7 +145,6 @@ def type_filter(_type, filters, limit=None):
 
         alt_set = alt_set.all()
         for award in alt_set:
-            #front-end specifically requested that id be a string for all types
             award['id'] = str(award['id'])
             if _type in ['award', 'award_category']:
                 code = None

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -37,10 +37,13 @@ def get_unreported_data_obj(queryset, filters, limit, spending_type, actual_tota
 
     result_set = []
     result_keys = ['id', 'code', 'type', 'name', 'amount']
+    if spending_type == "federal_account":
+        result_keys.append('account_number')
     for entry in queryset:
         condensed_entry = {}
         for key in result_keys:
-            condensed_entry[key] = entry[key]
+            #front-end specifically requested that id be a string for all types
+            condensed_entry[key] = entry[key] if key != 'id' else str(entry[key])
         result_set.append(condensed_entry)
 
     expected_total = GTASTotalObligation.objects.filter(fiscal_year=fiscal_year, fiscal_quarter=fiscal_quarter). \
@@ -143,6 +146,8 @@ def type_filter(_type, filters, limit=None):
 
         alt_set = alt_set.all()
         for award in alt_set:
+            #front-end specifically requested that id be a string for all types
+            award['id'] = str(award['id'])
             if _type in ['award', 'award_category']:
                 code = None
                 for code_type in ('piid', 'fain', 'uri'):


### PR DESCRIPTION
**Description:**
Adds account_number as a field to the v2/spending response when the type is a federal_account.

**Technical details:**
Annotates the response.  Also makes  'id's for all types for the v2/spending response into strings rather than ints.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [NA] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
8. [X] Jira Ticket [DEV-1549](https://federal-spending-transparency.atlassian.net/browse/DEV-1549):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
