### PR TITLE
DEV-2752: Fix migration

### DIFF
--- a/usaspending_api/references/migrations/0033_move_cgacs_back.py
+++ b/usaspending_api/references/migrations/0033_move_cgacs_back.py
@@ -12,6 +12,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # This doesn't need a reverse as the reverse for this entire migration is to drop the FREC table.
+        migrations.RunSQL(
+            ["drop table if exists frec"],
+        ),
         migrations.CreateModel(
             name='FREC',
             fields=[


### PR DESCRIPTION
Strike 1.  Last minute tweak to a migration was incorrect.  The FREC table was introduced in a previous pull request.  I moved the migration into the wrong file which caused Django to attempt to recreate an existing table.  This will safely work around the issue.