### PR TITLE
DEV-2419: Pull funding account title from correct table

### DIFF
--- a/usaspending_api/awards/tests/data/idv_funding_data.py
+++ b/usaspending_api/awards/tests/data/idv_funding_data.py
@@ -75,13 +75,20 @@ def create_funding_data_tree():
         )
 
         mommy.make(
+            'accounts.FederalAccount',
+            id=_id,
+            account_title='FederalAccount account title %s' % _sid
+        )
+
+        mommy.make(
             'accounts.TreasuryAppropriationAccount',
             treasury_account_identifier=_id,
+            federal_account_id=_id,
             reporting_agency_id=str(_id).zfill(3),
             reporting_agency_name='reporting agency name %s' % _sid,
             agency_id=str(_id).zfill(3),
             main_account_code=str(_id).zfill(4),
-            account_title='account title %s' % _sid
+            account_title='TreasuryAppropriationAccount account title %s' % _sid
         )
 
         mommy.make(

--- a/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
+++ b/usaspending_api/awards/tests/test_awards_idvs_funding_v2.py
@@ -44,7 +44,7 @@ class IDVFundingTestCase(TestCase):
                 'reporting_agency_name': 'reporting agency name %s' % _sid,
                 'agency_id': _sid.zfill(3),
                 'main_account_code': _sid.zfill(4),
-                'account_title': 'account title %s' % _sid,
+                'account_title': 'FederalAccount account title %s' % _sid,
                 'program_activity_code': _sid,
                 'program_activity_name': 'program activity %s' % _sid,
                 'object_class': '1' + _sid,

--- a/usaspending_api/awards/v2/views/idvs/funding.py
+++ b/usaspending_api/awards/v2/views/idvs/funding.py
@@ -15,7 +15,7 @@ from usaspending_api.common.validator.tinyshield import TinyShield
 
 
 SORTABLE_COLUMNS = {
-    'account_title': ['taa.account_title'],
+    'account_title': ['fa.account_title'],
     'object_class': ['oc.object_class_name', 'oc.object_class'],
     'piid': ['ca.piid'],
     'program_activity': ['rpa.program_activity_code', 'rpa.program_activity_name'],
@@ -54,7 +54,7 @@ GET_FUNDING_SQL = SQL("""
         taa.reporting_agency_name,
         taa.agency_id,
         taa.main_account_code,
-        taa.account_title,
+        fa.account_title,
         rpa.program_activity_code,
         rpa.program_activity_name,
         oc.object_class,
@@ -74,6 +74,8 @@ GET_FUNDING_SQL = SQL("""
             sa.submission_id = faba.submission_id
         left outer join treasury_appropriation_account taa on
             taa.treasury_account_identifier = faba.treasury_account_id
+        left outer join federal_account fa on
+            fa.id = taa.federal_account_id
         left outer join ref_program_activity rpa on
             rpa.id = faba.program_activity_id
         left outer join object_class oc on


### PR DESCRIPTION
**Description:**
The `Total Count of Federal Accounts` value appears incorrect when compared to the count of `Federal Account Name` values listed on the `Federal Account Funding` tab.  This pull request fixes that by pulling the preferred named instead of an alternate name.

**Technical details:**
The `api/v2/awards/idvs/funding/` endpoint should now pull `account_title` from `federal_account` instead of `treasury_appropriation_account`.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] No API documentation updates required
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] No materialized views affected
5. [X] Front end not affected
6. [X] Data validation completed
7. [X] No Operations tickets required
8. [X] Jira Ticket [DEV-2419](https://federal-spending-transparency.atlassian.net/browse/DEV-2419):
    - [X] Link to this Pull-Request
    - [X] Performance will be affected slightly as yet another table is drawn into the underlying query
    - [X] Before / After data comparison
