### PR TITLE
Less fragile delete statements for views

### DIFF
--- a/usaspending_api/database_scripts/etl/transaction_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/transaction_delta_view.sql
@@ -1,6 +1,7 @@
 -- Needs to be present in the Postgres DB if data needs to be retrieved for Elasticsearch
+DROP VIEW IF EXISTS transaction_delta_view;
 
-CREATE OR REPLACE VIEW transaction_delta_view AS
+CREATE VIEW transaction_delta_view AS
 SELECT
   UTM.transaction_id,
   FPDS.detached_award_proc_unique,

--- a/usaspending_api/database_scripts/matviews/vw_award_search.sql
+++ b/usaspending_api/database_scripts/matviews/vw_award_search.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE VIEW vw_award_search AS (
+DROP VIEW IF EXISTS vw_award_search;
+
+CREATE VIEW vw_award_search AS (
   SELECT * FROM mv_contract_award_search
   UNION ALL
   SELECT * FROM mv_directpayment_award_search


### PR DESCRIPTION
**Description:**
Small change to how the views are created. Merging into Staging first to avoid issues with the Prod deploy.

**Technical details:**
For Sprint 98 Staging Deploy ran into an issue with removing columns from `vw_award_search`. The problem is rooted in the `CREATE OR REPLACE VIEW` statement since according to Postgres ["the new query must generate the same columns that were generated by the existing view query..."](https://www.postgresql.org/docs/9.3/sql-createview.html) The solution is to first remove the view and then create the view.  

**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed (N/A)
6. [X] Data validation completed (N/A)
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123)  (N/A):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
