### PR TITLE
DEV-1829: Subaward Counts Initial Bugfixes

### DIFF
--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1134,11 +1134,6 @@ award_type_mapping = {
     'B': 'Purchase Order',
     'C': 'Delivery Order',
     'D': 'Definitive Contract',
-    'E': 'Unknown Type',
-    'F': 'Cooperative Agreement',
-    'G': 'Grant for Research',
-    'S': 'Funded Space Act Agreement',
-    'T': 'Training Grant'
 }
 contract_type_mapping = {
     'A': 'BPA Call',

--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1134,6 +1134,12 @@ award_type_mapping = {
     'B': 'Purchase Order',
     'C': 'Delivery Order',
     'D': 'Definitive Contract',
+    # While these types exist, they should not be included when returning all award types
+    # 'E': 'Unknown Type',
+    # 'F': 'Cooperative Agreement',
+    # 'G': 'Grant for Research',
+    # 'S': 'Funded Space Act Agreement',
+    # 'T': 'Training Grant'
 }
 contract_type_mapping = {
     'A': 'BPA Call',

--- a/usaspending_api/broker/management/commands/load_fsrs.py
+++ b/usaspending_api/broker/management/commands/load_fsrs.py
@@ -470,7 +470,9 @@ class Command(BaseCommand):
         self.process_subawards(db_cursor, shared_award_mappings, award_type, subaward_type, max_id)
 
     def cleanup_broken_links(self, db_cursor):
+        """ Given a db connection, try to update all the unlinked subawards to their parent awards  """
         broken_links = 0
+        fixed_links = 0
         fixed_ids = set()
         for award_type in ['procurement', 'grant']:
             broken_subawards = Subaward.objects.filter(award_id__isnull=True, award_type=award_type)
@@ -491,8 +493,9 @@ class Command(BaseCommand):
                     broken_subaward.updated_at = datetime.now(timezone.utc)
                     broken_subaward.save()
                     fixed_ids.add(award.id)
+                    fixed_links += 1
         award_update_id_list.update(fixed_ids)
-        logger.info('Fixed {} of {} broken links'.format(len(fixed_ids), broken_links))
+        logger.info('Fixed {} of {} broken links'.format(fixed_links, broken_links))
 
     @transaction.atomic
     def handle(self, *args, **options):

--- a/usaspending_api/broker/management/commands/load_fsrs.py
+++ b/usaspending_api/broker/management/commands/load_fsrs.py
@@ -66,13 +66,13 @@ class Command(BaseCommand):
             # "CONT_AW_" + contract_agency_code + contract_idv_agency_code + contract_number + idv_reference_number
             return (
                 'CONT_AW_'
-                + (row['contract_agency_code'].replace('-', '') if row['contract_agency_code'] else '-NONE-')
+                + (row['contract_agency_code'].replace('-', '') if row['contract_agency_code'] else 'NONE')
                 + '_'
-                + (row['contract_idv_agency_code'].replace('-', '') if row['contract_idv_agency_code'] else '-NONE-')
+                + (row['contract_idv_agency_code'].replace('-', '') if row['contract_idv_agency_code'] else 'NONE')
                 + '_'
-                + (row['contract_number'].replace('-', '') if row['contract_number'] else '-NONE-')
+                + (row['contract_number'].replace('-', '') if row['contract_number'] else 'NONE')
                 + '_'
-                + (row['idv_reference_number'].replace('-', '') if row['idv_reference_number'] else '-NONE-')
+                + (row['idv_reference_number'].replace('-', '') if row['idv_reference_number'] else 'NONE')
             )
         else:
             # For assistance awards, 'ASST_AW_' is NOT prepended because we are unable to build the full unique


### PR DESCRIPTION
**Description:**
Fixes two bugs related to the discrepancies between similar API endpoints/downloads.

**Technical details:**
- Bug 1: When not filtering by any award type versus filtering by all the award types we know, there are a couple award types that have been included that the project owners declared shouldn't be used. Code changes simply remove them (could comment them out though it's skeptical if they would return).
- Bug 2: When finding parent awards for subawards, the equivalent ids included dashes in their `NONE`s causing a mismatch and unlinked subawards. This resolves that and allows more subawards to be linked.
- Clarifying subaward log

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-1829](https://federal-spending-transparency.atlassian.net/browse/DEV-1829):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison

Note: this doesn't complete said ticket, only a couple aspects discovered from said ticket.

**Area for explaining above N/A when needed:**
```
Unit & integration tests updated - no unit tests affected
API documentation updated - no documentation affected
Matview impact assessment complete - no matviews affected
Frontend impact assessment completed - no frontend affected
```
