### PR TITLE
OPS-1036 remove debug log level for supervisor

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -21,6 +21,5 @@ startsecs=1
 startretries=10
 
 [supervisord]
-loglevel=debug
 logfile_maxbytes=104857600
 logfile=/data-act/backend/usaspending_api/logs/supervisord.log

--- a/usaspending_api/bulk_download/config/supervisord.conf
+++ b/usaspending_api/bulk_download/config/supervisord.conf
@@ -16,5 +16,4 @@ environment=
 command=python3 manage.py download_sqs_worker
 
 [supervisord]
-loglevel=debug
 logfile=/data-act/backend/usaspending_api/logs/supervisord.log


### PR DESCRIPTION
**High level description:**
Reduce verbosity of supervisord.log by not duplicating app logs in it.

**Technical details:**
It turns out that having this set at debug will duplicate any console logging output from the running python processes to the supervisor logs

- see: debug puts process output into the normal log: http://supervisord.org/logging.html#activity-log-levels
- see: about how child process stderr and stdout gets logged when defaulted to AUTO: http://supervisord.org/logging.html#child-process-logs
- see that the defaults when not set puts it in the /tmp dir with 50MB rotated files up to a max of 10 files: http://supervisord.org/configuration.html

**Link to JIRA Ticket:**
[OPS-1036](https://federal-spending-transparency.atlassian.net/browse/DEV-1036)

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [NA] Necessary PR reviewers:
    - [x] Backend
    - [NA] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [OPS-1036](https://federal-spending-transparency.atlassian.net/browse/OPS-1036):
    - [x] Link to this Pull-Request
    - [NA] Performance evaluation of affected (API | Script | Download)
    - [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Just an operational change
```
