### PR TITLE
DEV-2336: HOTFIX: Added carriage returns to readme file for Windows

### DIFF
--- a/usaspending_api/download/filestreaming/file_description.py
+++ b/usaspending_api/download/filestreaming/file_description.py
@@ -15,7 +15,10 @@ def build_file_description(source_file_template, sources):
 
 def save_file_description(working_dir, file_name, file_description):
 
-    # Honestly not even sure this deserves its own function.  So trivial.
+    # Because this file will be read by Windows machines, it will need carriage
+    # returns and line feeds.  /sigh.
+    file_description = '\r\n'.join(file_description.splitlines())
+
     # Build the destination path and create the file using the provided text.
     destination_file_path = os.path.join(working_dir, file_name)
     with open(destination_file_path, "w") as f:

--- a/usaspending_api/download/tests/unit/test_file_description.py
+++ b/usaspending_api/download/tests/unit/test_file_description.py
@@ -13,6 +13,12 @@ def test_save_file_description():
         assert file_path == f.name
         assert f.read().decode("utf-8") == "this is a test"
 
+    with NamedTemporaryFile() as f:
+        working_dir, file_name = os.path.split(f.name)
+        file_path = save_file_description(working_dir, file_name, "this\ris\na\r\ntest")
+        assert file_path == f.name
+        assert f.read().decode("utf-8") == "this\r\nis\r\na\r\ntest"
+
 
 def test_build_file_description():
 


### PR DESCRIPTION
**Description:**
Fixed an issue that was causing Windows to jam all of the readme paragraphs together in one great big giant long string.

**Technical details:**
As everyone is well aware (but at least one of us forgot), Windows likes CARRIAGE RETURN/LINE FEED for line endings.  These are now standard issue in the IDV download readme file.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] No API documentation affected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] No materialized views affected
5. [x] Front end unaffected
6. [x] Data unaffected
7. [x] No operations ticket required
8. [x] Jira Ticket [DEV-2336](https://federal-spending-transparency.atlassian.net/browse/DEV-2336):
    - [x] Link to this Pull-Request
