### PR TITLE
Upgraded Elasticsearch lib version and disable ssl cert checks when local

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,7 +18,7 @@ djangorestframework==3.5.4
 drf-extensions==0.3.1
 drf-tracking==1.4.0
 django-partial-index==0.5.2
-elasticsearch==6.1.1
+elasticsearch==6.2.0
 fiscalyear==0.1.0
 flake8==3.7.7
 Markdown==2.6.6
@@ -43,4 +43,4 @@ urllib3==1.24.2
 xlrd==1.0.0
 jsonpickle==0.9.6
 filechunkio==1.8
-pip==19.0.3
+pip==19.1.1


### PR DESCRIPTION
Thank you @willkjackson for figuring this out!

Changes should only be in effect during local development!

Requires `pip install -U requirements/requirement.txt` to upgrade external packages