### PR TITLE
[DEV-3442] adding overlooked update to FK field

### DIFF
--- a/usaspending_api/broker/management/commands/fpds_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fpds_nightly_loader.py
@@ -147,9 +147,12 @@ class Command(BaseCommand):
             queries.extend([fpds, tn, td])
         # Update Awards
         if update_award_ids:
+            # Removing FK values from awards so constraints don't cause script to fail
             # Adding to AWARD_UPDATE_ID_LIST so the transaction FKs will be recalculated
             AWARD_UPDATE_ID_LIST.extend(update_award_ids)
-            query_str = "UPDATE awards SET latest_transaction_id = null, earliest_transaction_id = null WHERE id IN ({});"
+            query_str = (
+                "UPDATE awards SET latest_transaction_id = null, earliest_transaction_id = null WHERE id IN ({});"
+            )
             update_awards_query = query_str.format(update_award_str_ids)
             queries.append(update_awards_query)
         if delete_award_ids:

--- a/usaspending_api/broker/management/commands/fpds_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fpds_nightly_loader.py
@@ -147,9 +147,9 @@ class Command(BaseCommand):
             queries.extend([fpds, tn, td])
         # Update Awards
         if update_award_ids:
-            # Adding to AWARD_UPDATE_ID_LIST so the latest_transaction will be recalculated
+            # Adding to AWARD_UPDATE_ID_LIST so the transaction FKs will be recalculated
             AWARD_UPDATE_ID_LIST.extend(update_award_ids)
-            query_str = "UPDATE awards SET latest_transaction_id = null WHERE id IN ({});"
+            query_str = "UPDATE awards SET latest_transaction_id = null, earliest_transaction_id = null WHERE id IN ({});"
             update_awards_query = query_str.format(update_award_str_ids)
             queries.append(update_awards_query)
         if delete_award_ids:


### PR DESCRIPTION
**Description:**
New FK column from awards to transaction_normalized (`earliest_transaction_id`) needs to be set to null along with `latest_transaction_id` when records are being purged. Value will be re-populated in a later stage of the script.

Thanks to @BrianZito for catching this in his open PR