### PR TITLE
DEV-2308: Office Backfill Funding Derivations

### DIFF
--- a/usaspending_api/broker/management/commands/derive_office_names.py
+++ b/usaspending_api/broker/management/commands/derive_office_names.py
@@ -32,17 +32,18 @@ class Command(load_base.Command):
         ds_cursor = connection.cursor()
 
         logger.info('Creating a temporary Office table copied from the Broker...')
-        db_cursor.execute('SELECT office_name, office_code FROM office')
+        db_cursor.execute('SELECT office_name, office_code, sub_tier_code FROM office')
         all_offices = dictfetchall(db_cursor)
         all_offices_list = []
         for o in all_offices:
             office_name = o['office_name'].replace("'", "''")
             office_code = o['office_code'].replace("'", "''")
-            all_offices_list.append("('" + office_name + "','" + office_code + "')")
+            sub_tier_code = o['sub_tier_code'].replace("'", "''")
+            all_offices_list.append("('" + office_name + "','" + office_code + "','" + sub_tier_code + "')")
         all_offices_str = ', '.join(all_offices_list)
 
-        ds_cursor.execute('CREATE TABLE temp_broker_office (office_name TEXT, office_code TEXT)')
-        ds_cursor.execute('INSERT INTO temp_broker_office (office_name, office_code) VALUES ' + all_offices_str)
+        ds_cursor.execute('CREATE TABLE temp_broker_office (office_name TEXT, office_code TEXT, sub_tier_code TEXT)')
+        ds_cursor.execute('INSERT INTO temp_broker_office (office_name, office_code, sub_tier_code) VALUES ' + all_offices_str)
 
         logger.info('Deriving FABS awarding_office_names with awarding_office_codes from the temporary Office table...')
         ds_cursor.execute(
@@ -64,6 +65,42 @@ class Command(load_base.Command):
             "WHERE t_fabs.funding_office_code = office.office_code "
             "  AND t_fabs.action_date >= '2018-10-01' "
             "  AND t_fabs.funding_office_name IS NULL "
+            "  AND t_fabs.funding_office_code IS NOT NULL")
+        logger.info(ds_cursor.rowcount)
+        # logger.info('Made changes to {} records'.format(ds_cursor.results))
+
+        logger.info("Deriving FABS funding_sub_tier_agency_co, funding_sub_tier_agency_na, funding_agency_code, "
+                    "funding_agency_name from the temporary Office table...")
+        ds_cursor.execute(
+            "WITH agency_list AS ("
+            "  SELECT "
+            "    tta.cgac_code AS agency_code,"
+            "    tta.name AS agency_name,"
+            "    sta.subtier_code AS sub_tier_code,"
+            "    sta.name AS sub_tier_name"
+            "  FROM agency AS a"
+            "  INNER JOIN toptier_agency tta ON tta.toptier_agency_id = a.toptier_agency_id"
+            "  INNER JOIN subtier_agency sta ON sta.subtier_agency_id = a.subtier_agency_id"
+            "),"
+            "office_list AS ("
+            "  SELECT "
+            "    office.office_code,"
+            "    agency_list.agency_code,"
+            "    agency_list.agency_name,"
+            "    agency_list.sub_tier_code,"
+            "    agency_list.sub_tier_name"
+            "  FROM temp_broker_office AS office"
+            "  INNER JOIN agency_list ON agency_list.sub_tier_code = office.sub_tier_code"
+            ")"
+            "UPDATE transaction_fabs AS t_fabs "
+            "SET funding_sub_tier_agency_co = office_list.sub_tier_code,"
+            "  funding_sub_tier_agency_na = office_list.sub_tier_name,"
+            "  funding_agency_code = office_list.agency_code,"
+            "  funding_agency_name = office_list.agency_name "
+            "FROM office_list "
+            "WHERE t_fabs.funding_office_code = office_list.office_code"
+            "  AND t_fabs.action_date >= '2018/10/01'"
+            "  AND t_fabs.funding_sub_tier_agency_co IS NULL"
             "  AND t_fabs.funding_office_code IS NOT NULL")
         logger.info(ds_cursor.rowcount)
         # logger.info('Made changes to {} records'.format(ds_cursor.results))

--- a/usaspending_api/broker/management/commands/derive_office_names.py
+++ b/usaspending_api/broker/management/commands/derive_office_names.py
@@ -43,7 +43,8 @@ class Command(load_base.Command):
         all_offices_str = ', '.join(all_offices_list)
 
         ds_cursor.execute('CREATE TABLE temp_broker_office (office_name TEXT, office_code TEXT, sub_tier_code TEXT)')
-        ds_cursor.execute('INSERT INTO temp_broker_office (office_name, office_code, sub_tier_code) VALUES ' + all_offices_str)
+        ds_cursor.execute('INSERT INTO temp_broker_office (office_name, office_code, sub_tier_code) VALUES ' +
+                          all_offices_str)
 
         logger.info('Deriving FABS awarding_office_names with awarding_office_codes from the temporary Office table...')
         ds_cursor.execute(


### PR DESCRIPTION
**Description:**
It was discovered that the office backfilling derivations script didn't account for funding agencies. This remediates that.

**Technical details:**
Should nearly match the equivalent broker SQL found in the [Broker PR](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1560)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created [OPS-645](https://federal-spending-transparency.atlassian.net/browse/OPS-645)
8. [x] Jira Ticket [DEV-2308](https://federal-spending-transparency.atlassian.net/browse/DEV-2308):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Matview impact assessment completed - no direct matview impact
Frontend impact assessment completed - no frontend impact
API documentation updated - no documentation needed
Unit & integration tests updated - no unit tests related to script
```
