### PR TITLE
DEV-1820 Fixing time period ordering

### DIFF
--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -153,7 +153,7 @@ def create_full_time_periods(min_date, max_date, group):
     return results
 
 
-def generate_date_ranged_results_from_queryset(filter_time_periods, queryset, date_range_type):
+def bolster_missing_time_periods(filter_time_periods, queryset, date_range_type, columns):
     """ Given the following, generate a list of dict results split by fiscal years/quarters/months
 
         Args:
@@ -162,6 +162,8 @@ def generate_date_ranged_results_from_queryset(filter_time_periods, queryset, da
             queryset: the resulting data to split into these results
             data_range_type: how the results are split
                 - 'fy', 'quarter', or 'month'
+            columns: dictionary of columns to include from the queryset
+                - {'name of field to be included in the resulting dict': 'column to be pulled from the queryset'}
         Returns:
             list of dict results split by fiscal years/quarters/months
     """
@@ -170,8 +172,11 @@ def generate_date_ranged_results_from_queryset(filter_time_periods, queryset, da
 
     for row in queryset:
         for item in results:
-            if str(item["time_period"]["fy"]) == str(row["fy"]) and str(item["time_period"][date_range_type]) == str(row[date_range_type]):
-                item["aggregated_amount"] = row["aggregated_amount"]
+            same_year = str(item["time_period"]["fy"]) == str(row["fy"])
+            same_period = str(item["time_period"][date_range_type]) == str(row[date_range_type])
+            if same_year and same_period:
+                for column_name, column_in_queryset in columns.items():
+                    item[column_name] = row[column_in_queryset]
 
     for result in results:
         result['time_period']['fiscal_year'] = result['time_period']['fy']

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -129,10 +129,11 @@ def min_and_max_from_date_ranges(filter_time_periods):
     return (dt.strptime(min_date, "%Y-%m-%d"), dt.strptime(max_date, "%Y-%m-%d"))
 
 
-def create_full_time_periods(min_date, max_date, group):
+def create_full_time_periods(min_date, max_date, group, columns):
+    cols = {col: 0 for col in columns.keys()}
     fiscal_years = [int(fy) for fy in range(generate_fiscal_year(min_date), generate_fiscal_year(max_date) + 1)]
     if group == "fy":
-        return [{"aggregated_amount": 0, "time_period": {"fy": str(fy)}} for fy in fiscal_years]
+        return [{**cols, **{"time_period": {"fy": str(fy)}}} for fy in fiscal_years]
 
     if group == "month":
         period = int(generate_fiscal_month(min_date))
@@ -146,7 +147,7 @@ def create_full_time_periods(min_date, max_date, group):
     results = []
     for fy in fiscal_years:
         while period <= rollover and not (period > ending and fy == fiscal_years[-1]):
-            results.append({"aggregated_amount": 0, "time_period": {"fy": str(fy), group: str(period)}})
+            results.append({**cols, **{"time_period": {"fy": str(fy), group: str(period)}}})
             period += 1
         period = 1
 
@@ -168,7 +169,7 @@ def bolster_missing_time_periods(filter_time_periods, queryset, date_range_type,
             list of dict results split by fiscal years/quarters/months
     """
     min_date, max_date = min_and_max_from_date_ranges(filter_time_periods)
-    results = create_full_time_periods(min_date, max_date, date_range_type)
+    results = create_full_time_periods(min_date, max_date, date_range_type, columns)
 
     for row in queryset:
         for item in results:

--- a/usaspending_api/search/tests/unit/test_new_awards_over_time.py
+++ b/usaspending_api/search/tests/unit/test_new_awards_over_time.py
@@ -114,14 +114,14 @@ def test_new_awards_month(add_award_recipients, client):
         elif i == 10:
             new_award_count = 1
         expected_results.append({
-            'time_period': {'fiscal_year': '2009', 'month': i},
+            'time_period': {'fiscal_year': '2009', 'month': str(i)},
             'new_award_count_in_period': new_award_count
         })
     # 2010
     for i in range(1, 13):
         new_award_count = 0
         expected_results.append({
-            'time_period': {'fiscal_year': '2010', 'month': i},
+            'time_period': {'fiscal_year': '2010', 'month': str(i)},
             'new_award_count_in_period': new_award_count
         })
     expected_response = {
@@ -148,7 +148,7 @@ def test_new_awards_month(add_award_recipients, client):
         if i == 4:
             new_award_count = 2
         expected_results.append({
-            'time_period': {'fiscal_year': '2008', 'month': i},
+            'time_period': {'fiscal_year': '2008', 'month': str(i)},
             'new_award_count_in_period': new_award_count
         })
     # 2009
@@ -159,14 +159,14 @@ def test_new_awards_month(add_award_recipients, client):
         elif i == 10:
             new_award_count = 1
         expected_results.append({
-            'time_period': {'fiscal_year': '2009', 'month': i},
+            'time_period': {'fiscal_year': '2009', 'month': str(i)},
             'new_award_count_in_period': new_award_count
         })
     # 2010
     for i in range(1, 13):
         new_award_count = 0
         expected_results.append({
-            'time_period': {'fiscal_year': '2010', 'month': i},
+            'time_period': {'fiscal_year': '2010', 'month': str(i)},
             'new_award_count_in_period': new_award_count
         })
     expected_response = {
@@ -210,14 +210,14 @@ def test_new_awards_quarter(add_award_recipients, client):
         elif i == 4:
             new_award_count = 1
         expected_results.append({
-            'time_period': {'fiscal_year': '2009', 'quarter': i},
+            'time_period': {'fiscal_year': '2009', 'quarter': str(i)},
             'new_award_count_in_period': new_award_count
         })
     # 2010
     for i in range(1, 5):
         new_award_count = 0
         expected_results.append({
-            'time_period': {'fiscal_year': '2010', 'quarter': i},
+            'time_period': {'fiscal_year': '2010', 'quarter': str(i)},
             'new_award_count_in_period': new_award_count
         })
     expected_response = {
@@ -234,7 +234,7 @@ def test_new_awards_quarter(add_award_recipients, client):
         if i == 2:
             new_award_count = 2
         expected_results.append({
-            'time_period': {'fiscal_year': '2008', 'quarter': i},
+            'time_period': {'fiscal_year': '2008', 'quarter': str(i)},
             'new_award_count_in_period': new_award_count
         })
     # 2009
@@ -245,14 +245,14 @@ def test_new_awards_quarter(add_award_recipients, client):
         elif i == 4:
             new_award_count = 1
         expected_results.append({
-            'time_period': {'fiscal_year': '2009', 'quarter': i},
+            'time_period': {'fiscal_year': '2009', 'quarter': str(i)},
             'new_award_count_in_period': new_award_count
         })
     # 2010
     for i in range(1, 5):
         new_award_count = 0
         expected_results.append({
-            'time_period': {'fiscal_year': '2010', 'quarter': i},
+            'time_period': {'fiscal_year': '2010', 'quarter': str(i)},
             'new_award_count_in_period': new_award_count
         })
 

--- a/usaspending_api/search/tests/unit/test_spending_over_time_details.py
+++ b/usaspending_api/search/tests/unit/test_spending_over_time_details.py
@@ -1,0 +1,189 @@
+# Stdlib imports
+from datetime import datetime
+import json
+import pytest
+
+# Core Django imports
+from rest_framework import status
+
+# Third-party app imports
+from django_mock_queries.query import MockModel
+
+# Imports from your apps
+from usaspending_api.common.helpers.unit_test_helper import add_to_mock_objects
+
+
+@pytest.fixture
+def populate_models(mock_matviews_qs):
+    mock_0 = MockModel(action_date=datetime(2010, 3, 1), generated_pragmatic_obligation=100.0)
+    mock_1 = MockModel(action_date=datetime(2011, 3, 1), generated_pragmatic_obligation=110.0)
+    mock_2 = MockModel(action_date=datetime(2012, 3, 1), generated_pragmatic_obligation=120.0)
+    mock_3 = MockModel(action_date=datetime(2013, 3, 1), generated_pragmatic_obligation=130.0)
+    mock_4 = MockModel(action_date=datetime(2014, 3, 1), generated_pragmatic_obligation=140.0)
+    mock_5 = MockModel(action_date=datetime(2015, 3, 1), generated_pragmatic_obligation=150.0)
+    mock_6 = MockModel(action_date=datetime(2016, 3, 1), generated_pragmatic_obligation=160.0)
+    mock_7 = MockModel(action_date=datetime(2017, 3, 1), generated_pragmatic_obligation=170.0)
+
+    add_to_mock_objects(mock_matviews_qs, [mock_0, mock_1, mock_2, mock_3, mock_4, mock_5, mock_6, mock_7])
+
+
+def get_spending_over_time_url():
+    return '/api/v2/search/spending_over_time/'
+
+
+def confirm_proper_ordering(group, results):
+    fiscal_year, period = 0, 0
+    for result in results:
+        assert int(result["time_period"]["fiscal_year"]) >= fiscal_year, "Fiscal Year is out of order!"
+        if int(result["time_period"]["fiscal_year"]) > fiscal_year:
+            fiscal_year = int(result["time_period"]["fiscal_year"])
+            period = 0
+        if group != "fiscal_year":
+            assert int(result["time_period"]["fiscal_year"]) >= period, "{} is out of order!".format(group)
+            if int(result["time_period"][group]) > period:
+                period = int(result["time_period"][group])
+
+
+@pytest.mark.django_db
+def test_spending_over_time_fy_ordering(populate_models, client, mock_matviews_qs):
+    group = "fiscal_year"
+    test_payload = {
+        "group": group,
+        "subawards": False,
+        "filters": {
+            "time_period": [
+                {"start_date": "2009-10-01", "end_date": "2017-09-30"},
+                {"start_date": "2017-10-01", "end_date": "2018-09-30"},
+            ]
+        },
+    }
+
+    expected_response = {
+        "group": group,
+        "results": [
+            {"aggregated_amount": 100.0, "time_period": {"fiscal_year": "2010"}},
+            {"aggregated_amount": 110.0, "time_period": {"fiscal_year": "2011"}},
+            {"aggregated_amount": 120.0, "time_period": {"fiscal_year": "2012"}},
+            {"aggregated_amount": 130.0, "time_period": {"fiscal_year": "2013"}},
+            {"aggregated_amount": 140.0, "time_period": {"fiscal_year": "2014"}},
+            {"aggregated_amount": 150.0, "time_period": {"fiscal_year": "2015"}},
+            {"aggregated_amount": 160.0, "time_period": {"fiscal_year": "2016"}},
+            {"aggregated_amount": 170.0, "time_period": {"fiscal_year": "2017"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2018"}},
+        ],
+    }
+
+    resp = client.post(get_spending_over_time_url(), content_type='application/json', data=json.dumps(test_payload))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.data, "Unexpected or missing content!"
+
+    # ensure ordering is correct
+    confirm_proper_ordering(group, resp.data["results"])
+
+
+@pytest.mark.django_db
+def test_spending_over_time_month_ordering(populate_models, client, mock_matviews_qs):
+    group = "month"
+    test_payload = {
+        "group": group,
+        "subawards": False,
+        "filters": {
+            "time_period": [
+                {"start_date": "2010-10-01", "end_date": "2011-09-30"},
+                {"start_date": "2012-10-01", "end_date": "2013-09-30"},
+            ]
+        },
+    }
+    expected_response = {
+        "group": group,
+        "results": [
+            {"time_period": {"fiscal_year": "2011", "month": "1"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "2"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "3"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "4"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "5"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "6"}, "aggregated_amount": 110.0},
+            {"time_period": {"fiscal_year": "2011", "month": "7"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "8"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "9"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "10"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "11"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2011", "month": "12"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "1"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "2"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "3"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "4"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "5"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "6"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "7"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "8"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "9"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "10"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "11"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2012", "month": "12"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "1"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "2"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "3"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "4"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "5"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "6"}, "aggregated_amount": 130.0},
+            {"time_period": {"fiscal_year": "2013", "month": "7"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "8"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "9"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "10"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "11"}, "aggregated_amount": 0},
+            {"time_period": {"fiscal_year": "2013", "month": "12"}, "aggregated_amount": 0},
+        ],
+    }
+
+    resp = client.post(get_spending_over_time_url(), content_type='application/json', data=json.dumps(test_payload))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.data, "Unexpected or missing content!"
+
+    # ensure ordering is correct
+    confirm_proper_ordering(group, resp.data["results"])
+
+
+@pytest.mark.django_db
+def test_spending_over_time_funny_dates_ordering(populate_models, client, mock_matviews_qs):
+    group = "month"
+    test_payload = {
+        "group": group,
+        "subawards": False,
+        "filters": {
+            "time_period": [
+                {"start_date": "2010-02-01", "end_date": "2010-03-31"},
+                {"start_date": "2011-02-01", "end_date": "2011-03-31"},
+            ]
+        },
+    }
+
+    expected_response = {
+        "results": [
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "5"}},
+            {"aggregated_amount": 100.0, "time_period": {"fiscal_year": "2010", "month": "6"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "7"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "8"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "9"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "10"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "11"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2010", "month": "12"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2011", "month": "1"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2011", "month": "2"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2011", "month": "3"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2011", "month": "4"}},
+            {"aggregated_amount": 0, "time_period": {"fiscal_year": "2011", "month": "5"}},
+            {"aggregated_amount": 110.0, "time_period": {"fiscal_year": "2011", "month": "6"}},
+        ],
+        "group": "month",
+    }
+
+    resp = client.post(get_spending_over_time_url(), content_type='application/json', data=json.dumps(test_payload))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.data, "Unexpected or missing content!"
+
+    # ensure ordering is correct
+    confirm_proper_ordering(group, resp.data["results"])

--- a/usaspending_api/search/v2/views/new_awards_over_time.py
+++ b/usaspending_api/search/v2/views/new_awards_over_time.py
@@ -9,7 +9,7 @@ from rest_framework.views import APIView
 from usaspending_api.awards.v2.filters.filter_helpers import combine_date_range_queryset
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.common.helpers.generic_helper import generate_date_ranged_results_from_queryset
+from usaspending_api.common.helpers.generic_helper import bolster_missing_time_periods
 from usaspending_api.core.validator.award_filter import AWARD_FILTER
 from usaspending_api.core.validator.tinyshield import TinyShield
 from usaspending_api.recipient.models import RecipientProfile, SummaryAwardRecipient
@@ -104,8 +104,9 @@ class NewAwardsOverTimeVisualizationViewSet(APIView):
 
         queryset, values = self.database_data_layer()
 
-        results = generate_date_ranged_results_from_queryset(filter_time_periods=self.filters['time_period'],
-                                                             queryset=queryset,
-                                                             date_range_type=values[-1],
-                                                             columns={'new_award_count_in_period': 'count'})
+        results = bolster_missing_time_periods(
+            filter_time_periods=self.filters['time_period'],
+            queryset=queryset,
+            date_range_type=values[-1],
+            columns={'new_award_count_in_period': 'count'})
         return Response({'group': self.groupings[self.json_request['group']], 'results': results})


### PR DESCRIPTION
**Description:**
The code for adding missing time periods into the response utilized a Python dictionary which isn't an ordered structure in Python 3.5. These edits utilize lists to maintain order

**Technical details:**
Decided to refactor the code a little

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
	- [x] Backend
	- [x] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-1820](https://federal-spending-transparency.atlassian.net/browse/DEV-1820):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected API
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
API request unchanged. Response is same structure.
Matviews untouched
No ops impact
```
