### PR TITLE
DEV-2336: Mark download jobs as failed if they fail before being queued

### DIFF
--- a/usaspending_api/awards/v2/filters/idv_filters.py
+++ b/usaspending_api/awards/v2/filters/idv_filters.py
@@ -26,7 +26,7 @@ def idv_order_filter(filters):
     idv_award_id = _get_idv_award_id(filters)
     descendant_award_ids = get_descendant_award_ids(idv_award_id, True)
     if len(descendant_award_ids) < 1:
-        raise InvalidParameterException('Provided IDV award id has no descendants')
+        raise InvalidParameterException('Provided IDV award id has no descendant orders')
     return Award.objects.filter(id__in=descendant_award_ids)
 
 


### PR DESCRIPTION
**Description:**
Fixes bug where download jobs were not being marked as failed if they failed before being queued.

**Requirements for PR merge:**

1. [X] No tests for this issue
2. [X] No API documentation needs to be updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] No materialized views were affected
5. [X] Front end should not be affected as this is a new feature
6. [X] Data validation completed
7. [X] No Operations ticket required
8. [X] Jira Ticket [DEV-DEV-2336](https://federal-spending-transparency.atlassian.net/browse/DEV-2336):
    - [X] Link to this Pull-Request
