### PR TITLE
Last minute IDV column changes

### DIFF
--- a/usaspending_api/awards/models_matviews.py
+++ b/usaspending_api/awards/models_matviews.py
@@ -183,6 +183,7 @@ class UniversalAwardView(models.Model):
     period_of_performance_start_date = models.DateField()
     period_of_performance_current_end_date = models.DateField()
     date_signed = models.DateField()
+    ordering_period_end_date = models.DateField(null=True)
 
     original_loan_subsidy_cost = models.DecimalField(max_digits=23, decimal_places=2, null=True, blank=True)
     face_value_loan_guarantee = models.DecimalField(max_digits=23, decimal_places=2, null=True, blank=True)

--- a/usaspending_api/awards/v2/lookups/lookups.py
+++ b/usaspending_api/awards/v2/lookups/lookups.py
@@ -1148,6 +1148,7 @@ contract_type_mapping = {
 }
 idv_type_mapping = {
     'IDV_A': 'GWAC Government Wide Acquisition Contract',
+    'IDV_B': 'IDC (Unknown)',
     'IDV_B_A': 'IDC Indefinite Delivery Contract / Requirements',
     'IDV_B_B': 'IDC Indefinite Delivery Contract / Indefinite Quantity',
     'IDV_B_C': 'IDC Indefinite Delivery Contract / Definite Quantity',

--- a/usaspending_api/awards/v2/lookups/matview_lookups.py
+++ b/usaspending_api/awards/v2/lookups/matview_lookups.py
@@ -21,6 +21,7 @@ default_mapping = {
 }
 
 award_contracts_mapping = default_mapping.copy()
+award_idv_mapping = default_mapping.copy()
 grant_award_mapping = default_mapping.copy()
 loan_award_mapping = default_mapping.copy()
 direct_payment_award_mapping = default_mapping.copy()
@@ -33,6 +34,14 @@ award_contracts_mapping.update({
     'Award Amount': 'total_obligation',
     'Contract Award Type': 'type_description',
 
+})
+
+award_idv_mapping.update({
+    'Award ID': 'piid',
+    'Start Date': 'period_of_performance_start_date',
+    'Award Amount': 'total_obligation',
+    'Contract Award Type': 'type_description',
+    'Last Date to Order': 'ordering_period_end_date',
 })
 
 grant_award_mapping.update({

--- a/usaspending_api/database_scripts/matview_generator/universal_award_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/universal_award_matview.json
@@ -38,6 +38,7 @@
     "  awards.period_of_performance_start_date,",
     "  awards.period_of_performance_current_end_date,",
     "  awards.date_signed,",
+    "  transaction_fpds.ordering_period_end_date::date,",
     "",
     "  transaction_fabs.original_loan_subsidy_cost,",
     "  transaction_fabs.face_value_loan_guarantee,",
@@ -194,6 +195,10 @@
       "name": "period_of_performance_current_end_date",
       "where": "action_date >= '2007-10-01'",
       "columns": [{"name": "period_of_performance_current_end_date", "order": "DESC NULLS LAST"}]
+    }, {
+      "name": "ordered_ordering_period_end_date",
+      "where": "action_date >= '2007-10-01'",
+      "columns": [{"name": "ordering_period_end_date", "order": "DESC NULLS LAST"}]
     }, {
       "name": "recipient_name",
       "where": "recipient_name IS NOT NULL AND action_date >= '2007-10-01'",

--- a/usaspending_api/search/tests/test_spending_by_award_type.py
+++ b/usaspending_api/search/tests/test_spending_by_award_type.py
@@ -30,7 +30,7 @@ def test_spending_by_award_type_success(client, refresh_matviews):
         data=json.dumps({
             "fields": ["Award ID", "Recipient Name"],
             "filters": {
-                "award_type_codes": ["IDV_A", "IDV_B_A", "IDV_B_B", "IDV_B_C", "IDV_C", "IDV_D", "IDV_E"]
+                "award_type_codes": ["IDV_A", "IDV_B", "IDV_B_A", "IDV_B_B", "IDV_B_C", "IDV_C", "IDV_D", "IDV_E"]
             }
         }))
     assert resp.status_code == status.HTTP_200_OK

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -148,11 +148,6 @@ class SpendingByAwardVisualizationViewSet(APIView):
         limited_queryset = queryset[(page - 1) * limit:page * limit + 1]  # lower limit : upper limit
         has_next = len(limited_queryset) > limit
 
-        from usaspending_api.common.helpers.generic_helper import generate_raw_quoted_query
-        print('=======================================')
-        print(request.path)
-        print(generate_raw_quoted_query(queryset))
-
         results = []
         for award in limited_queryset[:limit]:
             if subawards:


### PR DESCRIPTION
**Description:**
Added a new IDV-only column to UniversalAwardMatview and populated `type` and `type_description` with IDV values.

**Technical details:**
Added new IDV column dictionaries for SpendingByAward endpoint, new column (`ordering_period_end_date`) to UniversalAwardMatview.

After looking at the IDC data, it was discovered that there were unexpected NULL and NaN values in columns. A generic `IDV_B` award type was necessary to capture the IDCs without type A,B, or C 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
	- [ ] Backend
	- [ ] Frontend
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-1799](https://federal-spending-transparency.atlassian.net/browse/DEV-1799):
	- [ ] Link to this Pull-Request
	- [ ] Performance evaluation of affected API & Script
	- [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
