### PR TITLE
[Hotfix] Update to load_submission to resolve submission load issue

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -314,14 +314,18 @@ def get_submission_attributes(broker_submission_id, submission_data):
         submission_data["reporting_fiscal_period"],
     )
 
-    # if another submission lists the previous submission as it's previous submission, set to null and update later
+    # if another submission lists the previous submission as its previous submission, set to null and update later
     potential_conflicts = []
     if previous_submission:
         potential_conflicts = SubmissionAttributes.objects.filter(previous_submission=previous_submission)
         if potential_conflicts:
             logger.info("==== ATTENTION! Previous Submission ID Conflict Detected ====")
             for conflict in potential_conflicts:
-                logger.info("Temporarily setting {}'s Previous Submission ID from {} to Null".format(conflict, previous_submission.submission_id))
+                logger.info(
+                    "Temporarily setting {}'s Previous Submission ID from {} to null".format(
+                        conflict, previous_submission.submission_id
+                    )
+                )
                 conflict.previous_submission = None
                 conflict.save()
 

--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -340,7 +340,7 @@ def get_submission_attributes(broker_submission_id, submission_data):
     value_map = {
         "broker_submission_id": broker_submission_id,
         "reporting_fiscal_quarter": get_fiscal_quarter(submission_data["reporting_fiscal_period"]),
-        "previous_submission": None if previous_submission is None else previous_submission,
+        "previous_submission": previous_submission,
         # pull in broker's last update date to use as certified date
         "certified_date": submission_data["updated_at"].date()
         if type(submission_data["updated_at"]) == datetime
@@ -357,11 +357,11 @@ def get_submission_attributes(broker_submission_id, submission_data):
             conflict.cgac_code, conflict.reporting_fiscal_year, conflict.reporting_fiscal_period
         )
         logger.info(
-            "New Previous Submission ID for Submission ID {} was mapped to {} ".format(
+            "New Previous Submission ID for Submission ID {} permanently mapped to {} ".format(
                 conflict.submission_id, remapped_previous
             )
         )
-        conflict.previous_submission = None if remapped_previous is None else remapped_previous
+        conflict.previous_submission = remapped_previous
         conflict.save()
 
     return new_submission


### PR DESCRIPTION
**Description:**
Submissions loaded out of order were causing duplicates with multiple submissions pointing to the same submission as their "previous submission" record. The fix was to temporary reset the id to `null` and once the new submission was entered into SubmissionAttributtes to recalculate the previous submission for the pre-existing submissions.

**Technical details:**
None

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-3291](https://federal-spending-transparency.atlassian.net/browse/DEV-3291):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Script (a few hundred ms at most)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to the API or materialized views
No data operations need to be run as automatic jobs will apply the changes
```
