### PR TITLE
CSV names now inherit archive name on Award Data Archive

### DIFF
--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -177,12 +177,12 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None
         log_time = time.time()
         if download_job:
             # If detailed name exists, use existing name instead of output_name_template
-            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
+            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
                                    file_name=download_job.file_name)
             write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
                          download_job=download_job)
         else:
-            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
+            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
                                    output_name_template='{}_%s.csv'.format(source_name))
 
         # Zip the split CSVs into one zipfile

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -175,11 +175,15 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None
     try:
         # Split CSV into separate files
         log_time = time.time()
-        split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
-                               output_name_template='{}_%s.csv'.format(source_name))
         if download_job:
+            # If detailed name exists, use existing name instead of output_name_template
+            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
+                                   file_name=download_job.file_name)
             write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
                          download_job=download_job)
+        else:
+            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
+                                   output_name_template='{}_%s.csv'.format(source_name))
 
         # Zip the split CSVs into one zipfile
         log_time = time.time()

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -175,16 +175,20 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None
     try:
         # Split CSV into separate files
         log_time = time.time()
-        if download_job:
-            # If detailed name exists, use existing name instead of output_name_template
-            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
-                                   file_name=download_job.file_name)
-            write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
-                         download_job=download_job)
-        else:
-            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
-                                   output_name_template='{}_%s.csv'.format(source_name))
+        # Output template default:
+        # e.g. `Assistance_prime_transactions_delta_%s.csv`
+        output_template = '{}_%s.csv'.format(source_name)
 
+        if download_job is not None:
+            # Use existing detailed filename from parent file if it exists
+            # e.g. `019_Assistance_Delta_20180917_%s.csv`
+            output_template = '{}_%s.csv'.format(strip_file_extension(download_job.file_name))
+
+        split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
+                               output_name_template=output_template)
+
+        write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
+                     download_job=download_job)
         # Zip the split CSVs into one zipfile
         log_time = time.time()
         zipped_csvs = zipfile.ZipFile(zipfile_path, 'a', compression=zipfile.ZIP_DEFLATED, allowZip64=True)
@@ -347,3 +351,7 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
 def retrieve_db_string():
     """It is necessary for this to be a function so the test suite can mock the connection string"""
     return os.environ['DOWNLOAD_DATABASE_URL']
+
+
+def strip_file_extension(file_name):
+    return os.path.splitext(os.path.basename(file_name))[0]

--- a/usaspending_api/download/helpers.py
+++ b/usaspending_api/download/helpers.py
@@ -198,6 +198,7 @@ def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='o
         `output_name_template`: A %s-style template for the numbered output files.
         `output_path`: Where to stick the output files.
         `keep_headers`: Whether or not to print the headers in each output file.
+        `file_name`: Alternative naming convention for output files (optional)
     Example usage:
         >> from toolbox import csv_splitter;
         >> csv_splitter.split('/home/ben/input.csv');

--- a/usaspending_api/download/helpers.py
+++ b/usaspending_api/download/helpers.py
@@ -123,7 +123,7 @@ def multipart_upload(bucketname, regionname, source_path, keyname, headers={}, g
         bytes = min([bytes_per_chunk, remaining_bytes])
         part_num = i + 1
         pool.apply_async(_upload_part, [bucketname, regionname, mp.id,
-                         part_num, source_path, offset, bytes])
+                                        part_num, source_path, offset, bytes])
     pool.close()
     pool.join()
 
@@ -189,7 +189,7 @@ def write_to_download_log(message, download_job=None, is_debug=False, is_error=F
 # Split csv function mostly copied from Jordi Rivero's solution
 # https://gist.github.com/jrivero/1085501
 def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='output_%s.csv', output_path='.',
-              keep_headers=True):
+              keep_headers=True, file_name=None):
     """Splits a CSV file into multiple pieces.
 
     A quick bastardization of the Python CSV library.
@@ -205,10 +205,21 @@ def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='o
     split_csvs = []
     reader = csv.reader(open(file_path, 'r'), delimiter=delimiter)
     current_piece = 1
-    current_out_path = os.path.join(
-        output_path,
-        output_name_template % current_piece
-    )
+    if file_name is not None:
+        zip_idx = file_name.find(".zip")
+
+        if(zip_idx > 0):
+            file_name = "%s.csv" % file_name[:zip_idx]
+
+        current_out_path = os.path.join(
+            output_path,
+            file_name
+        )
+    else:
+        current_out_path = os.path.join(
+            output_path,
+            output_name_template % current_piece
+        )
     split_csvs.append(current_out_path)
     current_out_writer = csv.writer(open(current_out_path, 'w'), delimiter=delimiter)
     current_limit = row_limit

--- a/usaspending_api/download/helpers.py
+++ b/usaspending_api/download/helpers.py
@@ -188,39 +188,27 @@ def write_to_download_log(message, download_job=None, is_debug=False, is_error=F
 
 # Split csv function mostly copied from Jordi Rivero's solution
 # https://gist.github.com/jrivero/1085501
-def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='output_%s.csv', output_path='.',
-              keep_headers=True, file_name=None):
+def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='output_%s.csv',
+              keep_headers=True):
     """Splits a CSV file into multiple pieces.
 
     A quick bastardization of the Python CSV library.
     Arguments:
         `row_limit`: The number of rows you want in each output file. 10,000 by default.
         `output_name_template`: A %s-style template for the numbered output files.
-        `output_path`: Where to stick the output files.
         `keep_headers`: Whether or not to print the headers in each output file.
-        `file_name`: Alternative naming convention for output files (optional)
     Example usage:
         >> from toolbox import csv_splitter;
         >> csv_splitter.split('/home/ben/input.csv');
     """
     split_csvs = []
+    output_path = os.path.dirname(file_path)
     reader = csv.reader(open(file_path, 'r'), delimiter=delimiter)
     current_piece = 1
-    if file_name is not None:
-        zip_idx = file_name.find(".zip")
-
-        if(zip_idx > 0):
-            file_name = "%s.csv" % file_name[:zip_idx]
-
-        current_out_path = os.path.join(
-            output_path,
-            file_name
-        )
-    else:
-        current_out_path = os.path.join(
-            output_path,
-            output_name_template % current_piece
-        )
+    current_out_path = os.path.join(
+        output_path,
+        output_name_template % current_piece
+    )
     split_csvs.append(current_out_path)
     current_out_writer = csv.writer(open(current_out_path, 'w'), delimiter=delimiter)
     current_limit = row_limit


### PR DESCRIPTION
**Description:**
**Data Award Archive:** Archived files will lose its useful naming convention when unzipped, particularly the fiscal year, the download type (Full vs. Delta), creation date.

The contents of the archive files of Data Award Archive downloads are now inherited by the children `.csv` files.

**Technical details:**
Additional optional parameter named `file_name` has been added to `split_csv` function. When defined, the resulting archived `.csv` file inherits the archive name. 

**Requirements for PR merge:**

1. [x] Necessary PR reviewers:
	- [x] Backend
2. [x] Jira Ticket [DEV-1367](https://federal-spending-transparency.atlassian.net/browse/DEV-1367):