### PR TITLE
DEV-2245 new "ops reporter" function "required field" fix

### DIFF
--- a/usaspending_api/common/operations_reporter.py
+++ b/usaspending_api/common/operations_reporter.py
@@ -41,5 +41,6 @@ class OpsReporter:
         return json.dumps(self._internal_dict)
 
     def _verify_required_keys(self):
-        if set(self.required_keys) > set(self._internal_dict.keys()):
-            raise Exception("Failed to populate all of the required keys: {}".format(self.required_keys))
+        missing_required_keys = set(self.required_keys) - set(self._internal_dict.keys())
+        if missing_required_keys:
+            raise Exception("Missing required keys: {}".format(missing_required_keys))


### PR DESCRIPTION
**Description:**
Reviewing work that was piggybacked onto DEV-2245. This set comparison will only work if `set(self._internal_dict.keys())` is an empty set

**Technical details:**
Uses a set diff instead.

