### PR TITLE
Hotfix: Updating Final of FY for load B file submissions

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -554,8 +554,6 @@ def load_file_b(submission_attributes, prg_act_obj_cls_data, db_cursor):
     # Insert File B quarterly numbers for this submission
     TasProgramActivityObjectClassQuarterly.insert_quarterly_numbers(submission_attributes.submission_id)
 
-    FinancialAccountsByProgramActivityObjectClass.populate_final_of_fy()
-
     for key in skipped_tas:
         logger.info('Skipped %d rows due to missing TAS: %s', skipped_tas[key]['count'], key)
 

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -554,6 +554,8 @@ def load_file_b(submission_attributes, prg_act_obj_cls_data, db_cursor):
     # Insert File B quarterly numbers for this submission
     TasProgramActivityObjectClassQuarterly.insert_quarterly_numbers(submission_attributes.submission_id)
 
+    FinancialAccountsByProgramActivityObjectClass.populate_final_of_fy()
+
     for key in skipped_tas:
         logger.info('Skipped %d rows due to missing TAS: %s', skipped_tas[key]['count'], key)
 


### PR DESCRIPTION
**Description:**
Reverting new Final of FY logic for `FinancialAccountsByProgramActivityObjectClass` considering it's taxing for load_submission

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
	- [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-1819](https://federal-spending-transparency.atlassian.net/browse/DEV-1819):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Unit & integration tests updated - No unit tests affected
API documentation updated - No documentation affected
Matview impact assessment completed - No matviews affected
Frontend impact assessment completed - No frontend affected
Data validation completed - No data changes
Appropriate Operations ticket(s) created - No operations needed
```
