### PR TITLE
[DEV-3233] Fix for pre-existing function not obtaining the correct DB name

### DIFF
--- a/usaspending_api/common/helpers/orm_helpers.py
+++ b/usaspending_api/common/helpers/orm_helpers.py
@@ -1,7 +1,6 @@
 from datetime import date
-from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Func, IntegerField
-from usaspending_api.common.helpers.sql_helpers import get_connection
+from usaspending_api.common.helpers.sql_helpers import get_connection, get_primary_db_name
 from usaspending_api.awards.models_matviews import (
     ContractAwardSearchMatview,
     DirectPaymentAwardSearchMatview,
@@ -68,7 +67,7 @@ def generate_raw_quoted_query(queryset):
     Note: To add new python data types that should be quoted in queryset.query output,
         add them to TYPES_TO_QUOTE_IN_SQL global
     """
-    sql, params = queryset.query.get_compiler(DEFAULT_DB_ALIAS).as_sql()
+    sql, params = queryset.query.get_compiler(get_primary_db_name()).as_sql()
     str_fix_params = []
     for param in params:
         if isinstance(param, TYPES_TO_QUOTE_IN_SQL):


### PR DESCRIPTION
**Description:**
For reasons I am not aware of the DATABASES dictionary is populated differently in deployed applications vs default django configuration

**Technical details:**
Created a new helper function which replaces the built-in `django.db.DEFAULT_DB_ALIAS`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-3233](https://federal-spending-transparency.atlassian.net/browse/DEV-3233):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API  (N/A)
    - [x] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
Existing helper function split up to create a new function for the sql dumper
No API altered outside of correcting the bug
```
