### PR TITLE
[DEV-4122] Removed download base class from status view

### DIFF
--- a/usaspending_api/download/v2/download_status.py
+++ b/usaspending_api/download/v2/download_status.py
@@ -1,8 +1,11 @@
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.download.v2.base_download_viewset import BaseDownloadViewSet
+from usaspending_api.download.v2.base_download_viewset import get_download_job, get_file_path
 
 
-class DownloadStatusViewSet(BaseDownloadViewSet):
+class DownloadStatusViewSet(APIView):
     """
     This route gets the current status of a download job that that has been requested with the
     `v2/download/awards/` or `v2/download/transaction/` endpoint that same day. Accessed by both
@@ -20,3 +23,27 @@ class DownloadStatusViewSet(BaseDownloadViewSet):
             raise InvalidParameterException("Missing one or more required query parameters: file_name")
 
         return self.get_download_status_response(file_name=file_name)
+
+    def get_download_status_response(self, file_name: str):
+        """
+        Generate download status response which encompasses various elements to provide accurate
+        status for state of a download job
+        """
+        download_job = get_download_job(file_name)
+
+        # Compile url to file
+        file_path = get_file_path(file_name)
+
+        response = {
+            "status": download_job.job_status.name,
+            "message": download_job.error_message,
+            "file_name": file_name,
+            "file_url": file_path,
+            # converting size from bytes to kilobytes if file_size isn't None
+            "total_size": download_job.file_size / 1000 if download_job.file_size else None,
+            "total_columns": download_job.number_of_columns,
+            "total_rows": download_job.number_of_rows,
+            "seconds_elapsed": download_job.seconds_elapsed(),
+        }
+
+        return Response(response)


### PR DESCRIPTION
**Description:**
Django was incorrectly treating https://api.usaspending.gov/api/v2/download/status/ as an endpoint which supported POST. This was caused from class inheritance.

**Technical details:**
Minor reorganizing

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4122](https://federal-spending-transparency.atlassian.net/browse/DEV-4122):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Minor changes for API documentation site
```
