### PR TITLE
[DEV-3864] Elasticsearch ETL DB connections fix 

### DIFF
--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -14,7 +14,6 @@ from elasticsearch import helpers, TransportError
 from time import perf_counter, sleep
 
 from usaspending_api.awards.v2.lookups.elasticsearch_lookups import INDEX_ALIASES_TO_AWARD_TYPES
-from usaspending_api.common.elasticsearch.elasticsearch_sql_helpers import ensure_transaction_etl_view_exists
 from usaspending_api.common.csv_helpers import count_rows_in_csv_file
 from usaspending_api.common.helpers.sql_helpers import get_database_dsn_string
 
@@ -218,7 +217,6 @@ def db_rows_to_dict(cursor):
 def download_db_records(fetch_jobs, done_jobs, config):
     # There has been a reoccuring issue with .empty() returning true when the queue actually
     # contains multiple jobs. Wait a few seconds before starting to see if it helps
-    ensure_transaction_etl_view_exists()
     sleep(5)
     printf({"msg": "Queue has items: {}".format(not fetch_jobs.empty()), "f": "Download"})
     while not fetch_jobs.empty():

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -7,6 +7,7 @@ from time import perf_counter, sleep
 from usaspending_api import settings
 from usaspending_api.broker.helpers.last_load_date import get_last_load_date, update_last_load_date
 from usaspending_api.common.elasticsearch.client import instantiate_elasticsearch_client
+from usaspending_api.common.elasticsearch.elasticsearch_sql_helpers import ensure_transaction_etl_view_exists
 from usaspending_api.common.helpers.date_helper import datetime_command_line_argument_type, fy as parse_fiscal_year
 from usaspending_api.common.helpers.fiscal_year_helpers import create_fiscal_year_list
 from usaspending_api.etl.es_etl_helpers import (
@@ -103,6 +104,7 @@ class Command(BaseCommand):
         printf({"msg": "Starting script\n{}".format("=" * 56)})
         start_msg = "target index: {index_name} | FY(s): {fiscal_years} | Starting from: {starting_date}"
         printf({"msg": start_msg.format(**self.config)})
+        ensure_transaction_etl_view_exists()
 
         self.run_load_steps()
         self.complete_process()


### PR DESCRIPTION
**Description:**
Problem caused by using a persistent Django DB connection in a child process. A check to ensure a DB view is present leveraged pre-existing functions which used the Django connection.

**Technical details:**
The database connection needs to be new for each separate process. If the connection is accidentally used in another process, it _may_ appear to work for non-SSL connections. This issue was encountered before and the solution was to use psycopg2 to create a new short-lived connection for child process calls. This protects the parent process's DB connection.

Other solutions would be to manage the connections better. Two viable options (among others) are:

- close DB connections before executing leaves the parent process
- disabling persistent connections 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-3864](https://federal-spending-transparency.atlassian.net/browse/DEV-3864):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (N/A)
    - [x] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
Minor edit for when a check for a view occurs during an ETL script execution
```
