### PR TITLE
DEV-1689: Coalescing null values so the script will function properly

### DIFF
--- a/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
+++ b/usaspending_api/etl/management/commands/update_total_funding_amount_sql.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
     TRANSACTION_NORMALIZED_TFA = """
         UPDATE transaction_normalized AS txn
         SET non_federal_funding_amount = txf.non_federal_funding_amount,
-        funding_amount = txf.federal_action_obligation + txf.non_federal_funding_amount
+        funding_amount = COALESCE(txf.federal_action_obligation, 0) + COALESCE(txf.non_federal_funding_amount, 0)
         FROM transaction_fabs AS txf
         WHERE txf.transaction_id = txn.id;
     """


### PR DESCRIPTION
**Description:**
Fixing the backfilling script to properly normalize "funding_amount" so that the summed amount in awards/total_funding_amount is correct. 

**Technical details:**
In the backfilling script, the equation of non_federal_funding_amount and federal_action_obligation does not sum if one or both of the values are nulls. So we need to coalesce those nulls to zeros so they can always be summed.

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [X] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (OPS-409)
8. [x] Jira Ticket [DEV-1689](https://federal-spending-transparency.atlassian.net/browse/DEV-1689):
	- [X] Link to this Pull-Request
	- [NA] Performance evaluation of affected (API | Script | Download)
	- [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. Unit tests not applicable because this is a one time use script
2. No change to API endpoints
5. No frontend impact
8.b,c. No performance implications, script only to be run once.
```