### PR TITLE
Update location_filter_geocode.py

### DIFF
--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -7,7 +7,7 @@ from usaspending_api.common.elasticsearch.client import es_client_query
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 
-ALL_FOREIGN_COUNTIRES = "FOREIGN"
+ALL_FOREIGN_COUNTRIES = "FOREIGN"
 
 
 def geocode_filter_locations(

--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -244,7 +244,10 @@ def build_es_city_query(query: object, bool_should: bool,
 
     if state_code:
         # If a state was provided, include it in the filter to limit hits
-        query["bool"]["must"].append({"match": {"{}_state_code".format(scope): es_sanitize(state_code)}})
+        if bool_should:
+            query["bool"]["must"].append({"match": {"{}_state_code".format(scope): es_sanitize(state_code).upper()}})
+        else:
+            query["must"].append({"match": {"{}_state_code".format(scope): es_sanitize(state_code).upper()}})
 
     return query
 

--- a/usaspending_api/awards/v2/filters/location_filter_geocode.py
+++ b/usaspending_api/awards/v2/filters/location_filter_geocode.py
@@ -31,7 +31,7 @@ def geocode_filter_locations(
     # In this for-loop a django Q filter object is created from the python dict
     for country, state_zip in nested_values.items():
         country_qs = None
-        if country != ALL_FOREIGN_COUNTIRES:
+        if country != ALL_FOREIGN_COUNTRIES:
             country_qs = Q(**{q_str.format(scope, country_code) + '__exact': country})
         state_qs = Q()
 
@@ -194,7 +194,7 @@ def get_record_ids_by_city(
     }
     if country_code != "USA":
         # A non-USA selected country
-        if country_code != ALL_FOREIGN_COUNTIRES:
+        if country_code != ALL_FOREIGN_COUNTRIES:
             query["bool"]["must"].append({"match": {"{scope}_country_code".format(scope=scope): country_code}})
         # Create a "Should Not" query with a nested, to get everything non-USA
         query["bool"]["should"] = [

--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -10,6 +10,7 @@ from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 from usaspending_api.common.validator.tinyshield import validate_post_request
 from usaspending_api.awards.v2.filters.location_filter_geocode import ALL_FOREIGN_COUNTRIES
 
+
 models = [
     {
         "name": "filter|country_code",

--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -8,7 +8,7 @@ from usaspending_api.common.views import APIDocumentationView
 from usaspending_api.common.elasticsearch.client import es_client_query
 from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 from usaspending_api.common.validator.tinyshield import validate_post_request
-
+from usaspending_api.awards.v2.filters.location_filter_geocode import ALL_FOREIGN_COUNTRIES
 
 models = [
     {
@@ -73,7 +73,7 @@ def create_elasticsearch_query(return_fields, scope, search_text, country, state
     # so that we don't get inconsistent results when the limit gets down to a very low number (e.g. lower than the
     # number of shards we have) such that it may provide inconsistent results in repeated queries
     city_buckets = limit + 100
-    if country == 'FOREIGN':
+    if country == ALL_FOREIGN_COUNTRIES:
         aggs = {"states": {"terms": {"field": return_fields[2], "size": 100}}}
     else:
         aggs = {"states": {"terms": {"field": return_fields[1], "size": 100}}}
@@ -123,7 +123,7 @@ def create_es_search(scope, search_text, country=None, state=None):
     }
     if country != "USA":
         # A non-USA selected country
-        if country != "FOREIGN":
+        if country != ALL_FOREIGN_COUNTRIES:
             query["must"].append({"match": {"{scope}_country_code".format(scope=scope): country}})
         # Create a "Should Not" query with a nested bool, to get everything non-USA
         query["should"] = [

--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -8,7 +8,6 @@ from usaspending_api.common.views import APIDocumentationView
 from usaspending_api.common.elasticsearch.client import es_client_query
 from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 from usaspending_api.common.validator.tinyshield import validate_post_request
-from usaspending_api.awards.v2.filters.location_filter_geocode import build_es_city_query
 
 
 models = [
@@ -122,7 +121,47 @@ def create_es_search(scope, search_text, country=None, state=None):
             }
         ]
     }
-    return build_es_city_query(query, False, scope, country, state)
+    if country != "USA":
+        # A non-USA selected country
+        if country != "FOREIGN":
+            query["must"].append({"match": {"{scope}_country_code".format(scope=scope): country}})
+        # Create a "Should Not" query with a nested bool, to get everything non-USA
+        query["should"] = [
+          {
+            "bool": {
+              "must": {
+                "exists": {
+                  "field": "{}_country_code".format(scope)
+                }
+              },
+            }
+          }
+        ]
+        query["should"][0]["bool"]["must_not"] = [{"match": {"{}_country_code".format(scope): "USA"}},
+                                                  {"match_phrase": {
+                                                     "{}_country_code".format(scope): "UNITED STATES"}}]
+        query["minimum_should_match"] = 1
+    else:
+        # USA is selected as country
+        query["should"] = [{"match": {"{}_country_code".format(scope): "USA"}},
+                           {"match_phrase": {"{}_country_code".format(scope): "UNITED STATES"}}]
+        query["should"].append({
+              "bool": {
+                "must_not": {
+                  "exists": {
+                    "field": "{}_country_code".format(scope)
+                  }
+                },
+              }
+            })
+        query["minimum_should_match"] = 1
+        # null country codes are being considered as USA country codes
+
+    if state:
+        # If a state was provided, include it in the filter to limit hits
+        query["must"].append({"match": {"{}_state_code".format(scope): es_sanitize(state).upper()}})
+
+    return query
 
 
 def build_country_match(country_match_scope, country_match_country):

--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -143,8 +143,7 @@ def create_es_search(scope, search_text, country=None, state=None):
         query["minimum_should_match"] = 1
     else:
         # USA is selected as country
-        query["should"] = [{"match": {"{}_country_code".format(scope): "USA"}},
-                           {"match_phrase": {"{}_country_code".format(scope): "UNITED STATES"}}]
+        query["should"] = [build_country_match(scope, "USA"), build_country_match(scope, "UNITED STATES")]
         query["should"].append({
               "bool": {
                 "must_not": {


### PR DESCRIPTION
**Description:**
Fixing error with state code in city search autocomplete.

**Technical details:**
While condensing code for the previous city search PR, a bug was introduced that caused city search autocomplete to fail when searching using the state code. This fixes that issue by adding an if statement that differentiates between when the function for autocomplete and for the filter.

**Requirements for PR merge:**

1. [N/A] Unit & integration tests updated
2. [N/A] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [N/A] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [N/A] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [N/A] Link to this Pull-Request
    - [N/A] Performance evaluation of affected (API | Script | Download)
    - [N/A] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to performance, no changes to data/matviews, fixes bug introduced when making changes to previous PR
```
**Data validation**
Before - when using autocomplete for the city field with a state code:
```
{
    "search_text": "den",
    "limit": 40,
    "filter": {
        "country_code": "USA",
        "scope": "primary_place_of_performance",
        "state_code": "CO"
    }
}
```
returned `500`
After:
```
{
    "count": 3,
    "results": [
        {
            "city_name": "DENVER",
            "state_code": "CO"
        },
        {
            "city_name": "DENVER COUNTY",
            "state_code": "CO"
        },
        {
            "city_name": "DENVER DIVISION",
            "state_code": "CO"
        }
    ]
}
```