### PR TITLE
DEV-1909: Keyword filter exception for Subawards

### DIFF
--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -64,10 +64,10 @@ def subaward_filter(filters, for_downloads=False):
                 # award_ts_vector = piid + fain + uri + subaward_number
                 filter_obj = Q(keyword_ts_vector=keyword) | \
                     Q(award_ts_vector=keyword)
-                # Commenting out until NAICS is associated with subawards
+                # Commenting out until NAICS is associated with subawards in DAIMS 1.3.1
                 # if keyword.isnumeric():
                 #     filter_obj |= Q(naics_code__contains=keyword)
-                if len(keyword) == 4 and PSC.objects.all().filter(code__iexact=keyword).exists():
+                if len(keyword) == 4 and PSC.objects.filter(code__iexact=keyword).exists():
                     filter_obj |= Q(product_or_service_code__iexact=keyword)
 
                 return filter_obj

--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -64,8 +64,9 @@ def subaward_filter(filters, for_downloads=False):
                 # award_ts_vector = piid + fain + uri + subaward_number
                 filter_obj = Q(keyword_ts_vector=keyword) | \
                     Q(award_ts_vector=keyword)
-                if keyword.isnumeric():
-                    filter_obj |= Q(naics_code__contains=keyword)
+                # Commenting out until NAICS is associated with subawards
+                # if keyword.isnumeric():
+                #     filter_obj |= Q(naics_code__contains=keyword)
                 if len(keyword) == 4 and PSC.objects.all().filter(code__iexact=keyword).exists():
                     filter_obj |= Q(product_or_service_code__iexact=keyword)
 


### PR DESCRIPTION
**Description:**
Currently, NAICS is not in FSRS data. It will be added in DAIMS 1.3.1. This is a temporary fix until USAspending contains DAIMS 1.3.1 fields.

**Technical details:**
Commented out section to search NAICS (only when keyword text is numeric)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-1909](https://federal-spending-transparency.atlassian.net/browse/DEV-1909):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API
    - [x] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
Minor change for bugfix to not filter on non-existent field.
```
