### PR TITLE
DEV-1904: Enhance fabs_nightly_loader to accept FABS transaction ids

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -206,10 +206,10 @@ class Command(BaseCommand):
 
         else:
             with timer("obtaining delete records", logger.info):
-                ids_to_delete = get_fabs_records_to_delete(submission_ids, start_datetime, end_datetime)
+                ids_to_delete = get_fabs_records_to_delete(submission_ids, afa_ids, start_datetime, end_datetime)
 
             with timer("retrieving/diff-ing FABS Data", logger.info):
-                ids_to_upsert = get_fabs_transaction_ids(submission_ids, start_datetime, end_datetime)
+                ids_to_upsert = get_fabs_transaction_ids(submission_ids, afa_ids, start_datetime, end_datetime)
 
         update_award_ids = delete_fabs_transactions(ids_to_delete, do_not_log_deletions)
         upsert_fabs_transactions(ids_to_upsert, update_award_ids)

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -201,11 +201,15 @@ class Command(BaseCommand):
             submission_ids = get_new_submission_ids(last_load_date)
             logger.info('Processing data for FABS starting from %s' % last_load_date)
 
-        with timer("obtaining delete records", logger.info):
-            ids_to_delete = get_fabs_records_to_delete(submission_ids, afa_ids, start_datetime, end_datetime)
+        if is_incremental_load and not submission_ids:
+            logger.info("No new submissions. Exiting.")
 
-        with timer("retrieving/diff-ing FABS Data", logger.info):
-            ids_to_upsert = get_fabs_transaction_ids(submission_ids, afa_ids, start_datetime, end_datetime)
+        else:
+            with timer("obtaining delete records", logger.info):
+                ids_to_delete = get_fabs_records_to_delete(submission_ids, start_datetime, end_datetime)
+
+            with timer("retrieving/diff-ing FABS Data", logger.info):
+                ids_to_upsert = get_fabs_transaction_ids(submission_ids, start_datetime, end_datetime)
 
         update_award_ids = delete_fabs_transactions(ids_to_delete, do_not_log_deletions)
         upsert_fabs_transactions(ids_to_upsert, update_award_ids)


### PR DESCRIPTION
**Description:**

Enhanced `fabs_nightly_loader` to accept FABS transaction ids.

**Requirements for PR merge:**

1. [X] No tests to be updated
2. [X] API documentation affected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] No materialized views affected
5. [X] Front end is unaffected
6. [X] Data validation completed
7. [X] Operations ticket [OPS-624](https://federal-spending-transparency.atlassian.net/browse/OPS-624)
8. [X] Jira Ticket [DEV-1904](https://federal-spending-transparency.atlassian.net/browse/DEV-1904):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison
