### PR TITLE
[Hotfix] Change to search field used by v2/autocomplete/glossary

### DIFF
--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -48,7 +48,7 @@ class BaseAutocompleteViewSet(APIView):
         queryset = Agency.objects.filter(
             Q(subtier_agency__name__icontains=search_text)
             | Q(subtier_agency__abbreviation__icontains=search_text)
-            ).order_by('-toptier_flag', 'toptier_agency_id', 'subtier_agency__name').distinct(
+        ).order_by('-toptier_flag', 'toptier_agency_id', 'subtier_agency__name').distinct(
             'toptier_flag', 'toptier_agency_id', 'subtier_agency__name')
         # The below is a one-off fix to promote FEMA as a subtier to the top when "FEMA" is searched
         # This is the only way to do this because you cannot use annotate and distinct together
@@ -205,13 +205,13 @@ class GlossaryAutocompleteViewSet(BaseAutocompleteViewSet):
 
         queryset = Definition.objects.all()
 
-        glossary_terms = queryset.filter(slug__icontains=search_text)[:limit]
+        glossary_terms = queryset.filter(term__icontains=search_text)[:limit]
         serializer = DefinitionSerializer(glossary_terms, many=True)
 
         response = {
             'search_text': search_text,
             'results': glossary_terms.values_list('term', flat=True),
-            'count':  glossary_terms.count(),
+            'count': glossary_terms.count(),
             'matched_terms':
                 serializer.data
         }


### PR DESCRIPTION
**Description:**
`api/v2/autocomplete/glossary/` behavior was unexpectedly different than
`api/v1/references/glossary/autocomplete/`.

**Technical details:**
Changed the search field from `slug` to `term`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)
  Found after [DEV-2430](https://federal-spending-transparency.atlassian.net/browse/DEV-2430) was tested in staging

**Area for explaining above N/A when needed:**
```
Minor view logic change, no impact to API or database.
It would have been good to write tests to maintain this behavior
```
