### PR TITLE
DEV-1402: Allow Multiple Parents for Recipient Profile page

### DIFF
--- a/usaspending_api/api_docs/api_documentation/recipient/recipient_profile.md
+++ b/usaspending_api/api_docs/api_documentation/recipient/recipient_profile.md
@@ -25,7 +25,7 @@ This endpoint returns a high-level overview of a specific recipient, given its i
 
 + Response 200 (application/json)
     + Attributes (RecipientOverview)
-    
+
 ## Recipient Children [/api/v2/recipient/children/{duns}/{?year}]
 
 This endpoint returns a list of child recipients belonging to the given parent recipient DUNS.
@@ -58,6 +58,8 @@ This endpoint returns a list of child recipients belonging to the given parent r
     Parent recipient's DUNS number. `null` if the recipient does not have a parent recipient, or the parent recipient's DUNS is not provided.
 + `parent_id`: `0036a0cb-0d88-2db3-59e0-0f9af8ffef57-P` (required, string, nullable)
     A unique identifier for the parent recipient. `null` if the recipient does not have a parent recipient.
++ `parents`: (required, array)
+    An array of RecipientParent objects.
 + location: (required, RecipientLocation, fixed-type)
 + `business_types`: `minority_owned_business`, `for_profit_organization` (required, array[string], fixed-type)
     An array of business type field names used to categorize recipients.
@@ -66,7 +68,7 @@ This endpoint returns a list of child recipients belonging to the given parent r
 + `total_transactions`: 327721 (required, number)
     The number of transactions associated with this recipient for the given time period.
 + `recipient_level`: C (required, string)
-    A letter representing the recipient level. `R` for neither parent nor child, `P` for Parent Recipient, or `C` for child recipient. 
+    A letter representing the recipient level. `R` for neither parent nor child, `P` for Parent Recipient, or `C` for child recipient.
     + Members
         + R
         + P
@@ -74,11 +76,11 @@ This endpoint returns a list of child recipients belonging to the given parent r
 
 ## RecipientLocation (object)
 + `address_line1`: 123 Sesame St (required, string, nullable)
-    The first line of the recipient's street address. 
+    The first line of the recipient's street address.
 + `address_line2`: (required, string, nullable)
-    Second line of the recipient's street address. 
+    Second line of the recipient's street address.
 + `address_line3`: (required, string, nullable)
-    Third line of the recipient's street address. 
+    Third line of the recipient's street address.
 + `foreign_province`: (required, string, nullable)
     Name of the province in which the recipient is located, if it is outside the United States.
 + `city_name`: McLean (required, string, nullable)
@@ -86,7 +88,7 @@ This endpoint returns a list of child recipients belonging to the given parent r
 + `county_name`: (required, string, nullable)
     Name of the county in which the recipient is located.
 + `state_code`: VA (required, string, nullable)
-    Code for the state in which the recipient is located. 
+    Code for the state in which the recipient is located.
 + zip: `22102` (required, string, nullable)
     Recipient's zip code (5 digits)
 + zip4: (required, string, nullable)
@@ -98,8 +100,8 @@ This endpoint returns a list of child recipients belonging to the given parent r
 + `country_code`: USA (required, string, nullable)
      Code for the country in which the recipient is located.
 + `congressional_code`: `05` (required, string, nullable)
-    Number for the recipient's congressional district. 
- 
+    Number for the recipient's congressional district.
+
 ## ChildRecipient (object)
 + name: Child of ABC Corporation (required, string, nullable)
     Name of the child recipient. `null` if the child recipient's name is not provided.
@@ -111,3 +113,11 @@ This endpoint returns a list of child recipients belonging to the given parent r
     The state or province in which the child recipient is located.
 + amount: 300200000 (required, number)
     The aggregate monetary value of transactions associated with this child recipient for the selected time period.
+
+## RecipientParent (object)
++  `parent_name`: `stark industries` (required, string, nullable)
+    A Parent Legal or Entity Recipient Name
++  `parent_id`: `00aa11bb-cc22-dd44-ee55-ff66gg77hh88-P` (required, string, nullable)
+    A Parent Legal or Entity Recipient internal ID value
++  `parent_duns`: `001234567` (required, string, nullable)
+    A Parent Legal or Entity DUNS

--- a/usaspending_api/recipient/tests/integration/test_recipient.py
+++ b/usaspending_api/recipient/tests/integration/test_recipient.py
@@ -262,10 +262,10 @@ def test_extract_parent_from_hash():
 
     expected_name = TEST_RECIPIENT_LOOKUPS[parent_hash]['legal_business_name']
     expected_duns = parent_duns
-    parent_duns, parent_name, parent_id = recipients.extract_parent_from_hash(recipient_hash)
-    assert parent_duns == expected_duns
-    assert parent_name == expected_name
-    assert parent_id == expected_parent_id
+    parents = recipients.extract_parents_from_hash(recipient_hash)
+    assert expected_duns == parents[0]["parent_duns"]
+    assert expected_name == parents[0]["parent_name"]
+    assert expected_parent_id == parents[0]["parent_id"]
 
 
 @pytest.mark.django_db
@@ -282,10 +282,10 @@ def test_extract_parent_from_hash_failure():
     expected_name = None
     expected_duns = parent_duns
     expected_parent_id = None
-    parent_duns, parent_name, parent_id = recipients.extract_parent_from_hash(recipient_hash)
-    assert parent_duns == expected_duns
-    assert parent_name == expected_name
-    assert parent_id == expected_parent_id
+    parents = recipients.extract_parents_from_hash(recipient_hash)
+    assert expected_duns == parents[0]["parent_duns"]
+    assert expected_name == parents[0]["parent_name"]
+    assert expected_parent_id == parents[0]["parent_id"]
 
 
 @pytest.mark.django_db
@@ -507,6 +507,11 @@ def test_recipient_overview(client, mock_matviews_qs):
         'parent_name': 'PARENT RECIPIENT',
         'parent_duns': '000000001',
         'parent_id': '00077a9a-5a70-8919-fd19-330762af6b84-P',
+        'parents': [{
+            'parent_duns': '000000001',
+            'parent_id': '00077a9a-5a70-8919-fd19-330762af6b84-P',
+            'parent_name': 'PARENT RECIPIENT',
+        }],
         'business_types': sorted(['expected', 'business', 'cat'] + ['category_business']),
         'location': {
             'address_line1': 'PARENT ADDRESS LINE 1',


### PR DESCRIPTION
**Description:**
Modified the `restock_recipient_profile` script to include 100% of all parent DUNS listed for any given recipient DUNS instead of only listing the most recent parent DUNS.

**Technical details:**
Instead of finding the most-recent parent DUNS, the SQL script creates an array of all distinct parent DUNS for each DUNS in the transaction data. There were minimal SQL edits and slightly more Python edits to handle multiple parents instead of having 1 parent DUNS.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
	- [x] Backend
	- [x] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-1402](https://federal-spending-transparency.atlassian.net/browse/DEV-1402):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Materialized Views were not altered in this PR.
Automated ETL scripts will update recipient_profile without requiring any manual effort
```
