### PR TITLE
Added pre-commit hooks for Black, flake8, and debug statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: (/migrations/)
+exclude: /(\.git|\.venv|venv|migrations)/
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+exclude: (/migrations/)
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: debug-statements
+    -   id: flake8
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black
+        language_version: python3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 120
 target_version = ['py35']
-exclude = 'migrations'
+exclude = '/migrations/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 120
 target_version = ['py35']
-exclude = '/migrations/'
+exclude = '/(\.git|\.venv|venv|migrations)/'

--- a/requirements/requirements-contrib.txt
+++ b/requirements/requirements-contrib.txt
@@ -7,6 +7,7 @@ git+https://github.com/fedspendingtransparency/django-mock-queries#egg=django-mo
 mccabe==0.6.1
 mock==3.0.5
 model-mommy==1.6.0
+pre-commit==1.20.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pytest-cov==2.8.1

--- a/usaspending_api/common/management/commands/reset_migrations.py
+++ b/usaspending_api/common/management/commands/reset_migrations.py
@@ -4,15 +4,12 @@ from django.db import connection
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
 
-logger = logging.getLogger('console')
+logger = logging.getLogger("console")
 # if we're ever planning to run this again, update this to receive the app
 # list as a command argument instead of hard-coding here
-app_list = ['accounts', 'awards', 'common', 'financial_activities', 'references', 'submissions']
+app_list = ["accounts", "awards", "common", "financial_activities", "references", "submissions"]
 
-remove_ghost_migrations = (
-    "DELETE FROM django_migrations "
-    "WHERE app in %s "
-)
+remove_ghost_migrations = "DELETE FROM django_migrations " "WHERE app in %s "
 
 
 class Command(BaseCommand):
@@ -23,6 +20,7 @@ class Command(BaseCommand):
     2. adds a new set of 0001_initial migration files that reflect the
        current state of the database
     """
+
     help = "Resets Django migrations"
 
     def handle(self, *args, **options):
@@ -34,9 +32,8 @@ class Command(BaseCommand):
         with connection.cursor() as cursor:
             cursor.execute(remove_ghost_migrations, [tuple(app_list)])
             rows = cursor.rowcount
-        logger.info('Removed {} django_migrations records for apps {}'.format(
-            rows, app_list))
+        logger.info("Removed {} django_migrations records for apps {}".format(rows, app_list))
 
         # fake the intial migrations
         for app in app_list:
-            call_command('migrate', app_label=app, fake_initial=True, interactive=False)
+            call_command("migrate", app_label=app, fake_initial=True, interactive=False)

--- a/usaspending_api/common/management/commands/reset_migrations.py
+++ b/usaspending_api/common/management/commands/reset_migrations.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("console")
 # list as a command argument instead of hard-coding here
 app_list = ["accounts", "awards", "common", "financial_activities", "references", "submissions"]
 
-remove_ghost_migrations = "DELETE FROM django_migrations " "WHERE app in %s "
+remove_ghost_migrations = "DELETE FROM django_migrations WHERE app in %s "
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
**Description:**

As a means by which to cut down on the number of bogus commits to GitHub (which should help with our Travis queues), this will implement pre-commit hooks that Black, flake8, and check for debug statements in code locally before allowing a git commit to finish.

If you want to try it out, pull this branch and run:
```
pip install pre-commit
pre-commit install
```
Then make some bogus changes and try to commit them.

If you do not wish to participate in pre-commits, you can either uninstall `pre-commit` or commit your code with the `--no-verify` switch.  Code checks will continue to occur in Travis, this is just a way to short circuit certain common errors that can be quickly and easily caught before wasting precious Travis time/energy/resources.

**IMPORTANT**

If Black updates any files, the commit will fail and those files will be moved out of the `git` staging area (obviously, since they have been edited).  You will need to re-add those files to staging (`git add` or however you do it using the GUI) before you re-commit your commit.