### PR TITLE
Mod/dev 1684 remove download values

### DIFF
--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -12,9 +12,7 @@ from usaspending_api.common.helpers.generic_helper import generate_test_db_conne
 from usaspending_api.download.lookups import JOB_STATUS
 from usaspending_api.etl.award_helpers import update_awards
 from usaspending_api.download.filestreaming import csv_generation
-
-EXPECTED_COLUMNS_TRANSACTIONS = 275
-EXPECTED_COLUMNS_AWARDS = 261
+from usaspending_api.download.v2.download_column_historical_lookups import query_paths
 
 
 @pytest.fixture
@@ -168,7 +166,7 @@ def test_download_awards_status(client, download_test_data, refresh_matviews):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 3
-    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_AWARDS
+    assert resp.json()["total_columns"] == len(query_paths["award"]["d1"])
 
     # Test with columns specified
     dl_resp = client.post(
@@ -206,7 +204,7 @@ def test_download_contract_status(client, download_test_data, refresh_matviews):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 1
-    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
+    assert resp.json()["total_columns"] == len(query_paths["transaction"]["d1"])
 
     # Test with columns specified
     dl_resp = client.post(
@@ -244,7 +242,7 @@ def test_download_idv_status(client, download_test_data, refresh_matviews):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 1
-    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
+    assert resp.json()["total_columns"] == len(query_paths["transaction"]["d1"])
 
     # Test with columns specified
     dl_resp = client.post(
@@ -284,7 +282,7 @@ def test_download_transactions_status(client, download_test_data, refresh_matvie
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 2
-    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
+    assert resp.json()["total_columns"] == len(query_paths["transaction"]["d1"])
 
     # Test with columns specified
     dl_resp = client.post(
@@ -322,4 +320,4 @@ def test_download_transactions_limit(client, download_test_data, refresh_matview
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 2
-    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
+    assert resp.json()["total_columns"] == len(query_paths["transaction"]["d1"])

--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -13,6 +13,8 @@ from usaspending_api.download.lookups import JOB_STATUS
 from usaspending_api.etl.award_helpers import update_awards
 from usaspending_api.download.filestreaming import csv_generation
 
+EXPECTED_COLUMNS_TRANSACTIONS = 275
+EXPECTED_COLUMNS_AWARDS = 261
 
 @pytest.fixture
 def download_test_data(db):
@@ -165,7 +167,7 @@ def test_download_awards_status(client, download_test_data, refresh_matviews):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 3
-    assert resp.json()["total_columns"] == 263
+    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_AWARDS
 
     # Test with columns specified
     dl_resp = client.post(
@@ -203,7 +205,7 @@ def test_download_contract_status(client, download_test_data, refresh_matviews):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 1
-    assert resp.json()["total_columns"] == 277
+    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
 
     # Test with columns specified
     dl_resp = client.post(
@@ -241,7 +243,7 @@ def test_download_idv_status(client, download_test_data, refresh_matviews):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 1
-    assert resp.json()["total_columns"] == 277
+    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
 
     # Test with columns specified
     dl_resp = client.post(
@@ -281,7 +283,7 @@ def test_download_transactions_status(client, download_test_data, refresh_matvie
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 2
-    assert resp.json()["total_columns"] == 277
+    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS
 
     # Test with columns specified
     dl_resp = client.post(
@@ -319,4 +321,4 @@ def test_download_transactions_limit(client, download_test_data, refresh_matview
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 2
-    assert resp.json()["total_columns"] == 277
+    assert resp.json()["total_columns"] == EXPECTED_COLUMNS_TRANSACTIONS

--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -16,6 +16,7 @@ from usaspending_api.download.filestreaming import csv_generation
 EXPECTED_COLUMNS_TRANSACTIONS = 275
 EXPECTED_COLUMNS_AWARDS = 261
 
+
 @pytest.fixture
 def download_test_data(db):
     # Populate job status lookup table

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -518,7 +518,6 @@ query_paths = {
                     "award__latest_transaction__contract_data__other_not_for_profit_organ",
                 ),
                 ("the_ability_one_program", "award__latest_transaction__contract_data__the_ability_one_program"),
-                ("annual_revenue", "award__latest_transaction__contract_data__annual_revenue"),
                 (
                     "private_university_or_college",
                     "award__latest_transaction__contract_data__private_university_or_coll",
@@ -1025,7 +1024,6 @@ query_paths = {
                 ("nonprofit_organization", "transaction__contract_data__nonprofit_organization"),
                 ("other_not_for_profit_organization", "transaction__contract_data__other_not_for_profit_organ"),
                 ("the_ability_one_program", "transaction__contract_data__the_ability_one_program"),
-                ("annual_revenue", "transaction__contract_data__annual_revenue"),
                 ("private_university_or_college", "transaction__contract_data__private_university_or_coll"),
                 (
                     "state_controlled_institution_of_higher_learning",

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -518,7 +518,6 @@ query_paths = {
                     "award__latest_transaction__contract_data__other_not_for_profit_organ",
                 ),
                 ("the_ability_one_program", "award__latest_transaction__contract_data__the_ability_one_program"),
-                ("number_of_employees", "award__latest_transaction__contract_data__number_of_employees"),
                 ("annual_revenue", "award__latest_transaction__contract_data__annual_revenue"),
                 (
                     "private_university_or_college",
@@ -1026,7 +1025,6 @@ query_paths = {
                 ("nonprofit_organization", "transaction__contract_data__nonprofit_organization"),
                 ("other_not_for_profit_organization", "transaction__contract_data__other_not_for_profit_organ"),
                 ("the_ability_one_program", "transaction__contract_data__the_ability_one_program"),
-                ("number_of_employees", "transaction__contract_data__number_of_employees"),
                 ("annual_revenue", "transaction__contract_data__annual_revenue"),
                 ("private_university_or_college", "transaction__contract_data__private_university_or_coll"),
                 (


### PR DESCRIPTION
**Description:**
Remove number_of_employees and annual_revenue from downloads

**Technical details:**
Values remain in the data model and loader. They simply no longer appear on the site.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-1684](https://federal-spending-transparency.atlassian.net/browse/DEV-1684):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Download
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
