### PR TITLE
CSV names now inherit archive name on Award Data Archive

### DIFF
--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -182,29 +182,29 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None
     try:
         # Split CSV into separate files
         # e.g. `Assistance_prime_transactions_delta_%s.csv`
+
+        log_time = time.time()
+
+        output_template = '{}_%s.csv'.format(source_name)
+
+        split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
+                               output_name_template=output_template)
+
         if download_job:
-            log_time = time.time()
-
-            write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
-                         download_job=download_job)
-
-            output_template = '{}_%s.csv'.format(source_name)
-
-            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
-                                   output_name_template=output_template)
-
             write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
                          download_job=download_job)
 
         # Zip the split CSVs into one zipfile
         log_time = time.time()
         zipped_csvs = zipfile.ZipFile(zipfile_path, 'a', compression=zipfile.ZIP_DEFLATED, allowZip64=True)
+
         for split_csv_part in split_csvs:
             zipped_csvs.write(split_csv_part, os.path.basename(split_csv_part))
 
         if download_job:
             write_to_log(message='Writing to zipfile took {} seconds'.format(time.time() - log_time),
                          download_job=download_job)
+
     except Exception as e:
         logger.error(e)
         raise e

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -158,9 +158,8 @@ def parse_source(source, columns, download_job, working_dir, start_time, message
         with open(source_path, 'r') as source_csv:
             download_job.number_of_rows += sum(1 for row in csv.reader(source_csv)) - 1
             download_job.save()
-        inherit_source_name = False
-        if download_job.monthly_download is True:
-            inherit_source_name = True
+
+        inherit_source_name = download_job.monthly_download
 
         # Create a separate process to split the large csv into smaller csvs and write to zip; wait
         zip_process = multiprocessing.Process(target=split_and_zip_csvs, args=(zipfile_path, source_path, source_name,
@@ -181,7 +180,7 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None
         # e.g. `Assistance_prime_transactions_delta_%s.csv`
         log_time = time.time()
         output_template = '{}_%s.csv'.format(source_name)
-        if inherit_source_name is True:
+        if inherit_source_name:
             # Use existing detailed filename from parent file if it exists
             # e.g. `019_Assistance_Delta_20180917_%s.csv`
             output_template = '{}_%s.csv'.format(strip_file_extension(download_job.file_name))

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -179,7 +179,7 @@ def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None
         log_time = time.time()
         output_template = '{}_%s.csv'.format(source_name)
 
-        if download_job is not None and download_job.monthly_download == True:
+        if download_job is not None and download_job.monthly_download is True:
             # Use existing detailed filename from parent file if it exists
             # e.g. `019_Assistance_Delta_20180917_%s.csv`
             output_template = '{}_%s.csv'.format(strip_file_extension(download_job.file_name))

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -175,13 +175,21 @@ def parse_source(source, columns, download_job, working_dir, start_time, message
 
 def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None):
     try:
-        # Split CSV into separate files
+        # e.g. `Assistance_prime_transactions_delta_%s.csv`
         log_time = time.time()
-        split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT, output_path=os.path.dirname(source_path),
-                               output_name_template='{}_%s.csv'.format(source_name))
-        if download_job:
-            write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
-                         download_job=download_job)
+        output_template = '{}_%s.csv'.format(source_name)
+
+        if download_job is not None and download_job.monthly_download == True:
+            # Use existing detailed filename from parent file if it exists
+            # e.g. `019_Assistance_Delta_20180917_%s.csv`
+            output_template = '{}_%s.csv'.format(strip_file_extension(download_job.file_name))
+
+        split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
+                               output_name_template=output_template)
+
+        write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
+                     download_job=download_job)
+
         # Zip the split CSVs into one zipfile
         log_time = time.time()
         zipped_csvs = zipfile.ZipFile(zipfile_path, 'a', compression=zipfile.ZIP_DEFLATED, allowZip64=True)
@@ -342,3 +350,7 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
 def retrieve_db_string():
     """It is necessary for this to be a function so the test suite can mock the connection string"""
     return os.environ['DOWNLOAD_DATABASE_URL']
+
+
+def strip_file_extension(file_name):
+    return os.path.splitext(os.path.basename(file_name))[0]

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -180,15 +180,21 @@ def parse_source(source, columns, download_job, working_dir, start_time, message
 
 def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None):
     try:
+        # Split CSV into separate files
         # e.g. `Assistance_prime_transactions_delta_%s.csv`
-        log_time = time.time()
-        output_template = '{}_%s.csv'.format(source_name)
+        if download_job:
+            log_time = time.time()
 
-        split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
-                               output_name_template=output_template)
+            write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
+                         download_job=download_job)
 
-        write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
-                     download_job=download_job)
+            output_template = '{}_%s.csv'.format(source_name)
+
+            split_csvs = split_csv(source_path, row_limit=EXCEL_ROW_LIMIT,
+                                   output_name_template=output_template)
+
+            write_to_log(message='Splitting csvs took {} seconds'.format(time.time() - log_time),
+                         download_job=download_job)
 
         # Zip the split CSVs into one zipfile
         log_time = time.time()

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -158,10 +158,13 @@ def parse_source(source, columns, download_job, working_dir, start_time, message
         with open(source_path, 'r') as source_csv:
             download_job.number_of_rows += sum(1 for row in csv.reader(source_csv)) - 1
             download_job.save()
+        inherit_source_name = False
+        if download_job.monthly_download is True:
+            inherit_source_name = True
 
         # Create a separate process to split the large csv into smaller csvs and write to zip; wait
         zip_process = multiprocessing.Process(target=split_and_zip_csvs, args=(zipfile_path, source_path, source_name,
-                                                                               download_job,))
+                                                                               download_job, inherit_source_name))
         zip_process.start()
         wait_for_process(zip_process, start_time, download_job, message)
         download_job.save()
@@ -173,13 +176,12 @@ def parse_source(source, columns, download_job, working_dir, start_time, message
         os.remove(temp_file_path)
 
 
-def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None):
+def split_and_zip_csvs(zipfile_path, source_path, source_name, download_job=None, inherit_source_name=False):
     try:
         # e.g. `Assistance_prime_transactions_delta_%s.csv`
         log_time = time.time()
         output_template = '{}_%s.csv'.format(source_name)
-
-        if download_job is not None and download_job.monthly_download is True:
+        if inherit_source_name is True:
             # Use existing detailed filename from parent file if it exists
             # e.g. `019_Assistance_Delta_20180917_%s.csv`
             output_template = '{}_%s.csv'.format(strip_file_extension(download_job.file_name))

--- a/usaspending_api/download/helpers.py
+++ b/usaspending_api/download/helpers.py
@@ -137,7 +137,7 @@ def write_to_download_log(message, download_job=None, is_debug=False, is_error=F
 
 # Split csv function mostly copied from Jordi Rivero's solution
 # https://gist.github.com/jrivero/1085501
-def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='output_%s.csv', output_path='.',
+def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='output_%s.csv',
               keep_headers=True):
     """Splits a CSV file into multiple pieces.
 
@@ -145,13 +145,13 @@ def split_csv(file_path, delimiter=',', row_limit=10000, output_name_template='o
     Arguments:
         `row_limit`: The number of rows you want in each output file. 10,000 by default.
         `output_name_template`: A %s-style template for the numbered output files.
-        `output_path`: Where to stick the output files.
         `keep_headers`: Whether or not to print the headers in each output file.
     Example usage:
         >> from toolbox import csv_splitter;
         >> csv_splitter.split('/home/ben/input.csv');
     """
     split_csvs = []
+    output_path = os.path.dirname(file_path)
     reader = csv.reader(open(file_path, 'r'), delimiter=delimiter)
     current_piece = 1
     current_out_path = os.path.join(

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
         working_dir = '{}_{}_delta_gen_{}/'.format(settings.CSV_LOCAL_PATH, agency_code, timestamp)
         if not os.path.exists(working_dir):
             os.mkdir(working_dir)
-        source_name = '{}_{}_delta'.format(award_type, VALUE_MAPPINGS['transactions']['download_name'])
+        source_name = '{}_{}_Delta_{}'.format(agency_code, award_type, datetime.strftime(date.today(), '%Y%m%d'))
         source_path = os.path.join(working_dir, '{}.csv'.format(source_name))
 
         # Create a unique temporary file with the raw query
@@ -130,10 +130,10 @@ class Command(BaseCommand):
         self.add_deletion_records(source_path, working_dir, award_type, agency_code, source, generate_since)
         if csv_row_count(source_path, has_header=True) > 0:
             # Split the CSV into multiple files and zip it up
-            zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
-                                                         datetime.strftime(date.today(), '%Y%m%d'))
+            zipfile_path = '{}{}.zip'.format(settings.CSV_LOCAL_PATH, source_name)
+
             logger.info('Creating compressed file: {}'.format(os.path.basename(zipfile_path)))
-            split_and_zip_csvs(zipfile_path, source_path, source_name, inherit_source_name=True)
+            split_and_zip_csvs(zipfile_path, source_path, source_name)
         else:
             zipfile_path = None
 

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -129,12 +129,11 @@ class Command(BaseCommand):
         # Append deleted rows to the end of the file
         self.add_deletion_records(source_path, working_dir, award_type, agency_code, source, generate_since)
         if csv_row_count(source_path, has_header=True) > 0:
-            inherit_source_name = True
             # Split the CSV into multiple files and zip it up
             zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
                                                          datetime.strftime(date.today(), '%Y%m%d'))
             logger.info('Creating compressed file: {}'.format(os.path.basename(zipfile_path)))
-            split_and_zip_csvs(zipfile_path, source_path, source_name, inherit_source_name)
+            split_and_zip_csvs(zipfile_path, source_path, source_name, inherit_source_name=True)
         else:
             zipfile_path = None
 

--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -129,11 +129,12 @@ class Command(BaseCommand):
         # Append deleted rows to the end of the file
         self.add_deletion_records(source_path, working_dir, award_type, agency_code, source, generate_since)
         if csv_row_count(source_path, has_header=True) > 0:
+            inherit_source_name = True
             # Split the CSV into multiple files and zip it up
             zipfile_path = '{}{}_{}_Delta_{}.zip'.format(settings.CSV_LOCAL_PATH, agency_code, award_type,
                                                          datetime.strftime(date.today(), '%Y%m%d'))
             logger.info('Creating compressed file: {}'.format(os.path.basename(zipfile_path)))
-            split_and_zip_csvs(zipfile_path, source_path, source_name)
+            split_and_zip_csvs(zipfile_path, source_path, source_name, inherit_source_name)
         else:
             zipfile_path = None
 


### PR DESCRIPTION
**Description:**
**Data Award Archive:** Archived files will lose its useful naming convention when unzipped, particularly the fiscal year, the download type (Full vs. Delta), creation date.

The contents of the archive files of Data Award Archive downloads are now inherited by the children `.csv` files.

**Technical details:**
The `download_job.monthly_download` argument is used to determine the inheritance of the archive name and files. 


**Requirements for PR merge:**

1. [x] Necessary PR reviewers:
	- [x] Backend
2. [x] Jira Ticket [DEV-1367](https://federal-spending-transparency.atlassian.net/browse/DEV-1367):