### PR TITLE
Added ability to dump urls supported by Django

### DIFF
--- a/usaspending_api/common/management/commands/dump_urls.py
+++ b/usaspending_api/common/management/commands/dump_urls.py
@@ -1,0 +1,22 @@
+import re
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    help = 'Dump the list of URLs known by Django'
+
+    def handle(self, *args, **options):
+        from usaspending_api import urls
+        trim_stuff = re.compile(r'^\^|\$$')
+
+        def _dump_urls(base, urls):
+            for url in urls:
+                o = base + trim_stuff.sub('', url.regex.pattern)
+                if hasattr(url, 'url_patterns'):
+                    _dump_urls(o, url.url_patterns)
+                else:
+                    print(o)
+
+        _dump_urls('/', urls.urlpatterns)


### PR DESCRIPTION
**Description:**
Simple management command to dump out all of the urls supported by/known to Django.

**Technical details:**
`python manage.py dump_urls`

**Requirements for PR merge:**

1. [X] No unit or integration tests to update
2. [X] No API documentation needed
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] No materialized views affected
5. [X] Front end not impacted
6. [X] No data was affected
7. [X] No Operations ticket required
8. [X] No Jira ticket