### PR TITLE
[DEV-3930] Remove is_toptier from agency list filter

### DIFF
--- a/usaspending_api/references/v1/urls.py
+++ b/usaspending_api/references/v1/urls.py
@@ -3,9 +3,6 @@ from django.conf.urls import url
 from usaspending_api.references.v1 import views
 from usaspending_api.common.views import RemovedEndpointView
 
-mode_list = {"get": "list", "post": "list"}
-mode_detail = {"get": "retrieve", "post": "retrieve"}
-
 
 urlpatterns = [
     url(r"^filter", views.FilterEndpoint.as_view()),

--- a/usaspending_api/references/v2/urls.py
+++ b/usaspending_api/references/v2/urls.py
@@ -2,9 +2,6 @@ from django.conf.urls import url
 
 from usaspending_api.references.v2.views import agency, toptier_agencies, data_dictionary, glossary, naics
 
-mode_list = {"get": "list", "post": "list"}
-mode_detail = {"get": "retrieve", "post": "retrieve"}
-
 
 urlpatterns = [
     url(r"^agency/(?P<pk>[0-9]+)/$", agency.AgencyViewSet.as_view()),

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -50,9 +50,7 @@ class ToptierAgenciesViewSet(APIView):
             )
 
         # get agency queryset, distinct toptier id to avoid duplicates, take first ordered agency id for consistency
-        agency_queryset = (
-            Agency.objects.filter(toptier_flag=True).order_by("toptier_agency_id", "id").distinct("toptier_agency_id")
-        )
+        agency_queryset = Agency.objects.order_by("toptier_agency_id", "id").distinct("toptier_agency_id")
 
         for agency in agency_queryset:
             toptier_agency = agency.toptier_agency


### PR DESCRIPTION
**Description:**

Very minor tweak to how the agency list is generated as it was inappropriately using the `is_toptier` flag.

**Technical details:**

Also removed a couple pieces of dead code.

**Requirements for PR merge:**

1. [x] Tests unaffected
2. [x] API documentation unaffected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-3930](https://federal-spending-transparency.atlassian.net/browse/DEV-3930):
    - [x] Link to this Pull-Request