### PR TITLE
COLDFIX: Using the py-gfm that attempts to enforce its compatibility with Markdown<3.0

### DIFF
--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -30,7 +30,7 @@ importlib-metadata==0.20
 jdcal==1.4.1
 jmespath==0.9.4
 jsonpickle==1.2
-Markdown==3.1.1
+Markdown<3.0
 more-itertools==7.2.0
 numpy==1.17.2
 openpyxl==2.4.7
@@ -38,7 +38,7 @@ pandas==0.25.1
 pip>=19.2
 pluggy==0.12.0
 psycopg2-binary==2.7.5
-py-gfm==0.1.3
+py-gfm==0.1.4
 py==1.8.0
 pycodestyle==2.5.0
 pyflakes==2.1.1


### PR DESCRIPTION
**Description:**
Setting the requirements to work around incompatibilities of `py-gfm` with `Markdown>=3.0`

**Technical details:**


So the `GithubFlavoredMarkdownExtension` we use is not up-to-date/compatible with newer versions of the Markdown lib.
https://github.com/fedspendingtransparency/usaspending-api/blob/dev/usaspending_api/api_docs/templatetags/docs.py#L5

So the maintainer of that library (`py-gfm`) just pinned their requirement to `Markdown<3.0`.
https://github.com/Zopieux/py-gfm/compare/0.1.3...0.1.4#diff-2eeaed663bd0d25b7e608891384b7298R13

The “fix” then for us, given our dependencies, would be to likewise Pin our Markdown, and upgrade to py-gfm 0.1.4.

I did this and the app comes up without the error.

Given we’re still waiting on final approval of the changes before staging deploy, i’ll put this PR up to dev.

That way pip will at least warn us in red text when/if we have incompatible libraries.

See also:

- https://bugzilla.redhat.com/show_bug.cgi?id=1716500#c8
- https://github.com/Zopieux/py-gfm/issues/13


**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [NA] Jira Ticket [DEV-3064](https://federal-spending-transparency.atlassian.net/browse/DEV-3064):
    - [x] Link to this Pull-Request
    - [NA] Performance evaluation of affected (API | Script | Download)
    - [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Dependencies fix
```
