### PR TITLE
Re-adding API caching to data_dictionary API and fixing ordering issue

### DIFF
--- a/usaspending_api/references/management/commands/load_rosetta.py
+++ b/usaspending_api/references/management/commands/load_rosetta.py
@@ -84,7 +84,7 @@ def extract_data_from_source_file(path: str = None) -> dict:
         else:
             sections.append(section)
 
-    elements = {}
+    elements = OrderedDict()
     for i, row in enumerate(sheet.values):
         if i < 2:
             continue

--- a/usaspending_api/references/v2/views/data_dictionary.py
+++ b/usaspending_api/references/v2/views/data_dictionary.py
@@ -2,6 +2,7 @@ import logging
 
 from rest_framework.response import Response
 
+from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.exceptions import NoDataFoundException
 from usaspending_api.common.views import APIDocumentationView
 from usaspending_api.references.models import Rosetta
@@ -15,6 +16,7 @@ class DataDictionaryViewSet(APIDocumentationView):
     endpoint_doc: /references/data_dictionary.md
     """
 
+    @cache_response()
     def get(self, request, format=None):
         try:
             api_response = Rosetta.objects.filter(document_name="api_response").values("document")[0]


### PR DESCRIPTION
Re-adding API Caching per @willkjackson's request. Also fixing issue with Python 3.5 dictionary ordering