### PR TITLE
DEV-2184: Added funding_agency_id to IDV Funding API endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/award/idv/Funding.md
+++ b/usaspending_api/api_contracts/contracts/award/idv/Funding.md
@@ -55,6 +55,7 @@ Returns File C financial data for an IDV (Indefinite Delivery Vehicle) award's d
                         "reporting_fiscal_year": 2018,
                         "reporting_fiscal_quarter": 4,
                         "piid": "15B30518FTM230002",
+                        "funding_agency_id": 259,
                         "reporting_agency_id": "015",
                         "reporting_agency_name": "Department of Justice",
                         "agency_id": "015",
@@ -72,6 +73,7 @@ Returns File C financial data for an IDV (Indefinite Delivery Vehicle) award's d
                         "reporting_fiscal_year": 2018,
                         "reporting_fiscal_quarter": 3,
                         "piid": "15B30518FTM230002",
+                        "funding_agency_id": 259,
                         "reporting_agency_id": "015",
                         "reporting_agency_name": "Department of Justice",
                         "agency_id": "015",
@@ -89,6 +91,7 @@ Returns File C financial data for an IDV (Indefinite Delivery Vehicle) award's d
                         "reporting_fiscal_year": 2018,
                         "reporting_fiscal_quarter": 2,
                         "piid": "15B30518FTM230002",
+                        "funding_agency_id": 259,
                         "reporting_agency_id": "015",
                         "reporting_agency_name": "Department of Justice",
                         "agency_id": "015",
@@ -106,6 +109,7 @@ Returns File C financial data for an IDV (Indefinite Delivery Vehicle) award's d
                         "reporting_fiscal_year": 2018,
                         "reporting_fiscal_quarter": 1,
                         "piid": "15B30518FTM230002",
+                        "funding_agency_id": 259,
                         "reporting_agency_id": "015",
                         "reporting_agency_name": "Department of Justice",
                         "agency_id": "015",
@@ -119,11 +123,11 @@ Returns File C financial data for an IDV (Indefinite Delivery Vehicle) award's d
                     }
                 ],
                 "page_metadata": {
-                    "page": 1,
-                    "previous": null,
-                    "hasPrevious": false,
                     "hasNext": false,
-                    "next": null
+                    "hasPrevious": false,
+                    "next": null,
+                    "page": 1,
+                    "previous": null
                 }
             }
 
@@ -147,9 +151,13 @@ Returns File C financial data for an IDV (Indefinite Delivery Vehicle) award's d
     Fiscal quarter of the submission date.
 + `piid` (required, string, nullable)
     Procurement Instrument Identifier (PIID).
++ `funding_agency_id` (required, number, nullable)
+    Internal surrogate identifier of the funding agency.
 + `reporting_agency_id` (required, string, nullable)
+    CGAC of the reporting agency.
 + `reporting_agency_name` (required, string, nullable)
 + `agency_id` (required, string, nullable)
+    CGAC of the funding agency.
 + `main_account_code` (required, string, nullable)
 + `account_title` (required, string, nullable)
     Federal Account Title

--- a/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
+++ b/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
@@ -39,6 +39,11 @@ class IDVFundingTestCase(TestCase):
             _sid = str(_id).zfill(3)
 
             mommy.make(
+                'references.Agency',
+                id=9000 + _id
+            )
+
+            mommy.make(
                 'awards.Award',
                 id=_id,
                 generated_unique_award_id='GENERATED_UNIQUE_AWARD_ID_%s' % _sid,
@@ -46,7 +51,8 @@ class IDVFundingTestCase(TestCase):
                 piid='piid_%s' % _sid,
                 fpds_agency_id='fpds_agency_id_%s' % _sid,
                 parent_award_piid='piid_%s' % _spid if _spid else None,
-                fpds_parent_agency_id='fpds_agency_id_%s' % _spid if _spid else None
+                fpds_parent_agency_id='fpds_agency_id_%s' % _spid if _spid else None,
+                funding_agency_id=9000 + _id
             )
 
             if _id in IDVS:
@@ -120,6 +126,7 @@ class IDVFundingTestCase(TestCase):
                 'reporting_fiscal_year': 2000 + _id,
                 'reporting_fiscal_quarter': _id % 4 + 1,
                 'piid': 'piid_%s' % _sid,
+                'funding_agency_id': 9000 + _id,
                 'reporting_agency_id': _sid.zfill(3),
                 'reporting_agency_name': 'reporting agency name %s' % _sid,
                 'agency_id': _sid.zfill(3),

--- a/usaspending_api/awards/v2/views/idvs/funding.py
+++ b/usaspending_api/awards/v2/views/idvs/funding.py
@@ -49,6 +49,7 @@ GET_FUNDING_SQL = SQL("""
         sa.reporting_fiscal_year,
         sa.reporting_fiscal_quarter,
         ca.piid,
+        ca.funding_agency_id,
         taa.reporting_agency_id,
         taa.reporting_agency_name,
         taa.agency_id,


### PR DESCRIPTION
**Description:**
By request, added `funding_agency_id` to IDV Funding API endpoint.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend
4. [x] No materialized views were affected
5. [x] Frontend impact assessment completed
6. [X] No data was affected
7. [X] No operations ticket required
8. [X] Jira Ticket [DEV-2184](https://federal-spending-transparency.atlassian.net/browse/DEV-2184):
    - [X] Link to this Pull-Request
