### PR TITLE
Fix/Dev-2740: Handle parent recipients differently and cover missed cases

### DIFF
--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -174,8 +174,8 @@ def create_recipient_object(db_row_dict):
                 "parent_recipient_hash", obtain_recipient_uri(
                     db_row_dict["_parent_recipient_name"],
                     db_row_dict["_parent_recipient_unique_id"],
-                    None,
-                    db_row_dict["_recipient_unique_id"]
+                    None,                                           # parent_recipient_unique_id
+                    True                                            # is_parent_recipient
                 )
             ),
             ("parent_recipient_name", db_row_dict["_parent_recipient_name"]),

--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -5,24 +5,40 @@ def obtain_recipient_uri(
         recipient_name,
         recipient_unique_id,
         parent_recipient_unique_id=None,
-        child_recipient_unique_id=None):
-    if not recipient_unique_id:
-        return create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id)
-    return fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, child_recipient_unique_id)
+        is_parent_recipient=False):
+    # No need to create a hash when the parent recipient does not exist
+    if is_parent_recipient and not (recipient_name and recipient_unique_id):
+        return None
+    elif not recipient_unique_id:
+        return create_recipient_uri_without_duns(
+            recipient_name,
+            recipient_unique_id,
+            parent_recipient_unique_id,
+            is_parent_recipient
+        )
+    return fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, is_parent_recipient)
 
 
-def create_recipient_uri_without_duns(recipient_name, recipient_unique_id, parent_recipient_unique_id=None):
+def create_recipient_uri_without_duns(
+        recipient_name,
+        recipient_unique_id,
+        parent_recipient_unique_id=None,
+        is_parent_recipient=False):
     recipient_hash = generate_missing_recipient_hash(recipient_name, recipient_unique_id)
-    recipient_level = obtain_recipient_level({"duns": recipient_unique_id, "parent_duns": parent_recipient_unique_id})
+    recipient_level = obtain_recipient_level({
+        "duns": recipient_unique_id,
+        "parent_duns": parent_recipient_unique_id,
+        "is_parent_recipient": is_parent_recipient
+    })
     return combine_recipient_hash_and_level(recipient_hash, recipient_level)
 
 
-def fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, child_recipient_unique_id):
+def fetch_recipient_uri_with_duns(recipient_unique_id, parent_recipient_unique_id, is_parent_recipient):
     recipient_hash = fetch_recipient_hash_using_duns(recipient_unique_id)
     recipient_level = obtain_recipient_level({
         "duns": recipient_unique_id,
         "parent_duns": parent_recipient_unique_id,
-        "child_duns": child_recipient_unique_id
+        "is_parent_recipient": is_parent_recipient
     })
     return combine_recipient_hash_and_level(recipient_hash, recipient_level)
 
@@ -58,7 +74,7 @@ def obtain_recipient_level(recipient_record: dict) -> str:
 
 
 def recipient_is_parent(recipient_record: dict) -> bool:
-    return recipient_record["child_duns"] is not None
+    return recipient_record["is_parent_recipient"]
 
 
 def recipient_is_standalone(recipient_record: dict) -> bool:

--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -7,7 +7,7 @@ def obtain_recipient_uri(
         parent_recipient_unique_id=None,
         is_parent_recipient=False):
     # No need to create a hash when the parent recipient does not exist
-    if is_parent_recipient and not (recipient_name and recipient_unique_id):
+    if is_parent_recipient and not recipient_unique_id:
         return None
     elif not recipient_unique_id:
         return create_recipient_uri_without_duns(


### PR DESCRIPTION
**Description:**
Missed some cases when originally implementing this API change for DEV-2740. This PR should handle when a parent recipient does not exist for a provided recipient.

**Technical details:**
Use a boolean to determine when a recipient is a parent and also check if the recipient has a name and unique id before creating a hash when the recipient does not exist. If the parent recipient does not exist return None.

**Requirements for PR merge:**
1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-2740](https://federal-spending-transparency.atlassian.net/browse/DEV-2740):
    - [ ] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
