### PR TITLE
DEV-1904: Added end date support to fabs_nightly_loader

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -414,10 +414,15 @@ class Command(BaseCommand):
         else:
             logger.info('Nothing to insert...')
 
-        # Update the date for the last time the data load was run
-        ExternalDataLoadDate.objects.filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']).delete()
-        ExternalDataLoadDate(
-            last_load_date=start_date, external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']
-        ).save()
+        # If an end date was provided, do NOT save the last_load_date.
+        # last_load_date is designed for incremental, periodic updates,
+        # not targeted time periods.
+        if load_to_date is None:
+
+            # Update the date for the last time the data load was run
+            ExternalDataLoadDate.objects.filter(external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']).delete()
+            ExternalDataLoadDate(
+                last_load_date=start_date, external_data_type_id=lookups.EXTERNAL_DATA_TYPE_DICT['fabs']
+            ).save()
 
         logger.info('FABS UPDATE FINISHED!')

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             SELECT UPPER(afa_generated_unique) AS afa_generated_unique
             FROM   published_award_financial_assistance
             WHERE  created_at >= %(start_date)s
-            AND    (created_at < %(end_date)s OR %(end_date)s is null)
+            AND    (created_at < %(end_date)s OR %(end_date)s IS NULL)
             AND    UPPER(correction_delete_indicatr) = 'D'
         """
 
@@ -53,8 +53,8 @@ class Command(BaseCommand):
             SELECT published_award_financial_assistance_id
             FROM   published_award_financial_assistance
             WHERE  created_at >= %(start_date)s
-            AND    (created_at < %(end_date)s OR %(end_date)s is null)
-            AND    is_active IS True
+            AND    (created_at < %(end_date)s OR %(end_date)s IS NULL)
+            AND    is_active IS TRUE
             AND    UPPER(correction_delete_indicatr) IS DISTINCT FROM 'D'
         """
 


### PR DESCRIPTION
**Description:**
In support of DEV-1904, added end date support to `fabs_nightly_loader` so that we might reload specific date ranges.

**Requirements for PR merge:**

1. [X] No unit or integration tests for this management command
2. [X] No API documentation for this management command
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations
4. [X] Materialized views are unaffected
5. [X] Frontend is unaffected
6. [X] Data validation completed
7. [X] Operations ticket [OPS-607](https://federal-spending-transparency.atlassian.net/browse/OPS-607)
8. [X] Jira Ticket [DEV-1904](https://federal-spending-transparency.atlassian.net/browse/DEV-1904)
