### PR TITLE
[DEV-2353] _Hotfix_ Adding IDV types to monthly download commands

### DIFF
--- a/usaspending_api/download/management/commands/populate_monthly_delta_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_delta_files.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('console')
 AWARD_MAPPINGS = {
     'Contracts': {
         'agency_field': 'agency_id',
-        'award_types': ['contracts'],
+        'award_types': ['contracts', 'idvs'],
         'column_headers': {
             0: 'agency_id', 1: 'parent_award_agency_id', 2: 'award_id_piid', 3: 'modification_number',
             4: 'parent_award_id', 5: 'transaction_number'

--- a/usaspending_api/download/management/commands/populate_monthly_files.py
+++ b/usaspending_api/download/management/commands/populate_monthly_files.py
@@ -19,7 +19,7 @@ from usaspending_api.references.models import ToptierAgency
 logger = logging.getLogger('console')
 
 award_mappings = {
-    'contracts': ['contracts'],
+    'contracts': ['contracts', 'idvs'],
     'assistance': ['grants', 'direct_payments', 'loans', 'other_financial_assistance']
 }
 


### PR DESCRIPTION
**Description:**
Adding IDV award type codes to the `contracts` award types used by the management commands for generating the monthly files.

**Technical details:**
Added the pre-defined IDV type codes to the mapping objects.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Operations
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-2353](https://federal-spending-transparency.atlassian.net/browse/DEV-2353):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected script
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
This does not touch the database or API endpoints
No existing tests to update for monthly scripts
```
