### PR TITLE
DEV-2189: Refactor Glossary Endpoints to V2

### DIFF
--- a/usaspending_api/api_contracts/contracts/references/Glossary.md
+++ b/usaspending_api/api_contracts/contracts/references/Glossary.md
@@ -1,0 +1,83 @@
+FORMAT: 1A
+HOST: https://api.usaspending.gov
+
+# Glossary
+
+These endpoints are used to power USAspending.gov's glossary components. 
+
+
+
+## List Glossary [/api/v2/references/glossary/{?limit,page}]
+
+This endpoint returns a list of glossary data.
+
++ Parameters
+    + `page`: `1` (optional, integer)
+        Page number to return
+    + `limit`: `10` (optional, integer)
+        Maximum number to return
+
+### List Glossary [GET]
+
++ Response 200 (application/json)
+    + Attributes (GlossaryListingObject)
+
+## Glossary Autocomplete [/api/v2/autocomplete/glossary/]
+
+This endpoint returns glossary autocomplete data for submitted text snippet.
+
+
++ Parameters
+    + search_text: `ab` (required, string)
+        The text snippet that you are trying to autocomplete using a glossary term.
+    + limit: `10` (optional, integer)
+        Maximum number to return
+
+### List Autocomplete Glossary [POST]
+
++ Request (application/json)
+
+    + Attributes
+
+        + search_text: `ab` (required, string)
+        The text snippet that you are trying to autocomplete using a glossary term.
+        + limit: `10` (optional, number)
+        Maximum number to return
+        
++ Response 200 (application/json)
+    + Attributes (GlossaryAutocompleteObject)
+
+
+# Data Structures
+
+## GlossaryListingObject (object)
++ page_metadata:(required, PageMetadata)
++ results:( required, array[GlossaryListing])
+
+## PageMetadata (object)
++ page: 1 (required, number)
++ count: 10 (required, number)
++ next: 2 (required, number, nullable)
++ previous: 1 (required, number, nullable)
++ hasNext: true (required, boolean)
++ hasPrevious: false (required, boolean)
+
+## GlossaryListing (object)
++ term: Acquisition of Assets (required, string)
++ slug: acquisition-of-assets (required, string)
++ data_act_term: Acquisition of Assets (required, string)
++ plain: This major object class includes lorem ipsum (required, string)
++ official : This major object class covers object classes 31.0 through 33.0 lorem ipsum (required, string)
++ resources: Learn More: Circular No. A-11 (required, string, nullable)
+
+## GlossaryAutocompleteObject (object)
++ results: (GlossaryTerms, fixed-type)
++ counts: (required, CountObject, fixed-type)
+
+
+## GlossaryTerms (object)
++ search_text: ab (required, string)
++ term: (required, array[string])
+
+## CountObject (object)
++ term: 4 (required, number)

--- a/usaspending_api/references/tests/test_glossary.py
+++ b/usaspending_api/references/tests/test_glossary.py
@@ -37,3 +37,8 @@ def test_glossary_endpoint(client, glossary_data):
     assert len(resp.data['results']) > 0
     for itm in resp.data['results']:
         assert 'congress' in itm['plain'].lower()
+
+    # This should probably be broken out into a new file once we sunset v1
+    resp = client.get('/api/v2/references/glossary/?limit=9999')  
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 128

--- a/usaspending_api/references/tests/test_glossary.py
+++ b/usaspending_api/references/tests/test_glossary.py
@@ -39,6 +39,6 @@ def test_glossary_endpoint(client, glossary_data):
         assert 'congress' in itm['plain'].lower()
 
     # This should probably be broken out into a new file once we sunset v1
-    resp = client.get('/api/v2/references/glossary/?limit=9999')  
+    resp = client.get('/api/v2/references/glossary/?limit=9999')
     assert resp.status_code == 200
     assert len(resp.data["results"]) == 128

--- a/usaspending_api/references/tests/test_glossary_autocomplete.py
+++ b/usaspending_api/references/tests/test_glossary_autocomplete.py
@@ -14,11 +14,13 @@ def glossary_data(db):
     mommy.make(
         Definition,
         term='Word',
+        slug="ab",
         plain='Plaintext response.',
         official='Official language.')
     mommy.make(
         Definition,
         term='Word2',
+        slug="aa",
         plain='Plaintext response. 2',
         official='Official language. 2')
     mommy.make(
@@ -41,6 +43,43 @@ def test_glossary_autocomplete(client, glossary_data, fields, value, expected):
 
     check_autocomplete('references/glossary', client, fields, value, expected)
 
+@pytest.mark.django_db
+def test_glossary_v2_autocomplete(client):
+    mommy.make(
+        Definition,
+        term='Abacus',
+        slug="ab",)
+    mommy.make(
+        Definition,
+        term="Aardvark",
+        slug="aa")
+        
+    resp = client.post(
+        '/api/v2/autocomplete/glossary/',
+        content_type='application/json',
+        data=json.dumps({"search_text":"ab"}))
+    json_response = json.loads(resp.content.decode("utf-8"))
+    assert resp.status_code == status.HTTP_200_OK
+    assert json_response['results']['search_text'] == "ab"
+    assert json_response['results']['term'] == ["Abacus"]
+
+    resp = client.post(
+        '/api/v2/autocomplete/glossary/',
+        content_type='application/json',
+        data=json.dumps({"search_text":"aa"}))
+    json_response = json.loads(resp.content.decode("utf-8"))
+    assert resp.status_code == status.HTTP_200_OK
+    assert json_response['results']['search_text'] == "aa"
+    assert json_response['results']['term'] == ["Aardvark"]
+
+    resp = client.post(
+        '/api/v2/autocomplete/glossary/',
+        content_type='application/json',
+        data=json.dumps({"search_text":"a"}))
+    json_response = json.loads(resp.content.decode("utf-8"))
+    assert resp.status_code == status.HTTP_200_OK
+    assert json_response['results']['search_text'] == "a"
+    assert sorted(json_response['results']['term']) == ["Aardvark","Abacus"]
 
 @pytest.mark.django_db
 def test_bad_glossary_autocomplete_request(client):
@@ -48,6 +87,16 @@ def test_bad_glossary_autocomplete_request(client):
 
     resp = client.post(
         '/api/v1/references/glossary/autocomplete/',
+        content_type='application/json',
+        data=json.dumps({}))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+@pytest.mark.django_db
+def test_bad_v2_glossary_autocomplete_request(client):
+    """Verify error on bad autocomplete request for awards."""
+
+    resp = client.post(
+        '/api/v2/autocomplete/glossary/',
         content_type='application/json',
         data=json.dumps({}))
     assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/usaspending_api/references/tests/test_glossary_autocomplete.py
+++ b/usaspending_api/references/tests/test_glossary_autocomplete.py
@@ -14,13 +14,11 @@ def glossary_data(db):
     mommy.make(
         Definition,
         term='Word',
-        slug="ab",
         plain='Plaintext response.',
         official='Official language.')
     mommy.make(
         Definition,
         term='Word2',
-        slug="aa",
         plain='Plaintext response. 2',
         official='Official language. 2')
     mommy.make(

--- a/usaspending_api/references/tests/test_glossary_autocomplete.py
+++ b/usaspending_api/references/tests/test_glossary_autocomplete.py
@@ -41,6 +41,7 @@ def test_glossary_autocomplete(client, glossary_data, fields, value, expected):
 
     check_autocomplete('references/glossary', client, fields, value, expected)
 
+
 @pytest.mark.django_db
 def test_glossary_v2_autocomplete(client):
     mommy.make(
@@ -51,11 +52,11 @@ def test_glossary_v2_autocomplete(client):
         Definition,
         term="Aardvark",
         slug="aa")
-        
+
     resp = client.post(
         '/api/v2/autocomplete/glossary/',
         content_type='application/json',
-        data=json.dumps({"search_text":"ab"}))
+        data=json.dumps({"search_text": "ab"}))
     json_response = json.loads(resp.content.decode("utf-8"))
     assert resp.status_code == status.HTTP_200_OK
     assert json_response['results']['search_text'] == "ab"
@@ -64,7 +65,7 @@ def test_glossary_v2_autocomplete(client):
     resp = client.post(
         '/api/v2/autocomplete/glossary/',
         content_type='application/json',
-        data=json.dumps({"search_text":"aa"}))
+        data=json.dumps({"search_text": "aa"}))
     json_response = json.loads(resp.content.decode("utf-8"))
     assert resp.status_code == status.HTTP_200_OK
     assert json_response['results']['search_text'] == "aa"
@@ -73,11 +74,12 @@ def test_glossary_v2_autocomplete(client):
     resp = client.post(
         '/api/v2/autocomplete/glossary/',
         content_type='application/json',
-        data=json.dumps({"search_text":"a"}))
+        data=json.dumps({"search_text": "a"}))
     json_response = json.loads(resp.content.decode("utf-8"))
     assert resp.status_code == status.HTTP_200_OK
     assert json_response['results']['search_text'] == "a"
-    assert sorted(json_response['results']['term']) == ["Aardvark","Abacus"]
+    assert sorted(json_response['results']['term']) == ["Aardvark", "Abacus"]
+
 
 @pytest.mark.django_db
 def test_bad_glossary_autocomplete_request(client):
@@ -88,6 +90,7 @@ def test_bad_glossary_autocomplete_request(client):
         content_type='application/json',
         data=json.dumps({}))
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
 
 @pytest.mark.django_db
 def test_bad_v2_glossary_autocomplete_request(client):

--- a/usaspending_api/references/v2/urls.py
+++ b/usaspending_api/references/v2/urls.py
@@ -2,8 +2,10 @@ from django.conf.urls import url
 from rest_framework.routers import DefaultRouter
 
 from usaspending_api.references.v1 import views
-from usaspending_api.references.v2.views import agency, toptier_agencies, data_dictionary
+from usaspending_api.references.v2.views import agency, toptier_agencies, data_dictionary, glossary
 
+
+# This does not appear to be used and looks like its an artifact from a copy-pasta of v1 urls. Can probably delete?
 glossary_router = DefaultRouter()
 glossary_router.register('glossary', views.GlossaryViewSet)
 
@@ -15,4 +17,5 @@ urlpatterns = [
     url(r'^agency/(?P<pk>[0-9]+)/$', agency.AgencyViewSet.as_view()),
     url(r'^toptier_agencies/$', toptier_agencies.ToptierAgenciesViewSet.as_view()),
     url(r'^data_dictionary/$', data_dictionary.DataDictionaryViewSet.as_view()),
+    url(r'^glossary/$', glossary.GlossaryViewSet.as_view()),
 ]

--- a/usaspending_api/references/v2/urls_autocomplete.py
+++ b/usaspending_api/references/v2/urls_autocomplete.py
@@ -1,7 +1,8 @@
 from django.conf.urls import url
 from usaspending_api.references.v2.views.autocomplete import AwardingAgencyAutocompleteViewSet, \
     FundingAgencyAutocompleteViewSet, CFDAAutocompleteViewSet, \
-    NAICSAutocompleteViewSet, PSCAutocompleteViewSet, RecipientAutocompleteViewSet
+    NAICSAutocompleteViewSet, PSCAutocompleteViewSet, RecipientAutocompleteViewSet, \
+    GlossaryAutocompleteViewSet
 
 urlpatterns = [
     url(r'^awarding_agency', AwardingAgencyAutocompleteViewSet.as_view()),
@@ -10,4 +11,5 @@ urlpatterns = [
     url(r'^naics', NAICSAutocompleteViewSet.as_view()),
     url(r'^psc', PSCAutocompleteViewSet.as_view()),
     url(r'^recipient', RecipientAutocompleteViewSet.as_view()),
+    url(r'^glossary', GlossaryAutocompleteViewSet.as_view()),
     ]

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -215,7 +215,6 @@ class GlossaryAutocompleteViewSet(BaseAutocompleteViewSet):
                 'term':glossary_terms.count()
             }
         }
-
         return Response(response)
 
 

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -208,11 +208,11 @@ class GlossaryAutocompleteViewSet(BaseAutocompleteViewSet):
             'results':{
                 'search_text':search_text,
                 'term':
-                    glossary_terms.values_list('term', flat=True)
+                    glossary_terms.values_list('term', flat=True)[:limit]
 
             },
             'counts':{
-                'term':glossary_terms.count()
+                'term':min(glossary_terms.count(), limit)
             }
         }
         return Response(response)

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -5,7 +5,7 @@ from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.awards.models import LegalEntity
 
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.references.models import Agency, Cfda, NAICS, PSC
+from usaspending_api.references.models import Agency, Cfda, NAICS, PSC, Definition
 from usaspending_api.references.v1.serializers import AgencySerializer
 
 
@@ -192,3 +192,31 @@ class RecipientAutocompleteViewSet(BaseAutocompleteViewSet):
         }
 
         return Response(response)
+
+class GlossaryAutocompleteViewSet(BaseAutocompleteViewSet):
+
+    @cache_response()
+    def post(self, request):
+        
+        search_text, limit = self.get_request_payload(request)
+
+        queryset = Definition.objects.all()
+        
+        glossary_terms = queryset.filter(slug__icontains=search_text)
+
+        response = {
+            'results':{
+                'search_text':search_text,
+                'term':
+                    glossary_terms.values_list('term', flat=True)
+
+            },
+            'counts':{
+                'term':glossary_terms.count()
+            }
+        }
+
+        return Response(response)
+
+
+

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -193,29 +193,27 @@ class RecipientAutocompleteViewSet(BaseAutocompleteViewSet):
 
         return Response(response)
 
+
 class GlossaryAutocompleteViewSet(BaseAutocompleteViewSet):
 
     @cache_response()
     def post(self, request):
-        
+
         search_text, limit = self.get_request_payload(request)
 
         queryset = Definition.objects.all()
-        
+
         glossary_terms = queryset.filter(slug__icontains=search_text)
 
         response = {
-            'results':{
-                'search_text':search_text,
+            'results': {
+                'search_text': search_text,
                 'term':
                     glossary_terms.values_list('term', flat=True)[:limit]
 
             },
-            'counts':{
-                'term':min(glossary_terms.count(), limit)
+            'counts': {
+                'term': min(glossary_terms.count(), limit)
             }
         }
         return Response(response)
-
-
-

--- a/usaspending_api/references/v2/views/glossary.py
+++ b/usaspending_api/references/v2/views/glossary.py
@@ -1,5 +1,11 @@
+from rest_framework.response import Response
+from rest_framework.request import Request
 
-
+from usaspending_api.common.helpers.generic_helper import get_pagination
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.common.views import APIDocumentationView
+from usaspending_api.common.serializers import LimitableSerializer
+from usaspending_api.references.models import Definition
 
 
 class DefinitionSerializer(LimitableSerializer):
@@ -8,3 +14,38 @@ class DefinitionSerializer(LimitableSerializer):
 
         model = Definition
         fields = ['term', 'slug', 'data_act_term', 'plain', 'official', 'resources']
+
+
+class GlossaryViewSet(APIDocumentationView):
+    """
+    This view returns paginated glossary terms in a list
+    """
+
+    @cache_response()
+    def get(self, request: Request) -> Response:
+        """
+        Accepts only pagination-related query parameters
+        """
+
+        get_request = request.query_params
+        limit = get_request.get('limit', 500)
+        page = get_request.get('page', 1)
+
+        queryset = Definition.objects.all()
+        queryset, pagination = get_pagination(queryset, int(limit), int(page))
+
+        serializer = DefinitionSerializer(queryset, many=True)
+        response = {
+            "page_metadata":pagination,
+            "results":serializer.data
+        }
+
+        return Response(response)
+
+
+
+
+
+
+
+

--- a/usaspending_api/references/v2/views/glossary.py
+++ b/usaspending_api/references/v2/views/glossary.py
@@ -36,16 +36,8 @@ class GlossaryViewSet(APIDocumentationView):
 
         serializer = DefinitionSerializer(queryset, many=True)
         response = {
-            "page_metadata":pagination,
-            "results":serializer.data
+            "page_metadata": pagination,
+            "results": serializer.data
         }
 
         return Response(response)
-
-
-
-
-
-
-
-

--- a/usaspending_api/references/v2/views/glossary.py
+++ b/usaspending_api/references/v2/views/glossary.py
@@ -1,0 +1,10 @@
+
+
+
+
+class DefinitionSerializer(LimitableSerializer):
+
+    class Meta:
+
+        model = Definition
+        fields = ['term', 'slug', 'data_act_term', 'plain', 'official', 'resources']


### PR DESCRIPTION
**Description:**
Glossary endpoint migration to v2

**Technical details:**
Migrated using basic application of strategy developed in DEV-2192, does continue use of serializers but they are strictly limited. Passing unit tests, and contract passes Dredd. The responses are exact replicas of the current v1 responses, but the requests do need to be modified by the front end, per the API Contract.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend 
4. [NA] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-2189](https://federal-spending-transparency.atlassian.net/browse/DEV-2189):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
New endpoint so no before/after, and no effect on matviews and no need for ops ticket as no data changes
```
