### PR TITLE
dev-3054 add indiana

### DIFF
--- a/usaspending_api/common/helpers/data_constants.py
+++ b/usaspending_api/common/helpers/data_constants.py
@@ -14,6 +14,7 @@ state_to_code_dict = {
     "hawaii": "HI",
     "idaho": "ID",
     "illinois": "IL",
+    "indiana": "IN",
     "iowa": "IA",
     "kansas": "KS",
     "kentucky": "KY",


### PR DESCRIPTION
Further research (https://www.in.gov/core/) has concluded that Indiana is, in fact, a state.