### PR TITLE
Mod/dev 2478 city autocomplete ordering

### DIFF
--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -179,7 +179,7 @@ def query_elasticsearch(query):
     results = []
     if hits and hits["hits"]["total"] > 0:
         results = parse_elasticsearch_response(hits)
-        results = sorted(results, key=lambda x: (x["city_name"], x["state_code"]))
+        results = sorted(results, key=lambda x: x.pop("hits"), reverse=True)
     return results
 
 
@@ -188,8 +188,12 @@ def parse_elasticsearch_response(hits):
     for city in hits["aggregations"]["cities"]["buckets"]:
         if len(city["states"]["buckets"]) > 0:
             for state_code in city["states"]["buckets"]:
-                results.append(OrderedDict([("city_name", city["key"]), ("state_code", state_code["key"])]))
+                results.append(OrderedDict([("city_name", city["key"]),
+                                            ("state_code", state_code["key"]),
+                                            ("hits", state_code["doc_count"])]))
         else:
             # for cities without states, useful for foreign country results
-            results.append(OrderedDict([("city_name", city["key"]), ("state_code", None)]))
+            results.append(OrderedDict([("city_name", city["key"]),
+                                        ("state_code", None),
+                                        ("hits", state_code["doc_count"])]))
     return results

--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -195,5 +195,5 @@ def parse_elasticsearch_response(hits):
             # for cities without states, useful for foreign country results
             results.append(OrderedDict([("city_name", city["key"]),
                                         ("state_code", None),
-                                        ("hits", state_code["doc_count"])]))
+                                        ("hits", city["doc_count"])]))
     return results


### PR DESCRIPTION
**Description:**
Changed sort method for the city search autocomplete results from alphabetical to by number of hits.
**Technical details:**
The previous implementation sorted alphabetically by city name and then by state code, the new implementation adds a "hits" field to the results, which is pulled from the doc_count returned by elasticsearch, and sorts by that number.

**Requirements for PR merge:**

1. [N/A] Unit & integration tests updated
2. [N/A] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-2748](https://federal-spending-transparency.atlassian.net/browse/DEV-2748):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No change to matviews, no ops ticket needed
```
**Performance**
Before - 19 ms
After - 22 ms

**Frontend Impact**
No impact to frontend, but ordering changes will be visible to the user

**Data Validation**
Before -
```
{
    "count": 436,
    "results": [
        {
            "city_name": "NEW ALBANY",
            "state_code": "IN"
        },
        {
            "city_name": "NEW ALBANY",
            "state_code": "MS"
        },
        {
            "city_name": "NEW ALBANY",
            "state_code": "OH"
        },
        {
            "city_name": "NEW ALBANY",
            "state_code": "PA"
        },
        {
            "city_name": "NEW ALBANY",
            "state_code": "TX"
        },
        {
            "city_name": "NEW ALBANY",
            "state_code": "WI"
        },
        {
            "city_name": "NEW ALEXANDRIA",
            "state_code": "PA"
        },
        {
            "city_name": "NEW ATHENS",
            "state_code": "IL"
        },
        {
            "city_name": "NEW ATHENS",
            "state_code": "OH"
        },
        {
            "city_name": "NEW ATHENS",
            "state_code": "WI"
        },
        {
            "city_name": "NEW AUBURN",
            "state_code": "MN"
        }
---
    ]
}
```
After - 
```
    "count": 436,
    "results": [
        {
            "city_name": "NEW YORK",
            "state_code": "NY"
        },
        {
            "city_name": "NEW ORLEANS",
            "state_code": "LA"
        },
        {
            "city_name": "NEWPORT NEWS",
            "state_code": "VA"
        },
        {
            "city_name": "NEW FRANKEN",
            "state_code": "WI"
        },
        {
            "city_name": "NEW HAVEN",
            "state_code": "CT"
        },
        {
            "city_name": "NEWARK",
            "state_code": "DE"
        }
]
```