### PR TITLE
DEV-2307: Minor bug fix for IDV funding endpoint

### DIFF
--- a/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
+++ b/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
@@ -1,7 +1,5 @@
 import json
 
-from django.db import connection
-from django.db.models import Max
 from django.test import TestCase
 from model_mommy import mommy
 from rest_framework import status

--- a/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
+++ b/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
@@ -1,8 +1,11 @@
 import json
 
+from django.db import connection
+from django.db.models import Max
 from django.test import TestCase
 from model_mommy import mommy
 from rest_framework import status
+from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.awards.v2.views.idvs.funding import SORTABLE_COLUMNS
 
 
@@ -318,3 +321,21 @@ class IDVFundingTestCase(TestCase):
             {'award_id': 2, 'piid': 'piid_013', 'limit': 3, 'page': 1, 'sort': 'piid', 'order': 'asc'},
             (None, None, 1, False, False, 13)
         )
+
+    def test_dev_2307(self):
+
+        # Make one of the transaction_obligated_amount values NaN.  Going from
+        # the drawing above, if we update contract 12, we should see this
+        # record for IDV 7.
+        FinancialAccountsByAwards.objects.filter(pk=12).update(transaction_obligated_amount='NaN')
+
+        # Retrieve the NaN value.
+        response = self.client.post(
+            ENDPOINT,
+            {'award_id': 7, 'sort': 'transaction_obligated_amount', 'order': 'desc'}
+        )
+        assert response.status_code == 200
+        result = json.loads(response.content.decode('utf-8'))
+        assert len(result['results']) == 2
+        for r in result['results']:
+            assert r['transaction_obligated_amount'] in (None, 110011.11)

--- a/usaspending_api/awards/v2/views/idvs/funding.py
+++ b/usaspending_api/awards/v2/views/idvs/funding.py
@@ -59,7 +59,7 @@ GET_FUNDING_SQL = SQL("""
         rpa.program_activity_name,
         oc.object_class,
         oc.object_class_name,
-        faba.transaction_obligated_amount
+        nullif(faba.transaction_obligated_amount, 'NaN') transaction_obligated_amount
     from
         cte
         inner join awards pa on
@@ -101,8 +101,8 @@ class IDVFundingViewSet(APIDocumentationView):
     """Returns File C funding records associated with an IDV."""
 
     @staticmethod
-    def _parse_and_validate_request(request: Request) -> dict:
-        return TinyShield(deepcopy(TINY_SHIELD_MODELS)).block(request)
+    def _parse_and_validate_request(request_data: dict) -> dict:
+        return TinyShield(deepcopy(TINY_SHIELD_MODELS)).block(request_data)
 
     @staticmethod
     def _business_logic(request_data: dict) -> list:


### PR DESCRIPTION
**Description:**
Bug was found with `transaction_obligated_amount` in IDV Funding endpoint that was causing peculiar front end sorting issues.

**Technical details:**
Database contains NaN values which do not translate to JSON.  Fix was to convert to NULL which is functionally equivalent in this context.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [X] Necessary PR reviewers:
    - [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-2037](https://federal-spending-transparency.atlassian.net/browse/DEV-2037):
    - [X] Link to this Pull-Request
