### PR TITLE
[DEV-3634] Path resilience to execute c to d linkage .sql file

### DIFF
--- a/usaspending_api/common/helpers/etl_helpers.py
+++ b/usaspending_api/common/helpers/etl_helpers.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import logging
+from pathlib import Path
 
+from django.conf import settings
 from django.db import connection
 
 from usaspending_api.common.exceptions import InvalidParameterException
@@ -8,12 +10,14 @@ from usaspending_api.common.helpers.sql_helpers import read_sql_file
 
 
 logger = logging.getLogger("console")
-ETL_SQL_FILE_PATH = "usaspending_api/etl/management/sql/c_file_linkage/"
+
+_APP_DIR = Path(settings.BASE_DIR).resolve() / "usaspending_api"
+_ETL_SQL_FILE_PATH = _APP_DIR / "etl/management/sql/c_file_linkage/"
 
 
 def get_unlinked_count(file_name):
 
-    file_path = ETL_SQL_FILE_PATH + file_name
+    file_path = str(_ETL_SQL_FILE_PATH / file_name)
     sql_commands = read_sql_file(file_path=file_path)
 
     if len(sql_commands) != 1:
@@ -45,7 +49,7 @@ def update_c_to_d_linkages(type):
     else:
         raise InvalidParameterException("Invalid type provided to process C to D linkages.")
 
-    file_paths = [ETL_SQL_FILE_PATH + file_name for file_name in file_names]
+    file_paths = [str(_ETL_SQL_FILE_PATH / file_name) for file_name in file_names]
 
     starting_unlinked_count = get_unlinked_count(file_name=unlinked_count_file_name)
     logger.info("Current count of unlinked %s records: %s" % (type, str(starting_unlinked_count)))

--- a/usaspending_api/etl/transaction_loaders/tests/integration/test_fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/tests/integration/test_fpds_loader.py
@@ -90,7 +90,6 @@ class FPDSLoaderIntegrationTestCase(TestCase):
         assert new_award.id == tx_norm_awd_ids[0] == tx_norm_awd_ids[1] == tx_norm_awd_ids[2]
 
         # And the single award created should refer to the first transaction processed that spawned the award (101)s
-        # TODO: Check if this is true??
         assert new_award.transaction_unique_id == "101"
 
         # Award's latest_transaction should point to transaction with latest action_date


### PR DESCRIPTION
**Description:**
Better logic to determine the path to the .sql file to execute

**Technical details:**
- Use `settings.py` to find the BASE_DIR and establish path to SQL file from there. 
- This was determined by running the test from pycharm, which runs it _not_ from the root dir

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-3634](https://federal-spending-transparency.atlassian.net/browse/DEV-3634):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Fixes based on unit test failure (when run from non-root dir, e.g. in PyCharm)
```
