### PR TITLE
DEV-1721: Dedupe Account Downloads (older FYQs)

### DIFF
--- a/usaspending_api/accounts/tests/unit/test_account_download_filter.py
+++ b/usaspending_api/accounts/tests/unit/test_account_download_filter.py
@@ -61,8 +61,8 @@ def test_tas_account_filter_later_qtr_treasury():
     fed_acct2 = mommy.make('accounts.FederalAccount')
 
     # Create TAS models
-    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1)
-    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2)
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1, tas_rendering_label='1')
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2, tas_rendering_label='2')
 
     # Create file A models
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,
@@ -84,15 +84,25 @@ def test_tas_account_filter_later_qtr_award_financial():
     fed_acct1 = mommy.make('accounts.FederalAccount')
     fed_acct2 = mommy.make('accounts.FederalAccount')
 
+    # Create Program Activities
+    prog1 = mommy.make('references.RefProgramActivity', program_activity_code='0001')
+    prog2 = mommy.make('references.RefProgramActivity', program_activity_code='0002')
+
+    # Create Object Classes
+    obj_cls1 = mommy.make('references.ObjectClass', object_class='001')
+    obj_cls2 = mommy.make('references.ObjectClass', object_class='002')
+
     # Create TAS models
-    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1)
-    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2)
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1, tas_rendering_label='1')
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2, tas_rendering_label='2')
 
     # Create file A models
     mommy.make('awards.FinancialAccountsByAwards', treasury_account=tas1,
-               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31')
+               reporting_period_start='1699-10-01', reporting_period_end='1699-12-31',
+               program_activity=prog1, object_class=obj_cls1)
     mommy.make('awards.FinancialAccountsByAwards', treasury_account=tas2,
-               reporting_period_start='1700-04-01', reporting_period_end='1700-06-30')
+               reporting_period_start='1700-04-01', reporting_period_end='1700-06-30',
+               program_activity=prog2, object_class=obj_cls2)
 
     queryset = account_download_filter('award_financial', FinancialAccountsByAwards, {
         'fy': 1700,
@@ -109,8 +119,8 @@ def test_tas_account_filter_later_qtr_federal():
     fed_acct2 = mommy.make('accounts.FederalAccount')
 
     # Create TAS models
-    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1)
-    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2)
+    tas1 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct1, tas_rendering_label='1')
+    tas2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fed_acct2, tas_rendering_label='2')
 
     # Create file A models
     mommy.make('accounts.AppropriationAccountBalances', treasury_account_identifier=tas1,

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -90,7 +90,7 @@ def account_download_filter(account_type, download_table, filters, account_level
                                               'object_class__object_class']
         }
         distinct_cols = unique_columns_mapping[account_type]
-        order_by_cols = unique_columns_mapping[account_type] + ['-reporting_period_start']
+        order_by_cols = distinct_cols + ['-reporting_period_start']
         latest_ids_q = download_table.objects.filter(**query_filters).distinct(*distinct_cols).order_by(*order_by_cols)
         latest_ids = list(latest_ids_q.values_list(unique_id_mapping[account_type], flat=True))
         if latest_ids:

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -10,6 +10,31 @@ from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.download.v2.download_column_historical_lookups import query_paths
 from usaspending_api.references.models import ToptierAgency
 
+# Account Download Logic
+#
+# Account Balances (A file):
+# 	- Treasury Account
+# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
+# 		2. Only include the most recently submitted TASs (uniqueness based on TAS)
+# 	- Federal Account
+# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
+# 		2. Only include the most recently submitted TASs (uniqueness based on TAS)
+# 		3. Group by Federal Accounts
+# Account Breakdown by Program Activity & Object Class (B file):
+# 	- Treasury Account
+# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
+# 		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
+# 	- Federal Account
+# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
+# 		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
+# 		3. Group by Federal Accounts
+# Account Breakdown by Award (C file):
+# 	- Treasury Account
+# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
+# 	- Federal Account
+# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
+# 		2. Group by Federal Accounts
+
 
 def account_download_filter(account_type, download_table, filters, account_level='treasury_account'):
     query_filters = {}

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -66,7 +66,8 @@ def account_download_filter(account_type, download_table, filters, account_level
         order_by_cols = unique_columns_mapping[account_type] + ['-reporting_period_start']
         latest_ids_q = download_table.objects.filter(**query_filters).distinct(*distinct_cols).order_by(*order_by_cols)
         latest_ids = list(latest_ids_q.values_list(unique_id_mapping[account_type], flat=True))
-        query_filters['{}__in'.format(unique_id_mapping[account_type])] = latest_ids
+        if latest_ids:
+            query_filters['{}__in'.format(unique_id_mapping[account_type])] = latest_ids
 
     # Make derivations based on the account level
     if account_level == 'treasury_account':

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -10,30 +10,32 @@ from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.download.v2.download_column_historical_lookups import query_paths
 from usaspending_api.references.models import ToptierAgency
 
-# Account Download Logic
-#
-# Account Balances (A file):
-# 	- Treasury Account
-# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
-# 		2. Only include the most recently submitted TASs (uniqueness based on TAS)
-# 	- Federal Account
-# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
-# 		2. Only include the most recently submitted TASs (uniqueness based on TAS)
-# 		3. Group by Federal Accounts
-# Account Breakdown by Program Activity & Object Class (B file):
-# 	- Treasury Account
-# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
-# 		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
-# 	- Federal Account
-# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
-# 		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
-# 		3. Group by Federal Accounts
-# Account Breakdown by Award (C file):
-# 	- Treasury Account
-# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
-# 	- Federal Account
-# 		1. Get all TASs matching the filers from Q1 to the FSQ selected
-# 		2. Group by Federal Accounts
+"""
+Account Download Logic
+
+Account Balances (A file):
+	- Treasury Account
+		1. Get all TASs matching the filers from Q1 to the FSQ selected
+		2. Only include the most recently submitted TASs (uniqueness based on TAS)
+	- Federal Account
+		1. Get all TASs matching the filers from Q1 to the FSQ selected
+		2. Only include the most recently submitted TASs (uniqueness based on TAS)
+		3. Group by Federal Accounts
+Account Breakdown by Program Activity & Object Class (B file):
+	- Treasury Account
+		1. Get all TASs matching the filers from Q1 to the FSQ selected
+		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
+	- Federal Account
+		1. Get all TASs matching the filers from Q1 to the FSQ selected
+		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
+		3. Group by Federal Accounts
+Account Breakdown by Award (C file):
+	- Treasury Account
+		1. Get all TASs matching the filers from Q1 to the FSQ selected
+	- Federal Account
+		1. Get all TASs matching the filers from Q1 to the FSQ selected
+		2. Group by Federal Accounts
+"""
 
 
 def account_download_filter(account_type, download_table, filters, account_level='treasury_account'):

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -14,27 +14,27 @@ from usaspending_api.references.models import ToptierAgency
 Account Download Logic
 
 Account Balances (A file):
-	- Treasury Account
-		1. Get all TASs matching the filers from Q1 to the FSQ selected
-		2. Only include the most recently submitted TASs (uniqueness based on TAS)
-	- Federal Account
-		1. Get all TASs matching the filers from Q1 to the FSQ selected
-		2. Only include the most recently submitted TASs (uniqueness based on TAS)
-		3. Group by Federal Accounts
+    - Treasury Account
+        1. Get all TASs matching the filers from Q1 to the FSQ selected
+        2. Only include the most recently submitted TASs (uniqueness based on TAS)
+    - Federal Account
+        1. Get all TASs matching the filers from Q1 to the FSQ selected
+        2. Only include the most recently submitted TASs (uniqueness based on TAS)
+        3. Group by Federal Accounts
 Account Breakdown by Program Activity & Object Class (B file):
-	- Treasury Account
-		1. Get all TASs matching the filers from Q1 to the FSQ selected
-		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
-	- Federal Account
-		1. Get all TASs matching the filers from Q1 to the FSQ selected
-		2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
-		3. Group by Federal Accounts
+    - Treasury Account
+        1. Get all TASs matching the filers from Q1 to the FSQ selected
+        2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
+    - Federal Account
+        1. Get all TASs matching the filers from Q1 to the FSQ selected
+        2. Only include the most recently submitted TASs (uniqueness based on TAS/PA/OC/DR)
+        3. Group by Federal Accounts
 Account Breakdown by Award (C file):
-	- Treasury Account
-		1. Get all TASs matching the filers from Q1 to the FSQ selected
-	- Federal Account
-		1. Get all TASs matching the filers from Q1 to the FSQ selected
-		2. Group by Federal Accounts
+    - Treasury Account
+        1. Get all TASs matching the filers from Q1 to the FSQ selected
+    - Federal Account
+        1. Get all TASs matching the filers from Q1 to the FSQ selected
+        2. Group by Federal Accounts
 """
 
 


### PR DESCRIPTION
**High level description:**
Extension of [PR-1602](https://github.com/fedspendingtransparency/usaspending-api/pull/1602) to handle FYQs prior to the latest

**Technical Details**
* Moving the `final_of_fy` logic to the account downloads endpoint
* Including Account Download duplication logic

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-1721](https://federal-spending-transparency.atlassian.net/browse/DEV-1721):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download) (largest download took a couple minutes on staging)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Matview impact assessment completed - No matviews affected
Frontend impact assessment completed - Front-End not affected
Appropriate Operations ticket(s) created - No OPS work necessary
```
