### PR TITLE
Added ability to disable API response cache check

### DIFF
--- a/usaspending_api/common/cache_decorator.py
+++ b/usaspending_api/common/cache_decorator.py
@@ -2,6 +2,8 @@
 import logging
 from rest_framework_extensions.cache.decorators import CacheResponse
 
+from usaspending_api.common.experimental_api_flags import should_skip_api_cache_check
+
 logger = logging.getLogger("console")
 
 
@@ -12,7 +14,10 @@ class CustomCacheResponse(CacheResponse):
         )
         response = None
         try:
-            response = self.cache.get(key)
+            if should_skip_api_cache_check(request):
+                logger.info("Skipping API cache check due to 'disable-cache-check' flag")
+            else:
+                response = self.cache.get(key)
         except Exception:
             msg = "Problem while retrieving key [{k}] from cache for path:'{p}'"
             logger.exception(msg.format(k=key, p=str(request.path)))

--- a/usaspending_api/common/experimental_api_flags.py
+++ b/usaspending_api/common/experimental_api_flags.py
@@ -5,16 +5,43 @@ need to have experimental functionality alongside the expected functionality as 
 in Production.
 
 EXPERIMENTAL_API_HEADER - HTTP Header expected to access experimental functionality.
-ELASTICSEARCH_HEADER_VALUE - Value expected to access Elasticsearch functionality on specific endpoints.
+
+_ExperimentalHeaderValue - Enum representing the different possible Experimental headers
+    ELASTICSEARCH - Access Elasticsearch functionality on specific endpoints.
+    DISABLE_REQUEST_CACHE - Disable the API Request Cache where the decorator is used.
 """
+from enum import Enum
+
 from rest_framework.request import Request
 
 EXPERIMENTAL_API_HEADER = "HTTP_X_EXPERIMENTAL_API"
-ELASTICSEARCH_HEADER_VALUE = "elasticsearch"
+
+
+class ExperimentalHeaderValue(Enum):
+    ELASTICSEARCH = "elasticsearch"
+    DISABLE_API_CACHE_CHECK = "disable-cache-check"
+
+
+def _has_experimental_header(request: Request, expected_header: ExperimentalHeaderValue) -> bool:
+    """
+    When making an API Request an HTTP Header can be used multiple times with different values. This will cause
+    the values to be passed over as 'HTTP_X_EXPERIMENTAL_API': 'value1,value2,value3'.
+
+    Returns True if the 'expected_header' is one of the 'HTTP_X_EXPERIMENTAL_API' HTTP Headers.
+    """
+    experimental_headers = request.META.get(EXPERIMENTAL_API_HEADER, "").split(",")
+    return expected_header.value in experimental_headers
 
 
 def is_experimental_elasticsearch_api(request: Request) -> bool:
     """
-    Returns True or False depending on if the expected_header_value matches what is sent with the request.
+    Returns True if the 'elasticsearch' header is part of 'HTTP_X_EXPERIMENTAL_API' HTTP Header; false otherwise
     """
-    return request.META.get(EXPERIMENTAL_API_HEADER) == ELASTICSEARCH_HEADER_VALUE
+    return _has_experimental_header(request, ExperimentalHeaderValue.ELASTICSEARCH)
+
+
+def should_skip_api_cache_check(request: Request) -> bool:
+    """
+    Returns True if the 'disable-cache-check' header is part of 'HTTP_X_EXPERIMENTAL_API' HTTP Header; false otherwise
+    """
+    return _has_experimental_header(request, ExperimentalHeaderValue.DISABLE_API_CACHE_CHECK)

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from model_mommy import mommy
 from rest_framework import status
 
-from usaspending_api.common.experimental_api_flags import EXPERIMENTAL_API_HEADER, ELASTICSEARCH_HEADER_VALUE
+from usaspending_api.common.experimental_api_flags import EXPERIMENTAL_API_HEADER, ExperimentalHeaderValue
 from usaspending_api.search.tests.data.search_filters_test_data import non_legacy_filters, legacy_filters
 from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings
 
@@ -403,7 +403,7 @@ def test_spending_by_award_elasticsearch_http_header(client, monkeypatch, elasti
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_200_OK
     assert len(logging_statements) == 1, "Expected one logging statement"
@@ -447,7 +447,7 @@ def test_spending_by_award_elasticsearch_http_header(client, monkeypatch, elasti
                 "order": "desc",
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_200_OK
     assert len(logging_statements) == 0, "Expected zero logging statements for Sub Awards with the Header"
@@ -502,7 +502,7 @@ def test_success_with_all_filters(client, monkeypatch, elasticsearch_award_index
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_200_OK, f"Failed to return 200 Response"
     assert len(logging_statements) == 1, "Expected one logging statement"
@@ -563,7 +563,7 @@ def _test_correct_response_for_keywords(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -591,7 +591,7 @@ def _test_correct_response_for_time_period(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -619,7 +619,7 @@ def _test_correct_response_for_award_type_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 3, "Award ID": "abc333", "generated_internal_id": "CONT_AWD_TESTING_3", "recipient_id": None},
@@ -653,7 +653,7 @@ def _test_correct_response_for_agencies(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -682,7 +682,7 @@ def _test_correct_response_for_tas_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -711,7 +711,7 @@ def _test_correct_response_for_pop_location(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -743,7 +743,7 @@ def _test_correct_response_for_recipient_location(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None},
@@ -773,7 +773,7 @@ def _test_correct_response_for_recipient_search_text(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {
@@ -807,7 +807,7 @@ def _test_correct_response_for_recipient_type_names(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None},
@@ -837,7 +837,7 @@ def _test_correct_response_for_award_amounts(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None},
@@ -867,7 +867,7 @@ def _test_correct_response_for_cfda_program(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {
@@ -901,7 +901,7 @@ def _test_correct_response_for_naics_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -930,7 +930,7 @@ def _test_correct_response_for_psc_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -959,7 +959,7 @@ def _test_correct_response_for_contract_pricing_type_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -990,7 +990,7 @@ def _test_correct_response_for_set_aside_type_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -1019,7 +1019,7 @@ def _test_correct_response_for_set_extent_competed_type_codes(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1", "recipient_id": None}
@@ -1050,7 +1050,7 @@ def _test_correct_response_for_recipient_id(client):
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {
@@ -1080,7 +1080,7 @@ def test_failure_with_invalid_filters(client, monkeypatch, elasticsearch_award_i
         "/api/v2/search/spending_by_award",
         content_type="application/json",
         data=json.dumps({}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert len(logging_statements) == 0, "Expected zero logging statements"
@@ -1092,7 +1092,7 @@ def test_failure_with_invalid_filters(client, monkeypatch, elasticsearch_award_i
         "/api/v2/search/spending_by_award",
         content_type="application/json",
         data=json.dumps({"fields": [], "filters": {}, "page": 1, "limit": 60, "subawards": False}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert len(logging_statements) == 0, "Expected zero logging statements"
@@ -1115,7 +1115,7 @@ def test_failure_with_invalid_filters(client, monkeypatch, elasticsearch_award_i
                 "subawards": False,
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert len(logging_statements) == 0, "Expected zero logging statements"

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -4,7 +4,7 @@ import pytest
 from rest_framework import status
 from model_mommy import mommy
 
-from usaspending_api.common.experimental_api_flags import ELASTICSEARCH_HEADER_VALUE, EXPERIMENTAL_API_HEADER
+from usaspending_api.common.experimental_api_flags import EXPERIMENTAL_API_HEADER, ExperimentalHeaderValue
 from usaspending_api.search.tests.data.search_filters_test_data import non_legacy_filters
 from usaspending_api.search.v2.views.spending_over_time import GROUPING_LOOKUP
 
@@ -266,7 +266,7 @@ def test_spending_over_time_elasticsearch_http_header(client, monkeypatch, elast
         "/api/v2/search/spending_over_time",
         content_type="application/json",
         data=json.dumps({"group": "fiscal_year", "filters": {"keywords": ["test", "testing"]}}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_200_OK
     assert len(logging_statements) == 1, "Expected one logging statement"
@@ -290,7 +290,7 @@ def test_spending_over_time_elasticsearch_http_header(client, monkeypatch, elast
         "/api/v2/search/spending_over_time",
         content_type="application/json",
         data=json.dumps({"group": "fiscal_year", "subawards": True, "filters": {"keywords": ["test", "testing"]}}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_200_OK
     assert len(logging_statements) == 0, "Expected zero logging statements for Sub Awards with the Header"
@@ -326,7 +326,7 @@ def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction
             "/api/v2/search/spending_over_time",
             content_type="application/json",
             data=json.dumps({"group": group, "filters": non_legacy_filters()}),
-            **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+            **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
         )
         assert resp.status_code == status.HTTP_200_OK, f"Failed to return 200 Response for group: {group}"
         assert len(logging_statements) == 1, "Expected one logging statement"
@@ -387,7 +387,7 @@ def _test_correct_response_for_keywords(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -424,7 +424,7 @@ def _test_correct_response_for_time_period(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 24036.0, "time_period": {"fiscal_year": "2012"}},
@@ -452,7 +452,7 @@ def _test_correct_response_for_award_type_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -491,7 +491,7 @@ def _test_correct_response_for_agencies(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -550,7 +550,7 @@ def _test_correct_response_for_tas_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -589,7 +589,7 @@ def _test_correct_response_for_pop_location(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -628,7 +628,7 @@ def _test_correct_response_for_recipient_location(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -662,7 +662,7 @@ def _test_correct_response_for_recipient_search_text(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -696,7 +696,7 @@ def _test_correct_response_for_recipient_type_names(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -734,7 +734,7 @@ def _test_correct_response_for_award_amounts(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -768,7 +768,7 @@ def _test_correct_response_for_cfda_program(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -802,7 +802,7 @@ def _test_correct_response_for_naics_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -836,7 +836,7 @@ def _test_correct_response_for_psc_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -874,7 +874,7 @@ def _test_correct_response_for_contract_pricing_type_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -910,7 +910,7 @@ def _test_correct_response_for_set_aside_type_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -944,7 +944,7 @@ def _test_correct_response_for_set_extent_competed_type_codes(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -980,7 +980,7 @@ def _test_correct_response_for_recipient_id(client):
                 },
             }
         ),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     expected_result = [
         {"aggregated_amount": 0, "time_period": {"fiscal_year": "2008"}},
@@ -1016,7 +1016,7 @@ def test_failure_with_invalid_filters(client, monkeypatch, elasticsearch_transac
         "/api/v2/search/spending_over_time",
         content_type="application/json",
         data=json.dumps({"group": "fiscal_year"}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert len(logging_statements) == 0, "Expected zero logging statements"
@@ -1028,7 +1028,7 @@ def test_failure_with_invalid_filters(client, monkeypatch, elasticsearch_transac
         "/api/v2/search/spending_over_time",
         content_type="application/json",
         data=json.dumps({"group": "fiscal_year", "filters": {}}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert len(logging_statements) == 0, "Expected zero logging statements"
@@ -1051,7 +1051,7 @@ def test_failure_with_invalid_group(client, monkeypatch, elasticsearch_transacti
         "/api/v2/search/spending_over_time",
         content_type="application/json",
         data=json.dumps({"group": "not a valid group", "filters": {"keywords": ["test", "testing"]}}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert len(logging_statements) == 0, "Expected zero logging statements"
@@ -1066,7 +1066,7 @@ def test_failure_with_invalid_group(client, monkeypatch, elasticsearch_transacti
         "/api/v2/search/spending_over_time",
         content_type="application/json",
         data=json.dumps({"filters": {"keywords": ["test", "testing"]}}),
-        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+        **{EXPERIMENTAL_API_HEADER: ExperimentalHeaderValue.ELASTICSEARCH.value},
     )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert len(logging_statements) == 0, "Expected zero logging statements"


### PR DESCRIPTION
**Description:**
Able to use the `disable-cache-check` flag as part of the `X-Experimental-API` HTTP Header to disable the API Response cache check. Keith brought up previously adding functionality for multiple headers, but I did not realize that passing two of the same headers simply adds them together such as `"header-value-1,header-value-2"`.

**Technical details:**
Rework to the Experimental Flags and also allow the API Response Cache check to be disabled through the use of an HTTP Header.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4050](https://federal-spending-transparency.atlassian.net/browse/DEV-4050):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
Relates to DEV-4050, but is not directly part of that story.
