### PR TITLE
added Elasticsearch env variable to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,3 +66,4 @@ services:
     command: /bin/sh -c "python -u manage.py runserver 0.0.0.0:8000"
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/data_store_api
+      ES_HOSTNAME: host.docker.internal:9200


### PR DESCRIPTION
**Description:**
Added Elasticsearch env variable to docker-compose

**Technical details:**
Docker-Compose doesn't use normal env vars to find where elasticsearch is, so it has been added to the docker-compose.yml. This assumes you are running your elasticsearch on localhost on the standard port.

**Requirements for PR merge:**

1. [N/A ] Unit & integration tests updated
2. [N/A ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A ] Matview impact assessment completed
5. [N/A ] Frontend impact assessment completed
6. [N/A ] Data validation completed
7. [ N/A] Appropriate Operations ticket(s) created
8. [N/A ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
