### PR TITLE
[DEV-4096] Remove problematic fixture

### DIFF
--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -23,29 +23,10 @@ from usaspending_api.conftest_helpers import (
     ensure_broker_server_dblink_exists,
     remove_unittest_queue_data_files,
 )
-from usaspending_api.etl.broker_etl_helpers import PhonyCursor
 
 
 logger = logging.getLogger("console")
 VALID_DB_CURSORS = [DEFAULT_DB_ALIAS, "data_broker"]
-
-
-@pytest.fixture()
-def mock_db_cursor(monkeypatch, request):
-    db_cursor_dict = request.param
-
-    for cursor in VALID_DB_CURSORS:
-        if cursor in db_cursor_dict:
-            data_file_key = cursor + "_data_file"
-
-            if data_file_key not in db_cursor_dict:
-                # Missing data file for the mocked cursor. Skipping PhonyCursor setup.
-                continue
-
-            db_cursor_dict[cursor].cursor.return_value = PhonyCursor(db_cursor_dict[data_file_key])
-            del db_cursor_dict[data_file_key]
-
-    monkeypatch.setattr("django.db.connections", db_cursor_dict)
 
 
 @pytest.fixture()

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import tempfile
 
 from django.conf import settings
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.db import connections
 from django.test import override_settings
 from django_mock_queries.query import MockSet
 from pathlib import Path
@@ -26,7 +26,6 @@ from usaspending_api.conftest_helpers import (
 
 
 logger = logging.getLogger("console")
-VALID_DB_CURSORS = [DEFAULT_DB_ALIAS, "data_broker"]
 
 
 @pytest.fixture()

--- a/usaspending_api/download/tests/integration/test_download_accounts.py
+++ b/usaspending_api/download/tests/integration/test_download_accounts.py
@@ -54,7 +54,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         toptier_agency_id=102,
         name="Bureau of Money",
@@ -65,7 +65,7 @@ def download_test_data(db):
     )
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv", generated_unique_award_id="CONT_IDV_1")

--- a/usaspending_api/download/tests/integration/test_download_accounts_dev_3997.py
+++ b/usaspending_api/download/tests/integration/test_download_accounts_dev_3997.py
@@ -48,8 +48,8 @@ def get_csv_contents_and_clean_up(zip_file_path):
     return [{k: v for k, v in r.items() if k in important_columns} for r in csv_reader]
 
 
-@pytest.mark.django_db
-def test_download_accounts_dev_3997(client, transactional_db):
+@pytest.mark.django_db(transaction=True)
+def test_download_accounts_dev_3997(client):
     """
     As part of DEV-3997, special roll-ups/excisions were added to File B downloads.  This tests to
     ensure those are happening correctly.  The specific conditions we are testing for:

--- a/usaspending_api/download/tests/integration/test_download_assistance.py
+++ b/usaspending_api/download/tests/integration/test_download_assistance.py
@@ -49,7 +49,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -62,7 +62,7 @@ def download_test_data(db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv")

--- a/usaspending_api/download/tests/integration/test_download_awards.py
+++ b/usaspending_api/download/tests/integration/test_download_awards.py
@@ -49,7 +49,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -62,7 +62,7 @@ def download_test_data(db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv")

--- a/usaspending_api/download/tests/integration/test_download_contract.py
+++ b/usaspending_api/download/tests/integration/test_download_contract.py
@@ -49,7 +49,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -62,7 +62,7 @@ def download_test_data(db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv")

--- a/usaspending_api/download/tests/integration/test_download_count.py
+++ b/usaspending_api/download/tests/integration/test_download_count.py
@@ -48,7 +48,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -61,7 +61,7 @@ def download_test_data(db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv")

--- a/usaspending_api/download/tests/integration/test_download_idv.py
+++ b/usaspending_api/download/tests/integration/test_download_idv.py
@@ -49,7 +49,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -62,7 +62,7 @@ def download_test_data(db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv")

--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -50,7 +50,7 @@ def download_test_data(transactional_db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -63,7 +63,7 @@ def download_test_data(transactional_db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv", generated_unique_award_id="CONT_IDV_NEW")

--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -16,7 +16,7 @@ from usaspending_api.etl.award_helpers import update_awards
 
 
 @pytest.fixture
-def download_test_data(db):
+def download_test_data(transactional_db):
     # Populate job status lookup table
     for js in JOB_STATUS:
         mommy.make("download.JobStatus", job_status_id=js.id, name=js.name, description=js.desc)
@@ -113,7 +113,6 @@ def download_test_data(db):
     update_awards()
 
 
-@pytest.mark.django_db(transaction=True)
 def test_download_assistance_status(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
 
@@ -144,7 +143,6 @@ def test_download_assistance_status(client, download_test_data):
     assert resp.json()["total_columns"] == 2
 
 
-@pytest.mark.django_db(transaction=True)
 def test_download_awards_status(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
 
@@ -184,7 +182,6 @@ def test_download_awards_status(client, download_test_data):
     assert resp.json()["total_columns"] == 5
 
 
-@pytest.mark.django_db(transaction=True)
 def test_download_contract_status(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
 
@@ -222,7 +219,6 @@ def test_download_contract_status(client, download_test_data):
     assert resp.json()["total_columns"] == 2
 
 
-@pytest.mark.django_db(transaction=True)
 def test_download_idv_status(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
 
@@ -254,7 +250,6 @@ def test_download_idv_status(client, download_test_data):
     assert resp.json()["total_columns"] == 2
 
 
-@pytest.mark.django_db(transaction=True)
 def test_download_transactions_status(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
 
@@ -299,7 +294,6 @@ def test_download_transactions_status(client, download_test_data):
     assert resp.json()["total_columns"] == 2
 
 
-@pytest.mark.django_db(transaction=True)
 def test_download_transactions_limit(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
 

--- a/usaspending_api/download/tests/integration/test_download_transactions.py
+++ b/usaspending_api/download/tests/integration/test_download_transactions.py
@@ -50,7 +50,7 @@ def download_test_data(db):
     aa2 = mommy.make("references.Agency", id=2, toptier_agency=ata2, toptier_flag=False)
 
     # Create Funding Top Agency
-    mommy.make(
+    ata3 = mommy.make(
         "references.ToptierAgency",
         name="Bureau of Money",
         toptier_code="102",
@@ -63,7 +63,7 @@ def download_test_data(db):
     mommy.make("references.SubtierAgency", name="Bureau of Things")
 
     # Create Funding Agency
-    mommy.make("references.Agency", id=3, toptier_flag=False)
+    mommy.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False)
 
     # Create Awards
     award1 = mommy.make("awards.Award", id=123, category="idv")

--- a/usaspending_api/download/tests/integration/test_download_transactions.py
+++ b/usaspending_api/download/tests/integration/test_download_transactions.py
@@ -107,7 +107,6 @@ def download_test_data(db):
     update_awards()
 
 
-@pytest.mark.django_db
 def test_download_transactions_without_columns(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     resp = client.post(
@@ -120,7 +119,6 @@ def test_download_transactions_without_columns(client, download_test_data):
     assert ".zip" in resp.json()["file_url"]
 
 
-@pytest.mark.django_db
 def test_download_transactions_with_columns(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     resp = client.post(
@@ -144,7 +142,6 @@ def test_download_transactions_with_columns(client, download_test_data):
     assert ".zip" in resp.json()["file_url"]
 
 
-@pytest.mark.django_db
 def test_download_transactions_bad_limit(client):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     resp = client.post(
@@ -155,7 +152,6 @@ def test_download_transactions_bad_limit(client):
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-@pytest.mark.django_db
 def test_download_transactions_excessive_limit(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     resp = client.post(
@@ -166,7 +162,6 @@ def test_download_transactions_excessive_limit(client, download_test_data):
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-@pytest.mark.django_db
 def test_download_transactions_bad_column_list_raises(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     payload = {"filters": {"award_type_codes": []}, "columns": ["modification_number", "bogus_column"]}
@@ -177,7 +172,6 @@ def test_download_transactions_bad_column_list_raises(client, download_test_data
     assert "modification_number" not in resp.json()["detail"]
 
 
-@pytest.mark.django_db
 def test_download_transactions_bad_filter_type_raises(client, download_test_data):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     payload = {"filters": "01", "columns": []}

--- a/usaspending_api/download/tests/integration/test_download_transactions.py
+++ b/usaspending_api/download/tests/integration/test_download_transactions.py
@@ -142,6 +142,7 @@ def test_download_transactions_with_columns(client, download_test_data):
     assert ".zip" in resp.json()["file_url"]
 
 
+@pytest.mark.django_db
 def test_download_transactions_bad_limit(client):
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
     resp = client.post(

--- a/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
+++ b/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
@@ -1,248 +1,240 @@
-import logging
 import copy
 import pytest
 
 from django.core.management import call_command
 from django.db import connections
 from django.db.models import Q
-from django.test import TestCase
 from model_mommy import mommy
 
 from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.etl.transaction_loaders.data_load_helpers import format_insert_or_update_column_sql
 
 
-@pytest.mark.usefixtures("broker_db_setup", "db")
-class LoadSubmissionIntegrationTests(TestCase):
-    logger = logging.getLogger(__name__)
-    multi_db = True
+@pytest.fixture
+def data_fixture(db, broker_db_setup):
+    # Setup default data in USAspending Test DB
+    mommy.make(
+        "accounts.TreasuryAppropriationAccount",
+        treasury_account_identifier=-99999,
+        allocation_transfer_agency_id="999",
+        agency_id="999",
+        beginning_period_of_availability="1700-01-01",
+        ending_period_of_availability="1700-12-31",
+        availability_type_code="000",
+        main_account_code="0000",
+        sub_account_code="0000",
+        tas_rendering_label="1004-1002-1003-1007-1008",
+    )
+    mommy.make("references.ObjectClass", id=0, major_object_class="00", object_class="000", direct_reimbursable=None)
 
-    @classmethod
-    def setUpClass(cls):
-        # Setup default data in USAspending Test DB
-        mommy.make(
-            "accounts.TreasuryAppropriationAccount",
-            treasury_account_identifier=-99999,
-            allocation_transfer_agency_id="999",
-            agency_id="999",
-            beginning_period_of_availability="1700-01-01",
-            ending_period_of_availability="1700-12-31",
-            availability_type_code="000",
-            main_account_code="0000",
-            sub_account_code="0000",
-            tas_rendering_label="1004-1002-1003-1007-1008",
-        )
-        mommy.make(
-            "references.ObjectClass", id=0, major_object_class="00", object_class="000", direct_reimbursable=None
-        )
-
-        # Setup default data in Broker Test DB
-        broker_objects_to_insert = {
-            "tas_lookup": {"broker_object": _assemble_broker_tas_lookup_records(), "conflict_column": "tas_id"},
-            "submission": {"broker_object": _assemble_broker_submission_records(), "conflict_column": "submission_id"},
-            "certified_award_financial": {
-                "broker_object": _assemble_certified_award_financial_records(),
-                "conflict_column": "certified_award_financial_id",
-            },
-        }
-        connection = connections["data_broker"]
-        with connection.cursor() as cursor:
-            for broker_table_name, value in broker_objects_to_insert.items():
-                broker_object = value["broker_object"]
-                conflict_column = value["conflict_column"]
-                for load_object in [dict(**{broker_table_name: _}) for _ in broker_object]:
-                    columns, values, pairs = format_insert_or_update_column_sql(cursor, load_object, broker_table_name)
-                    insert_sql = (
-                        f"INSERT INTO {broker_table_name} {columns} VALUES {values}"
-                        f" ON CONFLICT ({conflict_column}) DO UPDATE SET {pairs};"
-                    )
-                    cursor.execute(insert_sql)
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
-    def test_load_submission_transaction_obligated_amount(self):
-        """ Test load submission management command for File C transaction_obligated_amount NaNs """
-        call_command("load_submission", "-9999")
-
-        expected_results = 0
-        actual_results = FinancialAccountsByAwards.objects.filter(
-            Q(transaction_obligated_amount="NaN") | Q(transaction_obligated_amount=None)
-        ).count()
-
-        assert expected_results == actual_results
-
-    def test_load_submission_file_c_fain_and_uri(self):
-        """
-        Test load submission management command for File C records with FAIN and URI
-        """
-        mommy.make(
-            "awards.Award",
-            id=-999,
-            uri="RANDOM_LOAD_SUB_URI_999",
-            fain="RANDOM_LOAD_SUB_FAIN_999",
-            latest_transaction_id=-999,
-        )
-        mommy.make(
-            "awards.Award",
-            id=-1999,
-            uri="RANDOM_LOAD_SUB_URI_1999",
-            fain="RANDOM_LOAD_SUB_FAIN_1999",
-            latest_transaction_id=-1999,
-        )
-        mommy.make("awards.TransactionNormalized", id=-999)
-        mommy.make("awards.TransactionNormalized", id=-1999)
-
-        call_command("load_submission", "-9999")
-
-        expected_results = {"award_ids": [-1999, -999]}
-        actual_results = {
-            "award_ids": sorted(
-                list(
-                    FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+    # Setup default data in Broker Test DB
+    broker_objects_to_insert = {
+        "tas_lookup": {"broker_object": _assemble_broker_tas_lookup_records(), "conflict_column": "tas_id"},
+        "submission": {"broker_object": _assemble_broker_submission_records(), "conflict_column": "submission_id"},
+        "certified_award_financial": {
+            "broker_object": _assemble_certified_award_financial_records(),
+            "conflict_column": "certified_award_financial_id",
+        },
+    }
+    connection = connections["data_broker"]
+    with connection.cursor() as cursor:
+        for broker_table_name, value in broker_objects_to_insert.items():
+            broker_object = value["broker_object"]
+            conflict_column = value["conflict_column"]
+            for load_object in [dict(**{broker_table_name: _}) for _ in broker_object]:
+                columns, values, pairs = format_insert_or_update_column_sql(cursor, load_object, broker_table_name)
+                insert_sql = (
+                    f"INSERT INTO {broker_table_name} {columns} VALUES {values}"
+                    f" ON CONFLICT ({conflict_column}) DO UPDATE SET {pairs};"
                 )
-            )
-        }
+                cursor.execute(insert_sql)
 
-        assert expected_results == actual_results
 
-    def test_load_submission_file_c_uri(self):
-        """
-        Test load submission management command for File C records with only a URI
-        """
-        mommy.make("awards.Award", id=-997, uri="RANDOM_LOAD_SUB_URI", latest_transaction_id=-997)
-        mommy.make("awards.TransactionNormalized", id=-997)
+def test_load_submission_transaction_obligated_amount(data_fixture):
+    """ Test load submission management command for File C transaction_obligated_amount NaNs """
+    call_command("load_submission", "-9999")
 
-        call_command("load_submission", "-9999")
+    expected_results = 0
+    actual_results = FinancialAccountsByAwards.objects.filter(
+        Q(transaction_obligated_amount="NaN") | Q(transaction_obligated_amount=None)
+    ).count()
 
-        expected_results = {"award_ids": [-997]}
-        actual_results = {
-            "award_ids": list(
-                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
-            )
-        }
+    assert expected_results == actual_results
 
-        assert expected_results == actual_results
 
-    def test_load_submission_file_c_fain(self):
-        """
-        Test load submission management command for File C records with only a FAIN
-        """
-        mommy.make("awards.Award", id=-997, fain="RANDOM_LOAD_SUB_FAIN", latest_transaction_id=-997)
-        mommy.make("awards.TransactionNormalized", id=-997)
+def test_load_submission_file_c_fain_and_uri(data_fixture):
+    """
+    Test load submission management command for File C records with FAIN and URI
+    """
+    mommy.make(
+        "awards.Award",
+        id=-999,
+        uri="RANDOM_LOAD_SUB_URI_999",
+        fain="RANDOM_LOAD_SUB_FAIN_999",
+        latest_transaction_id=-999,
+    )
+    mommy.make(
+        "awards.Award",
+        id=-1999,
+        uri="RANDOM_LOAD_SUB_URI_1999",
+        fain="RANDOM_LOAD_SUB_FAIN_1999",
+        latest_transaction_id=-1999,
+    )
+    mommy.make("awards.TransactionNormalized", id=-999)
+    mommy.make("awards.TransactionNormalized", id=-1999)
 
-        call_command("load_submission", "-9999")
+    call_command("load_submission", "-9999")
 
-        expected_results = {"award_ids": [-997]}
-        actual_results = {
-            "award_ids": list(
-                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
-            )
-        }
-
-        assert expected_results == actual_results
-
-    def test_load_submission_file_c_piid_with_parent_piid(self):
-        """
-        Test load submission management command for File C records with only a piid and parent piid
-        """
-        mommy.make(
-            "awards.Award",
-            id=-997,
-            piid="RANDOM_LOAD_SUB_PIID",
-            parent_award_piid="RANDOM_LOAD_SUB_PARENT_PIID",
-            latest_transaction_id=-997,
+    expected_results = {"award_ids": [-1999, -999]}
+    actual_results = {
+        "award_ids": sorted(
+            list(FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True))
         )
-        mommy.make("awards.TransactionNormalized", id=-997)
+    }
 
-        call_command("load_submission", "-9999")
+    assert expected_results == actual_results
 
-        expected_results = {"award_ids": [-997, -997]}
-        actual_results = {
-            "award_ids": list(
-                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
-            )
-        }
 
-        assert expected_results == actual_results
+def test_load_submission_file_c_uri(data_fixture):
+    """
+    Test load submission management command for File C records with only a URI
+    """
+    mommy.make("awards.Award", id=-997, uri="RANDOM_LOAD_SUB_URI", latest_transaction_id=-997)
+    mommy.make("awards.TransactionNormalized", id=-997)
 
-    def test_load_submission_file_c_piid_with_no_parent_piid(self):
-        """
-        Test load submission management command for File C records with only a piid and no parent piid
-        """
-        mommy.make(
-            "awards.Award", id=-998, piid="RANDOM_LOAD_SUB_PIID", parent_award_piid=None, latest_transaction_id=-998
+    call_command("load_submission", "-9999")
+
+    expected_results = {"award_ids": [-997]}
+    actual_results = {
+        "award_ids": list(
+            FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
         )
-        mommy.make("awards.TransactionNormalized", id=-998)
+    }
 
-        call_command("load_submission", "-9999")
+    assert expected_results == actual_results
 
-        expected_results = {"award_ids": [-998]}
-        actual_results = {
-            "award_ids": list(
-                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
-            )
-        }
 
-        assert expected_results == actual_results
+def test_load_submission_file_c_fain(data_fixture):
+    """
+    Test load submission management command for File C records with only a FAIN
+    """
+    mommy.make("awards.Award", id=-997, fain="RANDOM_LOAD_SUB_FAIN", latest_transaction_id=-997)
+    mommy.make("awards.TransactionNormalized", id=-997)
 
-    def test_load_submission_file_c_piid_with_unmatched_parent_piid(self):
-        """
-        Test load submission management command for File C records that are not expected to be linked to Award data
-        """
-        mommy.make(
-            "awards.Award",
-            id=-1001,
-            piid="RANDOM_LOAD_SUB_PIID",
-            parent_award_piid="PARENT_LOAD_SUB_PIID_DNE",
-            latest_transaction_id=-1234,
+    call_command("load_submission", "-9999")
+
+    expected_results = {"award_ids": [-997]}
+    actual_results = {
+        "award_ids": list(
+            FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
         )
-        mommy.make("awards.TransactionNormalized", id=-1234)
+    }
 
-        call_command("load_submission", "-9999")
+    assert expected_results == actual_results
 
-        expected_results = {"award_ids": [-1001]}
-        actual_results = {
-            "award_ids": list(
-                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
-            )
-        }
 
-        assert expected_results == actual_results
+def test_load_submission_file_c_piid_with_parent_piid(data_fixture):
+    """
+    Test load submission management command for File C records with only a piid and parent piid
+    """
+    mommy.make(
+        "awards.Award",
+        id=-997,
+        piid="RANDOM_LOAD_SUB_PIID",
+        parent_award_piid="RANDOM_LOAD_SUB_PARENT_PIID",
+        latest_transaction_id=-997,
+    )
+    mommy.make("awards.TransactionNormalized", id=-997)
 
-    def test_load_submission_file_c_no_d_linkage(self):
-        """
-        Test load submission management command for File C records that are not expected to be linked to Award data
-        """
-        mommy.make(
-            "awards.Award",
-            id=-999,
-            piid="RANDOM_LOAD_SUB_PIID_DNE",
-            parent_award_piid="PARENT_LOAD_SUB_PIID_DNE",
-            latest_transaction_id=-999,
+    call_command("load_submission", "-9999")
+
+    expected_results = {"award_ids": [-997, -997]}
+    actual_results = {
+        "award_ids": list(
+            FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
         )
-        mommy.make("awards.TransactionNormalized", id=-999, award_id=-999)
+    }
 
-        call_command("load_submission", "-9999")
+    assert expected_results == actual_results
 
-        expected_results = {"award_ids": []}
-        actual_results = {
-            "award_ids": list(
-                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
-            )
-        }
 
-        assert expected_results == actual_results
+def test_load_submission_file_c_piid_with_no_parent_piid(data_fixture):
+    """
+    Test load submission management command for File C records with only a piid and no parent piid
+    """
+    mommy.make("awards.Award", id=-998, piid="RANDOM_LOAD_SUB_PIID", parent_award_piid=None, latest_transaction_id=-998)
+    mommy.make("awards.TransactionNormalized", id=-998)
 
-    def test_load_submission_file_c_zero_and_null_transaction_obligated_amount_ignored(self):
-        """
-        Test that the 'certified_award_financial` rows that have a 'transaction_obligated_amou'
-        of zero or null are not loaded from Broker.
-        """
-        call_command("load_submission", "-9999")
+    call_command("load_submission", "-9999")
 
-        assert FinancialAccountsByAwards.objects.all().count() == 6
+    expected_results = {"award_ids": [-998]}
+    actual_results = {
+        "award_ids": list(
+            FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+        )
+    }
+
+    assert expected_results == actual_results
+
+
+def test_load_submission_file_c_piid_with_unmatched_parent_piid(data_fixture):
+    """
+    Test load submission management command for File C records that are not expected to be linked to Award data
+    """
+    mommy.make(
+        "awards.Award",
+        id=-1001,
+        piid="RANDOM_LOAD_SUB_PIID",
+        parent_award_piid="PARENT_LOAD_SUB_PIID_DNE",
+        latest_transaction_id=-1234,
+    )
+    mommy.make("awards.TransactionNormalized", id=-1234)
+
+    call_command("load_submission", "-9999")
+
+    expected_results = {"award_ids": [-1001]}
+    actual_results = {
+        "award_ids": list(
+            FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+        )
+    }
+
+    assert expected_results == actual_results
+
+
+def test_load_submission_file_c_no_d_linkage(data_fixture):
+    """
+    Test load submission management command for File C records that are not expected to be linked to Award data
+    """
+    mommy.make(
+        "awards.Award",
+        id=-999,
+        piid="RANDOM_LOAD_SUB_PIID_DNE",
+        parent_award_piid="PARENT_LOAD_SUB_PIID_DNE",
+        latest_transaction_id=-999,
+    )
+    mommy.make("awards.TransactionNormalized", id=-999, award_id=-999)
+
+    call_command("load_submission", "-9999")
+
+    expected_results = {"award_ids": []}
+    actual_results = {
+        "award_ids": list(
+            FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+        )
+    }
+
+    assert expected_results == actual_results
+
+
+def test_load_submission_file_c_zero_and_null_transaction_obligated_amount_ignored(data_fixture):
+    """
+    Test that the 'certified_award_financial` rows that have a 'transaction_obligated_amou'
+    of zero or null are not loaded from Broker.
+    """
+    call_command("load_submission", "-9999")
+
+    assert FinancialAccountsByAwards.objects.all().count() == 6
 
 
 def _assemble_broker_tas_lookup_records() -> list:

--- a/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
+++ b/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
@@ -12,12 +12,12 @@ from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.etl.transaction_loaders.data_load_helpers import format_insert_or_update_column_sql
 
 
+@pytest.mark.usefixtures("broker_db_setup", "db")
 class LoadSubmissionIntegrationTests(TestCase):
     logger = logging.getLogger(__name__)
     multi_db = True
 
     @classmethod
-    @pytest.mark.usefixtures("broker_db_setup", "db")
     def setUpClass(cls):
         # Setup default data in USAspending Test DB
         mommy.make(
@@ -62,7 +62,6 @@ class LoadSubmissionIntegrationTests(TestCase):
     def tearDownClass(cls):
         pass
 
-    @pytest.mark.django_db
     def test_load_submission_transaction_obligated_amount(self):
         """ Test load submission management command for File C transaction_obligated_amount NaNs """
         call_command("load_submission", "-9999")
@@ -74,7 +73,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_fain_and_uri(self):
         """
         Test load submission management command for File C records with FAIN and URI
@@ -109,7 +107,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_uri(self):
         """
         Test load submission management command for File C records with only a URI
@@ -128,7 +125,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_fain(self):
         """
         Test load submission management command for File C records with only a FAIN
@@ -147,7 +143,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_piid_with_parent_piid(self):
         """
         Test load submission management command for File C records with only a piid and parent piid
@@ -172,7 +167,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_piid_with_no_parent_piid(self):
         """
         Test load submission management command for File C records with only a piid and no parent piid
@@ -193,7 +187,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_piid_with_unmatched_parent_piid(self):
         """
         Test load submission management command for File C records that are not expected to be linked to Award data
@@ -218,7 +211,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_no_d_linkage(self):
         """
         Test load submission management command for File C records that are not expected to be linked to Award data
@@ -243,7 +235,6 @@ class LoadSubmissionIntegrationTests(TestCase):
 
         assert expected_results == actual_results
 
-    @pytest.mark.django_db
     def test_load_submission_file_c_zero_and_null_transaction_obligated_amount_ignored(self):
         """
         Test that the 'certified_award_financial` rows that have a 'transaction_obligated_amou'

--- a/usaspending_api/references/tests/integration/test_city.py
+++ b/usaspending_api/references/tests/integration/test_city.py
@@ -53,8 +53,7 @@ def award_data_fixture(db):
     mommy.make("awards.Award", id=4, latest_transaction_id=4, is_fpds=True, type="A", piid="0003")
 
 
-@pytest.mark.django_db
-def test_city_search_matches_found(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_city_search_matches_found(client, award_data_fixture, elasticsearch_transaction_index):
 
     elasticsearch_transaction_index.update_index()
     body = {"filter": {"country_code": "USA", "scope": "recipient_location"}, "search_text": "arli", "limit": 20}
@@ -64,8 +63,7 @@ def test_city_search_matches_found(client, db, award_data_fixture, elasticsearch
         assert entry["city_name"].lower().find("arl") > -1
 
 
-@pytest.mark.django_db
-def test_city_search_no_matches(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_city_search_no_matches(client, award_data_fixture, elasticsearch_transaction_index):
 
     elasticsearch_transaction_index.update_index()
     body = {"filter": {"country_code": "USA", "scope": "recipient_location"}, "search_text": "bhqlg", "limit": 20}
@@ -85,8 +83,7 @@ def test_city_search_no_matches(client, db, award_data_fixture, elasticsearch_tr
         assert False  # this should never be reached
 
 
-@pytest.mark.django_db
-def test_city_search_special_characters(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_city_search_special_characters(client, award_data_fixture, elasticsearch_transaction_index):
 
     elasticsearch_transaction_index.update_index()
     body = {
@@ -100,8 +97,7 @@ def test_city_search_special_characters(client, db, award_data_fixture, elastics
         assert entry["city_name"].lower().find("arl") > -1
 
 
-@pytest.mark.django_db
-def test_city_search_non_usa(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_city_search_non_usa(client, award_data_fixture, elasticsearch_transaction_index):
     elasticsearch_transaction_index.update_index()
     body = {"filter": {"country_code": "GBR", "scope": "recipient_location"}, "search_text": "bri", "limit": 20}
     response = client.post("/api/v2/autocomplete/city", content_type="application/json", data=json.dumps(body))
@@ -116,8 +112,7 @@ def test_city_search_non_usa(client, db, award_data_fixture, elasticsearch_trans
         assert entry["city_name"].lower().find("bri") > -1
 
 
-@pytest.mark.django_db
-def test_city_search_foreign(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_city_search_foreign(client, award_data_fixture, elasticsearch_transaction_index):
     elasticsearch_transaction_index.update_index()
     body = {"filter": {"country_code": "FOREIGN", "scope": "recipient_location"}, "search_text": "bri", "limit": 20}
     response = client.post("/api/v2/autocomplete/city", content_type="application/json", data=json.dumps(body))
@@ -126,8 +121,7 @@ def test_city_search_foreign(client, db, award_data_fixture, elasticsearch_trans
         assert entry["city_name"].lower().find("bri") > -1
 
 
-@pytest.mark.django_db
-def test_city_search_nulls_are_usa(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_city_search_nulls_are_usa(client, award_data_fixture, elasticsearch_transaction_index):
     elasticsearch_transaction_index.update_index()
     body = {"filter": {"country_code": "USA", "scope": "recipient_location"}, "search_text": "phil", "limit": 20}
     response = client.post("/api/v2/autocomplete/city", content_type="application/json", data=json.dumps(body))

--- a/usaspending_api/references/tests/test_load_agencies.py
+++ b/usaspending_api/references/tests/test_load_agencies.py
@@ -36,8 +36,8 @@ def _get_record_count():
     )
 
 
-@pytest.mark.django_db
-def test_happy_path(transactional_db):
+@pytest.mark.django_db(transaction=True)
+def test_happy_path():
     """
     We're running this one without a transaction just to ensure the vacuuming doesn't blow up.  For
     the remaining tests we'll run inside of a transaction since it's faster.

--- a/usaspending_api/references/tests/test_load_object_classes.py
+++ b/usaspending_api/references/tests/test_load_object_classes.py
@@ -47,8 +47,8 @@ def mock_data(object_classes):
         writer.writerows([("MAX OC Code", "MAX Object Class name")] + object_classes)
 
 
-@pytest.mark.django_db
-def test_happy_path(transactional_db, remove_csv_file):
+@pytest.mark.django_db(transaction=True)
+def test_happy_path(remove_csv_file):
     """
     We're running this one without a transaction just to ensure the vacuuming doesn't blow up.  For
     the remaining tests we'll run inside of a transaction since it's faster.

--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -5,7 +5,7 @@ from rest_framework import status
 
 
 @pytest.fixture
-def create_agency_data(db):
+def create_agency_data():
     # Create agency - submission relationship
     # Create AGENCY AND TopTier AGENCY
     ttagency1 = mommy.make(

--- a/usaspending_api/search/tests/integration/test_spending_by_award_type_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award_type_count.py
@@ -12,7 +12,7 @@ from usaspending_api.search.tests.data.search_filters_test_data import non_legac
 
 
 @pytest.fixture
-def award_data_fixture(db):
+def award_data_fixture():
     mommy.make("awards.TransactionNormalized", id=2)
     mommy.make(
         "awards.Award",
@@ -99,7 +99,7 @@ def test_spending_by_award_type_failure(client):
 
 
 @pytest.mark.django_db
-def test_spending_by_award_no_intersection(client, db, award_data_fixture):
+def test_spending_by_award_no_intersection(client, award_data_fixture):
 
     request = {"subawards": False, "fields": ["Award ID"], "sort": "Award ID", "filters": {"award_type_codes": ["07"]}}
 

--- a/usaspending_api/search/tests/integration/test_spending_by_transaction.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_transaction.py
@@ -10,7 +10,7 @@ ENDPOINT = "/api/v2/search/spending_by_transaction/"
 
 
 @pytest.fixture
-def transaction_data(db):
+def transaction_data():
     mommy.make(
         "awards.TransactionNormalized",
         id=1,

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -10,7 +10,7 @@ from usaspending_api.search.v2.views.spending_over_time import GROUPING_LOOKUP
 
 
 @pytest.fixture
-def spending_over_time_test_data(db):
+def spending_over_time_test_data():
     """
     Generate minimum test data for 'spending_over_time' integration tests.
     Use some calculations inside of a loop to get a larger data sample.

--- a/usaspending_api/search/tests/unit/test_spending_by_award_count.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_award_count.py
@@ -134,8 +134,7 @@ def get_spending_by_award_count_url():
     return "/api/v2/search/spending_by_award_count/"
 
 
-@pytest.mark.django_db
-def test_spending_by_award_count(client, db, award_data_fixture):
+def test_spending_by_award_count(client, award_data_fixture):
     test_payload = {
         "subawards": False,
         "filters": {
@@ -159,8 +158,7 @@ def test_spending_by_award_count(client, db, award_data_fixture):
     assert expected_response == resp.data, "Unexpected or missing content!"
 
 
-@pytest.mark.django_db
-def test_spending_by_award_count_idvs(client, db, award_data_fixture):
+def test_spending_by_award_count_idvs(client, award_data_fixture):
     test_payload = {
         "subawards": False,
         "filters": {

--- a/usaspending_api/search/tests/unit/test_spending_over_time_details.py
+++ b/usaspending_api/search/tests/unit/test_spending_over_time_details.py
@@ -27,7 +27,7 @@ def populate_models(mock_matviews_qs):
 
 
 @pytest.fixture
-def pragmatic_fixture(db):
+def pragmatic_fixture():
     mommy.make(
         "awards.TransactionNormalized",
         id=1,
@@ -242,6 +242,7 @@ def test_spending_over_time_funny_dates_ordering(populate_models, client, mock_m
     confirm_proper_ordering(group, resp.data["results"])
 
 
+@pytest.mark.django_db
 def test_generated_pragmatic_obligation_calculation(pragmatic_fixture):
     assert SummaryTransactionView.objects.all().count() == 2  # ensure both transactions are loaded
 

--- a/usaspending_api/search/tests/unit/test_tas_search.py
+++ b/usaspending_api/search/tests/unit/test_tas_search.py
@@ -122,7 +122,6 @@ def mock_tas_data(db):
     )
 
 
-@pytest.mark.django_db
 def test_spending_by_award_tas_success(client, mock_tas_data):
 
     data = {
@@ -148,7 +147,6 @@ def test_spending_by_award_tas_success(client, mock_tas_data):
     assert len(resp.data["results"]) == 1
 
 
-@pytest.mark.django_db
 def test_spending_by_award_tas_dates(client, mock_tas_data):
     data = {
         "filters": {
@@ -175,7 +173,6 @@ def test_spending_by_award_tas_dates(client, mock_tas_data):
     assert len(resp.data["results"]) == 2
 
 
-@pytest.mark.django_db
 def test_spending_by_award_tas_sub_account(client, mock_tas_data):
     data = {
         "filters": {
@@ -202,7 +199,6 @@ def test_spending_by_award_tas_sub_account(client, mock_tas_data):
     assert len(resp.data["results"]) == 1
 
 
-@pytest.mark.django_db
 def test_spending_by_award_tas_ata(client, mock_tas_data):
     data = {
         "filters": {
@@ -217,7 +213,6 @@ def test_spending_by_award_tas_ata(client, mock_tas_data):
     assert len(resp.data["results"]) == 1
 
 
-@pytest.mark.django_db
 def test_spending_by_award_subaward_success(client, mock_tas_data):
     data = {
         "filters": {"tas_codes": [{"aid": "028", "main": "8006"}], "award_type_codes": ["A", "B", "C", "D"]},
@@ -241,7 +236,6 @@ def test_spending_by_award_subaward_success(client, mock_tas_data):
     assert len(resp.data["results"]) == 1
 
 
-@pytest.mark.django_db
 def test_spending_by_award_subaward_failure(client, mock_tas_data):
     data = {
         "filters": {"tas_codes": [{"aid": "000", "main": "0000"}], "award_type_codes": ["A", "B", "C", "D"]},
@@ -253,7 +247,6 @@ def test_spending_by_award_subaward_failure(client, mock_tas_data):
     assert len(resp.data["results"]) == 0
 
 
-@pytest.mark.django_db
 def test_spending_over_time(client, mock_tas_data):
     data = {"group": "fiscal_year", "filters": {"tas_codes": [{"aid": "028", "main": "8006"}]}, "subawards": False}
     resp = client.post("/api/v2/search/spending_over_time", content_type="application/json", data=json.dumps(data))
@@ -262,7 +255,6 @@ def test_spending_over_time(client, mock_tas_data):
     assert len(resp.data["results"]) == FiscalDate.today().fiscal_year - earliest_fiscal_year_we_care_about
 
 
-@pytest.mark.django_db
 def test_spending_by_geography(client, mock_tas_data):
     data = {
         "scope": "place_of_performance",
@@ -275,7 +267,6 @@ def test_spending_by_geography(client, mock_tas_data):
     assert len(resp.data["results"]) == 1
 
 
-@pytest.mark.django_db
 def test_spending_by_category(client, mock_tas_data):
     data = {
         "category": "awarding_agency",

--- a/usaspending_api/tests/test_award_index_elasticsearch.py
+++ b/usaspending_api/tests/test_award_index_elasticsearch.py
@@ -71,7 +71,7 @@ def create_query(should) -> dict:
     return query
 
 
-def test_date_range(db, award_data_fixture, elasticsearch_award_index):
+def test_date_range(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {
         "bool": {
@@ -100,7 +100,7 @@ def test_date_range(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_tas(db, award_data_fixture, elasticsearch_award_index):
+def test_tas(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {
         "nested": {
@@ -139,7 +139,7 @@ def test_tas(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_agency(db, award_data_fixture, elasticsearch_award_index):
+def test_agency(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"funding_toptier_agency_name.keyword": "Department of Transportation"}}
     client = elasticsearch_award_index.client
@@ -153,7 +153,7 @@ def test_agency(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_award_type(db, award_data_fixture, elasticsearch_award_index):
+def test_award_type(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"type": "A"}}
     query = create_query(should)
@@ -166,7 +166,7 @@ def test_award_type(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_award_id(db, award_data_fixture, elasticsearch_award_index):
+def test_award_id(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"display_award_id": "IND12PB00323"}}
     query = create_query(should)
@@ -179,7 +179,7 @@ def test_award_id(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_cfda(db, award_data_fixture, elasticsearch_award_index):
+def test_cfda(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"cfda_number.keyword": "84.063"}}
     query = create_query(should)
@@ -192,7 +192,7 @@ def test_cfda(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_recipient_location(db, award_data_fixture, elasticsearch_award_index):
+def test_recipient_location(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = [
         {"match": {"recipient_location_country_code": "USA"}},
@@ -216,7 +216,7 @@ def test_recipient_location(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_pop_location(db, award_data_fixture, elasticsearch_award_index):
+def test_pop_location(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = [
         {"match": {"pop_country_code": "USA"}},
@@ -239,7 +239,7 @@ def test_pop_location(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_naics(db, award_data_fixture, elasticsearch_award_index):
+def test_naics(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"naics_code.keyword": "331122"}}
     query = create_query(should)
@@ -252,7 +252,7 @@ def test_naics(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_psc(db, award_data_fixture, elasticsearch_award_index):
+def test_psc(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"product_or_service_code.keyword": "1510"}}
     query = create_query(should)
@@ -265,7 +265,7 @@ def test_psc(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_type_set_aside(db, award_data_fixture, elasticsearch_award_index):
+def test_type_set_aside(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"type_set_aside.keyword": "8AN"}}
     query = create_query(should)
@@ -278,7 +278,7 @@ def test_type_set_aside(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_contract_pricing(db, award_data_fixture, elasticsearch_award_index):
+def test_contract_pricing(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"type_of_contract_pricing.keyword": "2"}}
     query = create_query(should)
@@ -291,7 +291,7 @@ def test_contract_pricing(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_extent_competed(db, award_data_fixture, elasticsearch_award_index):
+def test_extent_competed(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     should = {"match": {"extent_competed": "F"}}
     query = create_query(should)
@@ -304,7 +304,7 @@ def test_extent_competed(db, award_data_fixture, elasticsearch_award_index):
     assert response["hits"]["total"] == 0
 
 
-def test_award_keyword(db, award_data_fixture, elasticsearch_award_index):
+def test_award_keyword(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     query = {
         "query": {"bool": {"filter": {"dis_max": {"queries": [{"query_string": {"query": "pop tarts"}}]}}}},

--- a/usaspending_api/tests/test_demo_elasticsearch_tests.py
+++ b/usaspending_api/tests/test_demo_elasticsearch_tests.py
@@ -12,7 +12,7 @@ def award_data_fixture(db):
     mommy.make("awards.Award", id=1, latest_transaction_id=1, is_fpds=True, type="A", piid="IND12PB00323")
 
 
-def test_positive_sample_query(db, award_data_fixture, elasticsearch_transaction_index):
+def test_positive_sample_query(award_data_fixture, elasticsearch_transaction_index):
     """
     A super simple direct search against Elasticsearch that returns one record.
     """
@@ -27,7 +27,7 @@ def test_positive_sample_query(db, award_data_fixture, elasticsearch_transaction
     assert response["hits"]["total"] == 1
 
 
-def test_negative_sample_query(db, award_data_fixture, elasticsearch_transaction_index):
+def test_negative_sample_query(award_data_fixture, elasticsearch_transaction_index):
     """
     A super simple direct search against Elasticsearch that returns no results.
     """
@@ -42,7 +42,7 @@ def test_negative_sample_query(db, award_data_fixture, elasticsearch_transaction
     assert response["hits"]["total"] == 0
 
 
-def test_a_search_endpoint(client, db, award_data_fixture, elasticsearch_transaction_index):
+def test_a_search_endpoint(client, award_data_fixture, elasticsearch_transaction_index):
     """
     An example of how one might test a keyword search.
     """


### PR DESCRIPTION
**Description:**

As part of a larger effort to clean up our pytests, removed a problematic fixture that would occasionally cause subsequent tests to fail depending up the order in which the tests were executed along with some other issues.

**Technical details:**

There were three primary issues.

Issue #0:  A fixture was attempting to monkeypatch Django connections directly rather than the file-being-tested’s reference to the connections object. This meant that if the file was loaded before the test, the connections object would not be overridden which lead to inconsistent test failures.  This was a confusing piece of code anyway and was only used in one place so I just removed it and applied the specific monkeypatch required for the test within the test itself.

Issue #1:  One of the newer tests was leaving data in the database. Whether or not this caused issues depended upon whether or not you were using a fresh databases for your tests and the order in which your tests were run.  The cause of this is not fully understood, but seems to be related to mixing pytest fixtures with Django tests.  Supposedly the two are compatible, but it was definitely the cause of the problem in this case.  My first attempt to fix this caused more problems than it helped so in the end I just converted the test to pytest using a fixture and everything seems to be happy now.

Issue #2:  We had several tests that mocked agency data.  They were using model mommy which has the nasty habit of creating foreign key records when they don’t exist (it’s actually a feature, but it causes problems if you’re not aware it’s happening).  This would occasionally cause key primary key conflicts depending on the order in which tests were run.  Modelmommy would create a record with primary key N because that was the next value in the series.  A test would then mock data with the same hardcoded primary key… *POOF* primary key violation.  This was an easy fix because, in every case, the correct foreign key record was already being mocked so it was simply a matter of referencing that value in the Agency mock data.

Bonus “Issue” #3:  We had a lot of very confusing mixtures of `db`/`transactional_db`/`@pytest.mark.django_db` in our tests.  For example, in one test, we had `transactional_db` on the fixture, `db` on the test, and `@pytest.mark.django_db` also on the test.  My first thought was that these were not playing well together, but was unable to force these to fail in testing.  So at the end of the day, I’m not sure these are a problem, but they are very, very confusing to someone trying to follow behind.  I only fixed these in a few places.  Perhaps in the future we can standardize usage to help with maintenance.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations tickets required
8. [x] Jira Ticket [DEV-4096](https://federal-spending-transparency.atlassian.net/browse/DEV-4096):
    - [x] Link to this Pull-Request