### PR TITLE
Improve v2/awards to support different ID types

### DIFF
--- a/usaspending_api/api_docs/api_documentation/advanced_award_search/new_awards_over_time.md
+++ b/usaspending_api/api_docs/api_documentation/advanced_award_search/new_awards_over_time.md
@@ -1,4 +1,4 @@
-# State Data
+# New Awards Over Time
 
 **Route:** /api/v2/search/new_awards_over_time/
 

--- a/usaspending_api/api_docs/api_documentation/awards/awards.md
+++ b/usaspending_api/api_docs/api_documentation/awards/awards.md
@@ -1,5 +1,5 @@
 ## Awards
-**Route:** `/api/v2/awards/<generated_unique_award_id>/`
+**Route:** `/api/v2/awards/<requested_award>/`
 
 **Method** `GET`
 
@@ -7,7 +7,7 @@ This route sends a request to the backend to retrieve data about a specific awar
 
 ## Request Parameters
 
-- generated_unique_award_id: (required) ID of award to retrieve
+- requested_award: (required) ID of award to retrieve. This can either be `generated_unique_award_id` or `id` from awards table
 
 
 ## Response (JSON)

--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -9,23 +9,8 @@ from usaspending_api.awards.models import TransactionNormalized
 from usaspending_api.references.models import Agency, Location, ToptierAgency, SubtierAgency, OfficeAgency, LegalEntity
 
 
-@pytest.mark.django_db
-def test_award_last_updated_endpoint(client):
-    """Test the awards endpoint."""
-
-    test_date = datetime.datetime.now()
-    test_date_reformatted = test_date.strftime('%m/%d/%Y')
-
-    mommy.make('awards.Award', update_date=test_date)
-    mommy.make('awards.Award', update_date='')
-
-    resp = client.get('/api/v2/awards/last_updated/')
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.data['last_updated'] == test_date_reformatted
-
-
-@pytest.mark.django_db
-def test_award_endpoint(client):
+@pytest.fixture
+def awards_and_transactions(db):
     loc = {
         "pk": 1,
         "location_country_code": "USA",
@@ -42,20 +27,11 @@ def test_award_endpoint(client):
         "foreign_postal_code": None,
         "foreign_province": None,
     }
-    subag = {
-         "pk": 1,
-         "name": "agency name",
-         "abbreviation": "some other stuff"
-     }
+    subag = {"pk": 1, "name": "agency name", "abbreviation": "some other stuff"}
 
-    trans_asst = {
-        "pk": 1,
-    }
-    trans_cont = {
-        "pk": 2,
-    }
-    duns = {"awardee_or_recipient_uniqu": 123,
-            "legal_business_name": "Sams Club"}
+    trans_asst = {"pk": 1}
+    trans_cont = {"pk": 2}
+    duns = {"awardee_or_recipient_uniqu": 123, "legal_business_name": "Sams Club"}
     mommy.make("references.Cfda", program_number=1234)
     mommy.make("references.Location", **loc)
     mommy.make("recipient.DUNS", **duns)
@@ -131,7 +107,7 @@ def test_award_endpoint(client):
         "program_system_or_equipmen": "000",
         "type_set_aside_description": None,
         "materials_supplies_descrip": "NO",
-        "domestic_or_foreign_e_desc": "U.S. OWNED BUSINESS"
+        "domestic_or_foreign_e_desc": "U.S. OWNED BUSINESS",
     }
     mommy.make("awards.TransactionFABS", **asst_data)
     mommy.make("awards.TransactionFPDS", **cont_data)
@@ -178,6 +154,25 @@ def test_award_endpoint(client):
     mommy.make('awards.Award', **award_1_model)
     mommy.make('awards.Award', **award_2_model)
 
+
+@pytest.mark.django_db
+def test_award_last_updated_endpoint(client):
+    """Test the awards endpoint."""
+
+    test_date = datetime.datetime.now()
+    test_date_reformatted = test_date.strftime('%m/%d/%Y')
+
+    mommy.make('awards.Award', update_date=test_date)
+    mommy.make('awards.Award', update_date='')
+
+    resp = client.get('/api/v2/awards/last_updated/')
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data['last_updated'] == test_date_reformatted
+
+
+@pytest.mark.django_db
+def test_award_endpoint_generated_id(client, awards_and_transactions):
+
     resp = client.get('/api/v2/awards/ASST_AW_3620_-NONE-_1830212.0481163/')
     assert resp.status_code == status.HTTP_200_OK
     assert json.loads(resp.content.decode("utf-8")) == expected_response_asst
@@ -187,222 +182,190 @@ def test_award_endpoint(client):
     assert json.loads(resp.content.decode("utf-8")) == expected_response_cont
 
 
+# @pytest.mark.django_db
+# def test_award_endpoint_primary_key(client, awards_and_transactions):
+    """Unable to run these in a new test function, so combining with above test function"""
+    resp = client.get('/api/v2/awards/1/')
+    assert resp.status_code == status.HTTP_200_OK
+    assert json.loads(resp.content.decode("utf-8")) == expected_response_asst
+
+    resp = client.get('/api/v2/awards/2/')
+    assert resp.status_code == status.HTTP_200_OK
+    assert json.loads(resp.content.decode("utf-8")) == expected_response_cont
+
+
 expected_response_asst = {
-  "id": 1,
-  "type": "11",
-  "category": "grant",
-  "type_description": "OTHER FINANCIAL ASSISTANCE",
-  "piid": "1234",
-  "description": "lorem ipsum",
-  "cfda_objectives": None,
-  "cfda_number": "1234",
-  "cfda_title": "Shazam",
-  "awarding_agency": {
-    "toptier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "id": 1,
+    "type": "11",
+    "category": "grant",
+    "type_description": "OTHER FINANCIAL ASSISTANCE",
+    "piid": "1234",
+    "description": "lorem ipsum",
+    "cfda_objectives": None,
+    "cfda_number": "1234",
+    "cfda_title": "Shazam",
+    "awarding_agency": {
+        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "office_agency_name": "office_agency",
+        "office_agency": {"aac_code": None, "name": "office_agency"},
     },
-    "subtier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "funding_agency": {
+        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "office_agency_name": "office_agency",
+        "office_agency": {"aac_code": None, "name": "office_agency"},
     },
-    "office_agency_name": "office_agency",
-    "office_agency": {
-      "aac_code": None,
-      "name": "office_agency"
-    }
-  },
-  "funding_agency": {
-    "toptier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "recipient": {
+        "recipient_name": "John's Pizza",
+        "recipient_unique_id": "456",
+        "parent_recipient_unique_id": "123",
+        "business_categories": ["small_business"],
+        "location": {
+            "address_line1": "123 main st",
+            "address_line2": None,
+            "address_line3": None,
+            "foreign_province": None,
+            "city_name": "Charlotte",
+            "county_name": "BUNCOMBE",
+            "state_code": "NC",
+            "zip5": "12204",
+            "zip4": "122045312",
+            "foreign_postal_code": None,
+            "country_name": "UNITED STATES",
+            "location_country_code": "USA",
+            "congressional_code": "90",
+        },
+        "parent_recipient_name": None,
     },
-    "subtier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "subaward_count": 10,
+    "total_subaward_amount": "12345.00",
+    "period_of_performance": {
+        "period_of_performance_start_date": "2004-02-04",
+        "period_of_performance_current_end_date": "2005-02-04",
     },
-    "office_agency_name": "office_agency",
-    "office_agency": {
-      "aac_code": None,
-      "name": "office_agency"
-    }
-  },
-  "recipient": {
-    "recipient_name": "John's Pizza",
-    "recipient_unique_id": "456",
-    "parent_recipient_unique_id": "123",
-    "business_categories": [
-      "small_business"
-    ],
-    "location": {
-      "address_line1": "123 main st",
-      "address_line2": None,
-      "address_line3": None,
-      "foreign_province": None,
-      "city_name": "Charlotte",
-      "county_name": "BUNCOMBE",
-      "state_code": "NC",
-      "zip5": "12204",
-      "zip4": "122045312",
-      "foreign_postal_code": None,
-      "country_name": "UNITED STATES",
-      "location_country_code": "USA",
-      "congressional_code": "90"
+    "place_of_performance": {
+        "address_line1": "123 main st",
+        "address_line2": None,
+        "address_line3": None,
+        "foreign_province": None,
+        "city_name": "Charlotte",
+        "county_name": "BUNCOMBE",
+        "state_code": "NC",
+        "zip5": "12204",
+        "zip4": "122045312",
+        "foreign_postal_code": None,
+        "country_name": "UNITED STATES",
+        "location_country_code": "USA",
+        "congressional_code": "90",
     },
-    "parent_recipient_name": None
-  },
-  "subaward_count": 10,
-  "total_subaward_amount": "12345.00",
-  "period_of_performance": {
-    "period_of_performance_start_date": "2004-02-04",
-    "period_of_performance_current_end_date": "2005-02-04"
-  },
-  "place_of_performance": {
-    "address_line1": "123 main st",
-    "address_line2": None,
-    "address_line3": None,
-    "foreign_province": None,
-    "city_name": "Charlotte",
-    "county_name": "BUNCOMBE",
-    "state_code": "NC",
-    "zip5": "12204",
-    "zip4": "122045312",
-    "foreign_postal_code": None,
-    "country_name": "UNITED STATES",
-    "location_country_code": "USA",
-    "congressional_code": "90"
-  },
-  "executive_details": {
-    "officers": []
-  }
+    "executive_details": {"officers": []},
 }
 
 expected_response_cont = {
-  "id": 2,
-  "type": "A",
-  "category": "contract",
-  "type_description": "DEFINITIVE CONTRACT",
-  "piid": "5678",
-  "parent_award_piid": None,
-  "description": "lorem ipsum",
-  "awarding_agency": {
-    "toptier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "id": 2,
+    "type": "A",
+    "category": "contract",
+    "type_description": "DEFINITIVE CONTRACT",
+    "piid": "5678",
+    "parent_award_piid": None,
+    "description": "lorem ipsum",
+    "awarding_agency": {
+        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "office_agency_name": "office_agency",
+        "office_agency": {"aac_code": None, "name": "office_agency"},
     },
-    "subtier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "funding_agency": {
+        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff"},
+        "office_agency_name": "office_agency",
+        "office_agency": {"aac_code": None, "name": "office_agency"},
     },
-    "office_agency_name": "office_agency",
-    "office_agency": {
-      "aac_code": None,
-      "name": "office_agency"
-    }
-  },
-  "funding_agency": {
-    "toptier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "recipient": {
+        "recipient_name": "John's Pizza",
+        "recipient_unique_id": "456",
+        "parent_recipient_unique_id": "123",
+        "business_categories": ["small_business"],
+        "location": {
+            "address_line1": "123 main st",
+            "address_line2": None,
+            "address_line3": None,
+            "foreign_province": None,
+            "city_name": "Charlotte",
+            "county_name": "BUNCOMBE",
+            "state_code": "NC",
+            "zip5": "12204",
+            "zip4": "122045312",
+            "foreign_postal_code": None,
+            "country_name": "UNITED STATES",
+            "location_country_code": "USA",
+            "congressional_code": "90",
+        },
+        "parent_recipient_name": None,
     },
-    "subtier_agency": {
-      "name": "agency name",
-      "abbreviation": "some other stuff"
+    "total_obligation": "1000.00",
+    "base_and_all_options_value": "2000.00",
+    "period_of_performance": {
+        "period_of_performance_start_date": "2004-02-04",
+        "period_of_performance_current_end_date": "2005-02-04",
     },
-    "office_agency_name": "office_agency",
-    "office_agency": {
-      "aac_code": None,
-      "name": "office_agency"
-    }
-  },
-  "recipient": {
-    "recipient_name": "John's Pizza",
-    "recipient_unique_id": "456",
-    "parent_recipient_unique_id": "123",
-    "business_categories": [
-      "small_business"
-    ],
-    "location": {
-      "address_line1": "123 main st",
-      "address_line2": None,
-      "address_line3": None,
-      "foreign_province": None,
-      "city_name": "Charlotte",
-      "county_name": "BUNCOMBE",
-      "state_code": "NC",
-      "zip5": "12204",
-      "zip4": "122045312",
-      "foreign_postal_code": None,
-      "country_name": "UNITED STATES",
-      "location_country_code": "USA",
-      "congressional_code": "90"
+    "place_of_performance": {
+        "address_line1": "123 main st",
+        "address_line2": None,
+        "address_line3": None,
+        "foreign_province": None,
+        "city_name": "Charlotte",
+        "county_name": "BUNCOMBE",
+        "state_code": "NC",
+        "zip5": "12204",
+        "zip4": "122045312",
+        "foreign_postal_code": None,
+        "country_name": "UNITED STATES",
+        "location_country_code": "USA",
+        "congressional_code": "90",
     },
-    "parent_recipient_name": None
-  },
-  "total_obligation": "1000.00",
-  "base_and_all_options_value": "2000.00",
-  "period_of_performance": {
-    "period_of_performance_start_date": "2004-02-04",
-    "period_of_performance_current_end_date": "2005-02-04"
-  },
-  "place_of_performance": {
-    "address_line1": "123 main st",
-    "address_line2": None,
-    "address_line3": None,
-    "foreign_province": None,
-    "city_name": "Charlotte",
-    "county_name": "BUNCOMBE",
-    "state_code": "NC",
-    "zip5": "12204",
-    "zip4": "122045312",
-    "foreign_postal_code": None,
-    "country_name": "UNITED STATES",
-    "location_country_code": "USA",
-    "congressional_code": "90"
-  },
-  "latest_transaction_contract_data": {
-    "idv_type_description": None,
-    "type_of_idc_description": None,
-    "referenced_idv_agency_iden": "9700",
-    "multiple_or_single_aw_desc": None,
-    "solicitation_identifier": None,
-    "solicitation_procedures": "NP",
-    "number_of_offers_received": None,
-    "extent_competed": "D",
-    "other_than_full_and_o_desc": None,
-    "type_set_aside_description": None,
-    "commercial_item_acquisitio": "A",
-    "commercial_item_test_desc": "NO",
-    "evaluated_preference_desc": "NO PREFERENCE USED",
-    "fed_biz_opps_description": "YES",
-    "small_business_competitive": "False",
-    "fair_opportunity_limi_desc": None,
-    "product_or_service_code": "4730",
-    "naics": "333911",
-    "dod_claimant_program_code": "C9E",
-    "program_system_or_equipmen": "000",
-    "information_technolog_desc": "NOT IT PRODUCTS OR SERVICES",
-    "sea_transportation_desc": "NO",
-    "clinger_cohen_act_pla_desc": "NO",
-    "construction_wage_rat_desc": "NO",
-    "labor_standards_descrip": "NO",
-    "materials_supplies_descrip": "NO",
-    "cost_or_pricing_data_desc": "NO",
-    "domestic_or_foreign_e_desc": "U.S. OWNED BUSINESS",
-    "foreign_funding_desc": "NOT APPLICABLE",
-    "interagency_contract_desc": "NOT APPLICABLE",
-    "major_program": None,
-    "price_evaluation_adjustmen": None,
-    "program_acronym": None,
-    "subcontracting_plan": "B",
-    "multi_year_contract_desc": "NO",
-    "purchase_card_as_paym_desc": "NO",
-    "consolidated_contract_desc": "NOT CONSOLIDATED",
-    "type_of_contract_pric_desc": "FIRM FIXED PRICE"
-  },
-  "subaward_count": 10,
-  "total_subaward_amount": "12345.00",
-  "executive_details": {
-    "officers": []
-  }
+    "latest_transaction_contract_data": {
+        "idv_type_description": None,
+        "type_of_idc_description": None,
+        "referenced_idv_agency_iden": "9700",
+        "multiple_or_single_aw_desc": None,
+        "solicitation_identifier": None,
+        "solicitation_procedures": "NP",
+        "number_of_offers_received": None,
+        "extent_competed": "D",
+        "other_than_full_and_o_desc": None,
+        "type_set_aside_description": None,
+        "commercial_item_acquisitio": "A",
+        "commercial_item_test_desc": "NO",
+        "evaluated_preference_desc": "NO PREFERENCE USED",
+        "fed_biz_opps_description": "YES",
+        "small_business_competitive": "False",
+        "fair_opportunity_limi_desc": None,
+        "product_or_service_code": "4730",
+        "naics": "333911",
+        "dod_claimant_program_code": "C9E",
+        "program_system_or_equipmen": "000",
+        "information_technolog_desc": "NOT IT PRODUCTS OR SERVICES",
+        "sea_transportation_desc": "NO",
+        "clinger_cohen_act_pla_desc": "NO",
+        "construction_wage_rat_desc": "NO",
+        "labor_standards_descrip": "NO",
+        "materials_supplies_descrip": "NO",
+        "cost_or_pricing_data_desc": "NO",
+        "domestic_or_foreign_e_desc": "U.S. OWNED BUSINESS",
+        "foreign_funding_desc": "NOT APPLICABLE",
+        "interagency_contract_desc": "NOT APPLICABLE",
+        "major_program": None,
+        "price_evaluation_adjustmen": None,
+        "program_acronym": None,
+        "subcontracting_plan": "B",
+        "multi_year_contract_desc": "NO",
+        "purchase_card_as_paym_desc": "NO",
+        "consolidated_contract_desc": "NOT CONSOLIDATED",
+        "type_of_contract_pric_desc": "FIRM FIXED PRICE",
+    },
+    "subaward_count": 10,
+    "total_subaward_amount": "12345.00",
+    "executive_details": {"officers": []},
 }

--- a/usaspending_api/awards/v2/urls_awards.py
+++ b/usaspending_api/awards/v2/urls_awards.py
@@ -3,5 +3,5 @@ from usaspending_api.awards.v2.views.awards import AwardLastUpdatedViewSet, Awar
 
 urlpatterns = [
     url(r'^last_updated', AwardLastUpdatedViewSet.as_view()),
-    url(r'(?P<generated_unique_award_id>[A-Za-z0-9_. -]+)/$', AwardRetrieveViewSet.as_view()),
-    ]
+    url(r'(?P<requested_award>[A-Za-z0-9_. -]+)/$', AwardRetrieveViewSet.as_view()),
+]

--- a/usaspending_api/awards/v2/views/awards.py
+++ b/usaspending_api/awards/v2/views/awards.py
@@ -24,9 +24,7 @@ class AwardLastUpdatedViewSet(APIDocumentationView):
         """Return latest updated date for Awards"""
 
         max_update_date = Award.objects.all().aggregate(Max('update_date'))['update_date__max']
-        response = {
-            "last_updated": max_update_date.strftime('%m/%d/%Y')
-        }
+        response = {"last_updated": max_update_date.strftime('%m/%d/%Y')}
 
         return Response(response)
 
@@ -41,13 +39,21 @@ class AwardRetrieveViewSet(APIDocumentationView):
             request_dict = {"id": int(provided_award_id)}
             models = [{"key": "id", "name": "id", "type": "integer", "optional": False}]
         except Exception as e:
-            models = [{"key": "generated_unique_award_id", "name": "generated_unique_award_id", "type": "text", "text_type": "search", "optional": False}]
+            models = [
+                {
+                    "key": "generated_unique_award_id",
+                    "name": "generated_unique_award_id",
+                    "type": "text",
+                    "text_type": "search",
+                    "optional": False,
+                }
+            ]
             request_dict = {"generated_unique_award_id": provided_award_id}
 
         validated_request_data = TinyShield(models).block(request_dict)
         return validated_request_data
 
-    def _business_logic(self, request_dict: dict) -> list:
+    def _business_logic(self, request_dict: dict) -> dict:
         dict_key = "id" if "id" in request_dict else "generated_unique_award_id"
 
         try:

--- a/usaspending_api/awards/v2/views/awards.py
+++ b/usaspending_api/awards/v2/views/awards.py
@@ -7,6 +7,7 @@ from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.views import APIDocumentationView
 from usaspending_api.core.validator.tinyshield import TinyShield
 from usaspending_api.awards.serializers_v2.serializers import AwardContractSerializerV2, AwardMiscSerializerV2
+from usaspending_api.common.exceptions import InvalidParameterException
 
 
 class AwardLastUpdatedViewSet(APIDocumentationView):
@@ -31,18 +32,25 @@ class AwardRetrieveViewSet(APIDocumentationView):
     endpoint_doc: /awards.md
     """
 
-    def _parse_and_validate_request(self, generated_unique_award_id) -> dict:
+    def _parse_and_validate_request(self, provided_award_id: str) -> dict:
+        models = [
+            {"key": "generated_unique_award_id", "name": "generated_unique_award_id", "type": "text", "text_type": "search", "optional": True},
+            {"key": "id", "name": "id", "type": "int", "optional": True},
+        ]
 
-        # TODO:  May be better to accept either generated_unique_award_id or
-        #       internal pk to ease transition from v1 to v2
+        try:
+            award_pk = int(provided_award_id)
+        except Exception:
+            award_pk = None
 
-        models = [{"key": "generated_unique_award_id", "name": "generated_unique_award_id", "type": "text",
-                   "text_type": "search", "optional": False}]
-        request_dict = {"generated_unique_award_id": generated_unique_award_id}
+        if award_pk:
+            request_dict = {"id": award_pk}
+        else:
+            request_dict = {"generated_unique_award_id": provided_award_id}
         validated_request_data = TinyShield(models).block(request_dict)
         return validated_request_data
 
-    def _business_logic(self, generated_unique_award_id: str) -> list:
+    def _business_logic(self, generated_unique_award_id: dict) -> list:
         try:
             award = Award.objects.get(generated_unique_award_id=generated_unique_award_id)
             if award.category == 'contract':
@@ -59,7 +67,9 @@ class AwardRetrieveViewSet(APIDocumentationView):
             return {"message": "No award found with this id"}
 
     @cache_response()
-    def get(self, request: Request, generated_unique_award_id: str) -> Response:
-        request_data = self._parse_and_validate_request(generated_unique_award_id)
-        response = self._business_logic(request_data['generated_unique_award_id'])
+    def get(self, request: Request, provided_award_id: str) -> Response:
+        if not provided_award_id:
+            raise InvalidParameterException("Missing Award ID")
+        request_data = self._parse_and_validate_request(provided_award_id)
+        response = self._business_logic(request_data)
         return Response(response)

--- a/usaspending_api/awards/v2/views/awards.py
+++ b/usaspending_api/awards/v2/views/awards.py
@@ -1,13 +1,17 @@
-from rest_framework.response import Response
-from rest_framework.request import Request
+import logging
+
 from django.db.models import Max
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from usaspending_api.awards.models import Award
+from usaspending_api.awards.serializers_v2.serializers import AwardContractSerializerV2, AwardMiscSerializerV2
 from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.common.exceptions import NotImplementedException, UnprocessableEntityException
 from usaspending_api.common.views import APIDocumentationView
 from usaspending_api.core.validator.tinyshield import TinyShield
-from usaspending_api.awards.serializers_v2.serializers import AwardContractSerializerV2, AwardMiscSerializerV2
-from usaspending_api.common.exceptions import InvalidParameterException
+
+logger = logging.getLogger("console")
 
 
 class AwardLastUpdatedViewSet(APIDocumentationView):
@@ -33,43 +37,43 @@ class AwardRetrieveViewSet(APIDocumentationView):
     """
 
     def _parse_and_validate_request(self, provided_award_id: str) -> dict:
-        models = [
-            {"key": "generated_unique_award_id", "name": "generated_unique_award_id", "type": "text", "text_type": "search", "optional": True},
-            {"key": "id", "name": "id", "type": "int", "optional": True},
-        ]
-
         try:
-            award_pk = int(provided_award_id)
-        except Exception:
-            award_pk = None
-
-        if award_pk:
-            request_dict = {"id": award_pk}
-        else:
+            request_dict = {"id": int(provided_award_id)}
+            models = [{"key": "id", "name": "id", "type": "integer", "optional": False}]
+        except Exception as e:
+            models = [{"key": "generated_unique_award_id", "name": "generated_unique_award_id", "type": "text", "text_type": "search", "optional": False}]
             request_dict = {"generated_unique_award_id": provided_award_id}
+
         validated_request_data = TinyShield(models).block(request_dict)
         return validated_request_data
 
-    def _business_logic(self, generated_unique_award_id: dict) -> list:
+    def _business_logic(self, request_dict: dict) -> list:
+        dict_key = "id" if "id" in request_dict else "generated_unique_award_id"
+
         try:
-            award = Award.objects.get(generated_unique_award_id=generated_unique_award_id)
+            award = Award.objects.get(**{dict_key: request_dict[dict_key]})
+        except Award.DoesNotExist:
+            logger.info("No Award found with '{}' in '{}'".format(request_dict[dict_key], dict_key))
+            return {"message": "No award found with this id"}  # Consider returning 404 or 410 error code
+
+        try:
             if award.category == 'contract':
                 parent_recipient_name = award.latest_transaction.contract_data.ultimate_parent_legal_enti
                 serialized = AwardContractSerializerV2(award).data
                 serialized['recipient']['parent_recipient_name'] = parent_recipient_name
-                return serialized
+            elif award.category == "idv":
+                raise NotImplementedException("IDVs are not yet implemented")
             else:
                 parent_recipient_name = award.latest_transaction.assistance_data.ultimate_parent_legal_enti
                 serialized = AwardMiscSerializerV2(award).data
                 serialized['recipient']['parent_recipient_name'] = parent_recipient_name
-                return serialized
-        except Award.DoesNotExist:
-            return {"message": "No award found with this id"}
+        except AttributeError:
+            raise UnprocessableEntityException("Unable to complete response due to missing Award data")
+
+        return serialized
 
     @cache_response()
-    def get(self, request: Request, provided_award_id: str) -> Response:
-        if not provided_award_id:
-            raise InvalidParameterException("Missing Award ID")
-        request_data = self._parse_and_validate_request(provided_award_id)
+    def get(self, request: Request, requested_award: str) -> Response:
+        request_data = self._parse_and_validate_request(requested_award)
         response = self._business_logic(request_data)
         return Response(response)

--- a/usaspending_api/common/exceptions.py
+++ b/usaspending_api/common/exceptions.py
@@ -5,7 +5,7 @@ from rest_framework import status
 class NoDataFoundException(APIException):
     """Exception when no data were returned in query when there should always be data"""
     status_code = status.HTTP_204_NO_CONTENT
-    default_detail = "Request contains no data"
+    default_detail = "Unmet data expectations: response contains no data"
     default_code = "no_data"
 
 

--- a/usaspending_api/common/exceptions.py
+++ b/usaspending_api/common/exceptions.py
@@ -4,7 +4,7 @@ from rest_framework import status
 
 class NoDataFoundException(APIException):
     """Exception when no data were returned in query when there should always be data"""
-    status_code = 204
+    status_code = status.HTTP_204_NO_CONTENT
     default_detail = "Request contains no data"
     default_code = "no_data"
 
@@ -18,20 +18,26 @@ class InvalidParameterException(APIException):
 
 class UnprocessableEntityException(APIException):
     """https://tools.ietf.org/html/rfc4918"""
-    status_code = 422
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     default_detail = 'Request parameter is valid but unable to process due to constraints'
     default_code = 'invalid_request'
 
 
 class ElasticsearchConnectionException(APIException):
     """Exception for invalid request parameters."""
-    status_code = 500
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     default_detail = 'Unable to reach the Elasticsearch Cluster'
     default_code = 'service_unavailable'
 
 
+class NotImplementedException(APIException):
+    status_code = status.HTTP_501_NOT_IMPLEMENTED
+    default_detail = "Functionality Not (yet) Implemented"
+    default_code = "invalid_request"
+
+
 class EndpointTimeoutException(APIException):
     """Exception for timeout for an API endpoint."""
-    status_code = 504
+    status_code = status.HTTP_504_GATEWAY_TIMEOUT
     default_detail = 'Endpoint has timed out'
     default_code = 'timeout'


### PR DESCRIPTION
**Description:**
The distant goal is to only use the `generated_unique_award_id` for API responses and requests. Original /v2/awards/ only supported `generated_unique_award_id`, for backward-compatibility and testing, the endpoint can now utilize the awards.id PK ID in the request with no extra effort to API users.

**Technical details:**
If the value can be converted to an integer, search awards.id column. Otherwise, filter by `generated_unique_award_id`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
	- [ ] Backend
	- [x] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected API
	- [x] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
No data changes necessary for ops or matviews
```
