### PR TITLE
[DEV-4032] Fixing SpendingByTransaction response fields

### DIFF
--- a/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
+++ b/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
@@ -6,12 +6,12 @@ from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings
 
 
 TRANSACTIONS_LOOKUP = {
-    "Recipient Name": "recipient_name.keyword",
+    "Recipient Name": "recipient_name",
     "Action Date": "action_date",
     "Transaction Amount": "transaction_amount",
-    "Award Type": "type_description.keyword",
-    "Awarding Agency": "awarding_toptier_agency_name.keyword",
-    "Awarding Sub Agency": "awarding_subtier_agency_name.keyword",
+    "Award Type": "type_description",
+    "Awarding Agency": "awarding_toptier_agency_name",
+    "Awarding Sub Agency": "awarding_subtier_agency_name",
     "Funding Agency": "funding_toptier_agency_name",
     "Funding Sub Agency": "funding_subtier_agency_name",
     "Issued Date": "period_of_performance_start_date",

--- a/usaspending_api/search/tests/test_spending_by_transaction.py
+++ b/usaspending_api/search/tests/test_spending_by_transaction.py
@@ -1,18 +1,36 @@
 import json
 import pytest
 
+from model_mommy import mommy
 from time import perf_counter
 from rest_framework import status
 
 
-@pytest.mark.skip
+ENDPOINT = "/api/v2/search/spending_by_transaction/"
+
+
+@pytest.fixture
+def transaction_data(db):
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=1,
+        award_id=1,
+        action_date="2010-10-01",
+        is_fpds=True,
+        type="A",
+        description="test",
+    )
+    mommy.make("awards.TransactionFPDS", transaction_id=1, legal_entity_zip5="abcde", piid="IND12PB00323")
+    mommy.make("awards.Award", id=1, latest_transaction_id=1, is_fpds=True, type="A", piid="IND12PB00323")
+
+
 @pytest.mark.django_db
-def test_spending_by_transaction_kws_success(client):
+def test_spending_by_transaction_kws_success(client, elasticsearch_transaction_index):
     """Verify error on bad autocomplete
     request for budget function."""
 
     resp = client.post(
-        "/api/v2/search/spending_by_transaction/",
+        ENDPOINT,
         content_type="application/json",
         data=json.dumps(
             {
@@ -34,9 +52,7 @@ def test_spending_by_transaction_kws_failure(client):
     """Verify error on bad autocomplete
     request for budget function."""
 
-    resp = client.post(
-        "/api/v2/search/spending_by_transaction/", content_type="application/json", data=json.dumps({"filters": {}})
-    )
+    resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps({"filters": {}}))
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -52,8 +68,84 @@ def test_no_intersection(client, refresh_matviews):
     }
     api_start = perf_counter()
 
-    resp = client.post("/api/v2/search/spending_by_award", content_type="application/json", data=json.dumps(request))
+    resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps(request))
     api_end = perf_counter()
     assert resp.status_code == status.HTTP_200_OK
     assert api_end - api_start < 0.5, "Response took over 0.5s! Investigate why"
     assert len(resp.data["results"]) == 0, "Results returned, there should be 0"
+
+
+@pytest.mark.django_db
+def test_all_fields_returned(client, transaction_data, elasticsearch_transaction_index):
+
+    elasticsearch_transaction_index.update_index()
+
+    fields = [
+        "Recipient Name",
+        "Action Date",
+        "Transaction Amount",
+        "Award Type",
+        "Awarding Agency",
+        "Awarding Sub Agency",
+        "Funding Agency",
+        "Funding Sub Agency",
+        "Issued Date",
+        "Loan Value",
+        "Subsidy Cost",
+        "Mod",
+        "Award ID",
+        "awarding_agency_id",
+        "internal_id",
+        "generated_internal_id",
+        "Last Date to Order",
+    ]
+
+    request = {
+        "filters": {"keyword": "test", "award_type_codes": ["A", "B", "C", "D"]},
+        "fields": fields,
+        "page": 1,
+        "limit": 5,
+        "sort": "Award ID",
+        "order": "desc",
+    }
+
+    resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps(request))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.data["results"]) > 0
+    for result in resp.data["results"]:
+        for field in fields:
+            assert field in result, f"Response item is missing field {field}"
+
+        assert "Sausage" not in result
+        assert "A" not in result
+
+
+@pytest.mark.django_db
+def test_subset_of_fields_returned(client, transaction_data, elasticsearch_transaction_index):
+
+    elasticsearch_transaction_index.update_index()
+
+    fields = ["Award ID", "Recipient Name", "Mod"]
+
+    request = {
+        "filters": {"keyword": "test", "award_type_codes": ["A", "B", "C", "D"]},
+        "fields": fields,
+        "page": 1,
+        "limit": 5,
+        "sort": "Award ID",
+        "order": "desc",
+    }
+
+    resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps(request))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.data["results"]) > 0
+    for result in resp.data["results"]:
+        for field in fields:
+            assert field in result, f"Response item is missing field {field}"
+
+        assert "internal_id" in result
+        assert "generated_internal_id" in result
+
+        assert "Last Date to Order" not in result


### PR DESCRIPTION
**Description:**
While the ES query field mapper was altered to match the ES index mapping, the values were not being returned by the API. This reverts the `.keyword` change from #2164 to the API business logic

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4032](https://federal-spending-transparency.atlassian.net/browse/DEV-4032):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API (N/A)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Fixing issue, no changes to database
```
