### PR TITLE
[DEV-4109] Part 3.1: Follow-up tweaks to script after test runs

### DIFF
--- a/usaspending_api/database_scripts/job_archive/recompute_all_awards.py
+++ b/usaspending_api/database_scripts/job_archive/recompute_all_awards.py
@@ -65,9 +65,9 @@ BSD_SIGNALS = {
 
 DEBUG, CLEANUP = False, False
 GET_FABS_AWARDS = (
-    "SELECT generated_unique_award_id FROM awards where is_fpds = FALSE AND id BETWEEN {minid} AND {maxid}"
+    "SELECT id FROM awards where is_fpds = FALSE AND id BETWEEN {minid} AND {maxid}"
 )
-GET_FPDS_AWARDS = "SELECT generated_unique_award_id FROM awards where is_fpds = TRUE AND id BETWEEN {minid} AND {maxid}"
+GET_FPDS_AWARDS = "SELECT id FROM awards where is_fpds = TRUE AND id BETWEEN {minid} AND {maxid}"
 GET_MIN_MAX_SQL = "SELECT MIN(id), MAX(id) FROM awards"
 MAX_ID, MIN_ID, CLOSING_TIME, ITERATION_ESTIMATED_SECONDS = None, None, None, None
 TOTAL_UPDATES, CHUNK_SIZE = 0, 20000
@@ -149,16 +149,16 @@ def run_update_query(fabs_awards, fpds_awards):
     loop = asyncio.new_event_loop()
     statements = []
 
-    predicate = f"WHERE tn.unique_award_key IN ({','.join(fabs_awards + fpds_awards)})"
+    predicate = f"WHERE tn.award_id IN ({','.join(fabs_awards + fpds_awards)})"
     all_sql = general_award_update_sql_string.format(predicate=predicate)
     statements.append(asyncio.ensure_future(async_run_create(all_sql), loop=loop))
 
     if fabs_awards:
-        predicate = f"WHERE tn.unique_award_key IN ({','.join(fabs_awards)})"
+        predicate = f"WHERE tn.award_id IN ({','.join(fabs_awards)})"
         fabs_sql = fabs_award_update_sql_string.format(predicate=predicate)
         statements.append(asyncio.ensure_future(async_run_create(fabs_sql), loop=loop))
     if fpds_awards:
-        predicate = f"WHERE tn.unique_award_key IN ({','.join(fpds_awards)})"
+        predicate = f"WHERE tn.award_id IN ({','.join(fpds_awards)})"
         fpds_sql = fpds_award_update_sql_string.format(predicate=predicate)
         statements.append(asyncio.ensure_future(async_run_create(fpds_sql), loop=loop))
 

--- a/usaspending_api/database_scripts/job_archive/recompute_all_awards.py
+++ b/usaspending_api/database_scripts/job_archive/recompute_all_awards.py
@@ -80,7 +80,7 @@ def _handle_exit_signal(signum, frame):
     signal_or_human = BSD_SIGNALS.get(signum, signum)
     logging.warning("Received signal {}. Attempting to gracefully exit".format(signal_or_human))
     teardown(successful_run=False)
-    raise SystemExit()
+    raise SystemExit(1)
 
 
 def datetime_command_line_argument_type(naive):
@@ -136,7 +136,7 @@ async def async_run_create(sql):
     except Exception:
         logging.exception("=== ERROR ===")
         logging.error("{}\n=============".format(sql))
-        raise SystemExit
+        raise SystemExit(1)
 
     if DEBUG:
         logging.info(sql)


### PR DESCRIPTION
**Description:**
Using `unique_award_key` for the award update SQL caused two issues:
1. Degraded performance (known)
1. Need to properly handle `unique_award_key` values with quotes

Also there was an issue with the fix script which didn't appropriately return a non-0 exit code for Jenkins to handle.

**Technical details:**
Since one script will check and correct bad FK values in `transaction_normalized`, using the FKs will not introduce data quality issues. The script will be run on a daily basis with a flag to test the FKs and ensure any drift is caught immediately and flagged.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-4109](https://federal-spending-transparency.atlassian.net/browse/DEV-4109):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Script
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to API behavior
No matviews were altered
```
