### PR TITLE
Warmfix: Remove unwanted header

### DIFF
--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -135,7 +135,7 @@ def test_download_assistance_status(client, download_test_data, refresh_matviews
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 1
-    assert resp.json()["total_columns"] == 89
+    assert resp.json()["total_columns"] == 88
 
     # Test with columns specified
     dl_resp = client.post(

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1359,7 +1359,6 @@ query_paths = {
                     "broker_subaward__place_of_perform_country_na",
                 ),
                 ("prime_award_description", "broker_subaward__award_description"),
-                ("prime_award_project_title", "broker_subaward__program_title"),
                 ("prime_award_cfda_number", "broker_subaward__cfda_numbers"),
                 ("prime_award_cfda_title", "broker_subaward__cfda_titles"),
                 ("subaward_type", "broker_subaward__subaward_type"),


### PR DESCRIPTION
**Description:**
DEV-3993 specified that `prime_award_project_title` was supposed to only be in subcontracts. This removed the header from subgrants.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-3993](https://federal-spending-transparency.atlassian.net/browse/DEV-3993):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
