### PR TITLE
added slash back to local download path

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -244,8 +244,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = "/static/"
-STATIC_ROOT = str(APP_DIR / "static/")
-STATICFILES_DIRS = (str(APP_DIR / "static_doc_files"),)
+STATIC_ROOT = str(APP_DIR / "static/") + "/"
+STATICFILES_DIRS = (str(APP_DIR / "static_doc_files") + "/",)
 
 LOGGING = {
     "version": 1,

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -48,7 +48,7 @@ if not USASPENDING_AWS_REGION:
     USASPENDING_AWS_REGION = os.environ.get("USASPENDING_AWS_REGION")
 
 # AWS locations for CSV files
-CSV_LOCAL_PATH = str(BASE_DIR / "csv_downloads")
+CSV_LOCAL_PATH = str(BASE_DIR / "csv_downloads") + "/"
 DOWNLOAD_ENV = ""
 BULK_DOWNLOAD_LOCAL_PATH = str(BASE_DIR / "bulk_downloads")
 

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -50,7 +50,7 @@ if not USASPENDING_AWS_REGION:
 # AWS locations for CSV files
 CSV_LOCAL_PATH = str(BASE_DIR / "csv_downloads") + "/"
 DOWNLOAD_ENV = ""
-BULK_DOWNLOAD_LOCAL_PATH = str(BASE_DIR / "bulk_downloads")
+BULK_DOWNLOAD_LOCAL_PATH = str(BASE_DIR / "bulk_downloads") + "/"
 
 BULK_DOWNLOAD_S3_BUCKET_NAME = ""
 BULK_DOWNLOAD_S3_REDIRECT_DIR = "generated_downloads"


### PR DESCRIPTION
Recent fancy string formatting changes cause local download files to save to the wrong folder, due to all slashes being deleted. This remedies the issue.