### PR TITLE
Fix for inappropriate TinyShield usage

### DIFF
--- a/usaspending_api/awards/v2/views/idvs/amounts.py
+++ b/usaspending_api/awards/v2/views/idvs/amounts.py
@@ -1,6 +1,7 @@
 import logging
 
 from collections import OrderedDict
+from copy import deepcopy
 
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
@@ -9,14 +10,14 @@ from rest_framework.response import Response
 from usaspending_api.awards.models import ParentAward
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.views import APIDocumentationView
-from usaspending_api.core.validator.award import get_internal_or_generated_award_id_rule
+from usaspending_api.core.validator.award import get_internal_or_generated_award_id_model
 from usaspending_api.core.validator.tinyshield import TinyShield
 
 
 logger = logging.getLogger('console')
 
 
-TINY_SHIELD_MODEL = [get_internal_or_generated_award_id_rule()]
+TINY_SHIELD_MODELS = [get_internal_or_generated_award_id_model()]
 
 
 class IDVAmountsViewSet(APIDocumentationView):
@@ -26,7 +27,7 @@ class IDVAmountsViewSet(APIDocumentationView):
 
     @staticmethod
     def _parse_and_validate_request(requested_award: str) -> dict:
-        return TinyShield(TINY_SHIELD_MODEL).block({'award_id': requested_award})
+        return TinyShield(deepcopy(TINY_SHIELD_MODELS)).block({'award_id': requested_award})
 
     @staticmethod
     def _business_logic(request_data: dict) -> OrderedDict:

--- a/usaspending_api/awards/v2/views/idvs/amounts.py
+++ b/usaspending_api/awards/v2/views/idvs/amounts.py
@@ -16,7 +16,7 @@ from usaspending_api.core.validator.tinyshield import TinyShield
 logger = logging.getLogger('console')
 
 
-TINY_SHIELD_RULES = TinyShield([get_internal_or_generated_award_id_rule()])
+TINY_SHIELD_MODEL = [get_internal_or_generated_award_id_rule()]
 
 
 class IDVAmountsViewSet(APIDocumentationView):
@@ -26,7 +26,7 @@ class IDVAmountsViewSet(APIDocumentationView):
 
     @staticmethod
     def _parse_and_validate_request(requested_award: str) -> dict:
-        return TINY_SHIELD_RULES.block({'award_id': requested_award})
+        return TinyShield(TINY_SHIELD_MODEL).block({'award_id': requested_award})
 
     @staticmethod
     def _business_logic(request_data: dict) -> OrderedDict:

--- a/usaspending_api/awards/v2/views/idvs/awards.py
+++ b/usaspending_api/awards/v2/views/idvs/awards.py
@@ -79,20 +79,16 @@ GET_CONTRACTS_SQL = SQL("""
 """)
 
 
-def _prepare_tiny_shield_rules():
-    """
-    Our TinyShield rules never change.  Encapsulate them here and store them
-    once in TINY_SHIELD_RULES.
-    """
-    models = customize_pagination_with_sort_columns(SORTABLE_COLUMNS, DEFAULT_SORT_COLUMN)
-    models.extend([
+def _prepare_tiny_shield_model():
+    model = customize_pagination_with_sort_columns(SORTABLE_COLUMNS, DEFAULT_SORT_COLUMN)
+    model.extend([
         get_internal_or_generated_award_id_rule(),
         {'key': 'idv', 'name': 'idv', 'type': 'boolean', 'default': True, 'optional': True}
     ])
-    return TinyShield(models)
+    return model
 
 
-TINY_SHIELD_RULES = _prepare_tiny_shield_rules()
+TINY_SHIELD_MODEL = _prepare_tiny_shield_model()
 
 
 class IDVAwardsViewSet(APIDocumentationView):
@@ -102,7 +98,7 @@ class IDVAwardsViewSet(APIDocumentationView):
 
     @staticmethod
     def _parse_and_validate_request(request: Request) -> dict:
-        return TINY_SHIELD_RULES.block(request)
+        return TinyShield(TINY_SHIELD_MODEL).block(request)
 
     @staticmethod
     def _business_logic(request_data: dict) -> list:

--- a/usaspending_api/awards/v2/views/transactions.py
+++ b/usaspending_api/awards/v2/views/transactions.py
@@ -34,20 +34,16 @@ class TransactionViewSet(APIDocumentationView):
     }
 
     def __init__(self):
-        """
-        Our TinyShield rules never change.  Encapsulate them here and store
-        them once in TINY_SHIELD_RULES.
-        """
-        models = customize_pagination_with_sort_columns(TransactionViewSet.transaction_lookup.keys(), 'action_date')
-        models.extend([
+        model = customize_pagination_with_sort_columns(TransactionViewSet.transaction_lookup.keys(), 'action_date')
+        model.extend([
             get_internal_or_generated_award_id_rule(),
             {'key': 'idv', 'name': 'idv', 'type': 'boolean', 'default': True, 'optional': True}
         ])
-        self._tiny_shield_rules = TinyShield(models)
+        self._tiny_shield_model = model
         super(TransactionViewSet, self).__init__()
 
     def _parse_and_validate_request(self, request_dict: dict) -> dict:
-        return self._tiny_shield_rules.block(request_dict)
+        return TinyShield(self._tiny_shield_model).block(request_dict)
 
     def _business_logic(self, request_data: dict) -> list:
         # By this point, our award_id has been validated and cleaned up by

--- a/usaspending_api/awards/v2/views/transactions.py
+++ b/usaspending_api/awards/v2/views/transactions.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.db.models import F
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -6,7 +8,7 @@ from usaspending_api.awards.models import TransactionNormalized
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.generic_helper import get_simple_pagination_metadata
 from usaspending_api.common.views import APIDocumentationView
-from usaspending_api.core.validator.award import get_internal_or_generated_award_id_rule
+from usaspending_api.core.validator.award import get_internal_or_generated_award_id_model
 from usaspending_api.core.validator.pagination import customize_pagination_with_sort_columns
 from usaspending_api.core.validator.tinyshield import TinyShield
 
@@ -34,16 +36,16 @@ class TransactionViewSet(APIDocumentationView):
     }
 
     def __init__(self):
-        model = customize_pagination_with_sort_columns(TransactionViewSet.transaction_lookup.keys(), 'action_date')
-        model.extend([
-            get_internal_or_generated_award_id_rule(),
+        models = customize_pagination_with_sort_columns(TransactionViewSet.transaction_lookup.keys(), 'action_date')
+        models.extend([
+            get_internal_or_generated_award_id_model(),
             {'key': 'idv', 'name': 'idv', 'type': 'boolean', 'default': True, 'optional': True}
         ])
-        self._tiny_shield_model = model
+        self._tiny_shield_models = models
         super(TransactionViewSet, self).__init__()
 
     def _parse_and_validate_request(self, request_dict: dict) -> dict:
-        return TinyShield(self._tiny_shield_model).block(request_dict)
+        return TinyShield(deepcopy(self._tiny_shield_models)).block(request_dict)
 
     def _business_logic(self, request_data: dict) -> list:
         # By this point, our award_id has been validated and cleaned up by

--- a/usaspending_api/awards/v2/views/transactions.py
+++ b/usaspending_api/awards/v2/views/transactions.py
@@ -36,7 +36,10 @@ class TransactionViewSet(APIDocumentationView):
     }
 
     def __init__(self):
-        models = customize_pagination_with_sort_columns(TransactionViewSet.transaction_lookup.keys(), 'action_date')
+        models = customize_pagination_with_sort_columns(
+            list(TransactionViewSet.transaction_lookup.keys()),
+            'action_date'
+        )
         models.extend([
             get_internal_or_generated_award_id_model(),
             {'key': 'idv', 'name': 'idv', 'type': 'boolean', 'default': True, 'optional': True}

--- a/usaspending_api/core/validator/award.py
+++ b/usaspending_api/core/validator/award.py
@@ -1,17 +1,17 @@
 """
-Some shortcuts for generating "standardized" basic award id TinyShield model strings.
+Some shortcuts for generating "standardized" basic award id TinyShield models.
 """
 
 
-def get_generated_award_id_rule(key='award_id', name='award_id', optional=False):
+def get_generated_award_id_model(key='award_id', name='award_id', optional=False):
     return {'key': key, 'name': name, 'type': 'text', 'text_type': 'search', 'optional': optional}
 
 
-def get_internal_award_id_rule(key='award_id', name='award_id', optional=False):
+def get_internal_award_id_model(key='award_id', name='award_id', optional=False):
     return {'key': key, 'name': name, 'type': 'integer', 'optional': optional}
 
 
-def get_internal_or_generated_award_id_rule(key='award_id', name='award_id', optional=False):
+def get_internal_or_generated_award_id_model(key='award_id', name='award_id', optional=False):
     return {'key': key, 'name': name, 'type': 'any', 'optional': optional, 'models': [
         {'type': 'integer'},
         {'type': 'text', 'text_type': 'search'}

--- a/usaspending_api/core/validator/tests/unit/test_award.py
+++ b/usaspending_api/core/validator/tests/unit/test_award.py
@@ -5,38 +5,38 @@ import pytest
 
 from usaspending_api.common.exceptions import InvalidParameterException, UnprocessableEntityException
 from usaspending_api.core.validator.tinyshield import TinyShield
-from usaspending_api.core.validator.award import get_generated_award_id_rule, get_internal_award_id_rule, \
-     get_internal_or_generated_award_id_rule
+from usaspending_api.core.validator.award import get_generated_award_id_model, get_internal_award_id_model, \
+     get_internal_or_generated_award_id_model
 from usaspending_api.core.validator.helpers import MAX_INT, MAX_ITEMS, MIN_INT
 
 
 def test_get_generate_award_id_rule():
-    models = [get_generated_award_id_rule()]
+    models = [get_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': 'abcd'})
     assert r == {'award_id': 'abcd'}
 
-    models = [get_generated_award_id_rule()]
+    models = [get_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': 'A' * MAX_ITEMS})
     assert r == {'award_id': 'A' * MAX_ITEMS}
 
-    models = [get_generated_award_id_rule(key='my_award_id')]
+    models = [get_generated_award_id_model(key='my_award_id')]
     r = TinyShield(models).block({'my_award_id': 'abcd'})
     assert r == {'my_award_id': 'abcd'}
 
-    models = [get_generated_award_id_rule(key='my_award_id', name='your_award_id')]
+    models = [get_generated_award_id_model(key='my_award_id', name='your_award_id')]
     r = TinyShield(models).block({'my_award_id': 'abcd'})
     assert r == {'my_award_id': 'abcd'}
 
-    models = [get_generated_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_generated_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({'my_award_id': 'abcd'})
     assert r == {'my_award_id': 'abcd'}
 
-    models = [get_generated_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_generated_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({})
     assert r == {}
 
     # Rule violations.
-    ts = TinyShield([get_generated_award_id_rule()])
+    ts = TinyShield([get_generated_award_id_model()])
 
     with pytest.raises(UnprocessableEntityException):
         ts.block({})
@@ -51,40 +51,40 @@ def test_get_generate_award_id_rule():
 
 
 def test_get_internal_award_id_rule():
-    models = [get_internal_award_id_rule()]
+    models = [get_internal_award_id_model()]
     r = TinyShield(models).block({'award_id': 12345})
     assert r == {'award_id': 12345}
 
-    models = [get_internal_award_id_rule()]
+    models = [get_internal_award_id_model()]
     r = TinyShield(models).block({'award_id': '12345'})
     assert r == {'award_id': 12345}
 
-    models = [get_internal_award_id_rule()]
+    models = [get_internal_award_id_model()]
     r = TinyShield(models).block({'award_id': MAX_INT})
     assert r == {'award_id': MAX_INT}
 
-    models = [get_internal_award_id_rule()]
+    models = [get_internal_award_id_model()]
     r = TinyShield(models).block({'award_id': MIN_INT})
     assert r == {'award_id': MIN_INT}
 
-    models = [get_internal_award_id_rule(key='my_award_id')]
+    models = [get_internal_award_id_model(key='my_award_id')]
     r = TinyShield(models).block({'my_award_id': 12345})
     assert r == {'my_award_id': 12345}
 
-    models = [get_internal_award_id_rule(key='my_award_id', name='your_award_id')]
+    models = [get_internal_award_id_model(key='my_award_id', name='your_award_id')]
     r = TinyShield(models).block({'my_award_id': 12345})
     assert r == {'my_award_id': 12345}
 
-    models = [get_internal_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_internal_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({'my_award_id': 12345})
     assert r == {'my_award_id': 12345}
 
-    models = [get_internal_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_internal_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({})
     assert r == {}
 
     # Rule violations.
-    ts = TinyShield([get_internal_award_id_rule()])
+    ts = TinyShield([get_internal_award_id_model()])
 
     with pytest.raises(UnprocessableEntityException):
         ts.block({})
@@ -101,55 +101,55 @@ def test_get_internal_award_id_rule():
 
 
 def test_get_internal_or_generated_award_id_rule():
-    models = [get_internal_or_generated_award_id_rule()]
+    models = [get_internal_or_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': 'abcd'})
     assert r == {'award_id': 'abcd'}
 
-    models = [get_internal_or_generated_award_id_rule()]
+    models = [get_internal_or_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': 'A' * MAX_ITEMS})
     assert r == {'award_id': 'A' * MAX_ITEMS}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id')]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id')]
     r = TinyShield(models).block({'my_award_id': 'abcd'})
     assert r == {'my_award_id': 'abcd'}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id', name='your_award_id')]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id', name='your_award_id')]
     r = TinyShield(models).block({'my_award_id': 'abcd'})
     assert r == {'my_award_id': 'abcd'}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({'my_award_id': 'abcd'})
     assert r == {'my_award_id': 'abcd'}
 
-    models = [get_internal_or_generated_award_id_rule()]
+    models = [get_internal_or_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': 12345})
     assert r == {'award_id': 12345}
 
-    models = [get_internal_or_generated_award_id_rule()]
+    models = [get_internal_or_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': '12345'})
     assert r == {'award_id': 12345}
 
-    models = [get_internal_or_generated_award_id_rule()]
+    models = [get_internal_or_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': MAX_INT})
     assert r == {'award_id': MAX_INT}
 
-    models = [get_internal_or_generated_award_id_rule()]
+    models = [get_internal_or_generated_award_id_model()]
     r = TinyShield(models).block({'award_id': MIN_INT})
     assert r == {'award_id': MIN_INT}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id')]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id')]
     r = TinyShield(models).block({'my_award_id': 12345})
     assert r == {'my_award_id': 12345}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id', name='your_award_id')]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id', name='your_award_id')]
     r = TinyShield(models).block({'my_award_id': 12345})
     assert r == {'my_award_id': 12345}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({'my_award_id': 12345})
     assert r == {'my_award_id': 12345}
 
-    models = [get_internal_or_generated_award_id_rule(key='my_award_id', name='your_award_id', optional=True)]
+    models = [get_internal_or_generated_award_id_model(key='my_award_id', name='your_award_id', optional=True)]
     r = TinyShield(models).block({})
     assert r == {}
 
@@ -157,7 +157,7 @@ def test_get_internal_or_generated_award_id_rule():
 def test_get_internal_or_generated_award_id_rule_bad():
 
     # Rule violations.
-    ts = TinyShield([get_internal_or_generated_award_id_rule()])
+    ts = TinyShield([get_internal_or_generated_award_id_model()])
 
     with pytest.raises(UnprocessableEntityException):
         ts.block({})


### PR DESCRIPTION
**Description:**
Resolves bug introduced by TinyShield usage misunderstanding.

**Technical details:**
In several locations in code, TinyShield objects were being reused.  In its current incarnation, this does not work.  A new TinyShield must be instantiated per use.

**Requirements for PR merge:**

3. [x] Necessary PR reviewers:
	- [x] Backend
