### PR TITLE
fix broken link to docs in spending_by_geography

### DIFF
--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -28,7 +28,7 @@ API_VERSION = settings.API_VERSION
 class SpendingByGeographyVisualizationViewSet(APIView):
     """
         This route takes award filters, and returns spending by state code, county code, or congressional district code.
-        endpoint_doc: /advanced award search/spending_by_geography.md
+        endpoint_doc: /advanced_award_search/spending_by_geography.md
     """
     geo_layer = None  # State, county or District
     geo_layer_filters = None  # Specific geo_layers to filter on


### PR DESCRIPTION
**Description:**
Simple fix to broken link in rendered page https://api.usaspending.gov/api/v2/search/spending_by_geography/ .  Doc link shows as "https://github.com/fedspendingtransparency/usaspending-api/blob/stg/usaspending_api/api_docs/api_documentation/advanced" but should show as 

"https://github.com/fedspendingtransparency/usaspending-api/blob/stg/usaspending_api/api_docs/api_documentation/advanced_award_search/spending_by_geography.md"

Root cause is missing underscores in spending_by_geography.py doc string

**Technical details:**
See above

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
	- [x] Backend
	- [ ] Frontend <OPTIONAL>
	- [ ] Operations <OPTIONAL>
	- [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
	- [ ] Link to this Pull-Request
	- [ ] Performance evaluation of affected (API | Script | Download)
	- [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
