### PR TITLE
DEV-1988, DEV-2000: Populate/Update Additional IDV Award Fields

### DIFF
--- a/usaspending_api/broker/management/sql/update_idv_additions_awards.sql
+++ b/usaspending_api/broker/management/sql/update_idv_additions_awards.sql
@@ -1,0 +1,18 @@
+-- Update all awards with their base_exercised_options_val, fpds_agency_id, and fpds_parent_agency_id
+WITH txn_totals AS (
+    SELECT
+        tx.award_id,
+        f.agency_id,
+        f.referenced_idv_agency_iden,
+        SUM(CAST(f.base_exercised_options_val AS double precision)) AS base_exercised_options_val
+    FROM transaction_fpds AS f
+    INNER JOIN transaction_normalized AS tx ON f.transaction_id = tx.id
+    GROUP BY tx.award_id, f.agency_id, f.referenced_idv_agency_iden
+)
+UPDATE awards a
+SET
+    base_exercised_options_val = t.base_exercised_options_val,
+    fpds_agency_id = t.agency_id,
+    fpds_parent_agency_id = t.referenced_idv_agency_iden
+FROM txn_totals AS t
+WHERE t.award_id = a.id

--- a/usaspending_api/etl/award_helpers.py
+++ b/usaspending_api/etl/award_helpers.py
@@ -123,6 +123,7 @@ def update_contract_awards(award_tuple=None):
         sql_txn_totals += 'WHERE tx.award_id IN %s '
     sql_txn_totals += 'GROUP BY tx.award_id) '
 
+    # Gather additional fpds fields such as agency_ids and types
     extra_fpds_fields = (
         "extra_fpds_fields AS ("
         "  SELECT"

--- a/usaspending_api/etl/award_helpers.py
+++ b/usaspending_api/etl/award_helpers.py
@@ -114,16 +114,17 @@ def update_contract_awards(award_tuple=None):
     # sum the base_and_all_options_value from contract_data for an award
     sql_txn_totals = (
         'txn_totals AS ('
-        'SELECT '
-        ' tx.award_id, SUM(CAST(f.base_and_all_options_value as double precision)) AS total_base_and_options_value '
-        'FROM transaction_fpds f INNER JOIN transaction_normalized as tx on '
-        'f.transaction_id = tx.id ')
+        'SELECT tx.award_id, '
+        'SUM(CAST(f.base_and_all_options_value AS double precision)) AS total_base_and_options_value, '
+        'SUM(CAST(f.base_exercised_options_val AS double precision)) AS base_exercised_options_val '
+        'FROM transaction_fpds AS f '
+        'INNER JOIN transaction_normalized AS tx ON f.transaction_id = tx.id ')
     if award_tuple:
         sql_txn_totals += 'WHERE tx.award_id IN %s '
     sql_txn_totals += 'GROUP BY tx.award_id) '
 
-    sql_award_types = (
-        "sql_award_types AS ("
+    extra_fpds_fields = (
+        "extra_fpds_fields AS ("
         "  SELECT"
         "    tx.award_id,"
         "    CASE WHEN pulled_from IS DISTINCT FROM 'IDV' THEN contract_award_type "
@@ -133,24 +134,30 @@ def update_contract_awards(award_tuple=None):
         "      WHEN idv_type = 'B' AND "
         "        (type_of_idc_description IS DISTINCT FROM NULL AND type_of_idc_description <> 'NAN') "
         "        THEN type_of_idc_description "
-        "      ELSE idv_type_description END AS type_description "
-        "  FROM transaction_fpds f INNER JOIN transaction_normalized as tx on f.transaction_id = tx.id "
+        "      ELSE idv_type_description END AS type_description, "
+        "    agency_id,"
+        "    referenced_idv_agency_iden"
+        "  FROM transaction_fpds AS f"
+        "  INNER JOIN transaction_normalized AS tx ON f.transaction_id = tx.id "
     )
     if award_tuple:
-        sql_award_types += "WHERE tx.award_id IN %s "
-    sql_award_types += ")"
+        extra_fpds_fields += "WHERE tx.award_id IN %s "
+    extra_fpds_fields += ")"
 
     # construct a sql query that uses the latest txn contract common table expression above and joins it to the
     # corresponding award. that joined data is used to update awards fields as appropriate (currently, there's only one
     # trasnaction_contract field that trickles up and updates an award record: base_and_all_options_value)
-    sql_update = 'WITH {}, {}'.format(sql_txn_totals, sql_award_types)
+    sql_update = 'WITH {}, {}'.format(sql_txn_totals, extra_fpds_fields)
     sql_update += (
         "UPDATE awards a "
         "SET base_and_all_options_value = t.total_base_and_options_value, "
-        " type = at.type, "
-        " type_description = at.type_description "
-        "FROM txn_totals t "
-        "INNER JOIN sql_award_types at ON t.award_id = at.award_id "
+        " base_exercised_options_val = t.base_exercised_options_val, "
+        " type = eff.type, "
+        " type_description = eff.type_description, "
+        " fpds_agency_id = eff.agency_id, "
+        " fpds_parent_agency_id = eff.referenced_idv_agency_iden "
+        "FROM txn_totals AS t "
+        "INNER JOIN extra_fpds_fields AS eff ON t.award_id = eff.award_id "
         "WHERE t.award_id = a.id "
     )
 

--- a/usaspending_api/etl/tests/test_award_helpers.py
+++ b/usaspending_api/etl/tests/test_award_helpers.py
@@ -184,26 +184,29 @@ def test_award_update_with_list():
 def test_award_update_from_contract_transaction():
     """Test award updates specific to contract transactions."""
 
-    # for contract type transactions, the base_and_all_options_value field should update the corresponding field on
-    # the award table
+    # for contract type transactions, the base_and_all_options_value and base_exercised_options_val fields
+    # should update the corresponding field on the award table
     award = mommy.make('awards.Award')
     txn = mommy.make('awards.TransactionNormalized', award=award)
     txn2 = mommy.make('awards.TransactionNormalized', award=award)
     mommy.make(
         'awards.TransactionFPDS',
         transaction=txn,
-        base_and_all_options_value=1000
+        base_and_all_options_value=1000,
+        base_exercised_options_val=100
     )
     mommy.make(
         'awards.TransactionFPDS',
         transaction=txn2,
-        base_and_all_options_value=1001
+        base_and_all_options_value=1001,
+        base_exercised_options_val=101
     )
 
     update_contract_awards()
     award.refresh_from_db()
 
     assert award.base_and_all_options_value == 2001
+    assert award.base_exercised_options_val == 201
 
 
 @pytest.mark.django_db
@@ -215,7 +218,8 @@ def test_award_update_contract_txn_with_list():
     mommy.make(
         'awards.TransactionFPDS',
         transaction=txn,
-        base_and_all_options_value=1000
+        base_and_all_options_value=1000,
+        base_exercised_options_val=100
     )
     # single award is updated
     count = update_contract_awards((awards[0].id,))
@@ -228,13 +232,15 @@ def test_award_update_contract_txn_with_list():
     mommy.make(
         'awards.TransactionFPDS',
         transaction=txn1,
-        base_and_all_options_value=4000
+        base_and_all_options_value=4000,
+        base_exercised_options_val=400
     )
     txn2 = mommy.make('awards.TransactionNormalized', award=awards[2])
     mommy.make(
         'awards.TransactionFPDS',
         transaction=txn2,
-        base_and_all_options_value=5000
+        base_and_all_options_value=5000,
+        base_exercised_options_val=500
     )
     # multiple awards updated
     count = update_contract_awards((awards[1].id, awards[2].id))
@@ -242,7 +248,9 @@ def test_award_update_contract_txn_with_list():
     awards[2].refresh_from_db()
     assert count == 2
     assert awards[1].base_and_all_options_value == 4000
+    assert awards[1].base_exercised_options_val == 400
     assert awards[2].base_and_all_options_value == 5000
+    assert awards[2].base_exercised_options_val == 500
 
 
 @pytest.mark.skip(reason="deletion feature not yet implemented")


### PR DESCRIPTION
**Description:**
Includes both a SQL script to populate and modifications to the FPDS nightly loader to update the following columns in the Awards table:
- `fpds_agency_id`
- `fpds_parent_agency_id`
- `base_exercised_options_val`

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
	- [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created - [OPS-494](https://federal-spending-transparency.atlassian.net/browse/OPS-494)
8. [x] Jira Tickets [DEV-1988](https://federal-spending-transparency.atlassian.net/browse/DEV-1988), [DEV-2000](https://federal-spending-transparency.atlassian.net/browse/DEV-2000):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (API | Script | Download)
	- [x] Before / After data comparison - 8 hours for one time backfilling

**Area for explaining above N/A when needed:**
```
API documentation - No documentation to modify/update/add
Matview impact assessment- This is just updating the Award table 
Frontend impact assessment - No frontend changes necessary
```
