### PR TITLE
Mod/dev 3746 deprecate more endpoints

### DIFF
--- a/usaspending_api/accounts/tests/test_federal_account_autocomplete.py
+++ b/usaspending_api/accounts/tests/test_federal_account_autocomplete.py
@@ -33,6 +33,7 @@ def fed_account_data(db):
         (["federal_account_code"], "999-0000", {"federal_account_code": "999-0000"}),
     ],
 )
+@pytest.mark.skip(reason="Deprecated endpoints; to remove later")
 @pytest.mark.django_db
 def test_awards_autocomplete(client, fed_account_data, fields, value, expected):
     """test partial-text search on awards."""
@@ -40,6 +41,7 @@ def test_awards_autocomplete(client, fed_account_data, fields, value, expected):
     check_autocomplete("federal_accounts", client, fields, value, expected)
 
 
+@pytest.mark.skip(reason="Deprecated endpoints; to remove later")
 @pytest.mark.django_db
 def test_bad_awards_autocomplete_request(client):
     """Verify error on bad autocomplete request for awards."""

--- a/usaspending_api/accounts/tests/test_tas_autocomplete.py
+++ b/usaspending_api/accounts/tests/test_tas_autocomplete.py
@@ -30,6 +30,7 @@ def tas_data(db):
         (["tas_rendering_label"], "ghi", {"tas_rendering_label": []}),
     ],
 )
+@pytest.mark.skip(reason="Deprecated endpoints; to remove later")
 @pytest.mark.django_db
 def test_awards_autocomplete(client, tas_data, fields, value, expected):
     """test partial-text search on awards."""
@@ -37,6 +38,7 @@ def test_awards_autocomplete(client, tas_data, fields, value, expected):
     check_autocomplete("tas", client, fields, value, expected)
 
 
+@pytest.mark.skip(reason="Deprecated endpoints; to remove later")
 @pytest.mark.django_db
 def test_bad_awards_autocomplete_request(client):
     """Verify error on bad autocomplete request for awards."""

--- a/usaspending_api/accounts/views/common.py
+++ b/usaspending_api/accounts/views/common.py
@@ -3,7 +3,7 @@ from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.common.mixins import FilterQuerysetMixin, AggregateQuerysetMixin
 from usaspending_api.common.views import CachedDetailViewSet
 from usaspending_api.common.serializers import AggregateSerializer
-from usaspending_api.common.api_versioning import removed, deprecated
+from usaspending_api.common.api_versioning import removed
 from django.utils.decorators import method_decorator
 
 

--- a/usaspending_api/accounts/views/common.py
+++ b/usaspending_api/accounts/views/common.py
@@ -23,8 +23,8 @@ class FinancialAccountsByAwardAggregateViewSet(FilterQuerysetMixin, AggregateQue
         return queryset
 
 
-@method_decorator(deprecated, name="list")
-@method_decorator(deprecated, name="retrieve")
+@method_decorator(removed, name="list")
+@method_decorator(removed, name="retrieve")
 class FinancialAccountsByAwardListViewSet(FilterQuerysetMixin, CachedDetailViewSet):
     """
     Handles requests for financial account data grouped by award.

--- a/usaspending_api/accounts/views/federal_account.py
+++ b/usaspending_api/accounts/views/federal_account.py
@@ -2,10 +2,11 @@ from usaspending_api.accounts.serializers import FederalAccountSerializer
 from usaspending_api.accounts.models import FederalAccount
 from usaspending_api.common.mixins import FilterQuerysetMixin
 from usaspending_api.common.views import CachedDetailViewSet, AutocompleteView
-from usaspending_api.common.api_versioning import deprecated
+from usaspending_api.common.api_versioning import deprecated, removed
 from django.utils.decorators import method_decorator
 
 
+@method_decorator(removed, name="post")
 class FederalAccountAutocomplete(FilterQuerysetMixin, AutocompleteView):
     """
     Handle autocomplete requests for federal account information.

--- a/usaspending_api/accounts/views/tas.py
+++ b/usaspending_api/accounts/views/tas.py
@@ -126,6 +126,7 @@ class TASCategoryQuarterList(FilterQuerysetMixin, CachedDetailViewSet):
         return ordered_queryset
 
 
+@method_decorator(removed, "post")
 class TreasuryAppropriationAccountAutocomplete(FilterQuerysetMixin, AutocompleteView):
     """
     Handle autocomplete requests for appropriation account (i.e., TAS) information.


### PR DESCRIPTION
**Description:**
Three endpoints were missed in initial work of DEV-3746. This adds the removed tag to them.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed 
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-3746](https://federal-spending-transparency.atlassian.net/browse/DEV-3746):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No documentation exists to update, because these are v1
```
