### PR TITLE
Mod/dev 2740 add parent recipient hash to /api/v2/awards/<award_id>

### DIFF
--- a/usaspending_api/api_contracts/contracts/awards/AwardProfile.md
+++ b/usaspending_api/api_contracts/contracts/awards/AwardProfile.md
@@ -190,11 +190,12 @@ This endpoint returns a list of data that is associated with the award profile p
 + recipient_hash: `e4096343-5e8f-352a-f8af-d2a8b0f0ae68-C` (required, string)
 + recipient_unique_id: `2424224` (required, string, nullable)
     The recipient's DUNS
++ parent_recipient_name: `HoneyWell` (string, nullable)
++ parent_recipient_hash: `18e9854a-6e51-29fe-0add-4f2ad80a4010-P` (string, nullable)
 + parent_recipient_unique_id: `2424232` (required, string, nullable)
     The recipient's parent's DUNS
 + location (required, Location, nullable)
     The recipeint's location
-+ parent_recipient_name: `HoneyWell` (string, nullable)
 + business_categories (required, array[string])
     Names of the recipients' business catagories in human readable format
 

--- a/usaspending_api/awards/tests/test_awards_idv_v2.py
+++ b/usaspending_api/awards/tests/test_awards_idv_v2.py
@@ -10,6 +10,22 @@ from usaspending_api.references.models import Agency, Location, ToptierAgency, S
 
 @pytest.fixture
 def awards_and_transactions(db):
+    parent_loc = {
+        "pk": 2,
+        "location_country_code": "USA",
+        "country_name": "UNITED STATES",
+        "state_code": "SC",
+        "city_name": "Charleston",
+        "county_name": "CHARLESTON",
+        "address_line1": "123 calhoun st",
+        "address_line2": None,
+        "address_line3": None,
+        "zip4": 294245897,
+        "congressional_code": "90",
+        "zip5": 29424,
+        "foreign_postal_code": None,
+        "foreign_province": None,
+    }
     loc = {
         "pk": 1,
         "location_country_code": "USA",
@@ -31,14 +47,25 @@ def awards_and_transactions(db):
     trans_asst = {"pk": 1}
     trans_cont = {"pk": 2}
     duns = {"awardee_or_recipient_uniqu": "123", "legal_business_name": "Sams Club"}
+    parent_recipient_lookup = {"duns": "123", "recipient_hash": "8ec6b128-58cf-3ee5-80bb-e749381dfcdc"}
     recipient_lookup = {"duns": "456", "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367"}
     mommy.make("references.Cfda", program_number=1234)
+    mommy.make("references.Location", **parent_loc)
     mommy.make("references.Location", **loc)
     mommy.make("recipient.DUNS", **duns)
+    mommy.make("recipient.RecipientLookup", **parent_recipient_lookup)
     mommy.make("recipient.RecipientLookup", **recipient_lookup)
     mommy.make("references.SubtierAgency", **subag)
     mommy.make("references.ToptierAgency", **subag)
     mommy.make("references.OfficeAgency", name="office_agency")
+
+    parent_le = {
+        "pk": 2,
+        "recipient_name": "Dave's Pizza LLC",
+        "recipient_unique_id": "123",
+        "business_categories": ["limited liability"],
+        "location": Location.objects.get(pk=2),
+    }
 
     le = {
         "pk": 1,
@@ -59,6 +86,7 @@ def awards_and_transactions(db):
     mommy.make("awards.TransactionNormalized", **trans_asst)
     mommy.make("awards.TransactionNormalized", **trans_cont)
     mommy.make("references.Agency", **ag)
+    mommy.make("references.LegalEntity", **parent_le)
     mommy.make("references.LegalEntity", **le)
 
     asst_data = {
@@ -166,7 +194,7 @@ def awards_and_transactions(db):
         "type_of_idc_description": "INDEFINITE DELIVERY / INDEFINITE QUANTITY",
         "type_set_aside": None,
         "type_set_aside_description": None,
-        "ultimate_parent_legal_enti": None,
+        "ultimate_parent_legal_enti": "Dave's Pizza LLC",
         "ultimate_parent_unique_ide": "123",
         "awarding_office_name": "awarding_office",
         "funding_office_name": "funding_office",
@@ -278,6 +306,8 @@ expected_response_idv = {
         "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367-C",
         "recipient_name": "John's Pizza",
         "recipient_unique_id": "456",
+        "parent_recipient_hash": "8ec6b128-58cf-3ee5-80bb-e749381dfcdc-P",
+        "parent_recipient_name": "Dave's Pizza LLC",
         "parent_recipient_unique_id": "123",
         "business_categories": ["small_business"],
         "location": {
@@ -295,7 +325,6 @@ expected_response_idv = {
             "location_country_code": "USA",
             "congressional_code": "90",
         },
-        "parent_recipient_name": None,
     },
     "total_obligation": 1000.0,
     "base_and_all_options": 2000.0,

--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -11,6 +11,22 @@ from usaspending_api.references.models import Agency, Location, ToptierAgency, S
 
 @pytest.fixture
 def awards_and_transactions(db):
+    parent_loc = {
+        "pk": 2,
+        "location_country_code": "USA",
+        "country_name": "UNITED STATES",
+        "state_code": "SC",
+        "city_name": "Charleston",
+        "county_name": "CHARLESTON",
+        "address_line1": "123 calhoun st",
+        "address_line2": None,
+        "address_line3": None,
+        "zip4": 294245897,
+        "congressional_code": "90",
+        "zip5": 29424,
+        "foreign_postal_code": None,
+        "foreign_province": None,
+    }
     loc = {
         "pk": 1,
         "location_country_code": "USA",
@@ -32,14 +48,25 @@ def awards_and_transactions(db):
     trans_asst = {"pk": 1}
     trans_cont = {"pk": 2}
     duns = {"awardee_or_recipient_uniqu": "123", "legal_business_name": "Sams Club"}
+    parent_recipient_lookup = {"duns": "123", "recipient_hash": "8ec6b128-58cf-3ee5-80bb-e749381dfcdc"}
     recipient_lookup = {"duns": "456", "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367"}
     mommy.make("references.Cfda", program_number=1234)
+    mommy.make("references.Location", **parent_loc)
     mommy.make("references.Location", **loc)
     mommy.make("recipient.DUNS", **duns)
+    mommy.make("recipient.RecipientLookup", **parent_recipient_lookup)
     mommy.make("recipient.RecipientLookup", **recipient_lookup)
     mommy.make("references.SubtierAgency", **sub_agency)
     mommy.make("references.ToptierAgency", **sub_agency)
     mommy.make("references.OfficeAgency", name="office_agency", office_agency_id=1)
+
+    parent_le = {
+        "pk": 2,
+        "recipient_name": "Dave's Pizza LLC",
+        "recipient_unique_id": "123",
+        "business_categories": ["limited liability"],
+        "location": Location.objects.get(pk=2),
+    }
 
     le = {
         "pk": 1,
@@ -56,6 +83,7 @@ def awards_and_transactions(db):
     mommy.make("awards.TransactionNormalized", **trans_asst)
     mommy.make("awards.TransactionNormalized", **trans_cont)
     mommy.make("references.Agency", **ag)
+    mommy.make("references.LegalEntity", **parent_le)
     mommy.make("references.LegalEntity", **le)
 
     asst_data = {
@@ -65,6 +93,7 @@ def awards_and_transactions(db):
         "cfda_title": "Shiloh",
         "awardee_or_recipient_legal": "John's Pizza",
         "awardee_or_recipient_uniqu": "456",
+        "ultimate_parent_legal_enti": "Dave's Pizza LLC",
         "ultimate_parent_unique_ide": "123",
         "legal_entity_country_code": "USA",
         "legal_entity_country_name": "UNITED STATES",
@@ -156,7 +185,7 @@ def awards_and_transactions(db):
         "type_of_contract_pric_desc": "FIRM FIXED PRICE",
         "type_of_idc_description": None,
         "type_set_aside_description": None,
-        "ultimate_parent_legal_enti": None,
+        "ultimate_parent_legal_enti": "Dave's Pizza LLC",
         "ultimate_parent_unique_ide": "123",
         "awarding_office_name": "awarding_office",
         "funding_office_name": "funding_office",
@@ -281,6 +310,8 @@ expected_response_asst = {
         "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367-C",
         "recipient_name": "John's Pizza",
         "recipient_unique_id": "456",
+        "parent_recipient_hash": "8ec6b128-58cf-3ee5-80bb-e749381dfcdc-P",
+        "parent_recipient_name": "Dave's Pizza LLC",
         "parent_recipient_unique_id": "123",
         "business_categories": ["small_business"],
         "location": {
@@ -298,7 +329,6 @@ expected_response_asst = {
             "location_country_code": "USA",
             "congressional_code": "90",
         },
-        "parent_recipient_name": None,
     },
     "subaward_count": 10,
     "total_subaward_amount": 12345.0,
@@ -351,6 +381,8 @@ expected_response_cont = {
         "recipient_hash": "f989e299-1f50-2600-f2f7-b6a45d11f367-C",
         "recipient_name": "John's Pizza",
         "recipient_unique_id": "456",
+        "parent_recipient_hash": "8ec6b128-58cf-3ee5-80bb-e749381dfcdc-P",
+        "parent_recipient_name": "Dave's Pizza LLC",
         "parent_recipient_unique_id": "123",
         "business_categories": ["small_business"],
         "location": {
@@ -368,7 +400,6 @@ expected_response_cont = {
             "location_country_code": "USA",
             "congressional_code": "90",
         },
-        "parent_recipient_name": None,
     },
     "total_obligation": 1000.0,
     "base_and_all_options": 2000.0,

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -169,8 +169,16 @@ def create_recipient_object(db_row_dict):
             ),
             ("recipient_name", db_row_dict["_recipient_name"]),
             ("recipient_unique_id", db_row_dict["_recipient_unique_id"]),
-            ("parent_recipient_unique_id", db_row_dict["_parent_recipient_unique_id"]),
+            (
+                "parent_recipient_hash", obtain_recipient_uri(
+                    db_row_dict["_parent_recipient_name"],
+                    db_row_dict["_parent_recipient_unique_id"],
+                    None,
+                    db_row_dict["_recipient_unique_id"]
+                )
+            ),
             ("parent_recipient_name", db_row_dict["_parent_recipient_name"]),
+            ("parent_recipient_unique_id", db_row_dict["_parent_recipient_unique_id"]),
             ("business_categories", fetch_business_categories_by_legal_entity_id(db_row_dict["_lei"])),
             (
                 "location",

--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -1,10 +1,10 @@
 from usaspending_api.recipient.models import RecipientLookup
 
 
-def obtain_recipient_uri(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
+def obtain_recipient_uri(recipient_name, recipient_unique_id, parent_recipient_unique_id=None, child_recipient_unique_id=None):
     if not recipient_unique_id:
         return create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
-    return fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id)
+    return fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, child_recipient_unique_id)
 
 
 def create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
@@ -13,9 +13,13 @@ def create_recipient_uri_without_duns(recipient_name, recipient_unique_id, paren
     return combine_recipient_hash_and_level(recipient_hash, recipient_level)
 
 
-def fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id):
+def fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, child_recipient_unique_id):
     recipient_hash = fetch_recipient_hash_using_duns(recipient_unique_id)
-    recipient_level = obtain_recipient_level({"duns": recipient_unique_id, "parent_duns": parent_recipient_unique_id})
+    recipient_level = obtain_recipient_level({
+        "duns": recipient_unique_id,
+        "parent_duns": parent_recipient_unique_id,
+        "child_duns": child_recipient_unique_id
+    })
     return combine_recipient_hash_and_level(recipient_hash, recipient_level)
 
 
@@ -40,12 +44,17 @@ def fetch_recipient_hash_using_duns(recipient_unique_id):
 
 def obtain_recipient_level(recipient_record: dict) -> str:
     level = None
-    if recipient_is_standalone(recipient_record):
+    if recipient_is_parent(recipient_record):
+        level = "P"
+    elif recipient_is_standalone(recipient_record):
         level = "R"
     elif recipient_is_child(recipient_record):
         level = "C"
-    # Can never be associated with a "parent" recipient profile level
     return level
+
+
+def recipient_is_parent(recipient_record: dict) -> bool:
+    return recipient_record["child_duns"] is not None
 
 
 def recipient_is_standalone(recipient_record: dict) -> bool:

--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -1,7 +1,11 @@
 from usaspending_api.recipient.models import RecipientLookup
 
 
-def obtain_recipient_uri(recipient_name, recipient_unique_id, parent_recipient_unique_id=None, child_recipient_unique_id=None):
+def obtain_recipient_uri(
+        recipient_name,
+        recipient_unique_id,
+        parent_recipient_unique_id=None,
+        child_recipient_unique_id=None):
     if not recipient_unique_id:
         return create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
     return fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, child_recipient_unique_id)


### PR DESCRIPTION
**Description:**
Added the parent_recipient_hash to the GET /api/v2/awards/<award_id> endpoint.

**Technical details:**
Adding a hash for the parent recipient to the recipient object that is returned on the above endpoint. Added a little logic to determine if a "-P" needs to be at the end of the hash.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend
4. [X] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [X] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-2740](https://federal-spending-transparency.atlassian.net/browse/DEV-2740):
    - [x] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
This PR particularly targets the subtasks on DEV-2740. They are: 
- [DEV-2867](https://federal-spending-transparency.atlassian.net/browse/DEV-2867)
- [DEV-2868](https://federal-spending-transparency.atlassian.net/browse/DEV-2868)
