### PR TITLE
[Warmfix][DEV-4032] Fix sorting on keyword search

### DIFF
--- a/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
+++ b/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
@@ -6,12 +6,12 @@ from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings
 
 
 TRANSACTIONS_LOOKUP = {
-    "Recipient Name": "recipient_name",
+    "Recipient Name": "recipient_name.keyword",
     "Action Date": "action_date",
     "Transaction Amount": "transaction_amount",
-    "Award Type": "type_description",
-    "Awarding Agency": "awarding_toptier_agency_name",
-    "Awarding Sub Agency": "awarding_subtier_agency_name",
+    "Award Type": "type_description.keyword",
+    "Awarding Agency": "awarding_toptier_agency_name.keyword",
+    "Awarding Sub Agency": "awarding_subtier_agency_name.keyword",
     "Funding Agency": "funding_toptier_agency_name",
     "Funding Sub Agency": "funding_subtier_agency_name",
     "Issued Date": "period_of_performance_start_date",
@@ -25,9 +25,15 @@ TRANSACTIONS_LOOKUP = {
     "Last Date to Order": "ordering_period_end_date",
 }
 
+TRANSACTIONS_SOURCE_LOOKUP = {key: value.replace(".keyword", "") for key, value in TRANSACTIONS_LOOKUP.items()}
 
 INDEX_ALIASES_TO_AWARD_TYPES = deepcopy(all_award_types_mappings)
 INDEX_ALIASES_TO_AWARD_TYPES["directpayments"] = INDEX_ALIASES_TO_AWARD_TYPES.pop("direct_payments")
 INDEX_ALIASES_TO_AWARD_TYPES["other"] = INDEX_ALIASES_TO_AWARD_TYPES.pop("other_financial_assistance")
 
-KEYWORD_DATATYPE_FIELDS = ["recipient_name", "awarding_toptier_agency_name", "awarding_subtier_agency_name"]
+KEYWORD_DATATYPE_FIELDS = [
+    "recipient_name.keyword",
+    "awarding_toptier_agency_name.keyword",
+    "awarding_subtier_agency_name.keyword",
+    "type_description.keyword",
+]

--- a/usaspending_api/search/tests/test_spending_by_transaction.py
+++ b/usaspending_api/search/tests/test_spending_by_transaction.py
@@ -149,3 +149,33 @@ def test_subset_of_fields_returned(client, transaction_data, elasticsearch_trans
         assert "generated_internal_id" in result
 
         assert "Last Date to Order" not in result
+
+
+@pytest.mark.django_db
+def test_columns_can_be_sorted(client, transaction_data, elasticsearch_transaction_index):
+
+    elasticsearch_transaction_index.update_index()
+
+    fields = [
+        "Action Date",
+        "Award ID",
+        "Awarding Agency",
+        "Awarding Sub Agency",
+        "Award Type",
+        "Mod",
+        "Recipient Name",
+        "Action Date",
+    ]
+
+    request = {
+        "filters": {"keyword": "test", "award_type_codes": ["A", "B", "C", "D"]},
+        "fields": fields,
+        "page": 1,
+        "limit": 5,
+        "order": "desc",
+    }
+
+    for field in fields:
+        request["sort"] = field
+        resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps(request))
+        assert resp.status_code == status.HTTP_200_OK, f"Failed to sort column: {field}"

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -3,15 +3,18 @@ import re
 
 from django.conf import settings
 
-from usaspending_api.awards.v2.lookups.elasticsearch_lookups import KEYWORD_DATATYPE_FIELDS
-from usaspending_api.awards.v2.lookups.elasticsearch_lookups import INDEX_ALIASES_TO_AWARD_TYPES
-from usaspending_api.awards.v2.lookups.elasticsearch_lookups import TRANSACTIONS_LOOKUP
+from usaspending_api.awards.v2.lookups.elasticsearch_lookups import (
+    TRANSACTIONS_LOOKUP,
+    TRANSACTIONS_SOURCE_LOOKUP,
+    KEYWORD_DATATYPE_FIELDS,
+    INDEX_ALIASES_TO_AWARD_TYPES,
+)
 from usaspending_api.common.elasticsearch.client import es_client_query
 
 logger = logging.getLogger("console")
 
 DOWNLOAD_QUERY_SIZE = settings.MAX_DOWNLOAD_LIMIT
-TRANSACTIONS_LOOKUP.update({v: k for k, v in TRANSACTIONS_LOOKUP.items()})
+TRANSACTIONS_SOURCE_LOOKUP.update({v: k for k, v in TRANSACTIONS_SOURCE_LOOKUP.items()})
 
 
 def es_sanitize(input_string):
@@ -36,7 +39,9 @@ def es_minimal_sanitize(keyword):
 
 
 def swap_keys(dictionary_):
-    return dict((TRANSACTIONS_LOOKUP.get(old_key, old_key), new_key) for (old_key, new_key) in dictionary_.items())
+    return dict(
+        (TRANSACTIONS_SOURCE_LOOKUP.get(old_key, old_key), new_key) for (old_key, new_key) in dictionary_.items()
+    )
 
 
 def format_for_frontend(response):
@@ -65,7 +70,7 @@ def search_transactions(request_data, lower_limit, limit):
     """
 
     keyword = request_data["filters"]["keywords"]
-    query_fields = [TRANSACTIONS_LOOKUP[i] for i in request_data["fields"]]
+    query_fields = [TRANSACTIONS_SOURCE_LOOKUP[i] for i in request_data["fields"]]
     query_fields.extend(["award_id", "generated_unique_award_id"])
     query_sort = TRANSACTIONS_LOOKUP[request_data["sort"]]
     query = {


### PR DESCRIPTION
**Description:**
Fix sorting on the keyword search page for:
* Recipient Name
* Awarding Agency
* Awarding Sub Agency
* Award Type

**Technical details:**
Changing the fields for the Elasticsearch transaction index meant that some changes needed to be made to keyword search to ensure that functionality was consistent with expected behavior. Adding `.keyword` to the `_source` fields in the ES query resulted in empty columns on the keyword page because it was trying to match `abc.keyword` to `abc`. Removing `.keyword` fixed empty columns, but broke sorting on those fields where it was removed. This solution is to put the `.keyword` usage back in place, but make sure to strip it out when passing fields to `_source`. 

Tests were added to verify that the sorting functionality is working for all possible fields to sort on.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [X] Necessary PR reviewers:
    - [X] Backend
4. [X] Matview impact assessment completed  (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4032](https://federal-spending-transparency.atlassian.net/browse/DEV-4032):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

Sorting by Recipient Name on Local:
![Screen Shot 2019-12-23 at 11 25 43 AM](https://user-images.githubusercontent.com/40359517/71377392-80c6bc80-2579-11ea-84e8-025adccb7b32.png)

Current screen in Staging when sorting by Recipient Name:
![Screen Shot 2019-12-23 at 11 25 23 AM](https://user-images.githubusercontent.com/40359517/71377393-80c6bc80-2579-11ea-8534-61a5f789b44a.png)


**Area for explaining above N/A when needed:**
```
```
