### PR TITLE
Fixing "Recipient Hash" value returned for /v2/awards/

### DIFF
--- a/usaspending_api/awards/tests/test_awards_idv_v2.py
+++ b/usaspending_api/awards/tests/test_awards_idv_v2.py
@@ -30,10 +30,12 @@ def awards_and_transactions(db):
 
     trans_asst = {"pk": 1}
     trans_cont = {"pk": 2}
-    duns = {"awardee_or_recipient_uniqu": 123, "legal_business_name": "Sams Club"}
+    duns = {"awardee_or_recipient_uniqu": "123", "legal_business_name": "Sams Club"}
+    recipient_lookup = {"duns": "456", "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367"}
     mommy.make("references.Cfda", program_number=1234)
     mommy.make("references.Location", **loc)
     mommy.make("recipient.DUNS", **duns)
+    mommy.make("recipient.RecipientLookup", **recipient_lookup)
     mommy.make("references.SubtierAgency", **subag)
     mommy.make("references.ToptierAgency", **subag)
     mommy.make("references.OfficeAgency", name="office_agency")
@@ -41,8 +43,8 @@ def awards_and_transactions(db):
     le = {
         "pk": 1,
         "recipient_name": "John's Pizza",
-        "recipient_unique_id": 456,
-        "parent_recipient_unique_id": 123,
+        "recipient_unique_id": "456",
+        "parent_recipient_unique_id": "123",
         "business_categories": ["small_business"],
         "location": Location.objects.get(pk=1),
     }
@@ -243,7 +245,7 @@ expected_response_idv = {
         "office_agency_name": "office_agency",
     },
     "recipient": {
-        "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367",
+        "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367-C",
         "recipient_name": "John's Pizza",
         "recipient_unique_id": "456",
         "parent_recipient_unique_id": "123",

--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -31,10 +31,12 @@ def awards_and_transactions(db):
     sub_agency = {"pk": 1, "name": "agency name", "abbreviation": "some other stuff"}
     trans_asst = {"pk": 1}
     trans_cont = {"pk": 2}
-    duns = {"awardee_or_recipient_uniqu": 123, "legal_business_name": "Sams Club"}
+    duns = {"awardee_or_recipient_uniqu": "123", "legal_business_name": "Sams Club"}
+    recipient_lookup = {"duns": "456", "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367"}
     mommy.make("references.Cfda", program_number=1234)
     mommy.make("references.Location", **loc)
     mommy.make("recipient.DUNS", **duns)
+    mommy.make("recipient.RecipientLookup", **recipient_lookup)
     mommy.make("references.SubtierAgency", **sub_agency)
     mommy.make("references.ToptierAgency", **sub_agency)
     mommy.make("references.OfficeAgency", name="office_agency", office_agency_id=1)
@@ -42,7 +44,6 @@ def awards_and_transactions(db):
     le = {
         "pk": 1,
         "business_categories": ["small_business"],
-        # "location": Location.objects.get(pk=1),
     }
 
     ag = {
@@ -273,7 +274,7 @@ expected_response_asst = {
         "office_agency_name": "office_agency",
     },
     "recipient": {
-        "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367",
+        "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367-C",
         "recipient_name": "John's Pizza",
         "recipient_unique_id": "456",
         "parent_recipient_unique_id": "123",
@@ -343,7 +344,7 @@ expected_response_cont = {
         "office_agency_name": "office_agency",
     },
     "recipient": {
-        "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367",
+        "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367-C",
         "recipient_name": "John's Pizza",
         "recipient_unique_id": "456",
         "parent_recipient_unique_id": "123",

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -14,10 +14,10 @@ from usaspending_api.awards.v2.data_layer.orm_mappers import (
 from usaspending_api.awards.models import (
     Award, FinancialAccountsByAwards, TransactionFABS, TransactionFPDS, ParentAward
 )
-from usaspending_api.common.helpers.date_helper import get_date_from_datetime
-from usaspending_api.recipient.models import RecipientProfile
-from usaspending_api.references.models import Agency, LegalEntity, LegalEntityOfficers, Cfda
 from usaspending_api.awards.v2.data_layer.orm_utils import delete_keys_from_dict, split_mapper_into_qs
+from usaspending_api.common.helpers.date_helper import get_date_from_datetime
+from usaspending_api.common.recipient_lookups import obtain_recipient_uri
+from usaspending_api.references.models import Agency, LegalEntity, LegalEntityOfficers, Cfda
 
 
 logger = logging.getLogger("console")
@@ -149,9 +149,10 @@ def create_recipient_object(db_row_dict):
     return OrderedDict(
         [
             (
-                "recipient_hash",
-                fetch_recipient_hash_using_name_and_duns(
-                    db_row_dict["_recipient_name"], db_row_dict["_recipient_unique_id"]
+                "recipient_hash", obtain_recipient_uri(
+                    db_row_dict["_recipient_name"],
+                    db_row_dict["_recipient_unique_id"],
+                    db_row_dict["_parent_recipient_unique_id"],
                 ),
             ),
             ("recipient_name", db_row_dict["_recipient_name"]),
@@ -315,25 +316,6 @@ def fetch_officers_by_legal_entity_id(legal_entity_id):
             )
 
     return {"officers": officers}
-
-
-def fetch_recipient_hash_using_name_and_duns(recipient_name, recipient_unique_id):
-    recipient = None
-    if recipient_unique_id:
-        recipient = (
-            RecipientProfile.objects.filter(recipient_unique_id=recipient_unique_id)
-            .values("recipient_hash", "recipient_level")
-            .first()
-        )
-
-    if not recipient:
-        # SQL: MD5(UPPER(CONCAT(awardee_or_recipient_uniqu, legal_business_name)))::uuid
-        import hashlib
-        import uuid
-
-        h = hashlib.md5("{}{}".format(recipient_unique_id, recipient_name).upper().encode("utf-8")).hexdigest()
-        return "{}-R".format(uuid.UUID(h))
-    return "{recipient_hash}-{recipient_level}".format(**recipient)
 
 
 def fetch_cfda_details_using_cfda_number(cfda):

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -320,7 +320,11 @@ def fetch_officers_by_legal_entity_id(legal_entity_id):
 def fetch_recipient_hash_using_name_and_duns(recipient_name, recipient_unique_id):
     recipient = None
     if recipient_unique_id:
-        recipient = RecipientProfile.objects.filter(recipient_unique_id=recipient_unique_id).values("recipient_hash", "recipient_level").first()
+        recipient = (
+            RecipientProfile.objects.filter(recipient_unique_id=recipient_unique_id)
+            .values("recipient_hash", "recipient_level")
+            .first()
+        )
 
     if not recipient:
         # SQL: MD5(UPPER(CONCAT(awardee_or_recipient_uniqu, legal_business_name)))::uuid
@@ -340,7 +344,9 @@ def fetch_cfda_details_using_cfda_number(cfda):
 
 
 def fetch_transaction_obligated_amount_by_internal_award_id(internal_award_id):
-    _sum = FinancialAccountsByAwards.objects.filter(
-        award_id=internal_award_id).aggregate(Sum('transaction_obligated_amount'))
+    _sum = (
+        FinancialAccountsByAwards.objects.filter(award_id=internal_award_id)
+        .aggregate(Sum("transaction_obligated_amount"))
+    )
     if _sum:
-        return _sum.get('transaction_obligated_amount__sum')
+        return _sum.get("transaction_obligated_amount__sum")

--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -4,8 +4,7 @@ from usaspending_api.recipient.models import RecipientLookup
 def obtain_recipient_uri(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
     if not recipient_unique_id:
         return create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
-
-    return fetch_recipient_hash_using_name_and_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
+    return fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id)
 
 
 def create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
@@ -14,13 +13,13 @@ def create_recipient_uri_without_duns(recipient_name, recipient_unique_id, paren
     return combine_recipient_hash_and_level(recipient_hash, recipient_level)
 
 
-def fetch_recipient_hash_using_name_and_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id):
+def fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id):
     recipient_hash = fetch_recipient_hash_using_duns(recipient_unique_id)
     recipient_level = obtain_recipient_level({"duns": recipient_unique_id, "parent_duns": parent_recipient_unique_id})
     return combine_recipient_hash_and_level(recipient_hash, recipient_level)
 
 
-def generate_missing_recipient_hash(recipient_unique_id, recipient_name):
+def generate_missing_recipient_hash(recipient_name, recipient_unique_id):
     # SQL: MD5(UPPER(CONCAT(awardee_or_recipient_uniqu, legal_business_name)))::uuid
     import hashlib
     import uuid
@@ -40,10 +39,12 @@ def fetch_recipient_hash_using_duns(recipient_unique_id):
 
 
 def obtain_recipient_level(recipient_record: dict) -> str:
+    level = None
     if recipient_is_standalone(recipient_record):
         level = "R"
     elif recipient_is_child(recipient_record):
         level = "C"
+    # Can never be associated with a "parent" recipient profile level
     return level
 
 

--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -1,0 +1,59 @@
+from usaspending_api.recipient.models import RecipientLookup
+
+
+def obtain_recipient_uri(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
+    if not recipient_unique_id:
+        return create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
+
+    return fetch_recipient_hash_using_name_and_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
+
+
+def create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
+    recipient_hash = generate_missing_recipient_hash(recipient_name, recipient_unique_id)
+    recipient_level = obtain_recipient_level({"duns": recipient_unique_id, "parent_duns": parent_recipient_unique_id})
+    return combine_recipient_hash_and_level(recipient_hash, recipient_level)
+
+
+def fetch_recipient_hash_using_name_and_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id):
+    recipient_hash = fetch_recipient_hash_using_duns(recipient_unique_id)
+    recipient_level = obtain_recipient_level({"duns": recipient_unique_id, "parent_duns": parent_recipient_unique_id})
+    return combine_recipient_hash_and_level(recipient_hash, recipient_level)
+
+
+def generate_missing_recipient_hash(recipient_unique_id, recipient_name):
+    # SQL: MD5(UPPER(CONCAT(awardee_or_recipient_uniqu, legal_business_name)))::uuid
+    import hashlib
+    import uuid
+
+    h = hashlib.md5("{}{}".format(recipient_unique_id, recipient_name).upper().encode("utf-8")).hexdigest()
+    return str(uuid.UUID(h))
+
+
+def fetch_recipient_hash_using_duns(recipient_unique_id):
+    recipient = (
+        RecipientLookup.objects.filter(duns=recipient_unique_id)
+        .values("recipient_hash")
+        .first()
+    )
+
+    return recipient["recipient_hash"] if recipient else None
+
+
+def obtain_recipient_level(recipient_record: dict) -> str:
+    if recipient_is_standalone(recipient_record):
+        level = "R"
+    elif recipient_is_child(recipient_record):
+        level = "C"
+    return level
+
+
+def recipient_is_standalone(recipient_record: dict) -> bool:
+    return recipient_record["parent_duns"] is None
+
+
+def recipient_is_child(recipient_record: dict) -> bool:
+    return recipient_record["parent_duns"] is not None
+
+
+def combine_recipient_hash_and_level(recipient_hash, recipient_level):
+    return "{}-{}".format(recipient_hash, recipient_level.upper())


### PR DESCRIPTION
**Description:**
Recipient Profile pages are contingent on the "level" of the recipient (Parent, Child, or Recipient). Since the API response value was not including the level in the string, the links were broker.

**Technical details:**
A little more complicated than desired since there isn't an easy way to lookup the recipient level from a transaction

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
	- [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-2034](https://federal-spending-transparency.atlassian.net/browse/DEV-2034):
	- [x] Link to this Pull-Request
	- [x] Performance evaluation of affected API
	- [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Minor edit to API response values for a specific field
```
