### PR TITLE
DEV-1689: Mapping from broker to usaspending for funding_amount in fabs_nightly_loader

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -250,7 +250,7 @@ class Command(BaseCommand):
             fad_field_map = {
                 "type": "assistance_type",
                 "description": "award_description",
-                "total_funding_amount":"funding_amount",
+                "total_funding_amount": "funding_amount",
             }
 
             transaction_normalized_dict = load_data_into_model(

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -250,6 +250,7 @@ class Command(BaseCommand):
             fad_field_map = {
                 "type": "assistance_type",
                 "description": "award_description",
+                "total_funding_amount":"funding_amount",
             }
 
             transaction_normalized_dict = load_data_into_model(

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -250,7 +250,7 @@ class Command(BaseCommand):
             fad_field_map = {
                 "type": "assistance_type",
                 "description": "award_description",
-                "total_funding_amount": "funding_amount",
+                "funding_amount": "total_funding_amount",
             }
 
             transaction_normalized_dict = load_data_into_model(


### PR DESCRIPTION
**Description:**
A change to the column name (total_funding_amount -> funding_amount ) in Transaction_Normalized cause the fabs nightly loader to stop populating the new column (funding_amount is blank for transactions populated after this change). This discrepancy is what causes the disconnect between federal_action_obligation and total_funding_amount in award, as the federal_action_obligation is summed from the properly populated transaction fields, while total_funding_amount is summed from the inconsistently populated funding_amount field. This change maps the data to the new column name in the fabs nightly loader. There will also be a data change to backfill the empty values.

**Technical details:**
The fabs_nightly_loader assumes incoming data from the broker maps 1:1 to column names in website unless there is a specific mapping in place. This adds the mapping, since the field in broker is total_funding_amount but the field in transaction_normalized is funding_amount.

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
	- [ ] Backend
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-1689](https://federal-spending-transparency.atlassian.net/browse/DEV-1689):
	- [X] Link to this Pull-Request
	- [X] Performance evaluation of affected (API | Script | Download)
	- [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. No unit tests are relevant because this change is simply mapping an incoming piece of data in one column, to another column with a slightly different name. There is nothing to really test.

2.No API Endpoints were updated

4. No matviews were changed, nor was the process to update them changed.

5. No API Endpoints were changed, so there is no impact to the front end.

8.c. No API endpoints were changed, so no before/after change is warranted.
```
