### PR TITLE
Mod/dev 2806 keyword country code

### DIFF
--- a/usaspending_api/database_scripts/etl/transaction_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/transaction_delta_view.sql
@@ -68,23 +68,23 @@ SELECT
   UTM.pulled_from,
   UTM.type,
 
-  UTM.pop_country_code,
+  COALESCE(UTM.pop_country_code, 'USA') AS pop_country_code,
   UTM.pop_country_name,
   UTM.pop_state_code,
   UTM.pop_county_code,
   UTM.pop_county_name,
   UTM.pop_zip5,
   UTM.pop_congressional_code,
-  TRIM(TRAILING FROM COALESCE(FPDS.place_of_perform_city_name, FABS.place_of_performance_city)) AS pop_city_name,
+  COALESCE(FPDS.place_of_perform_city_name, FABS.place_of_performance_city) AS pop_city_name,
 
-  UTM.recipient_location_country_code,
+  COALESCE(UTM.recipient_location_country_code, 'USA') AS recipient_location_country_code,
   UTM.recipient_location_country_name,
   UTM.recipient_location_state_code,
   UTM.recipient_location_county_code,
   UTM.recipient_location_county_name,
   UTM.recipient_location_zip5,
   UTM.recipient_location_congressional_code,
-  TRIM(TRAILING FROM COALESCE(FPDS.legal_entity_city_name, FABS.legal_entity_city_name)) AS recipient_location_city_name
+  COALESCE(FPDS.legal_entity_city_name, FABS.legal_entity_city_name) AS recipient_location_city_name
 
 FROM universal_transaction_matview UTM
 JOIN transaction_normalized TM ON (UTM.transaction_id = TM.id)

--- a/usaspending_api/database_scripts/etl/transaction_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/transaction_delta_view.sql
@@ -68,7 +68,7 @@ SELECT
   UTM.pulled_from,
   UTM.type,
 
-  COALESCE(UTM.pop_country_code, 'USA') AS pop_country_code,
+  UTM.pop_country_code,
   UTM.pop_country_name,
   UTM.pop_state_code,
   UTM.pop_county_code,
@@ -77,7 +77,7 @@ SELECT
   UTM.pop_congressional_code,
   COALESCE(FPDS.place_of_perform_city_name, FABS.place_of_performance_city) AS pop_city_name,
 
-  COALESCE(UTM.recipient_location_country_code, 'USA') AS recipient_location_country_code,
+  UTM.recipient_location_country_code,
   UTM.recipient_location_country_name,
   UTM.recipient_location_state_code,
   UTM.recipient_location_county_code,

--- a/usaspending_api/etl/es_transaction_template.json
+++ b/usaspending_api/etl/es_transaction_template.json
@@ -234,7 +234,12 @@
           "type": "keyword"
         },
         "pop_county_code": {
-          "type": "text"
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
         },
         "pop_county_name": {
           "type": "text"
@@ -255,7 +260,12 @@
         },
 
         "recipient_location_country_code": {
-          "type": "text"
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
         },
         "recipient_location_country_name": {
           "type": "text"


### PR DESCRIPTION
**Description:**
Added a `keyword` type to the country_code fields in the elastic search mappings, minor performance improvements, also allows country codes to be surfaced by autocomplete

**Technical details:**
Removed `TRIM` statements from `transaction_delta_view.sql` as they are redundant - whitespace was removed as part of city search fixes from sprint 84. Adds `keyword` to `pop_country_code` and `recipient_location_country_code` in `es_transaction_mapping.json` and `es_transaction_template.json`.

**Requirements for PR merge:**

1. [N/A] Unit & integration tests updated
2. [N/A] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [N/A] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created [DEV-2870](https://federal-spending-transparency.atlassian.net/browse/DEV-2870)
8. [X] Jira Ticket [DEV-2806](https://federal-spending-transparency.atlassian.net/browse/DEV-2806):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison
**Area for explaining above N/A when needed:**
```
No changes to matviews, no direct changes to frontend
```
**Data Comparison**
Before - 112 ms
```
{
    "results": [
        {
            "city_name": "LONDON",
            "state_code": null
        },
        {
            "city_name": "LONSHEIM",
            "state_code": null
        },
        {
            "city_name": "LONGUEUIL",
            "state_code": null
        }
}
```
After - 21 ms
```
{
    "results": [
        {
            "city_name": "LONDON",
            "state_code": "GBR"
        },
        {
            "city_name": "LONDON",
            "state_code": "CAN"
        },
        {
            "city_name": "LONDON",
            "state_code": "CANADA"
        },
        {
            "city_name": "LONDON",
            "state_code": "UNITED KINGDOM"
        },
        {
            "city_name": "LONGUEUIL",
            "state_code": "CANADA"
        },
        {
            "city_name": "LONSHEIM",
            "state_code": "DEU"
        }
    ]
}
```