### PR TITLE
DEV-3597: Removed Corps of Engineers (096) from DoD rollup

### DIFF
--- a/usaspending_api/references/constants.py
+++ b/usaspending_api/references/constants.py
@@ -8,7 +8,7 @@ WEBSITE_AWARD_BINS = {
     ">500M": {"lower": 500000000, "upper": None},
 }
 
-# Air Force, Army, and Navy are to be reported under DoD.  096 has a ticket to be removed.
+# Air Force, Army, and Navy are to be reported under DoD.
 DOD_CGAC = "097"  # DoD's toptier identifier.
-DOD_SUBSUMED_CGAC = ["017", "021", "057", "096"]  # Toptier identifiers for Air Force, Army, and Navy (ignoring 096).
+DOD_SUBSUMED_CGAC = ["017", "021", "057"]  # Toptier identifiers for Air Force, Army, and Navy.
 DOD_ARMED_FORCES_CGAC = [DOD_CGAC] + DOD_SUBSUMED_CGAC  # The list of ALL agencies reported under DoD.


### PR DESCRIPTION
**Description:**

Turned out to be completely trivial.  Removed 096 from the list of DoD rollup agencies.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-3597](https://federal-spending-transparency.atlassian.net/browse/DEV-3597):
    - [x] Link to this Pull-Request