### PR TITLE
DEV-2764: Update Top Tier Agency Reference Endpoint with Congressional Justification

### DIFF
--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -5,10 +5,11 @@ from rest_framework import status
 
 
 @pytest.fixture
-def financial_spending_data(db):
+def create_agency_data(db):
     # Create agency - submission relationship
     # Create AGENCY AND TopTier AGENCY
-    ttagency1 = mommy.make('references.ToptierAgency', name="tta_name", cgac_code='100', abbreviation='tta_abrev')
+    ttagency1 = mommy.make('references.ToptierAgency', name="tta_name", cgac_code='100', abbreviation='tta_abrev',
+                           justification='test.com/cj')
     ttagency2 = mommy.make('references.ToptierAgency', name="tta_name_2", cgac_code='200', abbreviation='tta_abrev_2')
 
     mommy.make('references.Agency', id=1, toptier_agency=ttagency1, toptier_flag=True)
@@ -41,8 +42,8 @@ def financial_spending_data(db):
 
 
 @pytest.mark.django_db
-def test_award_type_endpoint(client, financial_spending_data):
-    """Test the award_type endpoint."""
+def test_award_type_endpoint(client, create_agency_data):
+    """Test the toptier_agency endpoint."""
 
     resp = client.get('/api/v2/references/toptier_agencies/')
     assert resp.status_code == status.HTTP_200_OK
@@ -51,6 +52,7 @@ def test_award_type_endpoint(client, financial_spending_data):
                                       'active_fy': '2017',
                                       'agency_id': 1,
                                       'agency_name': 'tta_name',
+                                      'congressional_justification_url': 'test.com/cj',
                                       'budget_authority_amount': 2.0,
                                       'current_total_budget_authority_amount': 8361447130497.72,
                                       'obligated_amount': 2.0,
@@ -61,6 +63,7 @@ def test_award_type_endpoint(client, financial_spending_data):
                                       'active_fy': '2017',
                                       'agency_id': 2,
                                       'agency_name': 'tta_name_2',
+                                      'congressional_justification_url': None,
                                       'budget_authority_amount': 14.0,
                                       'current_total_budget_authority_amount': 8361447130497.72,
                                       'obligated_amount': 14.0,
@@ -75,6 +78,7 @@ def test_award_type_endpoint(client, financial_spending_data):
                          'active_fy': '2017',
                          'agency_id': 2,
                          'agency_name': 'tta_name_2',
+                         'congressional_justification_url': None,
                          'budget_authority_amount': 14.0,
                          'current_total_budget_authority_amount': 8361447130497.72,
                          'obligated_amount': 14.0,
@@ -84,6 +88,7 @@ def test_award_type_endpoint(client, financial_spending_data):
                          'active_fq': '2', 'active_fy': '2017',
                          'agency_id': 1,
                          'agency_name': 'tta_name',
+                         'congressional_justification_url': 'test.com/cj',
                          'budget_authority_amount': 2.0,
                          'current_total_budget_authority_amount': 8361447130497.72,
                          'obligated_amount': 2.0,

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -102,10 +102,12 @@ class ToptierAgenciesViewSet(APIDocumentationView):
             if toptier_agency.abbreviation is not None:
                 abbreviation = toptier_agency.abbreviation
 
+            cj = toptier_agency.justification if len(toptier_agency.justification) > 0 else None
             # craft response
             response['results'].append({'agency_id': agency.id,
                                         'abbreviation': abbreviation,
                                         'agency_name': toptier_agency.name,
+                                        'congressional_justification_url': cj,
                                         'active_fy': str(active_fiscal_year),
                                         'active_fq': str(active_fiscal_quarter),
                                         'outlay_amount': float(aggregate_dict['outlay_amount']),

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -102,7 +102,7 @@ class ToptierAgenciesViewSet(APIDocumentationView):
             if toptier_agency.abbreviation is not None:
                 abbreviation = toptier_agency.abbreviation
 
-            cj = toptier_agency.justification if len(toptier_agency.justification) > 0 else None
+            cj = toptier_agency.justification if toptier_agency.justification else None
             # craft response
             response['results'].append({'agency_id': agency.id,
                                         'abbreviation': abbreviation,


### PR DESCRIPTION
**Description:**
Adds the Congressional Justification URL to the toptier_agency endpoint response

**Technical details:**
Builds on Brian's work here https://github.com/fedspendingtransparency/usaspending-api/pull/1845 to add the Congressional Justification from the model to the endpoint response

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [X] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-2764](https://federal-spending-transparency.atlassian.net/browse/DEV-2764):
    - [X] Link to this Pull-Request
    - [NA] Performance evaluation of affected (API | Script | Download)
    - [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Single field added to model, impact is negligible on response. No Matviews affected, frontend not impacted, no operations needs.
```
