### PR TITLE
[DEV-1526] Adding removal of the container once done migrating broker

### DIFF
--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -357,6 +357,7 @@ def broker_db_setup(django_db_setup, django_db_use_migrations):
     log_gen = docker_client.containers.run(
         broker_docker_image,
         broker_db_setup_command,
+        remove=True,
         network_mode="host",
         mounts=[mounted_src],
         stderr=True,


### PR DESCRIPTION
**Description:**
Basically doing `docker --rm`

**Technical details:**
If not done, it leaves around a stopped container after the `pytest` session is run, which can be seen with `docker ps --no-trunc -a`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-1526](https://federal-spending-transparency.atlassian.net/browse/DEV-1526):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Automated test frameworking work
```
