### PR TITLE
DEV-1873/OPS-519: Uppercase additional fields in subaward restock script

### DIFF
--- a/usaspending_api/broker/management/sql/restock_subawards.sql
+++ b/usaspending_api/broker/management/sql/restock_subawards.sql
@@ -167,8 +167,8 @@ CREATE TABLE public.temporary_restock_subaward AS (
             (
             SELECT
                 fp.id AS broker_award_id,
-                fp.internal_id,
-                fp.contract_number AS piid,
+                UPPER(fp.internal_id) internal_id,
+                UPPER(fp.contract_number) AS piid,
                 UPPER(''CONT_AW_'' ||
                     COALESCE(fp.contract_agency_code,''-NONE-'') || ''_'' ||
                     COALESCE(fp.contract_idv_agency_code,''-NONE-'') || ''_'' ||
@@ -233,7 +233,7 @@ CREATE TABLE public.temporary_restock_subaward AS (
             (
             SELECT
                 fg.id AS broker_award_id,
-                fg.internal_id,
+                UPPER(fg.internal_id) internal_id,
                 NULL AS piid,
                 NULL AS expected_generated_unique_award_id,
                 UPPER(fg.fain) AS fain,


### PR DESCRIPTION
**Description:**
Users found duplicated subawards in the USAspending database.  This addresses one of the underlying causes by uppercasing a couple of columns that were not being appropriately uppercased.

**Technical details:**
The `load_fsrs.py` delta loader was uppercasing the `internal_id` whereas `restock_subawards.py` was not.  This caused `load_fsrs.py` to reload some subawards since it was unable to find existing subawards due to the casing discrepancy.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created [OPS-519](https://federal-spending-transparency.atlassian.net/browse/OPS-519)
8. [X] Jira Ticket [DEV-1873](https://federal-spending-transparency.atlassian.net/browse/DEV-1873):
	- [X] Link to this Pull-Request
	- [X] Performance evaluation of affected (API | Script | Download)
	- [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. As far as I know, there are no tests for restock scripts
2. No API documentation should be affected
3. Only the backend is affected
5. Frontend should be unaffected
```
