### PR TITLE
DEV-1721: Dedupe Account Downloads A and B

### DIFF
--- a/usaspending_api/accounts/tests/unit/test_account_download_filter.py
+++ b/usaspending_api/accounts/tests/unit/test_account_download_filter.py
@@ -122,7 +122,8 @@ def test_tas_account_filter_later_qtr_federal():
         'fy': 1700,
         'quarter': 3
     }, 'federal_account')
-    assert queryset.count() == 1
+    # this count is 2 as the federal account downloads are now cumulative while still excluding duplicates
+    assert queryset.count() == 2
 
 
 @pytest.mark.django_db

--- a/usaspending_api/accounts/tests/unit/test_account_download_filter.py
+++ b/usaspending_api/accounts/tests/unit/test_account_download_filter.py
@@ -17,9 +17,9 @@ def test_fyq_filter():
 
     # Create file A models
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31', final_of_fy=True)
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas2,
-               reporting_period_start='1700-01-01', reporting_period_end='1700-03-31')
+               reporting_period_start='1700-01-01', reporting_period_end='1700-03-31', final_of_fy=True)
 
     queryset = account_download_filter('account_balances', AppropriationAccountBalances, {
         'fy': 1700,
@@ -41,9 +41,9 @@ def test_federal_account_filter():
 
     # Create file A models
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31', final_of_fy=True)
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas2,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31', final_of_fy=True)
 
     queryset = account_download_filter('account_balances', AppropriationAccountBalances, {
         'federal_account': fed_acct1.id,
@@ -66,9 +66,9 @@ def test_tas_account_filter_later_qtr_treasury():
 
     # Create file A models
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31', final_of_fy=True)
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas2,
-               reporting_period_start='1700-04-01', reporting_period_end='1700-06-30')
+               reporting_period_start='1700-04-01', reporting_period_end='1700-06-30', final_of_fy=True)
 
     queryset = account_download_filter('account_balances', AppropriationAccountBalances, {
         'fy': 1700,
@@ -114,9 +114,9 @@ def test_tas_account_filter_later_qtr_federal():
 
     # Create file A models
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31', final_of_fy=True)
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas2,
-               reporting_period_start='1700-04-01', reporting_period_end='1700-06-30')
+               reporting_period_start='1700-04-01', reporting_period_end='1700-06-30', final_of_fy=True)
 
     queryset = account_download_filter('account_balances', AppropriationAccountBalances, {
         'fy': 1700,

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -160,12 +160,11 @@ def retrieve_fyq_filters(account_type, account_level, filters):
         reporting_period_start = 'reporting_period_start'
         reporting_period_end = 'reporting_period_end'
 
-        # C files and TAS need all data, up to and including the FYQ in the filter
-        if account_type == 'award_financial' or account_level == 'treasury_account':
-            reporting_period_start = '{}__gte'.format(reporting_period_start)
-            reporting_period_end = '{}__lte'.format(reporting_period_end)
-            if str(filters['quarter']) != '1':
-                start_date = datetime.date(filters['fy']-1, 10, 1)
+        # For all files, filter up to and including the FYQ
+        reporting_period_start = '{}__gte'.format(reporting_period_start)
+        reporting_period_end = '{}__lte'.format(reporting_period_end)
+        if str(filters['quarter']) != '1':
+            start_date = datetime.date(filters['fy']-1, 10, 1)
     else:
         raise InvalidParameterException('fy and quarter are required parameters')
 

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -47,6 +47,10 @@ def account_download_filter(account_type, download_table, filters, account_level
     query_filters[reporting_period_start] = start_date
     query_filters[reporting_period_end] = end_date
 
+    if account_type in ['account_balances', 'object_class_program_activity']:
+        # only include the latest TASs, not all of them
+        query_filters['final_of_fy'] = True
+
     # Create the base queryset
     queryset = download_table.objects
 

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -160,11 +160,12 @@ def retrieve_fyq_filters(account_type, account_level, filters):
         reporting_period_start = 'reporting_period_start'
         reporting_period_end = 'reporting_period_end'
 
-        # For all files, filter up to and including the FYQ
-        reporting_period_start = '{}__gte'.format(reporting_period_start)
-        reporting_period_end = '{}__lte'.format(reporting_period_end)
-        if str(filters['quarter']) != '1':
-            start_date = datetime.date(filters['fy']-1, 10, 1)
+        # C files and TAS need all data, up to and including the FYQ in the filter
+        if account_type == 'award_financial' or account_level == 'treasury_account':
+            reporting_period_start = '{}__gte'.format(reporting_period_start)
+            reporting_period_end = '{}__lte'.format(reporting_period_end)
+            if str(filters['quarter']) != '1':
+                start_date = datetime.date(filters['fy']-1, 10, 1)
     else:
         raise InvalidParameterException('fy and quarter are required parameters')
 

--- a/usaspending_api/financial_activities/models.py
+++ b/usaspending_api/financial_activities/models.py
@@ -77,16 +77,22 @@ class FinancialAccountsByProgramActivityObjectClass(DataSourceTrackedModel):
 
     FINAL_OF_FY_SQL = """
         UPDATE financial_accounts_by_program_activity_object_class
-        SET final_of_fy = (treasury_account_id, submission_id) in
+        SET final_of_fy = (treasury_account_id, program_activity_id, object_class_id, submission_id) in
         ( SELECT DISTINCT ON
             (fabpaoc.treasury_account_id,
+             fabpaoc.program_activity_id,
+             fabpaoc.object_class,
              FY(s.reporting_period_start))
           fabpaoc.treasury_account_id,
+          fabpaoc.program_activity_id,
+          fabpaoc.object_class_id,
           s.submission_id
           FROM submission_attributes s
           JOIN financial_accounts_by_program_activity_object_class fabpaoc
               ON (s.submission_id = fabpaoc.submission_id)
           ORDER BY fabpaoc.treasury_account_id,
+                   fabpaoc.program_activity_id,
+                   fabpaoc.object_class_id,
                    FY(s.reporting_period_start),
                    s.reporting_period_start DESC)"""
 

--- a/usaspending_api/financial_activities/models.py
+++ b/usaspending_api/financial_activities/models.py
@@ -81,7 +81,7 @@ class FinancialAccountsByProgramActivityObjectClass(DataSourceTrackedModel):
         ( SELECT DISTINCT ON
             (fabpaoc.treasury_account_id,
              fabpaoc.program_activity_id,
-             fabpaoc.object_class,
+             fabpaoc.object_class_id,
              FY(s.reporting_period_start))
           fabpaoc.treasury_account_id,
           fabpaoc.program_activity_id,

--- a/usaspending_api/financial_activities/models.py
+++ b/usaspending_api/financial_activities/models.py
@@ -77,10 +77,11 @@ class FinancialAccountsByProgramActivityObjectClass(DataSourceTrackedModel):
 
     FINAL_OF_FY_SQL = """
         UPDATE financial_accounts_by_program_activity_object_class
-        SET final_of_fy = submission_id in
+        SET final_of_fy = (treasury_account_id, submission_id) in
         ( SELECT DISTINCT ON
             (fabpaoc.treasury_account_id,
              FY(s.reporting_period_start))
+          fabpaoc.treasury_account_id,
           s.submission_id
           FROM submission_attributes s
           JOIN financial_accounts_by_program_activity_object_class fabpaoc


### PR DESCRIPTION
**Description:**
Remove duplicates (selecting the most recent of a fiscal year) from A and B account download files.

**Technical details:**
- Simply filtering account downloads A/B on `final_of_fy`
- Updating `financial_accounts_by_program_activity_object_class` final_of_fy SQL to be more accurate

Uniqueness for A: TAS
Uniqueness for B: TAS/PA/OC/DR

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created [OPS-407](https://federal-spending-transparency.atlassian.net/browse/OPS-407)
8. [x] Jira Ticket [DEV-1721](https://federal-spending-transparency.atlassian.net/browse/DEV-1721):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download) (unchanged)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
API documentation updated - No documentation required
Matview impact assessment completed - No matviews involved
Frontend impact assessment completed - No frontend changes required
```
