### PR TITLE
DEV-2963/DEV-2853 HOTFIX: Separate TAS views for documentation purposes

### DIFF
--- a/usaspending_api/common/helpers/endpoint_documentation.py
+++ b/usaspending_api/common/helpers/endpoint_documentation.py
@@ -90,7 +90,9 @@ def validate_docs(url, url_object, master_endpoint_list):
             absolute_endpoint_doc = os.path.join(BASE_DIR, endpoint_doc)
             if not case_sensitive_file_exists(absolute_endpoint_doc):
                 messages.append(
-                    "{}.endpoint_doc ({}) references a file that does not exist".format(qualified_name, url)
+                    "{}.endpoint_doc ({}) references a file that does not exist ({})".format(
+                        qualified_name, url, endpoint_doc
+                    )
                 )
 
     if not (view_class.__doc__ or "").strip():

--- a/usaspending_api/common/renderers.py
+++ b/usaspending_api/common/renderers.py
@@ -94,12 +94,13 @@ class DocumentAPIRenderer(BrowsableAPIRenderer):
     @staticmethod
     def _get_current_git_branch(default=None):
         """
-        This is a bit of legacy code to figure out which git branch is current.
+        Attempt to figure out which git branch is current.  .git/HEAD typically
+        follows a structure of refs/heads/<branch name>.  We want <branch name>.
         """
         file_path = os.path.join(BASE_DIR, ".git/HEAD")
         if case_sensitive_file_exists(file_path):
             with open(file_path) as f:
-                return f.read().split("/")[-1].strip()
+                return "/".join(f.read().split("/", 2)[2:]).strip()
         return default
 
     @staticmethod

--- a/usaspending_api/references/v2/urls_autocomplete.py
+++ b/usaspending_api/references/v2/urls_autocomplete.py
@@ -10,13 +10,13 @@ from usaspending_api.references.v2.views.autocomplete import (
 )
 from usaspending_api.references.v2.views.city import CityAutocompleteViewSet
 from usaspending_api.references.v2.views.tas_autocomplete import (
-    TASATAAutocomplete,
-    TASAIDAutocomplete,
-    TASBPOAAutocomplete,
-    TASEPOAAutocomplete,
-    TASAAutocomplete,
-    TASMAINAutocomplete,
-    TASSUBAutocomplete
+    TASAutocompleteATA,
+    TASAutocompleteAID,
+    TASAutocompleteBPOA,
+    TASAutocompleteEPOA,
+    TASAutocompleteA,
+    TASAutocompleteMAIN,
+    TASAutocompleteSUB
 )
 
 
@@ -29,11 +29,11 @@ urlpatterns = [
     url(r"^recipient", RecipientAutocompleteViewSet.as_view()),
     url(r"^glossary", GlossaryAutocompleteViewSet.as_view()),
     url(r"^city", CityAutocompleteViewSet.as_view()),
-    url(r"^accounts/ata", TASATAAutocomplete.as_view()),
-    url(r"^accounts/aid", TASAIDAutocomplete.as_view()),
-    url(r"^accounts/bpoa", TASBPOAAutocomplete.as_view()),
-    url(r"^accounts/epoa", TASEPOAAutocomplete.as_view()),
-    url(r"^accounts/a", TASAAutocomplete.as_view()),
-    url(r"^accounts/main", TASMAINAutocomplete.as_view()),
-    url(r"^accounts/sub", TASSUBAutocomplete.as_view()),
+    url(r"^accounts/ata", TASAutocompleteATA.as_view()),
+    url(r"^accounts/aid", TASAutocompleteAID.as_view()),
+    url(r"^accounts/bpoa", TASAutocompleteBPOA.as_view()),
+    url(r"^accounts/epoa", TASAutocompleteEPOA.as_view()),
+    url(r"^accounts/a", TASAutocompleteA.as_view()),
+    url(r"^accounts/main", TASAutocompleteMAIN.as_view()),
+    url(r"^accounts/sub", TASAutocompleteSUB.as_view()),
 ]

--- a/usaspending_api/references/v2/urls_autocomplete.py
+++ b/usaspending_api/references/v2/urls_autocomplete.py
@@ -9,7 +9,15 @@ from usaspending_api.references.v2.views.autocomplete import (
     GlossaryAutocompleteViewSet,
 )
 from usaspending_api.references.v2.views.city import CityAutocompleteViewSet
-from usaspending_api.references.v2.views.tas_autocomplete import TASAutocomplete
+from usaspending_api.references.v2.views.tas_autocomplete import (
+    TASATAAutocomplete,
+    TASAIDAutocomplete,
+    TASBPOAAutocomplete,
+    TASEPOAAutocomplete,
+    TASAAutocomplete,
+    TASMAINAutocomplete,
+    TASSUBAutocomplete
+)
 
 
 urlpatterns = [
@@ -21,5 +29,11 @@ urlpatterns = [
     url(r"^recipient", RecipientAutocompleteViewSet.as_view()),
     url(r"^glossary", GlossaryAutocompleteViewSet.as_view()),
     url(r"^city", CityAutocompleteViewSet.as_view()),
-    url(r"^accounts/(?P<requested_component>ata|aid|bpoa|epoa|a|main|sub)", TASAutocomplete.as_view()),
+    url(r"^accounts/ata", TASATAAutocomplete.as_view()),
+    url(r"^accounts/aid", TASAIDAutocomplete.as_view()),
+    url(r"^accounts/bpoa", TASBPOAAutocomplete.as_view()),
+    url(r"^accounts/epoa", TASEPOAAutocomplete.as_view()),
+    url(r"^accounts/a", TASAAutocomplete.as_view()),
+    url(r"^accounts/main", TASMAINAutocomplete.as_view()),
+    url(r"^accounts/sub", TASSUBAutocomplete.as_view()),
 ]

--- a/usaspending_api/references/v2/views/tas_autocomplete.py
+++ b/usaspending_api/references/v2/views/tas_autocomplete.py
@@ -88,7 +88,7 @@ class TASAutocomplete(APIView):
         return Response(results)
 
 
-class TASATAAutocomplete(TASAutocomplete):
+class TASAutocompleteATA(TASAutocomplete):
     """
     Returns the list of potential Allocation Transfer Agency Identifiers
     narrowed by other components supplied in the Treasury Account filter.
@@ -97,7 +97,7 @@ class TASATAAutocomplete(TASAutocomplete):
     endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/ata.md"
 
 
-class TASAIDAutocomplete(TASAutocomplete):
+class TASAutocompleteAID(TASAutocomplete):
     """
     Returns the list of potential Agency Identifiers narrowed by other
     components supplied in the Treasury Account or Federal Account filter.
@@ -106,7 +106,7 @@ class TASAIDAutocomplete(TASAutocomplete):
     endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/aid.md"
 
 
-class TASBPOAAutocomplete(TASAutocomplete):
+class TASAutocompleteBPOA(TASAutocomplete):
     """
     Returns the list of potential Beginning Period of Availabilities
     narrowed by other components supplied in the Treasury Account filter.
@@ -115,7 +115,7 @@ class TASBPOAAutocomplete(TASAutocomplete):
     endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/bpoa.md"
 
 
-class TASEPOAAutocomplete(TASAutocomplete):
+class TASAutocompleteEPOA(TASAutocomplete):
     """
     Returns the list of potential Ending Period of Availabilities
     narrowed by other components supplied in the Treasury Account filter.
@@ -124,7 +124,7 @@ class TASEPOAAutocomplete(TASAutocomplete):
     endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/epoa.md"
 
 
-class TASAAutocomplete(TASAutocomplete):
+class TASAutocompleteA(TASAutocomplete):
     """
     Returns the list of potential Availability Type Codes
     narrowed by other components supplied in the Treasury Account filter.
@@ -133,7 +133,7 @@ class TASAAutocomplete(TASAutocomplete):
     endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/a.md"
 
 
-class TASMAINAutocomplete(TASAutocomplete):
+class TASAutocompleteMAIN(TASAutocomplete):
     """
     Returns the list of potential Main Account Codes narrowed by other
     components supplied in the Treasury Account or Federal Account filter.
@@ -142,7 +142,7 @@ class TASMAINAutocomplete(TASAutocomplete):
     endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/main.md"
 
 
-class TASSUBAutocomplete(TASAutocomplete):
+class TASAutocompleteSUB(TASAutocomplete):
     """
     Returns the list of potential Sub Account Codes
     narrowed by other components supplied in the Treasury Account filter.

--- a/usaspending_api/references/v2/views/tas_autocomplete.py
+++ b/usaspending_api/references/v2/views/tas_autocomplete.py
@@ -23,18 +23,23 @@ TINY_SHIELD_MODELS = [
 
 class TASAutocomplete(APIView):
     """
-    This endpoint supports all of the various TAS autocomplete components (ATA, AID, BPOA, EPOA, A, MAIN, SUB).
-    """
-    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/aid.md"
+    THIS IS AN ABSTRACT CLASS.  DO NOT INSTANTIATE DIRECTLY.  USE ONE OF THE
+    SUBCLASS FLAVORS BELOW.
 
+    This class supports all of the TAS autocomplete endpoints (ATA, AID, BPOA,
+    EPOA, A, MAIN, SUB).  The reason we split this up vs. service all TAS
+    components from a single view is purely for documentation reasons.
+    Each TAS component has slightly different documentation requirements
+    and since documentation is tied to the view class, we need a class per
+    endpoint.
+    """
     @staticmethod
     def _parse_and_validate_request(request_data):
         return TinyShield(deepcopy(TINY_SHIELD_MODELS)).block(request_data)
 
-    @staticmethod
-    def _business_logic(filters, requested_component, limit):
+    def _business_logic(self, filters, limit):
 
-        requested_column = TAS_COMPONENT_TO_FIELD_MAPPING[requested_component]
+        requested_column = TAS_COMPONENT_TO_FIELD_MAPPING[self.component]
         kwargs = {}
         for current_component, current_value in filters.items():
             current_column = TAS_COMPONENT_TO_FIELD_MAPPING[current_component]
@@ -52,7 +57,7 @@ class TASAutocomplete(APIView):
             .order_by(requested_column)[:limit]
         )
 
-        if requested_component in ("ata", "aid"):
+        if self.component in ("ata", "aid"):
 
             # Look up the agency names and abbreviations for ata and aid.
             cgacs = CGAC.objects.filter(cgac_code__in=results)
@@ -61,12 +66,12 @@ class TASAutocomplete(APIView):
             agency_names = {cgac.cgac_code: cgac.agency_name for cgac in cgacs}
             agency_abbreviations = {cgac.cgac_code: cgac.agency_abbreviation for cgac in cgacs}
 
-            # Build a new result set with the requested_component, agency_name,
+            # Build a new result set with the component, agency_name,
             # and agency_abbreviation.
             results = [
                 OrderedDict(
                     [
-                        (requested_component, r),
+                        (self.component, r),
                         ("agency_name", agency_names.get(r)),
                         ("agency_abbreviation", agency_abbreviations.get(r)),
                     ]
@@ -77,7 +82,70 @@ class TASAutocomplete(APIView):
         return {"results": results}
 
     @cache_response()
-    def post(self, request, requested_component):
+    def post(self, request):
         request_data = self._parse_and_validate_request(request.data)
-        results = self._business_logic(request_data.get("filters", {}), requested_component, request_data["limit"])
+        results = self._business_logic(request_data.get("filters", {}), request_data["limit"])
         return Response(results)
+
+
+class TASATAAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Allocation Transfer Agency Identifiers
+    narrowed by other components supplied in the Treasury Account filter.
+    """
+    component = "ata"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/ata.md"
+
+
+class TASAIDAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Agency Identifiers narrowed by other
+    components supplied in the Treasury Account or Federal Account filter.
+    """
+    component = "aid"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/aid.md"
+
+
+class TASBPOAAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Beginning Period of Availabilities
+    narrowed by other components supplied in the Treasury Account filter.
+    """
+    component = "bpoa"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/bpoa.md"
+
+
+class TASEPOAAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Ending Period of Availabilities
+    narrowed by other components supplied in the Treasury Account filter.
+    """
+    component = "epoa"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/epoa.md"
+
+
+class TASAAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Availability Type Codes
+    narrowed by other components supplied in the Treasury Account filter.
+    """
+    component = "a"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/a.md"
+
+
+class TASMAINAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Main Account Codes narrowed by other
+    components supplied in the Treasury Account or Federal Account filter.
+    """
+    component = "main"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/main.md"
+
+
+class TASSUBAutocomplete(TASAutocomplete):
+    """
+    Returns the list of potential Sub Account Codes
+    narrowed by other components supplied in the Treasury Account filter.
+    """
+    component = "sub"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/autocomplete/accounts/sub.md"


### PR DESCRIPTION
**Description:**
Originally all TAS autocomplete endpoints were serviced by the same view.   This caused documentation issues.  This pull requests separates them out into their own views.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-2963](https://federal-spending-transparency.atlassian.net/browse/DEV-2963)/[DEV-2853](https://federal-spending-transparency.atlassian.net/browse/DEV-2853):
    - [x] Link to this Pull-Request