### PR TITLE
Hotfix for awards not appearing in IDV results

### DIFF
--- a/usaspending_api/awards/v2/views/idvs/awards.py
+++ b/usaspending_api/awards/v2/views/idvs/awards.py
@@ -54,8 +54,8 @@ GET_CHILD_IDVS_SQL = SQL("""
         inner join parent_award pac on pac.parent_award_id = pap.award_id
         inner join awards ac on ac.id = pac.award_id
         inner join transaction_fpds tf on tf.transaction_id = ac.latest_transaction_id
-        inner join agency a on a.id = ac.funding_agency_id
-        inner join toptier_agency tta on tta.toptier_agency_id = a.toptier_agency_id
+        left outer join agency a on a.id = ac.funding_agency_id
+        left outer join toptier_agency tta on tta.toptier_agency_id = a.toptier_agency_id
     where
         pap.{award_id_column} = {award_id}
     order by
@@ -83,8 +83,8 @@ GET_CHILD_AWARDS_SQL = SQL("""
         inner join awards ac on ac.fpds_parent_agency_id = ap.fpds_agency_id and ac.parent_award_piid = ap.piid and
             ac.type not like 'IDV%'
         inner join transaction_fpds tf on tf.transaction_id = ac.latest_transaction_id
-        inner join agency a on a.id = ac.funding_agency_id
-        inner join toptier_agency tta on tta.toptier_agency_id = a.toptier_agency_id
+        left outer join agency a on a.id = ac.funding_agency_id
+        left outer join toptier_agency tta on tta.toptier_agency_id = a.toptier_agency_id
     where
         pap.{award_id_column} = {award_id}
     order by
@@ -113,8 +113,8 @@ GET_GRANDCHILD_AWARDS_SQL = SQL("""
         inner join awards ac on ac.fpds_parent_agency_id = ap.fpds_agency_id and ac.parent_award_piid = ap.piid and
             ac.type not like 'IDV%'
         inner join transaction_fpds tf on tf.transaction_id = ac.latest_transaction_id
-        inner join agency a on a.id = ac.funding_agency_id
-        inner join toptier_agency tta on tta.toptier_agency_id = a.toptier_agency_id
+        left outer join agency a on a.id = ac.funding_agency_id
+        left outer join toptier_agency tta on tta.toptier_agency_id = a.toptier_agency_id
     where
         pap.{award_id_column} = {award_id}
     order by


### PR DESCRIPTION
**Description:**
IDV child awards for which there was no funding agency information were not appearing the IDV child awards table on the IDV summary page.

**Technical details:**
This was due to the improper use of an inner join against the agency table.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] No API documentation updates required
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-2108](https://federal-spending-transparency.atlassian.net/browse/DEV-2108):
    - [x] Link to this Pull-Request
