### PR TITLE
DEV-3460: Auto detect Broker subaward reloads

### DIFF
--- a/usaspending_api/awards/management/commands/load_subawards.py
+++ b/usaspending_api/awards/management/commands/load_subawards.py
@@ -1,8 +1,9 @@
 import logging
-import os
 
+from collections import namedtuple
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from pathlib import Path
 from psycopg2.sql import Identifier, Literal, SQL
 from usaspending_api.common.helpers.sql_helpers import convert_composable_query_to_string, get_connection
 from usaspending_api.common.helpers.timing_helpers import Timer
@@ -12,61 +13,96 @@ logger = logging.getLogger("console")
 
 
 class Command(BaseCommand):
-    help = "Load subawards from Broker into USAspending."
 
-    def __init__(self, *args, **kwargs):
-        self.full_reload = False
-        self.log_sql = False
-        super().__init__(*args, **kwargs)
+    help = "Load subawards from Broker into USAspending."
+    full_reload = False
+    log_sql = False
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--full-reload",
             action="store_true",
+            default=self.full_reload,
             help="Empties the USAspending subaward and broker_subaward tables before loading.",
         )
 
         parser.add_argument(
-            "--sql",
+            "--log-sql",
             action="store_true",
+            default=self.log_sql,
             help="For debugging.  Log all SQL statements.  More verbose than you might expect.",
         )
 
     def handle(self, *args, **options):
 
-        # Pick out just the last bit of the module name (which should match the
-        # file name minus the extension).
-        module_name = __name__.split(".")[-1]
-        with Timer(module_name):
+        with Timer("Load subawards"):
 
             self.full_reload = options["full_reload"]
-            self.log_sql = options["sql"]
+            self.log_sql = options["log_sql"]
 
-            if self.full_reload:
-                logger.info("--full-reload flag supplied.  Performing a full reload.")
-                where = ""
+            where = self._prepare_where_clause()
+
+            # There are a couple of situations where we may need to automatically promote an
+            # incremental reload to a full reload.  An empty where clause implies that this
+            # needs to happen.
+            if where == "":
+                self.full_reload = True
+
+            try:
+                with transaction.atomic():
+                    self._perform_load(where)
+            except Exception:
+                logger.error("ALL CHANGES WERE ROLLED BACK DUE TO EXCEPTION")
+                raise
+
+    def _prepare_where_clause(self):
+        where = ""
+
+        if self.full_reload:
+            logger.info("--full-reload flag supplied.  Performing a full reload.")
+
+        else:
+            with Timer("Retrieve delta values"):
+                mm = self._get_mins_and_maxes()
+
+                logger.info(
+                    "FOUND broker_min_id={0.broker_min_id}, local_min_id={0.local_min_id}, "
+                    "local_max_id={0.local_max_id}, local_max_created_at={0.local_max_created_at}, "
+                    "local_max_updated_at={0.local_max_updated_at}".format(mm)
+                )
+
+            if mm.broker_min_id is None:
+                raise RuntimeError("Unable to determine minimum id from Broker subaward table.  No value returned.")
+
+            if mm.local_max_id is None and mm.local_max_created_at is None and mm.local_max_updated_at is None:
+                logger.info("USAspending's broker_subaward table is empty.  Promoting to full reload.")
+
+            # Automatic reload detection.  We can take advantage of the fact that Broker's subaward
+            # ids are serial autonumbers by checking for the lowest id from both tables and promoting
+            # to a full reload if we detect a difference.
+            elif mm.local_min_id != mm.broker_min_id:
+                logger.info(
+                    "Broker's subaward table appears to have been reloaded.  Promoting to full reload.  "
+                    "(min id {0.local_min_id} != {0.broker_min_id})".format(mm)
+                )
 
             else:
-                max_id, max_created_at, max_updated_at = self._get_maxes()
+                logger.info(
+                    "Performing an incremental load on USAspending's broker_subaward "
+                    "where id > {0.local_max_id}, created_at > {0.local_max_created_at}, or "
+                    "updated_at > {0.local_max_updated_at}".format(mm)
+                )
+                where = self._build_where(
+                    id=mm.local_max_id, created_at=mm.local_max_created_at, updated_at=mm.local_max_updated_at
+                )
 
-                if max_id is None and max_created_at is None and max_updated_at is None:
-                    logger.info("USAspending's broker_subaward table is empty.  Promoting to full reload.")
-                    self.full_reload = True
-                    where = ""
+        return where
 
-                else:
-                    logger.info(
-                        "Performing an incremental load on USAspending's broker_subaward "
-                        "where id > {}, created_at > {}, or "
-                        "updated_at > {}".format(max_id, max_created_at, max_updated_at)
-                    )
-                    where = self._build_where(id=max_id, created_at=max_created_at, updated_at=max_updated_at)
-
-            self._perform_load(where)
-
-    def _execute_sql(self, sql):
+    def _execute_sql(self, sql, fetcher=None):
         """
-        Pretty straightforward.  Executes some SQL.
+        Pretty straightforward.  Executes some SQL.  If a fetcher function is provided, returns the
+        result of calling the fetcher.  Be careful with fetchers.  Supplying a fetcher that
+        restructures results along with a query that does not return results will cause an exception.
         """
         if self.log_sql:
             logger.info(sql)
@@ -76,52 +112,58 @@ class Command(BaseCommand):
             cursor.execute(sql)
             rowcount = cursor.rowcount
             if rowcount > -1:
-                logger.info("{:,} rows affected".format(rowcount))
+                logger.info("{:,} rows {}".format(rowcount, "affected" if fetcher is None else "returned"))
+            if fetcher is not None:
+                return fetcher(cursor)
 
-    def _execute_sql_file(self, filename, where=None):
-        """
-        Read in a SQL file, perform any injections, execute the results.
-        """
-        filepath = os.path.join(os.path.split(__file__)[0], "load_subawards_sql", filename)
-
-        with open(filepath) as f:
-            sql = f.read()
+    def _execute_sql_file(self, filename, where=None, fetcher=None):
+        """ Read in a SQL file, perform any injections, execute the results. """
+        filepath = Path(__file__).resolve().parent / "load_subawards_sql" / filename
+        sql = filepath.read_text()
 
         if where is not None:
             sql = sql.format(where=where)
 
         with Timer(filename):
-            self._execute_sql(sql)
+            self._execute_sql(sql, fetcher=fetcher)
 
-    def _get_maxes(self):
+    def _get_mins_and_maxes(self):
         """
-        Get some values from the broker_subaward table that we can use to
-        identify new/updated records in Broker.
+        Get some preliminary data that will help us to identify records that require
+        adding or updating.
         """
-        sql = "select max(id), max(created_at), max(updated_at) from broker_subaward"
+        Results = namedtuple(
+            "MinsAndMaxes",
+            ["broker_min_id", "local_min_id", "local_max_id", "local_max_created_at", "local_max_updated_at"],
+        )
 
-        if self.log_sql:
-            logger.info(sql)
+        broker = self._execute_sql(
+            "select t.min_id from dblink('broker_server', 'select min(id) from subaward') as t (min_id integer)",
+            lambda c: c.fetchall()[0],  # Returns the first row
+        )
 
-        with Timer("Retrieve incremental values from broker_subaward"):
-            connection = get_connection()
-            with connection.cursor() as cursor:
-                cursor.execute(sql)
-                return cursor.fetchall()[0]
+        local = self._execute_sql(
+            "select min(id), max(id), max(created_at), max(updated_at) from broker_subaward",
+            lambda c: c.fetchall()[0],  # Returns the first row
+        )
+
+        return Results(
+            broker_min_id=broker[0],
+            local_min_id=local[0],
+            local_max_id=local[1],
+            local_max_created_at=local[2],
+            local_max_updated_at=local[3],
+        )
 
     def _perform_load(self, where):
-        """
-        The actual heavy lifting.  Call the SQLs necessary to load subawards.
-        """
-        if not self.full_reload:
+        """ The actual heavy lifting.  Call the SQLs necessary to load subawards. """
+        if self.full_reload:
+            with Timer("delete from broker_subaward"):
+                self._execute_sql("delete from broker_subaward")
+        else:
             self._execute_sql_file("010_find_new_awards.sql")
 
-        with transaction.atomic():
-            if self.full_reload:
-                with Timer("delete from broker_subaward"):
-                    self._execute_sql("delete from broker_subaward")
-            self._execute_sql_file("020_import_broker_subawards.sql", where=where)
-
+        self._execute_sql_file("020_import_broker_subawards.sql", where=where)
         self._execute_sql_file("030_frame_out_subawards.sql")
         self._execute_sql_file("040_enhance_with_awards_data.sql")
         self._execute_sql_file("050_enhance_with_transaction_data.sql")
@@ -134,28 +176,28 @@ class Command(BaseCommand):
         self._execute_sql_file("120_enhance_with_recipient_location_county_city.sql")
         self._execute_sql_file("130_enhance_with_recipient_location_country.sql")
 
+        if self.full_reload:
+            with Timer("delete from subaward"):
+                self._execute_sql("delete from subaward")
+
+        self._execute_sql_file("140_add_subawards.sql")
+
+        if self.full_reload:
+            self._execute_sql_file("150_reset_unlinked_award_subaward_fields.sql")
+
         # For update_award_totals, if we're performing a full reload, update
         # all awards that have subawards, otherwise, if this is an incremental
         # update, just update those awards that have may have been affected.
         if self.full_reload:
             where = "where award_id is not null"
         else:
-            where = "where award_id in (select award_id from temp_load_subawards_subaward where award_id is not null)"
+            where = (
+                "where award_id in (select distinct award_id from temp_load_subawards_subaward "
+                "where award_id is not null)"
+            )
 
-        with transaction.atomic():
-            if self.full_reload:
-                with Timer("delete from subaward"):
-                    self._execute_sql("delete from subaward")
-            self._execute_sql_file("140_add_subawards.sql")
-            if self.full_reload:
-                self._execute_sql_file("150_reset_unlinked_award_subaward_fields.sql")
-            self._execute_sql_file("160_update_award_subaward_fields.sql", where=where)
-
-        # We'll do this outside of the transaction since it doesn't hurt
-        # anything to reimport subawards.
+        self._execute_sql_file("160_update_award_subaward_fields.sql", where=where)
         self._execute_sql_file("170_mark_imported.sql")
-
-        self._execute_sql_file("900_cleanup.sql")
 
     @staticmethod
     def _build_where(**where_columns):
@@ -175,11 +217,14 @@ class Command(BaseCommand):
                 wheres.append(SQL("{} > {}").format(Identifier(column), Literal(value)))
 
         if wheres:
+            where = SQL("where {}").format(SQL(" or ").join(wheres))
+
             # Because our where clause is embedded in a dblink, we need to
             # wrap it in a literal again to get everything escaped properly.
-            where = SQL("where {}").format(SQL(" or ").join(wheres))
             where = Literal(convert_composable_query_to_string(where))
             where = convert_composable_query_to_string(where)
-            return where[1:-1]  # Remove outer quotes
+
+            # Remove outer quotes
+            return where[1:-1]
 
         return ""

--- a/usaspending_api/awards/management/commands/load_subawards_sql/030_frame_out_subawards.sql
+++ b/usaspending_api/awards/management/commands/load_subawards_sql/030_frame_out_subawards.sql
@@ -8,8 +8,7 @@ drop table if exists temp_load_subawards_subaward;
 
 
 
--- This will be dropped in the cleanup.sql file.
-create unlogged table temp_load_subawards_subaward as
+create temporary table temp_load_subawards_subaward as
     select * from subaward where 0 = 1;
 
 

--- a/usaspending_api/awards/management/commands/load_subawards_sql/090_create_temp_address_table.sql
+++ b/usaspending_api/awards/management/commands/load_subawards_sql/090_create_temp_address_table.sql
@@ -8,8 +8,7 @@ drop table if exists temp_load_subawards_address_lookup;
 
 -- Create a temporary working table containing all of the address information
 -- from ref_city_county_code that we'll need in subsequent steps.
--- This will be dropped in the cleanup.sql file.
-create unlogged table
+create temporary table
     temp_load_subawards_address_lookup as
 
 select

--- a/usaspending_api/awards/management/commands/load_subawards_sql/900_cleanup.sql
+++ b/usaspending_api/awards/management/commands/load_subawards_sql/900_cleanup.sql
@@ -1,2 +1,0 @@
-drop table if exists temp_load_subawards_subaward;
-drop table if exists temp_load_subawards_address_lookup;

--- a/usaspending_api/awards/tests/integration/test_load_subawards.py
+++ b/usaspending_api/awards/tests/integration/test_load_subawards.py
@@ -3,35 +3,45 @@ import pytest
 
 from datetime import date
 from django.core.management import call_command
+from model_mommy import mommy
+from pathlib import Path
 from usaspending_api.awards.management.commands.load_subawards import Command
 from usaspending_api.awards.models import BrokerSubaward, Subaward
+
+
+SAMPLE_DATA = json.loads(Path("usaspending_api/awards/tests/data/broker_subawards.json").read_text())
+MIN_ID = min([r["id"] for r in SAMPLE_DATA])
+MAX_ID = max([r["id"] for r in SAMPLE_DATA])
 
 
 @pytest.fixture
 def cursor_fixture(db, monkeypatch):
     """
-    Don't attempt to make the dblink call to Broker, but otherwise, allow all
-    other SQL executes to occur.
+    Don't attempt to make dblink calls to Broker, but allow other SQL executes to occur.
     """
     original_execute_sql = Command._execute_sql
 
-    def _execute_sql(self, sql):
+    def _execute_sql(self, sql, fetcher=None):
+
         if "dblink" not in sql and "broker_server" not in sql:
-            original_execute_sql(self, sql)
-        else:
-            BrokerSubaward.objects.all().delete()
-            with open("usaspending_api/awards/tests/data/broker_subawards.json") as json_data:
-                records = json.load(json_data)
-            for record in records:
-                BrokerSubaward.objects.create(**record)
+            # Allow non-dblink calls to happen "normally".
+            return original_execute_sql(self, sql, fetcher=fetcher)
+
+        if "select min(id) from subaward" in sql:
+            # Return the min id from the json file as original_execute_sql would have.
+            return [MIN_ID]
+
+        # Otherwise, mock a call to 020_import_broker_subawards.sql.
+        for record in SAMPLE_DATA:
+            BrokerSubaward.objects.get_or_create(pk=record["id"], defaults=record)
 
     monkeypatch.setattr("usaspending_api.awards.management.commands.load_subawards.Command._execute_sql", _execute_sql)
 
 
 def test_defaults(cursor_fixture):
     call_command("load_subawards")
-    assert BrokerSubaward.objects.all().count() == 4
-    assert Subaward.objects.all().count() == 4
+    assert BrokerSubaward.objects.count() == 4
+    assert Subaward.objects.count() == 4
 
     subaward = Subaward.objects.get(id=3613892)
 
@@ -119,11 +129,39 @@ def test_defaults(cursor_fixture):
 
 def test_full(cursor_fixture):
     call_command("load_subawards", "--full-reload")
-    assert BrokerSubaward.objects.all().count() == 4
-    assert Subaward.objects.all().count() == 4
+    assert BrokerSubaward.objects.count() == 4
+    assert Subaward.objects.count() == 4
 
 
 def test_sql_logging(cursor_fixture):
-    call_command("load_subawards", "--sql")
-    assert BrokerSubaward.objects.all().count() == 4
-    assert Subaward.objects.all().count() == 4
+    call_command("load_subawards", "--log-sql")
+    assert BrokerSubaward.objects.count() == 4
+    assert Subaward.objects.count() == 4
+
+
+def test_automatic_reload_detection(cursor_fixture):
+    call_command("load_subawards")
+    assert BrokerSubaward.objects.count() == 4
+    assert Subaward.objects.count() == 4
+
+    # Add a couple of bogus records so we can track whether or not a full reload was performed.
+    mommy.make("awards.BrokerSubaward", id=MAX_ID + 1)
+    mommy.make("awards.BrokerSubaward", id=MAX_ID + 2)
+    mommy.make("awards.BrokerSubaward", id=MAX_ID + 3)
+    assert BrokerSubaward.objects.count() == 7
+    assert Subaward.objects.count() == 4
+
+    # Performing an incremental load shouldn't change anything.
+    call_command("load_subawards")
+    assert BrokerSubaward.objects.count() == 7
+    assert Subaward.objects.count() == 4
+
+    # However, thanks to automatic reload detection, if we delete or renumber the subaward with
+    # the lowest id, a full reload should be triggered.
+    BrokerSubaward.objects.filter(id=MIN_ID).delete()
+    assert BrokerSubaward.objects.count() == 6
+    assert Subaward.objects.count() == 4
+
+    call_command("load_subawards")
+    assert BrokerSubaward.objects.count() == 4
+    assert Subaward.objects.count() == 4


### PR DESCRIPTION
**Description:**

In its current incarnation, the `load_subawards` management command does not perform deletes.  This is a problem when Broker reloads their subawards without a matching reload on the USAS side of the fence as we can end up with duplicate subawards.  This enhancement attempts to remedy that situation by looking for changes in the minimum Broker subaward serial autonumber id.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations tickets required
8. [x] Jira Ticket [DEV-3460](https://federal-spending-transparency.atlassian.net/browse/DEV-3460):
    - [x] Link to this Pull-Request