### PR TITLE
dev-3634 removed cleanup

### DIFF
--- a/usaspending_api/broker/management/commands/load_fpds_transactions.py
+++ b/usaspending_api/broker/management/commands/load_fpds_transactions.py
@@ -151,8 +151,9 @@ class Command(BaseCommand):
             self.load_fpds_incrementally(last_load)
 
         if self.modified_award_ids:
-            logger.info("cleaning orphaned metadata")
-            destroy_orphans()
+            # TODO: reactivate once this is performant. Currently the tables are too large to allow
+            # logger.info("cleaning orphaned metadata")
+            # destroy_orphans()
             logger.info(
                 "updating award values ({} awards touched by transaction modifications)".format(
                     len(self.modified_award_ids)

--- a/usaspending_api/broker/management/commands/load_fpds_transactions.py
+++ b/usaspending_api/broker/management/commands/load_fpds_transactions.py
@@ -4,7 +4,7 @@ import re
 import psycopg2
 from datetime import datetime, timezone
 
-from usaspending_api.etl.transaction_loaders.fpds_loader import load_ids, failed_ids, destroy_orphans, delete_stale_fpds
+from usaspending_api.etl.transaction_loaders.fpds_loader import load_ids, failed_ids, delete_stale_fpds
 from usaspending_api.common.retrieve_file_from_uri import RetrieveFileFromUri
 from usaspending_api.common.helpers.date_helper import datetime_command_line_argument_type
 from usaspending_api.common.helpers.sql_helpers import get_broker_dsn_string


### PR DESCRIPTION
Investigation has found that any angle of trying to find orphaned values takes prohibitively long, and that the amount of orphans has little impact on runtime. Given that work is under way to remove both of these tables altogether, I think it's a better choice to let this clutter accumulate for the time being, and invest time in either removing these tables, or developing a more complete way to deal with this problem if the tables can't go for some reason. 