### PR TITLE
FIX: [DEV-2896] Fixing download zip file overwriting

### DIFF
--- a/usaspending_api/download/filestreaming/zip_file.py
+++ b/usaspending_api/download/filestreaming/zip_file.py
@@ -10,19 +10,10 @@ def append_files_to_zip_file(file_paths, zip_file_path):
     NOTE: If a zip file already exists at zip_file_path, the given files will be added in addition to the ones
     already in the zip when using append (`a`) mode. If that zip contains a file with the same name as one provided,
     it will throw a UserWarning and duplicate the file.
+    Use caution in this case by removing the zip in the finally of an exception and also checking for and removing
+    the zip if it exists before you begin to create it from scratch
     """
     with zipfile.ZipFile(zip_file_path, "a", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as zip_file:
-        for file_path in file_paths:
-            archive_name = os.path.basename(file_path)
-            zip_file.write(file_path, archive_name)
-
-
-def write_files_to_zip_file(file_paths, zip_file_path):
-    """(Re)create a zip archive at the specified zip_file_path, and add all the files at provided file_paths to it.
-
-    NOTE: If a (zip) file already exists at zip_file_path, it will be overwritten in write (`w`) mode.
-    """
-    with zipfile.ZipFile(zip_file_path, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as zip_file:
         for file_path in file_paths:
             archive_name = os.path.basename(file_path)
             zip_file.write(file_path, archive_name)


### PR DESCRIPTION
**Description:**
Revert to using "append" mode when creating the download zip to fix the problem of each additional file added re-starting the zip from scratch. 

**Technical details:**
- Write mode `'w'` was introduced when creating the download zip as a precaution against re-using a stale, half-built zip file on a retry attempt of the bulk downloader (queue retry)
- Turns out our code does not create the zip in one-go, but in several calls to add files. 
- So put append mode `'a'` back into place instead
- And added a precautionary removal of a pre-established zip with the same file name on new download generations

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [x] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-2896](https://federal-spending-transparency.atlassian.net/browse/DEV-2896):
    - [x] Link to this Pull-Request
    - [NA] Performance evaluation of affected (API | Script | Download)
    - [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Small fix to a prior approved PR
```
