### PR TITLE
Fix typos and grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ Your prompt should then look as below to show you are _in_ the virtual environme
 
 [`pip`](https://pip.pypa.io/en/stable/installing/) `install` application dependencies
 
-:bulb: _(try a different WiFi if you're current one blocks dependency downloads)_
+:bulb: _(try a different WiFi if your current one blocks dependency downloads)_
 
     (usaspending-api) $ pip install -r requirements/requirements.txt
 
 Set environment variables (fill in the connection string placeholders, e.g. `USER`, `PASSWORD`, `HOST`, `PORT`)
-*note: default port for PostgreSQL is `5432`
+
+_Note: the default port for PostgreSQL is `5432`_
 
 ```shell
 

--- a/data_reformatting.md
+++ b/data_reformatting.md
@@ -18,7 +18,7 @@ Making sure our location-related fields are as robust and accurate as possible p
 
 We attempt to match incoming records that have partial location data to already-stored unique combinations of _state code_, _state name_, _city code_, _county code_, and _county name_.
 
-For example, if a record has a state code but no state name, we'll pull in state name from our master list of geographical data and add it to the record during the load.
+For example, if a record has a state code but no state name, we'll pull in the state name from our master list of geographical data and add it to the record during the load.
 
 ### Country Codes and Names
 
@@ -50,7 +50,7 @@ The following fields are canonicalized this way:
 **Data Source:** USAspending history  
 **Code:** `etl/helpers.py`
 
-Codes and descriptions in legacy Usaspending data are often stored in the same field. For example, a funding agency column looks like `7300: SMALL BUSINESS ADMINISTRATION`.
+Codes and descriptions in legacy USAspending data are often stored in the same field. For example, a funding agency column looks like `7300: SMALL BUSINESS ADMINISTRATION`.
 
 In these cases, we extract the code to use in our data load. We then use that code to look up the description against a canonical data source. Using a single, central source for code descriptions ensures data consistency.
 


### PR DESCRIPTION
**Description:**
While reviewing this codebase and getting my local installation ready, I noticed a couple of grammatical errors in the documentation.
