### PR TITLE
[DEV-1948] Memory efficient fabs loader

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -1,56 +1,75 @@
-import logging
 import boto3
+import logging
+import time
+
 from datetime import datetime, timedelta
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import connections, transaction
 from django.db.models import Count
-from django.conf import settings
 
-from usaspending_api.common.helpers.etl_helpers import update_c_to_d_linkages
-from usaspending_api.common.helpers.generic_helper import fy, timer, upper_case_dict_values
-from usaspending_api.etl.broker_etl_helpers import dictfetchall
 from usaspending_api.awards.models import TransactionFABS, TransactionNormalized, Award
-from usaspending_api.broker.models import ExternalDataLoadDate
 from usaspending_api.broker import lookups
 from usaspending_api.broker.helpers import get_business_categories
+from usaspending_api.broker.models import ExternalDataLoadDate
+from usaspending_api.common.helpers.etl_helpers import update_c_to_d_linkages
+from usaspending_api.common.helpers.generic_helper import fy, timer, upper_case_dict_values
+from usaspending_api.etl.award_helpers import update_awards, update_award_categories
+from usaspending_api.etl.broker_etl_helpers import dictfetchall
 from usaspending_api.etl.management.load_base import load_data_into_model, format_date, create_location
 from usaspending_api.references.models import LegalEntity, Agency
-from usaspending_api.etl.award_helpers import update_awards, update_award_categories
 
 
-logger = logging.getLogger('console')
-exception_logger = logging.getLogger("exceptions")
+logger = logging.getLogger("console")
 
-award_update_id_list = []
+AWARD_UPDATE_ID_LIST = []
+BATCH_FETCH_SIZE = 25000
 
 
 class Command(BaseCommand):
-    help = "Update FABS data nightly"
+    help = "Update FABS data in USAspending from a Broker DB"
+
+    @staticmethod
+    def get_fabs_records_to_delete(date):
+        db_cursor = connections["data_broker"].cursor()
+        db_query = " ".join([
+            "SELECT UPPER(afa_generated_unique) as afa_generated_unique",
+            "FROM published_award_financial_assistance",
+            "WHERE created_at >= %s",
+            "AND UPPER(correction_delete_indicatr) = 'D'",
+        ])
+
+        db_cursor.execute(db_query, [date])
+        db_rows = [id[0] for id in db_cursor.fetchall()]
+
+        logger.info("Number of records to delete: %s" % str(len(db_rows)))
+        return db_rows
 
     @staticmethod
     def get_fabs_transaction_ids(date):
         db_cursor = connections["data_broker"].cursor()
-        # The ORDER BY is important here because deletions must happen in a specific order and that order is defined
-        # by the Broker's PK since every modification is a new row
-        db_query = 'SELECT published_award_financial_assistance_id ' \
-                   'FROM published_award_financial_assistance ' \
-                   'WHERE created_at >= %s ' \
-                   'AND (is_active IS True OR UPPER(correction_delete_indicatr) = \'D\')'
-        db_args = [date]
+        db_query = " ".join([
+            "SELECT published_award_financial_assistance_id",
+            "FROM published_award_financial_assistance",
+            "WHERE created_at >= %s",
+            "AND is_active IS True",  # add UPPER(correction_delete_indicatr) IS DISTINCT FROM 'D' ?
+        ])
 
-        db_cursor.execute(db_query, db_args)
+        db_cursor.execute(db_query, [date])
         db_rows = [id[0] for id in db_cursor.fetchall()]
 
         logger.info("Number of records to insert/update: %s" % str(len(db_rows)))
         return db_rows
 
     @staticmethod
-    def fetch_fpds_data_generator(dap_uid_list):
+    def fetch_fabs_data_generator(dap_uid_list):
         start_time = datetime.now()
 
         db_cursor = connections["data_broker"].cursor()
 
-        db_query = "SELECT * FROM detached_award_procurement WHERE detached_award_procurement_id IN ({});"
+        db_query = " ".join([
+            "SELECT * FROM published_award_financial_assistance"
+            "WHERE published_award_financial_assistance_id IN ({});"])
 
         total_uid_count = len(dap_uid_list)
 
@@ -63,36 +82,6 @@ class Command(BaseCommand):
 
             db_cursor.execute(db_query.format(",".join(str(id) for id in fpds_ids_batch)))
             yield dictfetchall(db_cursor)  # this returns an OrderedDict
-
-    # @staticmethod
-    # def get_fabs_data(date):
-    #     db_cursor = connections['data_broker'].cursor()
-
-    #     # The ORDER BY is important here because deletions must happen in a specific order and that order is defined
-    #     # by the Broker's PK since every modification is a new row
-    #     db_query = 'SELECT * ' \
-    #                'FROM published_award_financial_assistance ' \
-    #                'WHERE created_at >= %s ' \
-    #                'AND (is_active IS True OR UPPER(correction_delete_indicatr) = \'D\')'
-    #     db_args = [date]
-
-    #     db_cursor.execute(db_query, db_args)
-    #     db_rows = dictfetchall(db_cursor)  # this returns an OrderedDict
-
-    #     ids_to_delete = []
-    #     final_db_rows = []
-
-    #     # Iterate through the result dict and determine what needs to be deleted and what needs to be added
-    #     for row in db_rows:
-    #         if row['correction_delete_indicatr'] and row['correction_delete_indicatr'].upper() == 'D':
-    #             ids_to_delete.append(row['afa_generated_unique'].upper())
-    #         else:
-    #             final_db_rows.append(row)
-
-    #     logger.info('Number of records to insert/update: %s' % str(len(final_db_rows)))
-    #     logger.info('Number of records to delete: %s' % str(len(ids_to_delete)))
-
-    #     return final_db_rows, ids_to_delete
 
     def find_related_awards(self, transactions):
         related_award_ids = [result[0] for result in transactions.values_list('award_id')]
@@ -139,8 +128,8 @@ class Command(BaseCommand):
             queries.extend([fabs, tn])
         # Update Awards
         if update_award_ids:
-            # Adding to award_update_id_list so the latest_transaction will be recalculated
-            award_update_id_list.extend(update_award_ids)
+            # Adding to AWARD_UPDATE_ID_LIST so the latest_transaction will be recalculated
+            AWARD_UPDATE_ID_LIST.extend(update_award_ids)
             update_awards_query = 'UPDATE "awards" ' \
                                   'SET "latest_transaction_id" = null ' \
                                   'WHERE "id" IN ({});'.format(update_award_str_ids)
@@ -163,8 +152,14 @@ class Command(BaseCommand):
             db_query = ''.join(queries)
             db_cursor.execute(db_query, [])
 
+    def insert_all_new_fabs(self, all_new_to_insert):
+        for to_insert in self.fetch_fabs_data_generator(all_new_to_insert):
+            start = time.perf_counter()
+            self.insert_new_fabs(to_insert=to_insert)
+            logger.info("Insertion took {:.2f}s".format(time.perf_counter() - start))
+
     @transaction.atomic
-    def insert_new_fabs(self, to_insert, total_rows):
+    def insert_new_fabs(self, to_insert):
         logger.info('Starting insertion of new FABS data')
 
         place_of_performance_field_map = {
@@ -204,13 +199,7 @@ class Command(BaseCommand):
             "foreign_city_name": "legal_entity_foreign_city"
         }
 
-        start_time = datetime.now()
-
-        for index, row in enumerate(to_insert, 1):
-            if not (index % 1000):
-                logger.info('Inserting Stale FABS: Inserting row {} of {} ({})'.format(str(index), str(total_rows),
-                                                                                       datetime.now() - start_time))
-
+        for row in to_insert:
             upper_case_dict_values(row)
 
             # Create new LegalEntityLocation and LegalEntity from the row data
@@ -263,7 +252,7 @@ class Command(BaseCommand):
             award.save()
 
             # Append row to list of Awards updated
-            award_update_id_list.append(award.id)
+            AWARD_UPDATE_ID_LIST.append(award.id)
 
             try:
                 last_mod_date = datetime.strptime(str(row['modified_at']), "%Y-%m-%d %H:%M:%S.%f").date()
@@ -381,37 +370,33 @@ class Command(BaseCommand):
 
         # Retrieve FABS data
         with timer('retrieving/diff-ing FABS Data', logger.info):
-            # to_insert, ids_to_delete = self.get_fabs_data(date=date)
             to_insert = self.get_fabs_transaction_ids(date=date)
 
         with timer("obtaining delete records", logger.info):
-            ids_to_delete = []
+            ids_to_delete = self.get_fabs_records_to_delete(date=date)
 
-        total_rows = len(to_insert)
-        total_rows_delete = len(ids_to_delete)
-
-        if total_rows_delete > 0:
+        if ids_to_delete:
             # Create a file with the deletion IDs and place in a bucket for ElasticSearch
             self.send_deletes_to_s3(ids_to_delete)
 
             # Delete FABS records by ID
-            with timer('deleting stale FABS data', logger.info):
+            with timer("deleting stale FABS data", logger.info):
                 self.delete_stale_fabs(ids_to_delete=ids_to_delete)
         else:
-            logger.info('Nothing to delete...')
+            logger.info("Nothing to delete...")
 
-        if total_rows > 0:
+        if to_insert:
             # Add FABS records
             with timer('inserting new FABS data', logger.info):
-                self.insert_new_fabs(to_insert=to_insert, total_rows=total_rows)
+                self.insert_all_new_fabs(to_insert=to_insert)
 
             # Update Awards based on changed FABS records
             with timer('updating awards to reflect their latest associated transaction info', logger.info):
-                update_awards(tuple(award_update_id_list))
+                update_awards(tuple(AWARD_UPDATE_ID_LIST))
 
             # Update AwardCategories based on changed FABS records
             with timer('updating award category variables', logger.info):
-                update_award_categories(tuple(award_update_id_list))
+                update_award_categories(tuple(AWARD_UPDATE_ID_LIST))
 
             # Check the linkages from file C to FABS records and update any that are missing
             with timer('updating C->D linkages', logger.info):

--- a/usaspending_api/etl/award_helpers.py
+++ b/usaspending_api/etl/award_helpers.py
@@ -95,9 +95,7 @@ def update_awards(award_tuple=None):
         'ON l.award_id = t.award_id '
         'WHERE t.award_id = a.id'
     )
-    if award_tuple:
-        logger.info("Award IDs: {}".format(award_tuple))
-    logger.info("SQL: {}".format(sql_update))
+
     with connection.cursor() as cursor:
         # If another expression is added and includes %s, you must add the tuple for that string interpolation to this
         # list (even if it uses the same one!)

--- a/usaspending_api/search/v2/views/search.py
+++ b/usaspending_api/search/v2/views/search.py
@@ -1,8 +1,7 @@
 import copy
 
 from django.conf import settings
-from django.db.models import Sum, Count, F, Value
-from django.db.models.functions import Coalesce
+from django.db.models import Sum, Count, F
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -12,9 +11,10 @@ from usaspending_api.awards.v2.filters.sub_award import subaward_filter
 from usaspending_api.awards.v2.filters.view_selector import spending_by_award_count
 from usaspending_api.awards.v2.lookups.lookups import (contract_type_mapping, loan_type_mapping,
                                                        non_loan_assistance_type_mapping, grant_type_mapping,
-                                                       contract_subaward_mapping, grant_subaward_mapping)
+                                                       contract_subaward_mapping, grant_subaward_mapping,
+                                                       idv_type_mapping)
 from usaspending_api.awards.v2.lookups.matview_lookups import (award_contracts_mapping, loan_award_mapping,
-                                                               non_loan_assistance_award_mapping)
+                                                               non_loan_assistance_award_mapping, award_idv_mapping)
 from usaspending_api.common.api_versioning import api_transformations, API_TRANSFORM_FUNCTIONS
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.exceptions import InvalidParameterException, UnprocessableEntityException
@@ -64,8 +64,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
             raise InvalidParameterException("Sort value '{}' not found in requested fields: {}".format(sort, fields))
 
         subawards_values = list(contract_subaward_mapping.keys()) + list(grant_subaward_mapping.keys())
-        awards_values = list(award_contracts_mapping.keys()) + list(loan_award_mapping) + \
-            list(non_loan_assistance_award_mapping.keys())
+        awards_values = list(award_contracts_mapping.keys()) + list(loan_award_mapping.keys()) + \
+            list(non_loan_assistance_award_mapping.keys()) + list(award_idv_mapping.keys())
 
         msg = "Sort value '{}' not found in {{}} mappings: {{}}".format(sort)
         if not subawards and sort not in awards_values:
@@ -94,6 +94,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
                     values.add(loan_award_mapping.get(field))
                 if non_loan_assistance_award_mapping.get(field):
                     values.add(non_loan_assistance_award_mapping.get(field))
+                if award_idv_mapping.get(field):
+                    values.add(award_idv_mapping.get(field))
 
         # Modify queryset to be ordered by requested "sort" in the request or default value(s)
         if sort:
@@ -111,6 +113,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
                     sort_filters = [award_contracts_mapping[sort]]
                 elif set(filters["award_type_codes"]) <= set(loan_type_mapping):  # loans
                     sort_filters = [loan_award_mapping[sort]]
+                elif set(filters["award_type_codes"]) <= set(idv_type_mapping):  # idvs
+                    sort_filters = [award_idv_mapping[sort]]
                 else:  # assistance data
                     sort_filters = [non_loan_assistance_award_mapping[sort]]
 
@@ -163,6 +167,9 @@ class SpendingByAwardVisualizationViewSet(APIView):
                 elif award['type'] in non_loan_assistance_type_mapping:  # assistance data
                     for field in fields:
                         row[field] = award.get(non_loan_assistance_award_mapping.get(field))
+                elif award['type'] in idv_type_mapping:
+                    for field in fields:
+                        row[field] = award.get(award_idv_mapping.get(field))
                 elif (award['type'] is None and award['piid']) or award['type'] in contract_type_mapping:
                     # IDV + contract
                     for field in fields:
@@ -212,16 +219,14 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
 
         if subawards:
             queryset = queryset.values('award_type').annotate(category_count=Count('subaward_id'))
-
         elif model == 'SummaryAwardView':
             queryset = queryset.values('category').annotate(category_count=Sum('counts'))
-
         else:
-            queryset = queryset.values('category').annotate(category_count=Count(Coalesce('category', Value('idvs'))))
+            queryset = queryset.values('category').annotate(category_count=Count('category'))
 
         categories = {
             'contract': 'contracts',
-            'idvs': 'idvs',
+            'idv': 'idvs',
             'grant': 'grants',
             'direct payment': 'direct_payments',
             'loans': 'loans',
@@ -233,7 +238,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         # DB hit here
         for award in queryset:
             if award[category_name] is None:
-                result_key = 'idvs' if not subawards else 'subcontracts'
+                result_key = 'other' if not subawards else 'subcontracts'
             elif award[category_name] not in categories.keys():
                 result_key = 'other'
             else:


### PR DESCRIPTION
**Description:**
Modified FABS ETL from Broker to USAspending to not retrieve 100% of the new data at the beginning of the script. Instead only the unique IDs are retrieved and used to pulled groups of IDs

**Technical details:**
Changed the script to use a generator to pull batches of transaction data from broker instead of pulled 100% of the new/modified/ and deleted transactions. The appropriate unique id list for "upserts" and deletes are pulled in the beginning of the script.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
	- [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [ ] Jira Ticket [DEV-1948](https://federal-spending-transparency.atlassian.net/browse/DEV-1948):
	- [ ] Link to this Pull-Request
	- [ ] Performance evaluation of affected (API | Script | Download)
	- [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Only ETL script changes
```
