### PR TITLE
DEV-2023: Fixed Bulk Download API bug for sub-awards

### DIFF
--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -91,7 +91,7 @@ def subaward_filter(filters, for_downloads=False):
             transaction_ids = [str(transaction_id) for transaction_id in transaction_ids]
             queryset = queryset.filter(latest_transaction_id__isnull=False)
             queryset &= queryset.extra(
-                where=['"latest_transaction_id" = ANY(\'{{{}}}\'::int[])'.format(','.join(transaction_ids))])
+                where=['"subaward_view"."latest_transaction_id" = ANY(\'{{{}}}\'::int[])'.format(','.join(transaction_ids))])
 
         elif key == "time_period":
             min_date = API_SEARCH_MIN_DATE

--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -90,8 +90,9 @@ def subaward_filter(filters, for_downloads=False):
             logger.info('Found {} transactions based on keyword: {}'.format(len(transaction_ids), keyword))
             transaction_ids = [str(transaction_id) for transaction_id in transaction_ids]
             queryset = queryset.filter(latest_transaction_id__isnull=False)
-            queryset &= queryset.extra(
-                where=['"subaward_view"."latest_transaction_id" = ANY(\'{{{}}}\'::int[])'.format(','.join(transaction_ids))])
+
+            sql_fragment = '"subaward_view"."latest_transaction_id" = ANY(\'{{{}}}\'::int[])'
+            queryset &= queryset.extra(where=[sql_fragment.format(','.join(transaction_ids))])
 
         elif key == "time_period":
             min_date = API_SEARCH_MIN_DATE

--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -91,7 +91,8 @@ def subaward_filter(filters, for_downloads=False):
             transaction_ids = [str(transaction_id) for transaction_id in transaction_ids]
             queryset = queryset.filter(latest_transaction_id__isnull=False)
 
-            sql_fragment = '"subaward_view"."latest_transaction_id" = ANY(\'{{{}}}\'::int[])'
+            # Prepare a SQL snippet to include in the predicate for searching an array of transaction IDs
+            sql_fragment = '"subaward_view"."latest_transaction_id" = ANY(\'{{{}}}\'::int[])'  # int[] -> int array type
             queryset &= queryset.extra(where=[sql_fragment.format(','.join(transaction_ids))])
 
         elif key == "time_period":


### PR DESCRIPTION
**Description:**
Added an explicit reference to the subaward materialized view to resolve a bug when trying to use the endpoint to generate downloads.

**Technical details:**
A line to add a SQL fragment caused ambiguity in the column reference.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-2023](https://federal-spending-transparency.atlassian.net/browse/DEV-2023):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Download
    - [x] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
No API behavior changes except correcting an error causing downloads to fail.
No impact to operations or frontend
```
