### PR TITLE
Mod/Dev-3222: Add TAS to download

### DIFF
--- a/usaspending_api/download/filestreaming/csv_generation.py
+++ b/usaspending_api/download/filestreaming/csv_generation.py
@@ -351,7 +351,9 @@ def apply_annotations_to_sql(raw_query, aliases):
 
     # Create a list from the derived values between SELECT and FROM
     remove_selects = query_before_from.replace(selects_str[0], "")
-    deriv_str_lookup = re.findall(r"(CASE|CONCAT|SUM|COALESCE|STRING_AGG|EXTRACT|\(SELECT|)(.*?) AS (.*?)( |$)", remove_selects)
+    deriv_str_lookup = re.findall(
+        r"(CASE|CONCAT|SUM|COALESCE|STRING_AGG|EXTRACT|\(SELECT|)(.*?) AS (.*?)( |$)", remove_selects
+    )
     deriv_dict = {}
     for str_match in deriv_str_lookup:
         # Remove trailing comma and surrounding quotes from the alias, add to dict, remove from alias list

--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -1,71 +1,55 @@
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models.functions import Concat
-from django.db.models import Value
 from usaspending_api.common.helpers.orm_helpers import FiscalYear
 
 
 def universal_transaction_matview_annotations():
-    federal_account_query_path = "transaction__award__financial_set__treasury_account__federal_account"
     annotation_fields = {
         "action_date_fiscal_year": FiscalYear("action_date"),
+        "treasury_accounts_funding_this_award": StringAgg(
+            "transaction__award__financial_set__treasury_account__tas_rendering_label", ";", distinct=True
+        ),
         "federal_accounts_funding_this_award": StringAgg(
-            Concat(
-                "{}__agency_identifier".format(federal_account_query_path),
-                Value("-"),
-                "{}__main_account_code".format(federal_account_query_path),
-            ),
+            "transaction__award__financial_set__treasury_account__federal_account__federal_account_code",
             ";",
             distinct=True,
-        )
+        ),
     }
     return annotation_fields
 
 
 def universal_award_matview_annotations():
-    federal_account_query = "award__financial_set__treasury_account__federal_account"
     annotation_fields = {
+        "treasury_accounts_funding_this_award": StringAgg(
+            "award__financial_set__treasury_account__tas_rendering_label", ";", distinct=True
+        ),
         "federal_accounts_funding_this_award": StringAgg(
-            Concat(
-                "{}__agency_identifier".format(federal_account_query),
-                Value("-"),
-                "{}__main_account_code".format(federal_account_query),
-            ),
-            ";",
-            distinct=True,
-        )
+            "award__financial_set__treasury_account__federal_account__federal_account_code", ";", distinct=True
+        ),
     }
     return annotation_fields
 
 
 def idv_order_annotations():
-    federal_account_query_path = "financial_set__treasury_account__federal_account"
     annotation_fields = {
+        "treasury_accounts_funding_this_award": StringAgg(
+            "financial_set__treasury_account__tas_rendering_label", ";", distinct=True
+        ),
         "federal_accounts_funding_this_award": StringAgg(
-            Concat(
-                "{}__agency_identifier".format(federal_account_query_path),
-                Value("-"),
-                "{}__main_account_code".format(federal_account_query_path),
-            ),
-            ";",
-            distinct=True,
-        )
+            "financial_set__treasury_account__federal_account__federal_account_code", ";", distinct=True
+        ),
     }
     return annotation_fields
 
 
 def idv_transaction_annotations():
-    federal_account_query_path = "award__financial_set__treasury_account__federal_account"
     annotation_fields = {
-        "federal_accounts_funding_this_award": StringAgg(
-            Concat(
-                "{}__agency_identifier".format(federal_account_query_path),
-                Value("-"),
-                "{}__main_account_code".format(federal_account_query_path),
-            ),
-            ";",
-            distinct=True,
+        "action_date_fiscal_year": FiscalYear("action_date"),
+        "treasury_accounts_funding_this_award": StringAgg(
+            "award__financial_set__treasury_account__tas_rendering_label", ";", distinct=True
         ),
-        "action_date_fiscal_year": FiscalYear("action_date")
+        "federal_accounts_funding_this_award": StringAgg(
+            "award__financial_set__treasury_account__federal_account__federal_account_code", ";", distinct=True
+        ),
     }
     return annotation_fields
 
@@ -73,6 +57,6 @@ def idv_transaction_annotations():
 def subaward_annotations():
     annotation_fields = {
         "subaward_action_date_fiscal_year": FiscalYear("subaward__action_date"),
-        "prime_award_action_date_fiscal_year": FiscalYear("award__date_signed")
+        "prime_award_action_date_fiscal_year": FiscalYear("award__date_signed"),
     }
     return annotation_fields

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -31,7 +31,7 @@ from usaspending_api.download.helpers.download_annotation_functions import (
     universal_award_matview_annotations,
     subaward_annotations,
     idv_order_annotations,
-    idv_transaction_annotations
+    idv_transaction_annotations,
 )
 
 
@@ -121,7 +121,7 @@ VALUE_MAPPINGS = {
         "contract_data": "latest_transaction__contract_data",
         "filter_function": idv_order_filter,
         "is_for_idv": True,
-        "annotations_function": idv_order_annotations
+        "annotations_function": idv_order_annotations,
     },
     "idv_federal_account_funding": {
         "source_type": "account",
@@ -139,7 +139,7 @@ VALUE_MAPPINGS = {
         "contract_data": "contract_data",
         "filter_function": idv_transaction_filter,
         "is_for_idv": True,
-        "annotations_function": idv_transaction_annotations
+        "annotations_function": idv_transaction_annotations,
     },
 }
 

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -54,6 +54,7 @@ query_paths = {
                 ("funding_sub_agency_name", "award__latest_transaction__contract_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "award__latest_transaction__contract_data__funding_office_code"),
                 ("funding_office_name", "award__latest_transaction__contract_data__funding_office_name"),
+                ("treasury_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("foreign_funding", "award__latest_transaction__contract_data__foreign_funding"),
                 ("foreign_funding_description", "award__latest_transaction__contract_data__foreign_funding_desc"),
@@ -583,6 +584,7 @@ query_paths = {
                 ("funding_sub_agency_name", "award__latest_transaction__assistance_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "award__latest_transaction__assistance_data__funding_office_code"),
                 ("funding_office_name", "award__latest_transaction__assistance_data__funding_office_name"),
+                ("treasury_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("recipient_duns", "award__latest_transaction__assistance_data__awardee_or_recipient_uniqu"),
                 ("recipient_name", "award__latest_transaction__assistance_data__awardee_or_recipient_legal"),
@@ -722,6 +724,7 @@ query_paths = {
                 ("funding_sub_agency_name", "transaction__contract_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "transaction__contract_data__funding_office_code"),
                 ("funding_office_name", "transaction__contract_data__funding_office_name"),
+                ("treasury_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("foreign_funding", "transaction__contract_data__foreign_funding"),
                 ("foreign_funding_description", "transaction__contract_data__foreign_funding_desc"),
@@ -1059,6 +1062,7 @@ query_paths = {
                 ("funding_sub_agency_name", "transaction__assistance_data__funding_sub_tier_agency_na"),
                 ("funding_office_code", "transaction__assistance_data__funding_office_code"),
                 ("funding_office_name", "transaction__assistance_data__funding_office_name"),
+                ("treasury_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("recipient_duns", "transaction__assistance_data__awardee_or_recipient_uniqu"),
                 ("recipient_name", "transaction__assistance_data__awardee_or_recipient_legal"),


### PR DESCRIPTION
**Description:**
Similar to Federal Account, TAS was added to the download. I also noticed an issue with Federal Account returning a "-" when should be null so I fixed that one liner as part of this PR. 

**Technical details:**
Following the approach that Brian and I put together to handle annotations on downloads, the tas_rendering_label was added. Some of the files that Brian and I have touched were updated as part of this PR after running Black.

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [X] Necessary PR reviewers:
    - [ ] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. [X] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-3222](https://federal-spending-transparency.atlassian.net/browse/DEV-3222):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
