### PR TITLE
DEV-2068: Quick fix for connection alias issue

### DIFF
--- a/usaspending_api/common/helpers/orm_helpers.py
+++ b/usaspending_api/common/helpers/orm_helpers.py
@@ -1,6 +1,7 @@
 from datetime import date
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Func, IntegerField
+from usaspending_api.common.helpers.sql_helpers import get_connection
 
 
 TYPES_TO_QUOTE_IN_SQL = (str, date)
@@ -54,5 +55,5 @@ def generate_where_clause(queryset):
     Returns the SQL and params from a queryset all ready to be plugged into an
     extra method.
     """
-    compiler = queryset.query.get_compiler(DEFAULT_DB_ALIAS)
+    compiler = queryset.query.get_compiler(get_connection().alias)
     return queryset.query.where.as_sql(compiler, compiler.connection)


### PR DESCRIPTION
Quick fix for connection alias issue.  This is a known landmine whereby the default connection string works in some environments but not in any of our "live" environments.  See [DEV-2852](https://federal-spending-transparency.atlassian.net/browse/DEV-2852) for more details.