### PR TITLE
Sanitize at the client level

### DIFF
--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from usaspending_api.common.elasticsearch.client import es_client_query
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 
 
 def geocode_filter_locations(scope: str, values: list, use_matview: bool = False) -> Q:
@@ -170,14 +169,14 @@ def get_award_ids_by_city(scope: str, city: str, country_code: str, state_code: 
     query = {
         "bool": {
             "must": [
-                {"match": {"{}_city_name".format(scope): es_sanitize(city)}},
-                {"match": {"{}_country_code".format(scope): es_sanitize(country_code)}},
+                {"match": {"{}_city_name".format(scope): city}},
+                {"match": {"{}_country_code".format(scope): country_code}},
             ]
         }
     }
     if state_code:
         # If a state was provided, include it in the filter to limit hits
-        query["bool"]["must"].append({"match": {"{}_state_code".format(scope): es_sanitize(state_code)}})
+        query["bool"]["must"].append({"match": {"{}_state_code".format(scope): state_code}})
 
     search_body = {
         "_source": ["award_id"],

--- a/usaspending_api/search/tests/unit/test_es_sanitize.py
+++ b/usaspending_api/search/tests/unit/test_es_sanitize.py
@@ -1,4 +1,4 @@
-from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
+from usaspending_api.common.elasticsearch.client import es_sanitize
 
 
 def test_sanitizer():

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -16,26 +16,6 @@ KEYWORD_DATATYPE_FIELDS = ["{}.raw".format(i) for i in KEYWORD_DATATYPE_FIELDS]
 TRANSACTIONS_LOOKUP.update({v: k for k, v in TRANSACTIONS_LOOKUP.items()})
 
 
-def preprocess(keyword):
-    keyword = concat_if_array(keyword)
-    """Remove Lucene special characters instead of escaping for now"""
-    processed_string = re.sub(r"[/:][^!]", "", keyword)
-    if len(processed_string) != len(keyword):
-        msg = "Stripped characters from ES keyword search string New: '{}' Original: '{}'"
-        logger.info(msg.format(processed_string, keyword))
-        keyword = processed_string
-    return keyword
-
-
-def es_sanitize(keyword):
-    """ Escapes reserved elasticsearch characters and removes when necessary """
-    processed_string = re.sub(r'([-&!|{}()^~*?:\\/"+\[\]<>])', '', keyword)
-    if len(processed_string) != len(keyword):
-        msg = "Stripped characters from ES search string New: '{}' Original: '{}'"
-        logger.info(msg.format(processed_string, keyword))
-    return processed_string
-
-
 def swap_keys(dictionary_):
     return dict((TRANSACTIONS_LOOKUP.get(old_key, old_key), new_key) for (old_key, new_key) in dictionary_.items())
 


### PR DESCRIPTION
**Description:**
changed sanitize to sanitize json bodies instead of individual strings

**Technical details:**
Rather than relying on lots of calls on every string input, this PR moves sanitizing code to the client and cleans at the last minute. This will conflict with the auto-complete, but that endpoint simply has to delete all sanitizing code.