### PR TITLE
add supervisor to server reqs, remove legacy file

### DIFF
--- a/requirements/legacy_requirements.txt
+++ b/requirements/legacy_requirements.txt
@@ -1,2 +1,0 @@
-# This file is to include packages for Python2 aka "Legacy Python"
-supervisor==3.3.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -38,6 +38,7 @@ pytz==2016.6.1
 requests==2.20.0
 retrying==1.3.3
 six==1.10.0
+supervisor==4.0.2
 unicodecsv==0.14.1
 urllib3==1.24.2
 xlrd==1.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -38,7 +38,6 @@ pytz==2016.6.1
 requests==2.20.0
 retrying==1.3.3
 six==1.10.0
-supervisor==4.0.2
 unicodecsv==0.14.1
 urllib3==1.24.2
 xlrd==1.0.0

--- a/requirements/server_requirements.txt
+++ b/requirements/server_requirements.txt
@@ -1,1 +1,2 @@
+supervisor==4.0.2
 uwsgi==2.0.17.1


### PR DESCRIPTION
During the deploy process (see fedspendingtransparency/data-act-build-tools#198) we use Python 2 to support an old version of supervisor. This upgrades that by moving it into the reqs file used w/Python 3, server_requirements.txt.

The conditional check will happen with the next deployment. Supervisord 4.0.2 is currently running in sandbox.