### PR TITLE
[HOTFIX] Added check for earliest transaction FKs

### DIFF
--- a/usaspending_api/etl/transaction_loaders/fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/fpds_loader.py
@@ -95,9 +95,8 @@ def delete_stale_fpds(date):
             # in the update awards stage later on
             cursor.execute(
                 "update awards set latest_transaction_id = null, earliest_transaction_id = null "
-                "where latest_transaction_id in ({}) returning id".format(
-                    ",".join([str(row[0]) for row in transaction_normalized_ids])
-                )
+                "where latest_transaction_id in ({ids}) or earliest_transaction_id in ({ids}) "
+                "returning id".format(ids=",".join([str(row[0]) for row in transaction_normalized_ids]))
             )
             awards_touched = cursor.fetchall()
 


### PR DESCRIPTION
**Description:**
SQL was missing check for awards with an earliest_transaction_id FK in the transactions to delete.

**Technical details:**
This is a quick edit, there might be a better approach to determine which awards should be altered during this step.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Fix for a lacking SQL statement in ETL script.
A new test should have been written to correct this, but I couldn't find any tests covering the deletes
```
