### PR TITLE
DEV-1880: Backfill FABS OfficeNames using Federal Hierarchy Office data

### DIFF
--- a/usaspending_api/broker/management/commands/derive_office_names.py
+++ b/usaspending_api/broker/management/commands/derive_office_names.py
@@ -1,9 +1,8 @@
 import logging
-import signal
 
-from django.db import connection, connections, transaction
+from django.db import connection, connections
 
-from usaspending_api.etl.broker_etl_helpers import dictfetchall
+from usaspending_api.etl.broker_etl_helpers import dictfetchall, PhonyCursor
 from usaspending_api.etl.management import load_base
 
 logger = logging.getLogger('console')

--- a/usaspending_api/broker/management/commands/derive_office_names.py
+++ b/usaspending_api/broker/management/commands/derive_office_names.py
@@ -1,7 +1,7 @@
 import logging
 import signal
 
-from django.db import connection, transaction
+from django.db import connection, connections, transaction
 
 from usaspending_api.etl.broker_etl_helpers import dictfetchall
 from usaspending_api.etl.management import load_base
@@ -18,42 +18,56 @@ class Command(load_base.Command):
     help = "Derives all FABS office names from the office codes in the Office table in the DATA Act broker. The \
                 DATA_BROKER_DATABASE_URL environment variable must set so we can pull Office data from their db."
 
-    @transaction.atomic
-    def handle_loading(self, db_cursor, *args, **options):
-
-        def signal_handler(signal, frame):
-            transaction.set_rollback(True)
-            raise Exception('Received interrupt signal. Aborting...')
-
-        signal.signal(signal.SIGINT, signal_handler)
-        signal.signal(signal.SIGTERM, signal_handler)
+    def handle(self, *args, **options):
+        # Grab the data broker database connections
+        if not options['test']:
+            try:
+                db_conn = connections['data_broker']
+                db_cursor = db_conn.cursor()
+            except Exception as err:
+                logger.critical('Could not connect to database. Is DATA_BROKER_DATABASE_URL set?')
+                logger.critical(print(err))
+                return
+        else:
+            db_cursor = PhonyCursor()
+        ds_cursor = connection.cursor()
 
         logger.info('Creating a temporary Office table copied from the Broker...')
         db_cursor.execute('SELECT office_name, office_code FROM office')
         all_offices = dictfetchall(db_cursor)
-        all_offices_str = ', '.join(["('" + o['office_name'] + "','" + o['office_code'] + "')" for o in all_offices])
+        all_offices_list = []
+        for o in all_offices:
+            office_name = o['office_name'].replace("'", "''")
+            office_code = o['office_code'].replace("'", "''")
+            all_offices_list.append("('" + office_name + "','" + office_code + "')")
+        all_offices_str = ', '.join(all_offices_list)
 
-        ds_cursor = connection.cursor()
         ds_cursor.execute('CREATE TABLE temp_broker_office (office_name TEXT, office_code TEXT)')
         ds_cursor.execute('INSERT INTO temp_broker_office (office_name, office_code) VALUES ' + all_offices_str)
 
         logger.info('Deriving FABS awarding_office_names with awarding_office_codes from the temporary Office table...')
-        ds_cursor.execute("UPDATE transaction_fabs AS t_fabs "
-                          "SET awarding_office_name = office.office_name "
-                          "FROM temp_broker_office AS office "
-                          "WHERE t_fabs.awarding_office_code = office.office_code "
-                          "  AND t_fabs.action_date >= '2018/10/01' "
-                          "  AND t_fabs.awarding_office_name IS NULL "
-                          "  AND t_fabs.awarding_office_code IS NOT NULL")
+        ds_cursor.execute(
+            "UPDATE transaction_fabs AS t_fabs "
+            "SET awarding_office_name = office.office_name "
+            "FROM temp_broker_office AS office "
+            "WHERE t_fabs.awarding_office_code = office.office_code "
+            "  AND t_fabs.action_date >= '2018-10-01' "
+            "  AND t_fabs.awarding_office_name IS NULL "
+            "  AND t_fabs.awarding_office_code IS NOT NULL")
+        logger.info(ds_cursor.rowcount)
+        # logger.info('Made changes to {} records'.format(ds_cursor.results))
 
         logger.info('Deriving FABS funding_office_names with funding_office_codes from the temporary Office table...')
-        ds_cursor.execute("UPDATE transaction_fabs AS t_fabs "
-                          "SET funding_office_name = office.office_name "
-                          "FROM temp_broker_office AS office "
-                          "WHERE t_fabs.funding_office_code = office.office_code "
-                          "  AND t_fabs.action_date >= '2018/10/01' "
-                          "  AND t_fabs.funding_office_name IS NULL "
-                          "  AND t_fabs.funding_office_code IS NOT NULL")
+        ds_cursor.execute(
+            "UPDATE transaction_fabs AS t_fabs "
+            "SET funding_office_name = office.office_name "
+            "FROM temp_broker_office AS office "
+            "WHERE t_fabs.funding_office_code = office.office_code "
+            "  AND t_fabs.action_date >= '2018-10-01' "
+            "  AND t_fabs.funding_office_name IS NULL "
+            "  AND t_fabs.funding_office_code IS NOT NULL")
+        logger.info(ds_cursor.rowcount)
+        # logger.info('Made changes to {} records'.format(ds_cursor.results))
 
         logger.info('Dropping temporary Office table...')
         ds_cursor.execute('DROP TABLE temp_broker_office')

--- a/usaspending_api/broker/management/commands/derive_office_names.py
+++ b/usaspending_api/broker/management/commands/derive_office_names.py
@@ -1,0 +1,61 @@
+import logging
+import signal
+
+from django.db import connection, transaction
+
+from usaspending_api.etl.broker_etl_helpers import dictfetchall
+from usaspending_api.etl.management import load_base
+
+logger = logging.getLogger('console')
+
+
+class Command(load_base.Command):
+    """
+    This command will derive all FABS office names from the office codes in the Office table in the DATA Act broker. It
+    will create a temporary Office table to JOIN on.
+    """
+
+    help = "Derives all FABS office names from the office codes in the Office table in the DATA Act broker. The \
+                DATA_BROKER_DATABASE_URL environment variable must set so we can pull Office data from their db."
+
+    @transaction.atomic
+    def handle_loading(self, db_cursor, *args, **options):
+
+        def signal_handler(signal, frame):
+            transaction.set_rollback(True)
+            raise Exception('Received interrupt signal. Aborting...')
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        logger.info('Creating a temporary Office table copied from the Broker...')
+        db_cursor.execute('SELECT office_name, office_code FROM office')
+        all_offices = dictfetchall(db_cursor)
+        all_offices_str = ', '.join(["('" + o['office_name'] + "','" + o['office_code'] + "')" for o in all_offices])
+
+        ds_cursor = connection.cursor()
+        ds_cursor.execute('CREATE TABLE temp_broker_office (office_name TEXT, office_code TEXT)')
+        ds_cursor.execute('INSERT INTO temp_broker_office (office_name, office_code) VALUES ' + all_offices_str)
+
+        logger.info('Deriving FABS awarding_office_names with awarding_office_codes from the temporary Office table...')
+        ds_cursor.execute("UPDATE transaction_fabs AS t_fabs "
+                          "SET awarding_office_name = office.office_name "
+                          "FROM temp_broker_office AS office "
+                          "WHERE t_fabs.awarding_office_code = office.office_code "
+                          "  AND t_fabs.action_date >= '2018/10/01' "
+                          "  AND t_fabs.awarding_office_name IS NULL "
+                          "  AND t_fabs.awarding_office_code IS NOT NULL")
+
+        logger.info('Deriving FABS funding_office_names with funding_office_codes from the temporary Office table...')
+        ds_cursor.execute("UPDATE transaction_fabs AS t_fabs "
+                          "SET funding_office_name = office.office_name "
+                          "FROM temp_broker_office AS office "
+                          "WHERE t_fabs.funding_office_code = office.office_code "
+                          "  AND t_fabs.action_date >= '2018/10/01' "
+                          "  AND t_fabs.funding_office_name IS NULL "
+                          "  AND t_fabs.funding_office_code IS NOT NULL")
+
+        logger.info('Dropping temporary Office table...')
+        ds_cursor.execute('DROP TABLE temp_broker_office')
+
+        logger.info('Finished derivations.')


### PR DESCRIPTION
**Description:**
Broker could not make OfficeName derivations for FY2019Q1 FABS records due to the lack of a reliable Office table. After Federal Hierarchy is merged into the Broker, we want to use its Office table to make these derivations.

**Technical details:**
New Django script that creates a temporary table with the Broker office data, derives the TransactionFABS AwardingOfficeName and FundingOfficeName using their corresponding OfficeCodes. Deletes the temporary Office table.

**Requirements for PR merge:**

1. Unit & integration tests updated N/A
2. API documentation updated N/A
3. [x] Necessary PR reviewers:
	- [x] Backend
	- Frontend <OPTIONAL>
	- Operations <OPTIONAL>
	- Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
	- [OPS-493](https://federal-spending-transparency.atlassian.net/browse/OPS-493) 
8. [x] Jira Ticket [DEV-1880](https://federal-spending-transparency.atlassian.net/browse/DEV-1880):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected (Script)
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Data load script shouldn't need unit or integration tests or documentation updates.

No frontend impact.

Locally updated 941 AwardingOfficeCodes and 918 FundingOfficeCodes in 56 ms.
Left 18 rows unchanged due to the Broker Office table not having those OfficeCodes.
```
