### PR TITLE
Odd issue with ORM

### DIFF
--- a/usaspending_api/awards/models_matviews.py
+++ b/usaspending_api/awards/models_matviews.py
@@ -765,7 +765,7 @@ class SubawardView(models.Model):
     award_report_fy_month = models.IntegerField()
     award_report_fy_year = models.IntegerField()
 
-    award = models.OneToOneField(Award, primary_key=True, null=True)
+    award = models.OneToOneField(Award, null=True)
     awarding_agency_id = models.IntegerField()
     funding_agency_id = models.IntegerField()
     awarding_toptier_agency_name = models.TextField()


### PR DESCRIPTION
**Description:**
A recent change seemed to have upset Django.

**Technical details:**
```SystemCheckError: System check identified some issues:

ERRORS:
awards.SubawardView.award: (fields.E007) Primary keys must not have null=True.
	HINT: Set null=False on the field, or remove primary_key=True argument.
```

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Minor edit to an unmanaged ORM model which shouldn't affect anything
```
