### PR TITLE
Mod/Dev-2973: Add federal accounts for award to download

### DIFF
--- a/usaspending_api/common/helpers/unit_test_helper.py
+++ b/usaspending_api/common/helpers/unit_test_helper.py
@@ -12,10 +12,18 @@ def mappings_test(download_type, sublevel):
     download_mapping = VALUE_MAPPINGS[download_type]
     table_name = download_mapping["table_name"]
     table = download_mapping["table"]
+    annotations_function = download_mapping.get("annotations_function")
 
     try:
-        query_values = lookup_mapping.query_paths[table_name][sublevel].values()
-        table.objects.values(*query_values)
+        if annotations_function is not None:
+            query_values = [
+                value for value in lookup_mapping.query_paths[table_name][sublevel].values() if value is not None
+            ]
+            annotations = annotations_function()
+        else:
+            query_values = [value for value in lookup_mapping.query_paths[table_name][sublevel].values()]
+            annotations = {}
+        table.objects.values(*query_values, **annotations)
     except FieldError:
         return False
     return True

--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -345,13 +345,13 @@ def apply_annotations_to_sql(raw_query, aliases):
     query_before_from = re.sub("SELECT ", "", " FROM".join(re.split(" FROM", query_before_group_by)[:-1]), count=1)
 
     # Create a list from the non-derived values between SELECT and FROM
-    selects_str = re.findall(r"SELECT (.*?) (CASE|CONCAT|SUM|COALESCE|\(SELECT|FROM)", raw_query)[0]
+    selects_str = re.findall(r"SELECT (.*?) (CASE|CONCAT|SUM|COALESCE|STRING_AGG|\(SELECT|FROM)", raw_query)[0]
     just_selects = selects_str[0] if selects_str[1] == "FROM" else selects_str[0][:-1]
     selects_list = [select.strip() for select in just_selects.strip().split(",")]
 
     # Create a list from the derived values between SELECT and FROM
     remove_selects = query_before_from.replace(selects_str[0], "")
-    deriv_str_lookup = re.findall(r"(CASE|CONCAT|SUM|COALESCE|\(SELECT|)(.*?) AS (.*?)( |$)", remove_selects)
+    deriv_str_lookup = re.findall(r"(CASE|CONCAT|SUM|COALESCE|STRING_AGG|\(SELECT|)(.*?) AS (.*?)( |$)", remove_selects)
     deriv_dict = {}
     for str_match in deriv_str_lookup:
         # Remove trailing comma and surrounding quotes from the alias, add to dict, remove from alias list

--- a/usaspending_api/download/filestreaming/csv_source.py
+++ b/usaspending_api/download/filestreaming/csv_source.py
@@ -46,5 +46,7 @@ class CsvSource:
 
     def row_emitter(self, headers_requested):
         headers = self.columns(headers_requested)
-        query_paths = [self.query_paths[hn] for hn in headers]
-        return self.queryset.values(*query_paths)
+        query_paths = [self.query_paths[hn] for hn in headers if self.query_paths[hn] is not None]
+        annotations_function = VALUE_MAPPINGS[self.source_type].get("annotations_function")
+        annotations = annotations_function() if annotations_function is not None else {}
+        return self.queryset.values(*query_paths, **annotations)

--- a/usaspending_api/download/helpers/download_annotations_helper.py
+++ b/usaspending_api/download/helpers/download_annotations_helper.py
@@ -1,0 +1,37 @@
+from django.contrib.postgres.aggregates import StringAgg
+from django.db.models.functions import Concat
+from django.db.models import Value
+
+
+def universal_transaction_matview_annotations():
+    # transaction__award__financial_set__treasury_account__federal_account__agency_identifier
+    federal_account_query_path = "transaction__award__financial_set__treasury_account__federal_account"
+    annotation_fields = {
+        "federal_accounts_funding_this_award": StringAgg(
+            Concat(
+                "{}__agency_identifier".format(federal_account_query_path),
+                Value("-"),
+                "{}__main_account_code".format(federal_account_query_path),
+            ),
+            ";",
+            distinct=True,
+        )
+    }
+    return annotation_fields
+
+
+def universal_award_matview_annotations():
+    # transaction__award__financial_set__treasury_account__federal_account__agency_identifier
+    federal_account_query_path = "award__financial_set__treasury_account__federal_account"
+    annotation_fields = {
+        "federal_accounts_funding_this_award": StringAgg(
+            Concat(
+                "{}__agency_identifier".format(federal_account_query_path),
+                Value("-"),
+                "{}__main_account_code".format(federal_account_query_path),
+            ),
+            ";",
+            distinct=True,
+        )
+    }
+    return annotation_fields

--- a/usaspending_api/download/helpers/download_annotations_helper.py
+++ b/usaspending_api/download/helpers/download_annotations_helper.py
@@ -4,7 +4,6 @@ from django.db.models import Value
 
 
 def universal_transaction_matview_annotations():
-    # transaction__award__financial_set__treasury_account__federal_account__agency_identifier
     federal_account_query_path = "transaction__award__financial_set__treasury_account__federal_account"
     annotation_fields = {
         "federal_accounts_funding_this_award": StringAgg(
@@ -21,7 +20,6 @@ def universal_transaction_matview_annotations():
 
 
 def universal_award_matview_annotations():
-    # transaction__award__financial_set__treasury_account__federal_account__agency_identifier
     federal_account_query_path = "award__financial_set__treasury_account__federal_account"
     annotation_fields = {
         "federal_accounts_funding_this_award": StringAgg(

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -26,6 +26,10 @@ from usaspending_api.awards.v2.filters.matview_filters import (
 from usaspending_api.awards.v2.filters.sub_award import subaward_download
 from usaspending_api.awards.v2.lookups.lookups import award_type_mapping
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
+from usaspending_api.download.helpers.download_annotations_helper import (
+    universal_transaction_matview_annotations,
+    universal_award_matview_annotations,
+)
 
 
 LookupType = namedtuple("LookupType", ["id", "name", "desc"])
@@ -54,6 +58,7 @@ VALUE_MAPPINGS = {
         "assistance_data": "award__latest_transaction__assistance_data",
         "filter_function": universal_award_matview_filter,
         "is_for_idv": False,
+        "annotations_function": universal_award_matview_annotations,
     },
     # Transaction Level
     "transactions": {
@@ -65,6 +70,7 @@ VALUE_MAPPINGS = {
         "assistance_data": "transaction__assistance_data",
         "filter_function": universal_transaction_matview_filter,
         "is_for_idv": False,
+        "annotations_function": universal_transaction_matview_annotations,
     },
     # SubAward Level
     "sub_awards": {

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -6,8 +6,8 @@ Sets up mappings from column names used in downloads to the query paths used to 
 Not in use while we pull CSV data from the non-historical tables. Until we switch to pulling CSV downloads from the
 historical tables TransactionFPDS and TransactionFABS, import download_column_lookups.py instead.
 
-NOTE: To allow for annotations to be used on download a pair of ("<alias>", None) is used so that a placeholder 
-for the column is made, but it can be removed to avoid being used as a query path. 
+NOTE: To allow for annotations to be used on download a pair of ("<alias>", None) is used so that a placeholder
+for the column is made, but it can be removed to avoid being used as a query path.
 """
 """
 Code to generate these from spreadsheets:

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -5,6 +5,9 @@ Sets up mappings from column names used in downloads to the query paths used to 
 
 Not in use while we pull CSV data from the non-historical tables. Until we switch to pulling CSV downloads from the
 historical tables TransactionFPDS and TransactionFABS, import download_column_lookups.py instead.
+
+NOTE: To allow for annotations to be used on download a pair of ("<alias>", None) is used so that a placeholder 
+for the column is made, but it can be removed to avoid being used as a query path. 
 """
 """
 Code to generate these from spreadsheets:
@@ -13,6 +16,7 @@ tail -n +3 'usaspending_api/data/DAIMS_IDD_Resorted+DRW+KB+GGv7/D2-Award (Financ
 d2_columns.csv
 
 """
+
 
 query_paths = {
     "award": {
@@ -50,6 +54,7 @@ query_paths = {
                 ("funding_sub_agency_name", "award__latest_transaction__contract_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "award__latest_transaction__contract_data__funding_office_code"),
                 ("funding_office_name", "award__latest_transaction__contract_data__funding_office_name"),
+                ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("foreign_funding", "award__latest_transaction__contract_data__foreign_funding"),
                 ("foreign_funding_description", "award__latest_transaction__contract_data__foreign_funding_desc"),
                 ("sam_exception", "award__latest_transaction__contract_data__sam_exception"),
@@ -568,6 +573,7 @@ query_paths = {
                 ("funding_sub_agency_name", "award__latest_transaction__assistance_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "award__latest_transaction__assistance_data__funding_office_code"),
                 ("funding_office_name", "award__latest_transaction__assistance_data__funding_office_name"),
+                ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("recipient_duns", "award__latest_transaction__assistance_data__awardee_or_recipient_uniqu"),
                 ("recipient_name", "award__latest_transaction__assistance_data__awardee_or_recipient_legal"),
                 ("recipient_parent_duns", "award__latest_transaction__assistance_data__ultimate_parent_unique_ide"),
@@ -695,6 +701,7 @@ query_paths = {
                 ("funding_sub_agency_name", "transaction__contract_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "transaction__contract_data__funding_office_code"),
                 ("funding_office_name", "transaction__contract_data__funding_office_name"),
+                ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("foreign_funding", "transaction__contract_data__foreign_funding"),
                 ("foreign_funding_description", "transaction__contract_data__foreign_funding_desc"),
                 ("sam_exception", "transaction__contract_data__sam_exception"),
@@ -1020,6 +1027,7 @@ query_paths = {
                 ("funding_sub_agency_name", "transaction__assistance_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "transaction__assistance_data__funding_office_code"),
                 ("funding_office_name", "transaction__assistance_data__funding_office_name"),
+                ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("recipient_duns", "transaction__assistance_data__awardee_or_recipient_uniqu"),
                 ("recipient_name", "transaction__assistance_data__awardee_or_recipient_legal"),
                 ("recipient_parent_name", "transaction__assistance_data__ultimate_parent_legal_enti"),
@@ -1489,18 +1497,23 @@ query_paths = {
         ),
     },
 }
-
 # IDV Orders are nearly identical to awards but start from the Awards table
 # instead of from UniversalAwardView materialized view so we need to lop off
 # the leading "award__" bit.
 query_paths["idv_orders"] = {
-    "d1": OrderedDict([(k, v[7:] if v.startswith("award__") else v) for k, v in query_paths["award"]["d1"].items()])
+    "d1": OrderedDict(
+        [(k, v[7:] if v.startswith("award__") else v) for k, v in query_paths["award"]["d1"].items() if v is not None]
+    )
 }
 
 # Likewise, IDV Transactions start directly in TransactionFPDS instead of
 # UniversalTransactionView.
 query_paths["idv_transaction_history"] = {
     "d1": OrderedDict(
-        [(k, v[13:] if v.startswith("transaction__") else v) for k, v in query_paths["transaction"]["d1"].items()]
+        [
+            (k, v[13:] if v.startswith("transaction__") else v)
+            for k, v in query_paths["transaction"]["d1"].items()
+            if v is not None
+        ]
     )
 }


### PR DESCRIPTION
**Description:**
Add the Federal Account to the award and transaction download. Added so that the column will display similar to "075-0512; 075-0580; 075-8004" where "<agency_identifier>-<main_account_code>".

Screenshot showing the new column and an entry:
<img width="520" alt="Screen Shot 2019-08-05 at 11 04 21 AM" src="https://user-images.githubusercontent.com/40359517/62485407-77c38300-b771-11e9-8739-698f3b2a36ee.png">



**Technical details:**
Representing annotations for downloads as an entry into the ordered dictionary with (<alias_name>, None). The None allows for easy removal when gathering all of the query paths, but allows for the correct location to be used with respect to order. The annotations are created as part of a function that is unique to each table. 

The hope is that any future annotations can be added to the annotations function per table and an entry with a matching alias can be added to the ordered dictionary to achieve what is needed.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. N/A API documentation updated
3. [X] Necessary PR reviewers:
    - [X] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-2973](https://federal-spending-transparency.atlassian.net/browse/DEV-2973):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
