### PR TITLE
Fix DEV-2297: Changing encoding to match source CSV

### DIFF
--- a/usaspending_api/references/management/commands/loadcfda.py
+++ b/usaspending_api/references/management/commands/loadcfda.py
@@ -99,7 +99,7 @@ def load_from_url(rfc_path_string):
 
 
 def load_cfda_csv_into_pandas(data_file_handle):
-    df = pd.read_csv(data_file_handle, dtype=str, encoding="latin1", na_filter=False)
+    df = pd.read_csv(data_file_handle, dtype=str, encoding="cp1252", na_filter=False)
     df.rename(columns=clean_col_names, inplace=True)
 
     for field in DATA_CLEANING_MAP.keys():


### PR DESCRIPTION
**Description:**
The source CSV files have an encoding of "Windows CP-1252" (`cp1252`). The loading scripts were incorrectly set to Latin-1 (`latin1`).

**Technical details:**
See Description

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [ ] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [x] Performance evaluation of affected script
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to materialized views or endpoints.
Changes will propagate to production once previously-create PRs reach master
```
