### PR TITLE
DEV-1799: Add IDV tab to Advanced Search, include IDV toggle in filters

### DIFF
--- a/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_award.md
+++ b/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_award.md
@@ -69,7 +69,7 @@ order (**OPTIONAL**): Optional parameter indicating what direction results shoul
 }
 ```
 ### Fields
-The possible fields returned are split by contracts or assistance awards (loans, grants, etc.)
+The possible fields returned are split by contracts (and IDV) or assistance awards (loans, grants, etc.)
 
 #### Possible Award Fields (available for every type of award)
 ```
@@ -94,7 +94,7 @@ The possible fields returned are split by contracts or assistance awards (loans,
     'Base Obligation Date': 'date_signed'
 ```
 
-#### Possible Contract Fields w/ db mapping
+#### Possible Contract (and IDV) Fields w/ db mapping
 ```
     'Award ID': 'piid',
     'Start Date': 'period_of_performance_start_date',

--- a/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_award_count.md
+++ b/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_award_count.md
@@ -3,7 +3,7 @@
 
 **Method:** `POST`
 
-This route takes award filters, and returns the number of awards in each award type (Contracts, Loans, Direct Payments, Grants, and Other).
+This route takes award filters, and returns the number of awards in each award type (Contracts, IDV, Loans, Direct Payments, Grants, and Other).
 
 ### Request
 
@@ -66,13 +66,14 @@ subawards (**OPTIONAL**): boolean value.  True when you want to group by Subawar
         "grants": 0,
         "loans": 0,
         "contracts": 0,
+        "idv": 0,
         "direct_payments": 1,
         "other": 0
     }
 }
 ```
 **Response Documentation**
-The result set always returns how many grants, loans, contracts, direct payments, and other awards are returned with the specified filters.
+The result set always returns how many grants, loans, contracts, idvs, direct payments, and other awards are returned with the specified filters.
 
 
 ### Response (JSON) - Subawards

--- a/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_award_count.md
+++ b/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_award_count.md
@@ -66,7 +66,7 @@ subawards (**OPTIONAL**): boolean value.  True when you want to group by Subawar
         "grants": 0,
         "loans": 0,
         "contracts": 0,
-        "idv": 0,
+        "idvs": 0,
         "direct_payments": 1,
         "other": 0
     }

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -116,6 +116,9 @@ def matview_search_filter(filters, model, for_downloads=False):
             # queryset &= model.objects.filter(type__in=value)
 
             idv_flag = all(i in value for i in idv_type_mapping.keys())
+            if not idv_flag and len([i for i in value if i in idv_type_mapping.keys()]) > 0:
+                raise InvalidParameterException("IDV award type filter currently not supported; award_type_codes " \
+                                                "parameter must include every IDV type or none at all.")
 
             filter_obj = Q(type__in=value)
             if idv_flag:

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -2,7 +2,7 @@ import logging
 import itertools
 from django.db.models import Q
 from usaspending_api.awards.v2.filters.location_filter_geocode import geocode_filter_locations
-from usaspending_api.awards.v2.lookups.lookups import contract_type_mapping
+from usaspending_api.awards.v2.lookups.lookups import idv_type_mapping
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.references.models import PSC
 from usaspending_api.accounts.views.federal_accounts_v2 import filter_on
@@ -112,11 +112,14 @@ def matview_search_filter(filters, model, for_downloads=False):
             queryset &= combine_date_range_queryset(value, model, min_date, API_MAX_DATE)
 
         elif key == "award_type_codes":
-            idv_flag = all(i in value for i in contract_type_mapping.keys())
+            # TODO: update Matviews and Awards to include IDV (and IDC) award types to remove IDV as an edge case
+            # queryset &= model.objects.filter(type__in=value)
+
+            idv_flag = all(i in value for i in idv_type_mapping.keys())
 
             filter_obj = Q(type__in=value)
             if idv_flag:
-                filter_obj |= Q(pulled_from='IDV') & Q(type__isnull=True)
+                filter_obj |= Q(pulled_from='IDV')
             queryset &= model.objects.filter(filter_obj)
 
         elif key == "agencies":

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -1,6 +1,8 @@
 import logging
 import itertools
+
 from django.db.models import Q
+
 from usaspending_api.awards.v2.filters.location_filter_geocode import geocode_filter_locations
 from usaspending_api.awards.v2.lookups.lookups import idv_type_mapping
 from usaspending_api.common.exceptions import InvalidParameterException
@@ -117,7 +119,7 @@ def matview_search_filter(filters, model, for_downloads=False):
 
             idv_flag = all(i in value for i in idv_type_mapping.keys())
             if not idv_flag and len([i for i in value if i in idv_type_mapping.keys()]) > 0:
-                raise InvalidParameterException("IDV award type filter currently not supported; award_type_codes " \
+                raise InvalidParameterException("IDV award type filter currently not supported; award_type_codes "
                                                 "parameter must include every IDV type or none at all.")
 
             filter_obj = Q(type__in=value)

--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1148,9 +1148,9 @@ contract_type_mapping = {
 }
 idv_type_mapping = {
     'IDV_A': 'GWAC Government Wide Acquisition Contract',
-    'IDV_B_A': 'IDC Indefinite Delivery Contract - ',
-    'IDV_B_B': 'IDC Indefinite Delivery Contract - ',
-    'IDV_B_C': 'IDC Indefinite Delivery Contract - ',
+    'IDV_B_A': 'IDC Indefinite Delivery Contract / Requirements',
+    'IDV_B_B': 'IDC Indefinite Delivery Contract / Indefinite Quantity',
+    'IDV_B_C': 'IDC Indefinite Delivery Contract / Definite Quantity',
     'IDV_C': 'FSS Federal Supply Schedule',
     'IDV_D': 'BOA Basic Ordering Agreement',
     'IDV_E': 'BPA Blanket Purchase Agreement'

--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1145,6 +1145,13 @@ contract_type_mapping = {
     'C': 'Delivery Order',
     'D': 'Definitive Contract'
 }
+idv_type_mapping = {
+    'IDV_A': 'GWAC Government Wide Acquisition Contract',
+    'IDV_B': 'IDC Indefinite Delivery Contract',
+    'IDV_C': 'FSS Federal Supply Schedule',
+    'IDV_D': 'BOA Basic Ordering Agreement',
+    'IDV_E': 'BPA Blanket Purchase Agreement'
+}
 grant_type_mapping = {
     '02': 'Block Grant',
     '03': 'Formula Grant',
@@ -1168,6 +1175,14 @@ assistance_type_mapping = {**grant_type_mapping, **direct_payment_type_mapping, 
 non_loan_assistance_type_mapping = {**grant_type_mapping, **direct_payment_type_mapping, **other_type_mapping}
 all_award_types_mappings = {
     'contracts': list(contract_type_mapping.keys()),
+    'grants': list(grant_type_mapping.keys()),
+    'direct_payments': list(direct_payment_type_mapping.keys()),
+    'loans': list(loan_type_mapping.keys()),
+    'other_financial_assistance': list(other_type_mapping.keys())
+}
+all_award_types_mappings_incl_idv = {
+    'contracts': list(contract_type_mapping.keys()),
+    'idvs': list(idv_type_mapping.keys()),
     'grants': list(grant_type_mapping.keys()),
     'direct_payments': list(direct_payment_type_mapping.keys()),
     'loans': list(loan_type_mapping.keys()),

--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1147,7 +1147,9 @@ contract_type_mapping = {
 }
 idv_type_mapping = {
     'IDV_A': 'GWAC Government Wide Acquisition Contract',
-    'IDV_B': 'IDC Indefinite Delivery Contract',
+    'IDV_B_A': 'IDC Indefinite Delivery Contract - ',
+    'IDV_B_B': 'IDC Indefinite Delivery Contract - ',
+    'IDV_B_C': 'IDC Indefinite Delivery Contract - ',
     'IDV_C': 'FSS Federal Supply Schedule',
     'IDV_D': 'BOA Basic Ordering Agreement',
     'IDV_E': 'BPA Blanket Purchase Agreement'

--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1118,6 +1118,7 @@ award_assistance_mapping = {**grant_award_mapping, **loan_award_mapping, **direc
 non_loan_assistance_award_mapping = assistance_award_mapping = {**grant_award_mapping, **direct_payment_award_mapping,
                                                                 **other_award_mapping}
 
+# TODO: include IDV mappings in the award_type_mapping and update award_filter.py
 award_type_mapping = {
     '02': 'Block Grant',
     '03': 'Formula Grant',
@@ -1182,6 +1183,7 @@ all_award_types_mappings = {
     'loans': list(loan_type_mapping.keys()),
     'other_financial_assistance': list(other_type_mapping.keys())
 }
+# TODO: delete this and update the all_award_types_mappings to include IDVs
 all_award_types_mappings_incl_idv = {
     'contracts': list(contract_type_mapping.keys()),
     'idvs': list(idv_type_mapping.keys()),

--- a/usaspending_api/core/validator/award_filter.py
+++ b/usaspending_api/core/validator/award_filter.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 
-from usaspending_api.awards.v2.lookups.lookups import award_type_mapping
+from usaspending_api.awards.v2.lookups.lookups import award_type_mapping, idv_type_mapping
 from usaspending_api.core.validator.helpers import TINY_SHIELD_SEPARATOR
 
 
 AWARD_FILTER = [
     {'name': 'award_ids', 'type': 'array', 'array_type': 'text', 'text_type': 'search'},
     {'name': 'award_type_codes', 'type': 'array', 'array_type': 'enum',
-     'enum_values': list(award_type_mapping.keys()) + ['no intersection']},
+     'enum_values': list(award_type_mapping.keys()) + list(idv_type_mapping.keys()) + ['no intersection']},
     {'name': 'contract_pricing_type_codes', 'type': 'array', 'array_type': 'text', 'text_type': 'search'},
     {'name': 'extent_competed_type_codes', 'type': 'array', 'array_type': 'text', 'text_type': 'search'},
     {'name': 'keywords', 'type': 'array', 'array_type': 'text', 'text_type': 'search', 'text_min': 3},

--- a/usaspending_api/search/tests/test_spending_by_award_type.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type.py
@@ -30,7 +30,7 @@ def test_spending_by_award_type_success(client, refresh_matviews):
         data=json.dumps({
             "fields": ["Award ID", "Recipient Name"],
             "filters": {
-                "award_type_codes": ["IDV_A", "IDV_B", "IDV_C", "IDV_D", "IDV_E"]
+                "award_type_codes": ["IDV_A", "IDV_B_A", "IDV_B_B", "IDV_B_C", "IDV_C", "IDV_D", "IDV_E"]
             }
         }))
     assert resp.status_code == status.HTTP_200_OK
@@ -67,7 +67,7 @@ def test_spending_by_award_type_failure(client, refresh_matviews):
         data=json.dumps({
             "fields": ["Award ID", "Recipient Name"],
             "filters": {
-                "award_type_codes": ["IDV_A", "IDV_B", "IDV_C"]
+                "award_type_codes": ["IDV_A", "IDV_B_A", "IDV_C", "IDV_D"]
             }
         }))
     assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/usaspending_api/search/tests/test_spending_by_award_type.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type.py
@@ -23,6 +23,18 @@ def test_spending_by_award_type_success(client, refresh_matviews):
         }))
     assert resp.status_code == status.HTTP_200_OK
 
+    # test IDV award types
+    resp = client.post(
+        '/api/v2/search/spending_by_award/',
+        content_type='application/json',
+        data=json.dumps({
+            "fields": ["Award ID", "Recipient Name"],
+            "filters": {
+                "award_type_codes": ["IDV_A", "IDV_B", "IDV_C", "IDV_D", "IDV_E"]
+            }
+        }))
+    assert resp.status_code == status.HTTP_200_OK
+
     # test all features
     resp = client.post(
         '/api/v2/search/spending_by_award',
@@ -47,8 +59,20 @@ def test_spending_by_award_type_success(client, refresh_matviews):
 
 @pytest.mark.django_db
 def test_spending_by_award_type_failure(client, refresh_matviews):
-    """Verify error on bad autocomplete request for budget function."""
 
+    # test incomplete IDV award types
+    resp = client.post(
+        '/api/v2/search/spending_by_award/',
+        content_type='application/json',
+        data=json.dumps({
+            "fields": ["Award ID", "Recipient Name"],
+            "filters": {
+                "award_type_codes": ["IDV_A", "IDV_B", "IDV_C"]
+            }
+        }))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    # test bad autocomplete request for budget function
     resp = client.post(
         '/api/v2/search/spending_by_award/',
         content_type='application/json',
@@ -242,38 +266,14 @@ def test_spending_by_award_both_zip_filter(client, mock_matviews_qs):
 @pytest.mark.django_db
 def test_spending_by_award_foreign_filter(client, mock_matviews_qs):
     """ Verify that foreign country filter is returning the correct results """
-    mock_model_0 = MockModel(award_id=0,
-                             piid=None,
-                             fain='aaa',
-                             uri=None,
-                             type='B',
-                             pulled_from="AWARD",
-                             recipient_location_country_name="UNITED STATES",
-                             recipient_location_country_code="USA")
-    mock_model_1 = MockModel(award_id=1,
-                             piid=None,
-                             fain='abc',
-                             uri=None,
-                             type='B',
-                             pulled_from="AWARD",
-                             recipient_location_country_name="",
-                             recipient_location_country_code="USA")
-    mock_model_2 = MockModel(award_id=2,
-                             piid=None,
-                             fain='abd',
-                             uri=None,
-                             type='B',
-                             pulled_from="AWARD",
-                             recipient_location_country_name="UNITED STATES",
-                             recipient_location_country_code="")
-    mock_model_3 = MockModel(award_id=3,
-                             piid=None,
-                             fain='abe',
-                             uri=None,
-                             type='B',
-                             pulled_from="AWARD",
-                             recipient_location_country_name="Gibraltar",
-                             recipient_location_country_code="GIB")
+    mock_model_0 = MockModel(award_id=0, piid=None, fain='aaa', uri=None, type='B', pulled_from="AWARD",
+                             recipient_location_country_name="UNITED STATES", recipient_location_country_code="USA")
+    mock_model_1 = MockModel(award_id=1, piid=None, fain='abc', uri=None, type='B', pulled_from="AWARD",
+                             recipient_location_country_name="", recipient_location_country_code="USA")
+    mock_model_2 = MockModel(award_id=2, piid=None, fain='abd', uri=None, type='B', pulled_from="AWARD",
+                             recipient_location_country_name="UNITED STATES", recipient_location_country_code="")
+    mock_model_3 = MockModel(award_id=3, piid=None, fain='abe', uri=None, type='B', pulled_from="AWARD",
+                             recipient_location_country_name="Gibraltar", recipient_location_country_code="GIB")
 
     add_to_mock_objects(mock_matviews_qs, [mock_model_0, mock_model_1, mock_model_2, mock_model_3])
     # add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_3])
@@ -283,12 +283,7 @@ def test_spending_by_award_foreign_filter(client, mock_matviews_qs):
         content_type='application/json',
         data=json.dumps({
             "filters": {
-                "award_type_codes": [
-                    "A",
-                    "B",
-                    "C",
-                    "D"
-                ],
+                "award_type_codes": ["A", "B", "C", "D"],
                 # "recipient_locations": [{"country": "USA"}]
                 "recipient_scope": "domestic"
             },
@@ -303,12 +298,7 @@ def test_spending_by_award_foreign_filter(client, mock_matviews_qs):
         content_type='application/json',
         data=json.dumps({
             "filters": {
-                "award_type_codes": [
-                    "A",
-                    "B",
-                    "C",
-                    "D"
-                ],
+                "award_type_codes": ["A", "B", "C", "D"],
                 "recipient_scope": "foreign"
             },
             "fields": ["Award ID"],

--- a/usaspending_api/search/tests/test_spending_by_award_type_count.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type_count.py
@@ -84,7 +84,7 @@ def test_spending_by_award_no_intersection(client, mock_matviews_qs):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["results"] == {
         "contracts": 0,
-        "idv": 0,
+        "idvs": 0,
         "grants": 0,
         "direct_payments": 0,
         "loans": 0,

--- a/usaspending_api/search/tests/test_spending_by_award_type_count.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type_count.py
@@ -84,6 +84,7 @@ def test_spending_by_award_no_intersection(client, mock_matviews_qs):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["results"] == {
         "contracts": 0,
+        "idv": 0,
         "grants": 0,
         "direct_payments": 0,
         "loans": 0,

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -196,7 +196,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
             raise InvalidParameterException("Missing required request parameters: 'filters'")
 
         results = {
-            "contracts": 0, "idv": 0, "grants": 0, "direct_payments": 0, "loans": 0, "other": 0
+            "contracts": 0, "idvs": 0, "grants": 0, "direct_payments": 0, "loans": 0, "other": 0
         } if not subawards else {
             "subcontracts": 0, "subgrants": 0
         }
@@ -219,11 +219,11 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
 
         else:
             queryset = queryset.values('category', 'pulled_from') \
-                .annotate(category_count=Count(Coalesce('category', Value('contract'))))
+                .annotate(category_count=Count(Coalesce('category', Value('idvs'))))
 
         categories = {
             'contract': 'contracts',
-            'idv': 'idv',
+            'idvs': 'idvs',
             'grant': 'grants',
             'direct payment': 'direct_payments',
             'loans': 'loans',
@@ -235,15 +235,11 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         # DB hit here
         for award in queryset:
             if award[category_name] is None:
-                result_key = 'contracts' if not subawards else 'subcontracts'
+                result_key = 'idv' if not subawards else 'subcontracts'
             elif award[category_name] not in categories.keys():
                 result_key = 'other'
             else:
                 result_key = categories[award[category_name]]
-
-            # Account for IDV records that were previously being counted as Contracts
-            if result_key == 'contracts' and award['pulled_from'] == 'IDV':
-                result_key = 'idv'
 
             results[result_key] += award['category_count']
 

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -214,12 +214,10 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
             queryset = queryset.values('award_type').annotate(category_count=Count('subaward_id'))
 
         elif model == 'SummaryAwardView':
-            queryset = queryset.values('category', 'pulled_from') \
-                .annotate(category_count=Sum('counts'))
+            queryset = queryset.values('category').annotate(category_count=Sum('counts'))
 
         else:
-            queryset = queryset.values('category', 'pulled_from') \
-                .annotate(category_count=Count(Coalesce('category', Value('idvs'))))
+            queryset = queryset.values('category').annotate(category_count=Count(Coalesce('category', Value('idvs'))))
 
         categories = {
             'contract': 'contracts',

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -235,7 +235,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         # DB hit here
         for award in queryset:
             if award[category_name] is None:
-                result_key = 'idv' if not subawards else 'subcontracts'
+                result_key = 'idvs' if not subawards else 'subcontracts'
             elif award[category_name] not in categories.keys():
                 result_key = 'other'
             else:


### PR DESCRIPTION
**Description:**
Separates out IDV counts and awards from Contracts counts and awards for the responses on the Advanced Search page.

**Technical details:**
Add `idv_type_mapping`s to the `award_type_filter`. Update the filter to accept all or none of the IDV mappings, which will toggle whether or not we include IDVs in the results.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
	- [x] Backend
	- [x] Frontend <OPTIONAL>
	- Operations N/A
	- Domain Expert N/A
4. Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
```
    Counts match up with DB counts when filters are applied.
```
7. Appropriate Operations ticket(s) created N/A
8. [ ] Jira Tickets: [DEV-1792](https://federal-spending-transparency.atlassian.net/browse/DEV-1792), [DEV-1799](https://federal-spending-transparency.atlassian.net/browse/DEV-1799):
	- [ ] Link to this Pull-Request
	- [x] Performance evaluation of affected (API)
	- [x] Before / After data comparison
```
    Performance unchanged, as the DB query is technically unchanged.
    Data is unchanged, front end will make requests for contracts _or_ IDVs, no longer both
at once.
```

**Area for explaining above N/A when needed:**
```
    No data changes needed for the MVP of these filters. For the next step, there will be impacts
to the matviews and more data validation will be needed.
```
