### PR TITLE
COLDFIX: Update/Create routers to prevent migrations against non-USAspending databases and throw exceptions for connections pointing to AWS databases during tests

### DIFF
--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -3,7 +3,6 @@ import os
 import pytest
 import tempfile
 
-from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 from django.test import override_settings
 from django_mock_queries.query import MockSet

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -192,16 +192,8 @@ def mock_matviews_qs(monkeypatch):
 
 
 def pytest_configure():
-    # This function re-added so tests would stop running against non-test databases.
-    #
-    # To make sure the test setup process doesn't try
-    # to set up another test db, remove everything but the default
-    # DATABASE_URL from the list of databases in django settings
-    test_db = settings.DATABASES.pop(DEFAULT_DB_ALIAS, None)
-    settings.DATABASES.clear()
-    settings.DATABASES[DEFAULT_DB_ALIAS] = test_db
-    # Also remove any database routers
-    settings.DATABASE_ROUTERS.clear()
+    # This function used to remove all non-default DB connections.  We undid this 10/2019 to allow testing of loaders.
+    pass
 
 
 def pytest_addoption(parser):

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import tempfile
 
-from django.db import DEFAULT_DB_ALIAS
+from django.db import connections, DEFAULT_DB_ALIAS
 from django.test import override_settings
 from django_mock_queries.query import MockSet
 from usaspending_api.common.helpers.generic_helper import generate_matviews
@@ -192,7 +192,12 @@ def mock_matviews_qs(monkeypatch):
 
 def pytest_configure():
     # This function used to remove all non-default DB connections.  We undid this 10/2019 to allow testing of loaders.
-    pass
+    for connection_name in connections:
+        host = connections[connection_name].settings_dict.get("HOST")
+        if "amazonaws" in host:
+            raise RuntimeError(
+                "Connection '{}' appears to be pointing to an AWS database: [{}]".format(connection_name, host)
+            )
 
 
 def pytest_addoption(parser):

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import tempfile
 
+from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 from django.test import override_settings
 from django_mock_queries.query import MockSet
@@ -191,8 +192,16 @@ def mock_matviews_qs(monkeypatch):
 
 
 def pytest_configure():
-    # this function used to remove all non-default DB connections. We undid this 10/2019 to allow testing of loaders
-    pass
+    # This function re-added so tests would stop running against non-test databases.
+    #
+    # To make sure the test setup process doesn't try
+    # to set up another test db, remove everything but the default
+    # DATABASE_URL from the list of databases in django settings
+    test_db = settings.DATABASES.pop(DEFAULT_DB_ALIAS, None)
+    settings.DATABASES.clear()
+    settings.DATABASES[DEFAULT_DB_ALIAS] = test_db
+    # Also remove any database routers
+    settings.DATABASE_ROUTERS.clear()
 
 
 def pytest_addoption(parser):

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -191,7 +191,6 @@ def mock_matviews_qs(monkeypatch):
 
 
 def pytest_configure():
-    # This function used to remove all non-default DB connections.  We undid this 10/2019 to allow testing of loaders.
     for connection_name in connections:
         host = connections[connection_name].settings_dict.get("HOST")
         if "amazonaws" in host:

--- a/usaspending_api/routers/replicas.py
+++ b/usaspending_api/routers/replicas.py
@@ -4,24 +4,21 @@ from django.db import DEFAULT_DB_ALIAS
 from usaspending_api.references.models import FilterHash
 from usaspending_api.download.models import DownloadJob
 
-"""
-The USAspending API is a *mostly* readonly application. This
-router is used to balance loads between multiple databases
-defined by the environment variables in settings.py, and
-handle the models that are *not* readonly appropriately.
-
-It splits requests among two databases but you can add more.
-"""
-
 
 class ReadReplicaRouter:
+    """
+    The USAspending API is *mostly* a readonly application.  This router is used to balance loads
+    between multiple databases defined by the environment variables in settings.py, and handle
+    the models that are *not* readonly appropriately.
+    """
 
     usaspending_db_list = (DEFAULT_DB_ALIAS, "db_r1")
-    broker_db_list = ("data_broker",)
 
     def db_for_read(self, model, **hints):
-        """ For reads, choose a connection randomly.  FilterHash and DownloadJob are writable tables so always
-            read from source (default) to mitigation replication lag issues. """
+        """
+        FilterHash and DownloadJob are writable tables so always read from source (default) to
+        mitigate replication lag.  Otherwise, choose a connection randomly.
+        """
         if model in [FilterHash, DownloadJob]:
             return DEFAULT_DB_ALIAS
         return random.choice(self.usaspending_db_list)
@@ -31,15 +28,15 @@ class ReadReplicaRouter:
         return DEFAULT_DB_ALIAS
 
     def allow_relation(self, obj1, obj2, **hints):
-        """ Relations are allowed between similar databases so USAspending to USAspending or Broker to Broker. """
-        return (obj1._state.db in self.usaspending_db_list and obj2._state.db in self.usaspending_db_list) or (
-            obj1._state.db in self.broker_db_list and obj2._state.db in self.broker_db_list
-        )
+        """ Relations are currently only allowed in USAspending. """
+        return obj1._state.db in self.usaspending_db_list and obj2._state.db in self.usaspending_db_list
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        """ We do not allow migrations against Broker. """
-        return db not in self.broker_db_list
+        """ Migrations should only run in USAspending, never in Broker. """
+        return db in self.usaspending_db_list
 
 
 class DefaultOnlyRouter(ReadReplicaRouter):
+    """ For when only the default connection is used.  Prevents migrations to Broker. """
+
     usaspending_db_list = (DEFAULT_DB_ALIAS,)

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -5,7 +5,6 @@ For the full list of settings and their values: https://docs.djangoproject.com/e
 
 import dj_database_url
 import os
-import sys
 
 from django.db import DEFAULT_DB_ALIAS
 from django.utils.crypto import get_random_string

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -192,6 +192,7 @@ if os.environ.get("DB_SOURCE"):
     DATABASE_ROUTERS = ["usaspending_api.routers.replicas.ReadReplicaRouter"]
 elif os.environ.get(dj_database_url.DEFAULT_ENV):
     DATABASES = {DEFAULT_DB_ALIAS: _configure_database_connection(dj_database_url.DEFAULT_ENV)}
+    DATABASE_ROUTERS = ["usaspending_api.routers.replicas.DefaultOnlyRouter"]
 else:
     raise EnvironmentError(
         "Either {} or DB_SOURCE/DB_R1 environment variable must be defined".format(dj_database_url.DEFAULT_ENV)
@@ -200,7 +201,7 @@ else:
 
 # import a second database connection for ETL, connecting to the data broker
 # using the environemnt variable, DATA_BROKER_DATABASE_URL - only if it is set
-if os.environ.get("DATA_BROKER_DATABASE_URL") and not sys.argv[1:2] == ["test"]:
+if os.environ.get("DATA_BROKER_DATABASE_URL"):
     DATABASES["data_broker"] = dj_database_url.parse(
         os.environ.get("DATA_BROKER_DATABASE_URL"), conn_max_age=CONNECTION_MAX_SECONDS
     )


### PR DESCRIPTION
After pulling the most recent version of `dev`, running certain tests locally increased from about a minute of run time to about 15 minutes.  This was unacceptable.

The issue was traced to [a change made as part of the new FPDS loader](https://github.com/fedspendingtransparency/usaspending-api/pull/2015/files#diff-d41742a07a26ba73b6844b153bf4b12aL195-R195) (thanks @sethstoudenmier!).

The problem was twofold:

- Part 1 was a user issue.  I had no idea my Broker connection string was actually being used for tests now (which, btw, was pointing to the PRODUCTION Broker server).  I added a check to throw an exception if it appeared any of the database connection strings are pointing to AWS during tests.  Running tests over the internet against an RDS introduces a SIGNIFICANT performance penalty.
- Part 2 was more of a Django issue.  Django apparently assumes all databases need a copy of the database so it was migrating models to all connections.  I added/updated our routers to prevent migrations to non-USAspending databases.

That's it.  The test I was running is back down to a minute.  Success!