### PR TITLE
Federal Accounts v2 migration for DOD CGAC list hierarchy

### DIFF
--- a/usaspending_api/accounts/tests/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/test_federal_account_v2.py
@@ -268,5 +268,5 @@ def test_federal_account_dod_cgac(client, fixture_data):
                                         'filters': {'fy': '2018'}}))
     response_data = resp.json()
     assert len(response_data['results']) == 2
-    assert response_data['results'][0]['account_name'].contains("CGAC_DOD")
-    assert response_data['results'][1]['account_name'].contains("CGAC_DOD")
+    assert "CGAC_DOD" in response_data['results'][0]['account_name']
+    assert "CGAC_DOD" in response_data['results'][1]['account_name']

--- a/usaspending_api/accounts/tests/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/test_federal_account_v2.py
@@ -264,7 +264,7 @@ def test_federal_account_dod_cgac(client, fixture_data):
     """ Verify DOD CGAC query returns CGAC code for all DOD departments in addition to DOD's '097' """
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
-                       data=json.dumps({'sort': {'agency_identifier': '097', 'direction': 'asc'},
+                       data=json.dumps({'agency_identifier': '097',
                                         'filters': {'fy': '2018'}}))
     response_data = resp.json()
     assert len(response_data['results']) == 2

--- a/usaspending_api/accounts/tests/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/test_federal_account_v2.py
@@ -24,6 +24,7 @@ def fixture_data(db):
     ta2 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fa2)
     ta3 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fa3)
     ta4 = mommy.make('accounts.TreasuryAppropriationAccount', federal_account=fa4)
+
     mommy.make('accounts.AppropriationAccountBalances',
                final_of_fy=True,
                treasury_account_identifier=ta0,
@@ -63,12 +64,13 @@ def fixture_data(db):
                final_of_fy=True,
                treasury_account_identifier=ta3,
                total_budgetary_resources_amount_cpe=2000,
-               submission__reporting_period_start='2017-03-01')
+               submission__reporting_period_start='2018-03-01')
     mommy.make('accounts.AppropriationAccountBalances',
                final_of_fy=True,
                treasury_account_identifier=ta4,
                total_budgetary_resources_amount_cpe=2000,
-               submission__reporting_period_start='2017-03-02')
+               submission__reporting_period_start='2018-03-02')
+
 
 @pytest.mark.django_db
 def test_federal_accounts_endpoint_exists(client, fixture_data):
@@ -256,14 +258,15 @@ def test_federal_account_invalid_param(client, fixture_data):
 
     assert resp.status_code == 400
 
+
 @pytest.mark.django_db
 def test_federal_account_dod_cgac(client, fixture_data):
     """ Verify DOD CGAC query returns CGAC code for all DOD departments in addition to DOD's '097' """
     resp = client.post('/api/v2/federal_accounts/',
                        content_type='application/json',
                        data=json.dumps({'sort': {'agency_identifier': '097', 'direction': 'asc'},
-                                        'filters': {'fy': '2017'}}))
+                                        'filters': {'fy': '2018'}}))
     response_data = resp.json()
-    assert len(response_data['results']) == 1
+    assert len(response_data['results']) == 2
     assert response_data['results'][0]['account_name'].contains("CGAC_DOD")
     assert response_data['results'][1]['account_name'].contains("CGAC_DOD")

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -1,7 +1,5 @@
 import ast
 from collections import OrderedDict
-from functools import reduce
-import operator
 from django.db.models import F, Func, OuterRef, Q, Subquery, Sum
 from django.utils.dateparse import parse_date
 from fiscalyear import FiscalDateTime


### PR DESCRIPTION
**Description:**
In Custom Account Data, under Agency dropdown item Department of Defense (CGAC code `097`) does not contain all of DOD Armed Forces CGAC codes (`097`, `021`, `057`, `017`, `096`), as the DOD Armed Forces CGAC code logic exists only in v2. This change migrates and integrates the current functionality of v1 into v2. Allowing for `federal_accounts` to be queried from Custom Account Data page

The front-end will also need changes in processing the updated v2 POST request response structure. 

**Technical details:**
The Custom Account Data page, using Department of Defense agency dropdown, sends a POST request to `/v1/federal_accounts` to retrieve the list of all federal accounts under DOD Armed Forces.

The DOD Armed Forces hierarchy under the Department of Defense is implemented in v2. This changes the backend to accept the parameter sent, `agency_identifier`, to accept and process the logic to retrieve the DOD Armed Forces CGAC codes (`097`, `021`, `057`, `017`, `096`) when the DOD CGAC (`097`) code is selected.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] Necessary PR reviewers:
	- [x] Backend
3. [ ] Frontend impact assessment completed
4. [ ] Data validation completed
5. [ ] Jira Ticket [DEV-1722](https://federal-spending-transparency.atlassian.net/browse/DEV-1722):

