### PR TITLE
HOTFIX - scrolling for funding table

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/awards/funding.md
+++ b/usaspending_api/api_contracts/contracts/v2/awards/funding.md
@@ -99,7 +99,6 @@ Lists federal account financial data for the requested award
 + `hasPrevious` (required, boolean)
 + `next` (required, number, nullable)
 + `previous` (required, number, nullable)
-+ `count` (required, number)
 
 ## AwardFundingResponse (object)
 + `reporting_fiscal_year` (required, number, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/awards/funding.md
+++ b/usaspending_api/api_contracts/contracts/v2/awards/funding.md
@@ -83,7 +83,6 @@ Lists federal account financial data for the requested award
                 ],
                 "page_metadata": {
                     "page": 1,
-                    "count": 2,
                     "next": null,
                     "previous": null,
                     "hasPrevious": false,

--- a/usaspending_api/awards/v2/views/funding.py
+++ b/usaspending_api/awards/v2/views/funding.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.common.helpers.generic_helper import get_pagination
+from usaspending_api.common.helpers.generic_helper import get_simple_pagination_metadata
 from usaspending_api.common.helpers.sql_helpers import build_composable_order_by, execute_sql_to_ordered_dictionary
 from usaspending_api.common.validator.award import get_internal_or_generated_award_id_model
 from usaspending_api.common.validator.pagination import customize_pagination_with_sort_columns
@@ -133,13 +133,12 @@ class AwardFundingViewSet(APIView):
             limit=Literal(request_data["limit"] + 1),
             offset=Literal((request_data["page"] - 1) * request_data["limit"]),
         )
-
         return execute_sql_to_ordered_dictionary(sql)
 
     @cache_response()
     def post(self, request: Request) -> Response:
         results = self._business_logic(request.data)
-        paginated_results, page_metadata = get_pagination(results, request.data["limit"], request.data["page"])
-        response = OrderedDict((("results", paginated_results), ("page_metadata", page_metadata)))
+        page_metadata = get_simple_pagination_metadata(len(results), request.data["limit"], request.data["page"])
+        response = OrderedDict((("results", results), ("page_metadata", page_metadata)))
 
         return Response(response)

--- a/usaspending_api/awards/v2/views/funding.py
+++ b/usaspending_api/awards/v2/views/funding.py
@@ -139,6 +139,6 @@ class AwardFundingViewSet(APIView):
     def post(self, request: Request) -> Response:
         results = self._business_logic(request.data)
         page_metadata = get_simple_pagination_metadata(len(results), request.data["limit"], request.data["page"])
-        response = OrderedDict((("results", results), ("page_metadata", page_metadata)))
+        response = OrderedDict((("results", results[: request.data["limit"]]), ("page_metadata", page_metadata)))
 
         return Response(response)

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -34,7 +34,7 @@ API_SEARCH_MIN_DATE = "2007-10-01"  # Beginning of FY2008
 SECRET_KEY = get_random_string()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ["*"]
 

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -34,7 +34,7 @@ API_SEARCH_MIN_DATE = "2007-10-01"  # Beginning of FY2008
 SECRET_KEY = get_random_string()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
**Description:**
Used the wrong method to get the metadata for the endpoint response was causing problems with the frontend infinite scroll feature

**Technical details:**
Used the get_pagination method instead of get_simple_pagination_data which was paginating the results for me even though I was already doing that in the sql. Issue wasn't discovered until the testing for awards with larger numbers of federal accounts that had more pagination needed.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [X] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed 
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-3489](https://federal-spending-transparency.atlassian.net/browse/DEV-3489):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
no ops tickets needed, no matview changes
```
