### PR TITLE
DEV-1904: Convert transaction loading to use file instead of command line parameter

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -110,6 +110,11 @@ def get_fabs_records_to_delete(submission_ids, afa_ids, start_datetime, end_date
     return ids
 
 
+def read_afa_ids_from_file(afa_id_file_path):
+    with open(afa_id_file_path) as f:
+        return tuple(l.rstrip() for l in f)
+
+
 class Command(BaseCommand):
     help = "Update FABS data in USAspending from Broker. Command line parameters " \
            "are ANDed together so, for example, providing a transaction id and a " \
@@ -134,15 +139,11 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--afa-ids",
-            metavar="ID",
-            nargs="+",
+            "--afa-id-file",
+            metavar="FILEPATH",
             type=str,
-            help='Broker transaction IDs (afa_generated_unique) to reload. Nonexistent '
-                 'IDs will be ignored. IMPORTANT: Due to a limitation with command line '
-                 'parameters, any transaction IDs that start with a dash should be '
-                 'wrapped in quotes and include a leading space, for example: '
-                 '" -none-_1234_5678_-none-"'
+            help='A file containing only broker transaction IDs (afa_generated_unique) '
+                 'to reload, one ID per line. Nonexistent IDs will be ignored.'
         )
 
         parser.add_argument(
@@ -184,12 +185,7 @@ class Command(BaseCommand):
             end_datetime = None
         else:
             submission_ids = tuple(options["submission_ids"]) if options["submission_ids"] else None
-            # Need to trim spaces on afa ids due to a limitation of command line
-            # parameters that are preceded with a dash.  The workaround is to wrap
-            # the value in quotes with a leading space.  This means we need to trim
-            # that space.  The downside is that afa ids that actually start with
-            # or end with spaces will never be found... but currently this never happens...
-            afa_ids = tuple(o.strip() for o in options["afa_ids"]) if options["afa_ids"] else None
+            afa_ids = read_afa_ids_from_file(options['afa_id_file']) if options['afa_id_file'] else None
             start_datetime = options["start_datetime"]
             end_datetime = options["end_datetime"]
 


### PR DESCRIPTION
**Description:**

Loading individual transactions originally used command line parameters but that was proving problematic due to python/shell/jenkins restrictions on accepting parameters with leading dashes and/or containing spaces.  Now we accept a file path that contains said ids.

**Requirements for PR merge:**

1. [X] No tests to be updated
2. [X] API documentation affected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] No materialized views affected
5. [X] Front end is unaffected
6. [X] Data validation completed
7. [X] Operations ticket [OPS-624](https://federal-spending-transparency.atlassian.net/browse/OPS-624)
8. [X] Jira Ticket [DEV-1904](https://federal-spending-transparency.atlassian.net/browse/DEV-1904):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison
