### PR TITLE
[DEV-4205] Elasticsearch spending_by_award_count endpoint

### DIFF
--- a/usaspending_api/common/elasticsearch/client.py
+++ b/usaspending_api/common/elasticsearch/client.py
@@ -130,7 +130,6 @@ def _es_count(index: str = None, body: dict = None, search: Search = None) -> El
         if search is not None:
             result = search.using(CLIENT).params().count()
         else:
-            print(body)
             result = CLIENT.count(index=index, body=body)
     except NameError as e:
         logger.error(error_template.format(type="Hostname", e=str(e)))

--- a/usaspending_api/common/elasticsearch/client.py
+++ b/usaspending_api/common/elasticsearch/client.py
@@ -77,29 +77,6 @@ def es_client_query(
     return None
 
 
-def es_client_query_count(
-    index: str = None, body: dict = None, timeout: str = "1m", retries: int = 5, search: Search = None
-) -> ElasticsearchResponse:
-    if CLIENT is None:
-        create_es_client()
-    if CLIENT is None:  # If CLIENT is still None, don't even attempt to connect to the cluster
-        retries = 0
-    elif retries > 20:
-        retries = 20
-    elif retries < 1:
-        retries = 1
-    for attempt in range(retries):
-        response = _es_count(index=index, body=body, search=search)
-        if response is None and search is None:
-            logger.info(f"Failure using these: Index='{index}', Body={json.dumps(body)}")
-        if response is None:
-            logger.info(f"Failure using these: Body={json.dumps(search.to_dict())}")
-        else:
-            return response
-    logger.error(f"Unable to reach elasticsearch cluster. {retries} attempt(s) made")
-    return None
-
-
 def _es_search(
     index: str = None, body: dict = None, search: Search = None, timeout: int = "1m"
 ) -> ElasticsearchResponse:
@@ -110,27 +87,6 @@ def _es_search(
             result = search.using(CLIENT).params(timeout=timeout).execute()
         else:
             result = CLIENT.search(index=index, body=body, timeout=timeout)
-    except NameError as e:
-        logger.error(error_template.format(type="Hostname", e=str(e)))
-    except (ConnectionError, ConnectionTimeout) as e:
-        logger.error(error_template.format(type="Connection", e=str(e)))
-    except NotFoundError as e:
-        logger.error(error_template.format(type="404 Not Found", e=str(e)))
-    except TransportError as e:
-        logger.error(error_template.format(type="Transport", e=str(e)))
-    except Exception as e:
-        logger.error(error_template.format(type="Generic", e=str(e)))
-    return result
-
-
-def _es_count(index: str = None, body: dict = None, search: Search = None) -> ElasticsearchResponse:
-    error_template = "[ERROR] ({type}) with ElasticSearch cluster: {e}"
-    result = None
-    try:
-        if search is not None:
-            result = search.using(CLIENT).params().count()
-        else:
-            result = CLIENT.count(index=index, body=body)
     except NameError as e:
         logger.error(error_template.format(type="Hostname", e=str(e)))
     except (ConnectionError, ConnectionTimeout) as e:

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -342,11 +342,11 @@ class SpendingByAwardVisualizationViewSet(APIView):
         last_id = None
         last_value = None
         if len(response) > 0:
-            last_id = (response[len(response) - 1].to_dict().get("generated_unique_award_id"),)
+            last_id = response[len(response) - 1].to_dict().get("generated_unique_award_id")
             last_value = (
                 response[len(response) - 1].to_dict().get("total_loan_value")
                 if set(self.filters["award_type_codes"]) <= set(loan_type_mapping)
-                else response[len(response) - 1].to_dict().get("total_obligation"),
+                else response[len(response) - 1].to_dict().get("total_obligation")
             )
         return {
             "limit": self.pagination["limit"],
@@ -355,9 +355,9 @@ class SpendingByAwardVisualizationViewSet(APIView):
                 "page": self.pagination["page"],
                 "hasNext": response.hits.total - (self.pagination["page"] - 1) * self.pagination["limit"]
                 > self.pagination["limit"],
+                "last_id": last_id,
+                "last_value": last_value,
             },
-            "last_id": last_id,
-            "last_value": last_value,
             "messages": [get_time_period_message()],
         }
 

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models import Count, Sum
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from elasticsearch_dsl import Search
+from elasticsearch_dsl import Search, Q
 
 from usaspending_api.awards.v2.filters.filter_helpers import add_date_range_comparison_types
 from usaspending_api.awards.v2.filters.sub_award import subaward_filter
@@ -15,7 +15,7 @@ from usaspending_api.awards.v2.lookups.lookups import all_awards_types_to_catego
 from usaspending_api.common.api_versioning import api_transformations, API_TRANSFORM_FUNCTIONS
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.data_connectors.spending_by_award_count_asyncpg import fetch_all_category_counts
-from usaspending_api.common.elasticsearch.client import es_client_query_count
+from usaspending_api.common.elasticsearch.client import es_client_query
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.experimental_api_flags import is_experimental_elasticsearch_api
 from usaspending_api.common.helpers.generic_helper import get_time_period_message
@@ -66,7 +66,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         elasticsearch = is_experimental_elasticsearch_api(request)
 
         if elasticsearch and not subawards:
-            logger.info("Using experimental Elasticsearch functionality for 'spending_by_award'")
+            logger.info("Using experimental Elasticsearch functionality for 'spending_by_award_count'")
             results = self.query_elasticsearch(filters)
             return Response({"results": results, "messages": [get_time_period_message()]})
 
@@ -141,20 +141,35 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
 
     def query_elasticsearch(self, filters) -> list:
         filter_query = QueryWithFilters.generate_elasticsearch_query(filters, query_type="awards")
-        contracts = Search(index="{}-contracts".format(settings.ES_AWARDS_QUERY_ALIAS_PREFIX)).filter(filter_query)
-        idvs = Search(index="{}-idvs".format(settings.ES_AWARDS_QUERY_ALIAS_PREFIX)).filter(filter_query)
-        grants = Search(index="{}-grants".format(settings.ES_AWARDS_QUERY_ALIAS_PREFIX)).filter(filter_query)
-        directpayments = Search(index="{}-directpayments".format(settings.ES_AWARDS_QUERY_ALIAS_PREFIX)).filter(
-            filter_query
+        s = Search(index=f"{settings.ES_AWARDS_QUERY_ALIAS_PREFIX}*").filter(filter_query)
+
+        s.aggs.bucket(
+            "types",
+            "filters",
+            filters={
+                "contracts": Q("terms", type=["A", "B", "C", "D"]),
+                "idvs": Q("terms", type=["IDV_A", "IDV_B", "IDV_B_A", "IDV_B_B", "IDV_B_C", "IDV_C", "IDV_D", "IDV_E"]),
+                "grants": Q("terms", type=["02", "03", "04", "05"]),
+                "direct_payments": Q("terms", type=["06", "10"]),
+                "loans": Q("terms", type=["07", "08"]),
+                "other": Q("terms", type=["09", "11"]),
+            },
         )
-        loans = Search(index="{}-loans".format(settings.ES_AWARDS_QUERY_ALIAS_PREFIX)).filter(filter_query)
-        other = Search(index="{}-other".format(settings.ES_AWARDS_QUERY_ALIAS_PREFIX)).filter(filter_query)
+        results = es_client_query(search=s)
+
+        contracts = results.aggregations.types.buckets.contracts.doc_count
+        idvs = results.aggregations.types.buckets.idvs.doc_count
+        grants = results.aggregations.types.buckets.grants.doc_count
+        direct_payments = results.aggregations.types.buckets.direct_payments.doc_count
+        loans = results.aggregations.types.buckets.loans.doc_count
+        other = results.aggregations.types.buckets.other.doc_count
+
         response = {
-            "contracts": es_client_query_count(search=contracts),
-            "direct_payments": es_client_query_count(search=directpayments),
-            "grants": es_client_query_count(search=grants),
-            "idvs": es_client_query_count(search=idvs),
-            "loans": es_client_query_count(search=loans),
-            "other": es_client_query_count(search=other),
+            "contracts": contracts,
+            "direct_payments": direct_payments,
+            "grants": grants,
+            "idvs": idvs,
+            "loans": loans,
+            "other": other,
         }
         return response


### PR DESCRIPTION
**Description:**
Adds elasticsearch capability to the `/api/v2/search/spending_by_award_count` endpoint.
**Technical details:**
Switch between the postgres implementation and the elasticsearch implementation by sending `X-Experimental-API/elasticsearch` header with the API request. Elasticsearch results are obtained by querying the different award type aliases with the same filters.
**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-4205](https://federal-spending-transparency.atlassian.net/browse/DEV-4205):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No change to matviews, no change to frontend, no ops tickets needed.
```
Request - 
```
{
                "subawards": false,
                "filters": {
                    "time_period": [
                        {"start_date": "2009-10-01", "end_date": "2017-09-30"},
                        {"start_date": "2017-10-01", "end_date": "2018-09-30"}
                    ]
                }
            }
```
Before - 57 ms
```
{
    "results": {
        "contracts": 49441,
        "idvs": 777,
        "grants": 4561,
        "direct_payments": 34445,
        "loans": 4889,
        "other": 8370
    },
    "messages": [
        "For searches, time period start and end dates are currently limited to an earliest date of 2007-10-01.  For data going back to 2000-10-01, use either the Custom Award Download feature on the website or one of our download or bulk_download API endpoints as listed on https://api.usaspending.gov/docs/endpoints."
    ]
}
```

After - 62 ms
```
{
    "results": {
        "contracts": 49441,
        "direct_payments": 34445,
        "grants": 4561,
        "idvs": 777,
        "loans": 4889,
        "other": 8370
    },
    "messages": [
        "For searches, time period start and end dates are currently limited to an earliest date of 2007-10-01.  For data going back to 2000-10-01, use either the Custom Award Download feature on the website or one of our download or bulk_download API endpoints as listed on https://api.usaspending.gov/docs/endpoints."
    ]
}
```