### PR TITLE
Minimalist fix to update grandchild count to 0

### DIFF
--- a/usaspending_api/references/tests/test_naics.py
+++ b/usaspending_api/references/tests/test_naics.py
@@ -57,8 +57,8 @@ def test_with_id(client, naics_test_data):
             "naics_description": "Oilseed and Grain Farming",
             "count": 2,
             "children": [
-                {"naics": "111110", "naics_description": "Soybean Farming", "count": 1},
-                {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 1},
+                {"naics": "111110", "naics_description": "Soybean Farming", "count": 0},
+                {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 0},
             ],
         }
     ]
@@ -66,7 +66,7 @@ def test_with_id(client, naics_test_data):
 
     resp = client.get("/api/v2/references/naics/111120/")
     assert resp.status_code == 200
-    expected_data = [{"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 1}]
+    expected_data = [{"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 0}]
     assert resp.data["results"] == expected_data
 
     # Nonexistent id.
@@ -129,8 +129,8 @@ def test_with_filter(client, naics_test_data):
                         "naics_description": "Oilseed and Grain Farming",
                         "count": 2,
                         "children": [
-                            {"naics": "111110", "naics_description": "Soybean Farming", "count": 1},
-                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 1},
+                            {"naics": "111110", "naics_description": "Soybean Farming", "count": 0},
+                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 0},
                         ],
                     }
                 ],
@@ -154,15 +154,15 @@ def test_with_filter(client, naics_test_data):
                         "naics_description": "Oilseed and Grain Farming",
                         "count": 2,
                         "children": [
-                            {"naics": "111110", "naics_description": "Soybean Farming", "count": 1},
-                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 1},
+                            {"naics": "111110", "naics_description": "Soybean Farming", "count": 0},
+                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 0},
                         ],
                     },
                     {
                         "naics": "1112",
                         "naics_description": "Vegetable and Melon Farming",
                         "count": 1,
-                        "children": [{"naics": "111211", "naics_description": "Potato Farming", "count": 1}],
+                        "children": [{"naics": "111211", "naics_description": "Potato Farming", "count": 0}],
                     },
                 ],
             }
@@ -185,8 +185,8 @@ def test_with_filter(client, naics_test_data):
                         "naics_description": "Oilseed and Grain Farming",
                         "count": 2,
                         "children": [
-                            {"naics": "111110", "naics_description": "Soybean Farming", "count": 1},
-                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 1},
+                            {"naics": "111110", "naics_description": "Soybean Farming", "count": 0},
+                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 0},
                         ],
                     },
                     {"naics": "1112", "naics_description": "Vegetable and Melon Farming", "count": 1, "children": []},
@@ -211,14 +211,14 @@ def test_with_filter(client, naics_test_data):
                         "naics_description": "Oilseed and Grain Farming",
                         "count": 2,
                         "children": [
-                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 1}
+                            {"naics": "111120", "naics_description": "Oilseed (except Soybean) Farming", "count": 0}
                         ],
                     },
                     {
                         "naics": "1112",
                         "naics_description": "Vegetable and Melon Farming",
                         "count": 1,
-                        "children": [{"naics": "111211", "naics_description": "Potato Farming", "count": 1}],
+                        "children": [{"naics": "111211", "naics_description": "Potato Farming", "count": 0}],
                     },
                 ],
             }

--- a/usaspending_api/references/v2/views/naics.py
+++ b/usaspending_api/references/v2/views/naics.py
@@ -13,6 +13,8 @@ from usaspending_api.references.models import NAICS
 
 logger = logging.getLogger("console")
 
+DEFAULT_CHILDREN = 0
+
 
 class NAICSViewSet(APIView):
     """
@@ -63,7 +65,7 @@ class NAICSViewSet(APIView):
                 result = OrderedDict()
                 result["naics"] = naic.code
                 result["naics_description"] = naic.description
-                result["count"] = 1
+                result["count"] = DEFAULT_CHILDREN
             results.append(result)
         results.sort(key=lambda x: x["naics"])
         return results
@@ -109,7 +111,7 @@ class NAICSViewSet(APIView):
             result = OrderedDict()
             result["naics"] = naic.code
             result["naics_description"] = naic.description
-            result["count"] = 1
+            result["count"] = DEFAULT_CHILDREN
             tier2_results[naic.code[:4]]["children"].append(result)
             tier2_results[naic.code[:4]]["children"].sort(key=lambda x: x["naics"])
         tier1_results = {}
@@ -176,7 +178,7 @@ class NAICSViewSet(APIView):
             else:
                 result["naics"] = naic.code
                 result["naics_description"] = naic.description
-                result["count"] = 1
+                result["count"] = DEFAULT_CHILDREN
             results.append(result)
 
         response_content = OrderedDict({"results": results})


### PR DESCRIPTION
**Description:**
If a NAICS has no child, its count is 0, not 1

**Technical details:**
I'd like to refactor this whole file, but it's not nessicary so I'll wait on another PR based on my whims tonight/tomorrow.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated 
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4202](https://federal-spending-transparency.atlassian.net/browse/DEV-4202):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
