### PR TITLE
DEV-2561: Corrected a number of hardcoded URLs

### DIFF
--- a/usaspending_api/api_docs/markdown/api_tutorial.md
+++ b/usaspending_api/api_docs/markdown/api_tutorial.md
@@ -28,7 +28,7 @@ Welcome to the introductory USAspending API tutorial. This tutorial is designed 
 
 _API_ stands for _Application Programmer Interface_. APIs make it easy for computer programs to request and receive information in a format they can understand.
 
-If you're looking for federal spending data that's designed to be read by humans instead of computers, you should head to <a href="https://beta.usaspending.gov">our website</a>.
+If you're looking for federal spending data that's designed to be read by humans instead of computers, you should head to <a href="https://www.usaspending.gov">our website</a>.
 
 ## Using the API <a name="using-the-api"></a>
 

--- a/usaspending_api/api_docs/unused_markdown/request_recipes.md
+++ b/usaspending_api/api_docs/unused_markdown/request_recipes.md
@@ -96,4 +96,4 @@ POST
 
 # Postman Collections <a name="postman"></a>
 
-[Postman](https://www.getpostman.com/) is a free app for making easy API requests. You can also use it to import and inspect a collection of pre-generated API requests. [Here is a postman collection](https://raw.githubusercontent.com/fedspendingtransparency/usaspending-api/master/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json) you can use to see how we generate the visualizations on [the search page](https://beta.usaspending.gov/#/search/).
+[Postman](https://www.getpostman.com/) is a free app for making easy API requests. You can also use it to import and inspect a collection of pre-generated API requests. [Here is a postman collection](https://raw.githubusercontent.com/fedspendingtransparency/usaspending-api/master/usaspending_api/static_doc_files/docs/usaspending_searchpage_postmancollection.json) you can use to see how we generate the visualizations on [the search page](https://www.usaspending.gov/#/search/).

--- a/usaspending_api/api_docs/unused_markdown/using_the_api.md
+++ b/usaspending_api/api_docs/unused_markdown/using_the_api.md
@@ -366,13 +366,13 @@ The endpoints described in this section generate files that reflect the site's u
 
 #### Award Data Archive
 
-On a monthly basis, the website pre-generates a series of commonly used files based on the agency, fiscal year, and award type. You can find these on the [Award Data Archive](https://beta.usaspending.gov/#/download_center/award_data_archive) page. You can also access this information via the API's [List Downloads Endpoint](https://api.usaspending.gov/api/v2/bulk_download/list_monthly_files/).
+On a monthly basis, the website pre-generates a series of commonly used files based on the agency, fiscal year, and award type. You can find these on the [Award Data Archive](https://www.usaspending.gov/#/download_center/award_data_archive) page. You can also access this information via the API's [List Downloads Endpoint](https://api.usaspending.gov/api/v2/bulk_download/list_monthly_files/).
 
 #### Generating Download Files
 
 **Reminder**: Before using these endpoints, check the  [Award Data Archive](https://usaspending.gov/#/download_center/award_data_archive) for pre-generated files
 
-There are several downloadable endpoints, all with different features/constraints. 
+There are several downloadable endpoints, all with different features/constraints.
 
 ##### Row Constraint Downloads
 
@@ -416,7 +416,7 @@ To check to see whether that request is complete, use the [Status Endpoint](http
   * `date_part`: Applies only when `group` is a data field and specifies which part of the date to group by; `year`, `month`, and `day` are currently supported, and `quarter` is coming soon
   * `show_nulls`: Whether to display results where the `group` data or the aggregate field data is null. In effect, this sets `show_null_aggregates` and `show_null_groups` to true. Defaults to false.
   * `show_null_groups`: Whether to display aggregates where all the `group` data is null. Defaults to false.
-  * `show_null_aggregates`: Whether to display entries where the aggregate is null. 
+  * `show_null_aggregates`: Whether to display entries where the aggregate is null.
 
   Requests to the summary endpoints can also contain the `filters` parameters as described in [POST Requests](#post-requests). **Note:** If you're filtering the data, the filters are applied before the data is summarized.
 

--- a/usaspending_api/references/management/commands/load_rosetta.py
+++ b/usaspending_api/references/management/commands/load_rosetta.py
@@ -40,7 +40,7 @@ DB_TO_XLSX_MAPPING = OrderedDict(
 class Command(BaseCommand):
     help = "Loads an Excel spreadsheet of DATA Act/USAspending data names across the various systems into <>"
 
-    s3_public_url = "http://files{}.usaspending.gov/docs/DATA+Transparency+Crosswalk.xlsx"
+    s3_public_url = "https://files{}.usaspending.gov/docs/DATA+Transparency+Crosswalk.xlsx"
 
     def add_arguments(self, parser):
         parser.add_argument("-p", "--path", help="filepath to a local Excel spreadsheet to load", default=None)

--- a/usaspending_api/templates/index.html
+++ b/usaspending_api/templates/index.html
@@ -25,7 +25,10 @@
         <div class="row">
             <nav class="navbar">
                 <div class="container usa-da-header-container">
-                    <h1><a href="/"><img class="logo" src='{% static "img/logo.png" %}'/> API</a></h1>
+                    <h1>
+                      <a href="https://www.usaspending.gov"><img class="logo" src='{% static "img/logo.png" %}'/></a>
+                      <a href="/">API</a>
+                    </h1>
                     <ul id="usa-da-header-link-holder" class="nav nav-row">
 
                         <li class="element first active ">


### PR DESCRIPTION
**Description:**
Running site scans flagged a number of minor links which either:
- Needed to be https
- Changed from beta.usaspending.gov to www.usaspending.gov

**Technical details:**
Instead of waiting for the code changes to propagate and reload the data dictionary, I manually added the "s" to the URL stored in the JSON doc in the DBs on staging and production

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-2561](https://federal-spending-transparency.atlassian.net/browse/DEV-2561):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (N/A)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No impact to API behavior
No additional operations
```
