### PR TITLE
DEV-3212: Minor tweak to TAS autocomplete ticket

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/tas_autocomplete_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/tas_autocomplete_matview.json
@@ -25,7 +25,7 @@
     "    taa.main_account_code,",
     "    taa.sub_account_code",
     "order by",
-    "    taa.agency_id, taa.main_account_code"
+    "    taa.main_account_code, taa.agency_id"
   ],
   "indexes": [
     {

--- a/usaspending_api/database_scripts/matview_generator/tas_search_matview.json
+++ b/usaspending_api/database_scripts/matview_generator/tas_search_matview.json
@@ -2,7 +2,7 @@
   "final_name": "tas_search_matview",
   "refresh": true,
   "matview_sql": [
-    "select distinct",
+    "select",
     "    min(faba.financial_accounts_by_awards_id) tas_search_id,",
     "    taa.allocation_transfer_agency_id,",
     "    taa.agency_id,",
@@ -27,7 +27,7 @@
     "    taa.sub_account_code,",
     "    faba.award_id",
     "order by",
-    "    taa.agency_id, taa.main_account_code, faba.award_id"
+    "    taa.main_account_code, taa.agency_id, faba.award_id"
   ],
   "indexes": [
     {


### PR DESCRIPTION
**Description:**

One more minor tweak to remove an unnecessary `distinct` and change sort order.  Very minor.  Nothing should be noticeably affected.