### PR TITLE
Hotfix connection issues during Elasticsearch ETL

### DIFF
--- a/usaspending_api/common/helpers/sql_helpers.py
+++ b/usaspending_api/common/helpers/sql_helpers.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from collections import OrderedDict
+from django.conf import settings
 from django.db import connections, router
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Func, IntegerField
@@ -15,6 +16,14 @@ from usaspending_api.common.exceptions import InvalidParameterException
 logger = logging.getLogger('console')
 
 TYPES_TO_QUOTE_IN_SQL = (str, datetime.date)
+
+
+def get_database_dsn_string(force_default=False):
+    if settings.IS_LOCAL or force_default:
+        db = settings.DATABASES["default"]
+    else:
+        db = settings.DATABASES["db_source"]
+    return "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(**db)
 
 
 def read_sql_file(file_path):

--- a/usaspending_api/common/helpers/sql_helpers.py
+++ b/usaspending_api/common/helpers/sql_helpers.py
@@ -19,10 +19,19 @@ TYPES_TO_QUOTE_IN_SQL = (str, datetime.date)
 
 
 def get_database_dsn_string(force_default=False):
+    """
+        This function parses the Django database configuration in settings.py and
+        returns a string DSN (https://en.wikipedia.org/wiki/Data_source_name) for
+        a PostgreSQL database
+
+        Will return a different database configuration for local vs deployed.
+        It is possible to force the "default" database by setting `force_default`
+    """
+
+    db = settings.DATABASES["db_source"]  # Primary DB connection in a deployed environment
     if settings.IS_LOCAL or force_default:
         db = settings.DATABASES["default"]
-    else:
-        db = settings.DATABASES["db_source"]
+
     return "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(**db)
 
 

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -182,7 +182,7 @@ def configure_sql_strings(config, filename, deleted_ids):
 
 
 def execute_sql_statement(cmd, results=False, verbose=False):
-    """ Simple function to execute SQL using the Django DB connection"""
+    """ Simple function to execute SQL using a psycopg2 connection"""
     rows = None
     if verbose:
         print(cmd)

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -7,14 +7,15 @@ import subprocess
 import tempfile
 
 from collections import defaultdict
+from django.conf import settings
 from datetime import datetime
 from elasticsearch import helpers
 from elasticsearch import TransportError
 from time import perf_counter, sleep
 
-from usaspending_api import settings
 from usaspending_api.awards.v2.lookups.elasticsearch_lookups import INDEX_ALIASES_TO_AWARD_TYPES
 from usaspending_api.common.csv_helpers import count_rows_in_csv_file
+from usaspending_api.common.helpers.sql_helpers import get_database_dsn_string
 
 # ==============================================================================
 # SQL Template Strings for Postgres Statements
@@ -185,8 +186,8 @@ def execute_sql_statement(cmd, results=False, verbose=False):
     rows = None
     if verbose:
         print(cmd)
-    dsn = "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(**settings.DATABASES["default"])
-    with psycopg2.connect(dsn=dsn) as connection:
+
+    with psycopg2.connect(dsn=get_database_dsn_string()) as connection:
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute(cmd)

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -2,12 +2,12 @@ import boto3
 import json
 import os
 import pandas as pd
+import psycopg2
 import subprocess
 import tempfile
 
 from collections import defaultdict
 from datetime import datetime
-from django.db import connection
 from elasticsearch import helpers
 from elasticsearch import TransportError
 from time import perf_counter, sleep
@@ -185,10 +185,13 @@ def execute_sql_statement(cmd, results=False, verbose=False):
     rows = None
     if verbose:
         print(cmd)
-    with connection.cursor() as cursor:
-        cursor.execute(cmd)
-        if results:
-            rows = db_rows_to_dict(cursor)
+    dsn = "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(**settings.DATABASES["default"])
+    with psycopg2.connect(dsn=dsn) as connection:
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute(cmd)
+            if results:
+                rows = db_rows_to_dict(cursor)
     return rows
 
 


### PR DESCRIPTION
**Description:**
The elasticsearch loader script was failing at the final step of updating the last load date in the postgres DB. This was new functionality and not fully tested outside of a local env.

**Technical details:**
Switched from using the Django connection to psycopg2's connect object for the child process spawned by the script.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
PR is only correcting a DB connection during an etl script
```
