### PR TITLE
added id for sorting

### DIFF
--- a/usaspending_api/awards/tests/unit/test_subawards.py
+++ b/usaspending_api/awards/tests/unit/test_subawards.py
@@ -49,12 +49,12 @@ def test_all_subawards(mock_matviews_qs):
     subawards_logic = svs._business_logic(test_params)
     assert [] == subawards_logic
 
-    sort("id",[strip_award_id(subaward_3), strip_award_id(subaward_1), strip_award_id(subaward_2)])
-    sort("amount", [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)])
-    sort("action_date", [strip_award_id(subaward_2), strip_award_id(subaward_1), strip_award_id(subaward_3)])
-    sort("recipient_name", [strip_award_id(subaward_2), strip_award_id(subaward_3), strip_award_id(subaward_1)])
+    assert request_with_sort("id") == [strip_award_id(subaward_3), strip_award_id(subaward_1), strip_award_id(subaward_2)]
+    assert request_with_sort("amount") == [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)]
+    assert request_with_sort("action_date") == [strip_award_id(subaward_2), strip_award_id(subaward_1), strip_award_id(subaward_3)]
+    assert request_with_sort("recipient_name") == [strip_award_id(subaward_2), strip_award_id(subaward_3), strip_award_id(subaward_1)]
 
-def sort(sort,response):
+def request_with_sort(sort):
     svs = SubawardsViewSet()
     test_payload = {
         "page": 1,
@@ -64,7 +64,7 @@ def sort(sort,response):
     }
     test_params = svs._parse_and_validate_request(test_payload)
     subawards_logic = svs._business_logic(test_params)
-    assert response == subawards_logic
+    return subawards_logic
 
 def test_specific_award(mock_matviews_qs):
     mock_model_1 = MockModel(**subaward_10)

--- a/usaspending_api/awards/tests/unit/test_subawards.py
+++ b/usaspending_api/awards/tests/unit/test_subawards.py
@@ -49,14 +49,14 @@ def test_all_subawards(mock_matviews_qs):
     subawards_logic = svs._business_logic(test_params)
     assert [] == subawards_logic
 
-    assert request_with_sort("id") \
-        == [strip_award_id(subaward_3), strip_award_id(subaward_1), strip_award_id(subaward_2)]
-    assert request_with_sort("amount") \
-        == [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)]
-    assert request_with_sort("action_date") \
-        == [strip_award_id(subaward_2), strip_award_id(subaward_1), strip_award_id(subaward_3)]
-    assert request_with_sort("recipient_name") \
-        == [strip_award_id(subaward_2), strip_award_id(subaward_3), strip_award_id(subaward_1)]
+    sub_1 = strip_award_id(subaward_1)
+    sub_2 = strip_award_id(subaward_2)
+    sub_3 = strip_award_id(subaward_3)
+
+    assert request_with_sort("id") == [sub_3, sub_1, sub_2]
+    assert request_with_sort("amount") == [sub_3, sub_2, sub_1]
+    assert request_with_sort("action_date") == [sub_2, sub_1, sub_3]
+    assert request_with_sort("recipient_name") == [sub_2, sub_3, sub_1]
 
 
 def request_with_sort(sort):

--- a/usaspending_api/awards/tests/unit/test_subawards.py
+++ b/usaspending_api/awards/tests/unit/test_subawards.py
@@ -49,10 +49,15 @@ def test_all_subawards(mock_matviews_qs):
     subawards_logic = svs._business_logic(test_params)
     assert [] == subawards_logic
 
-    assert request_with_sort("id") == [strip_award_id(subaward_3), strip_award_id(subaward_1), strip_award_id(subaward_2)]
-    assert request_with_sort("amount") == [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)]
-    assert request_with_sort("action_date") == [strip_award_id(subaward_2), strip_award_id(subaward_1), strip_award_id(subaward_3)]
-    assert request_with_sort("recipient_name") == [strip_award_id(subaward_2), strip_award_id(subaward_3), strip_award_id(subaward_1)]
+    assert request_with_sort("id") \
+        == [strip_award_id(subaward_3), strip_award_id(subaward_1), strip_award_id(subaward_2)]
+    assert request_with_sort("amount") \
+        == [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)]
+    assert request_with_sort("action_date") \
+        == [strip_award_id(subaward_2), strip_award_id(subaward_1), strip_award_id(subaward_3)]
+    assert request_with_sort("recipient_name") \
+        == [strip_award_id(subaward_2), strip_award_id(subaward_3), strip_award_id(subaward_1)]
+
 
 def request_with_sort(sort):
     svs = SubawardsViewSet()
@@ -65,6 +70,7 @@ def request_with_sort(sort):
     test_params = svs._parse_and_validate_request(test_payload)
     subawards_logic = svs._business_logic(test_params)
     return subawards_logic
+
 
 def test_specific_award(mock_matviews_qs):
     mock_model_1 = MockModel(**subaward_10)
@@ -84,6 +90,7 @@ def test_specific_award(mock_matviews_qs):
     expected_response = [strip_award_id(subaward_11), strip_award_id(subaward_10)]
 
     assert expected_response == subawards_logic
+
 
 subaward_1 = {
     "subaward_id": 2,

--- a/usaspending_api/awards/tests/unit/test_subawards.py
+++ b/usaspending_api/awards/tests/unit/test_subawards.py
@@ -49,13 +49,22 @@ def test_all_subawards(mock_matviews_qs):
     subawards_logic = svs._business_logic(test_params)
     assert [] == subawards_logic
 
+    sort("id",[strip_award_id(subaward_3), strip_award_id(subaward_1), strip_award_id(subaward_2)])
+    sort("amount", [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)])
+    sort("action_date", [strip_award_id(subaward_2), strip_award_id(subaward_1), strip_award_id(subaward_3)])
+    sort("recipient_name", [strip_award_id(subaward_2), strip_award_id(subaward_3), strip_award_id(subaward_1)])
+
+def sort(sort,response):
+    svs = SubawardsViewSet()
     test_payload = {
+        "page": 1,
+        "limit": 4,
+        "sort": sort,
         "order": "desc",
     }
     test_params = svs._parse_and_validate_request(test_payload)
     subawards_logic = svs._business_logic(test_params)
-    assert [strip_award_id(subaward_3), strip_award_id(subaward_2), strip_award_id(subaward_1)] == subawards_logic
-
+    assert response == subawards_logic
 
 def test_specific_award(mock_matviews_qs):
     mock_model_1 = MockModel(**subaward_10)
@@ -76,7 +85,6 @@ def test_specific_award(mock_matviews_qs):
 
     assert expected_response == subawards_logic
 
-
 subaward_1 = {
     "subaward_id": 2,
     "subaward_number": "000",
@@ -88,7 +96,7 @@ subaward_1 = {
         " chips cosby echo etsy forage future helvetica kale occupy salvia sartorial semiotics skateboard squid"
         " williamsburg yr. 8-bit banh beer before they sold out craft ethnic fingerstache fixie irony jean shorts"
         " life organic park photo booth retro salvia tattooed trade vhs williamsburg.",
-    "action_date": "2017-09-30",
+    "action_date": "2017-09-29",
     "amount": "100",
     "recipient_name": "ACME",
     "award_id": 99,

--- a/usaspending_api/awards/v2/views/subawards.py
+++ b/usaspending_api/awards/v2/views/subawards.py
@@ -51,9 +51,9 @@ class SubawardsViewSet(APIDocumentationView):
             queryset = queryset.filter(award_id=request_data["award_id"])
 
         if request_data["order"] == "desc":
-            queryset = queryset.order_by(F(request_data["sort"]).desc(nulls_last=True))
+            queryset = queryset.order_by(F(self.subaward_lookup[request_data["sort"]]).desc(nulls_last=True))
         else:
-            queryset = queryset.order_by(F(request_data["sort"]).asc(nulls_first=True))
+            queryset = queryset.order_by(F(self.subaward_lookup[request_data["sort"]]).asc(nulls_first=True))
 
         rows = list(queryset[lower_limit:upper_limit + 1])
         return [


### PR DESCRIPTION
**Description:**
Fixed bug that caused 500 error when attempting to sort subawards by id

**Technical details:**
subawards.py was not using the dictionary lookup to translate 'id' to 'subaward_id' in order to match with ORM object.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A ] Matview impact assessment completed
5. [N/A ] Frontend impact assessment completed
6. [N/A ] Data validation completed
7. [N/A ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-2798](https://federal-spending-transparency.atlassian.net/browse/DEV-2798):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
