### PR TITLE
[DEV-3074] Remove MockSet, MockModel, and deprecated Django code

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -3,7 +3,6 @@ coverage==4.5.4
 docker==4.1.0
 dredd-hooks==0.2.0
 flake8==3.7.8
-git+https://github.com/fedspendingtransparency/django-mock-queries#egg=django-mock-queries
 mccabe==0.6.1
 mock==3.0.5
 model-mommy==1.6.0

--- a/usaspending_api/awards/models/award.py
+++ b/usaspending_api/awards/models/award.py
@@ -99,10 +99,20 @@ class Award(DataSourceTrackedModel):
         help_text="The total of the face_value_loan_guarantee from associated transactions",
     )
     awarding_agency = models.ForeignKey(
-        "references.Agency", related_name="+", null=True, help_text="The awarding agency for the award", db_index=True
+        "references.Agency",
+        on_delete=models.CASCADE,
+        related_name="+",
+        null=True,
+        help_text="The awarding agency for the award",
+        db_index=True,
     )
     funding_agency = models.ForeignKey(
-        "references.Agency", related_name="+", null=True, help_text="The funding agency for the award", db_index=True
+        "references.Agency",
+        on_delete=models.CASCADE,
+        related_name="+",
+        null=True,
+        help_text="The funding agency for the award",
+        db_index=True,
     )
     date_signed = models.DateField(
         null=True, db_index=False, verbose_name="Award Date", help_text="The date the award was signed"
@@ -144,12 +154,14 @@ class Award(DataSourceTrackedModel):
     )
     latest_transaction = models.ForeignKey(
         "awards.TransactionNormalized",
+        on_delete=models.CASCADE,
         related_name="latest_for_award",
         null=True,
         help_text="The latest transaction by action_date and mod associated with this award",
     )
     earliest_transaction = models.ForeignKey(
         "awards.TransactionNormalized",
+        on_delete=models.CASCADE,
         related_name="earliest_for_award",
         null=True,
         help_text="The earliest transaction by action_date and mod associated with this award",

--- a/usaspending_api/awards/models/award.py
+++ b/usaspending_api/awards/models/award.py
@@ -154,14 +154,14 @@ class Award(DataSourceTrackedModel):
     )
     latest_transaction = models.ForeignKey(
         "awards.TransactionNormalized",
-        on_delete=models.CASCADE,
+        on_delete=models.DO_NOTHING,
         related_name="latest_for_award",
         null=True,
         help_text="The latest transaction by action_date and mod associated with this award",
     )
     earliest_transaction = models.ForeignKey(
         "awards.TransactionNormalized",
-        on_delete=models.CASCADE,
+        on_delete=models.DO_NOTHING,
         related_name="earliest_for_award",
         null=True,
         help_text="The earliest transaction by action_date and mod associated with this award",

--- a/usaspending_api/awards/models/award.py
+++ b/usaspending_api/awards/models/award.py
@@ -100,7 +100,7 @@ class Award(DataSourceTrackedModel):
     )
     awarding_agency = models.ForeignKey(
         "references.Agency",
-        on_delete=models.CASCADE,
+        on_delete=models.DO_NOTHING,
         related_name="+",
         null=True,
         help_text="The awarding agency for the award",
@@ -108,7 +108,7 @@ class Award(DataSourceTrackedModel):
     )
     funding_agency = models.ForeignKey(
         "references.Agency",
-        on_delete=models.CASCADE,
+        on_delete=models.DO_NOTHING,
         related_name="+",
         null=True,
         help_text="The funding agency for the award",

--- a/usaspending_api/awards/models/parent_award.py
+++ b/usaspending_api/awards/models/parent_award.py
@@ -2,9 +2,9 @@ from django.db import models
 
 
 class ParentAward(models.Model):
-    award = models.OneToOneField("awards.Award", primary_key=True)
+    award = models.OneToOneField("awards.Award", on_delete=models.CASCADE, primary_key=True)
     generated_unique_award_id = models.TextField(unique=True)
-    parent_award = models.ForeignKey("self", db_index=True, blank=True, null=True)
+    parent_award = models.ForeignKey("self", on_delete=models.CASCADE, db_index=True, blank=True, null=True)
 
     direct_idv_count = models.IntegerField()
     direct_contract_count = models.IntegerField()

--- a/usaspending_api/awards/models/transaction_normalized.py
+++ b/usaspending_api/awards/models/transaction_normalized.py
@@ -7,7 +7,7 @@ from usaspending_api.common.helpers.date_helper import fy
 class TransactionNormalized(models.Model):
     id = models.BigAutoField(primary_key=True)
     award = models.ForeignKey(
-        "awards.Award", on_delete=models.CASCADE, help_text="The award which this transaction is contained in"
+        "awards.Award", on_delete=models.DO_NOTHING, help_text="The award which this transaction is contained in"
     )
     usaspending_unique_transaction_id = models.TextField(
         blank=True,
@@ -70,14 +70,14 @@ class TransactionNormalized(models.Model):
     )
     awarding_agency = models.ForeignKey(
         "references.Agency",
-        on_delete=models.CASCADE,
+        on_delete=models.DO_NOTHING,
         related_name="%(app_label)s_%(class)s_awarding_agency",
         null=True,
         help_text="The agency which awarded this transaction",
     )
     funding_agency = models.ForeignKey(
         "references.Agency",
-        on_delete=models.CASCADE,
+        on_delete=models.DO_NOTHING,
         related_name="%(app_label)s_%(class)s_funding_agency",
         null=True,
         help_text="The agency which is funding this transaction",

--- a/usaspending_api/awards/models/transaction_normalized.py
+++ b/usaspending_api/awards/models/transaction_normalized.py
@@ -7,7 +7,7 @@ from usaspending_api.common.helpers.date_helper import fy
 class TransactionNormalized(models.Model):
     id = models.BigAutoField(primary_key=True)
     award = models.ForeignKey(
-        "awards.Award", models.CASCADE, help_text="The award which this transaction is contained in"
+        "awards.Award", on_delete=models.CASCADE, help_text="The award which this transaction is contained in"
     )
     usaspending_unique_transaction_id = models.TextField(
         blank=True,
@@ -70,12 +70,14 @@ class TransactionNormalized(models.Model):
     )
     awarding_agency = models.ForeignKey(
         "references.Agency",
+        on_delete=models.CASCADE,
         related_name="%(app_label)s_%(class)s_awarding_agency",
         null=True,
         help_text="The agency which awarded this transaction",
     )
     funding_agency = models.ForeignKey(
         "references.Agency",
+        on_delete=models.CASCADE,
         related_name="%(app_label)s_%(class)s_funding_agency",
         null=True,
         help_text="The agency which is funding this transaction",

--- a/usaspending_api/awards/tests/integration/test_subaward_endpoint.py
+++ b/usaspending_api/awards/tests/integration/test_subaward_endpoint.py
@@ -1,13 +1,15 @@
 import json
 import pytest
+
 from rest_framework import status
 
-# Core Django imports
-from django_mock_queries.query import MockModel
-
-# Imports from your apps
-from usaspending_api.common.helpers.unit_test_helper import add_to_mock_objects
-from usaspending_api.awards.tests.unit.test_subawards import subaward_1, subaward_2, subaward_3, subaward_12
+from usaspending_api.awards.tests.unit.test_subawards import (
+    create_subaward_test_data,
+    subaward_1,
+    subaward_2,
+    subaward_3,
+    subaward_12,
+)
 
 
 @pytest.mark.django_db
@@ -31,12 +33,8 @@ def test_subaward_failure(client):
 
 
 @pytest.mark.django_db
-def test_subaward_query_1(client, mock_matviews_qs):
-    mock_model_1 = MockModel(**subaward_1)
-    mock_model_2 = MockModel(**subaward_2)
-    mock_model_3 = MockModel(**subaward_3)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3])
+def test_subaward_query_1(client):
+    create_subaward_test_data(subaward_1, subaward_2, subaward_3)
     resp = client.post(
         "/api/v2/subawards/",
         content_type="application/json",
@@ -46,10 +44,8 @@ def test_subaward_query_1(client, mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_subaward_query_2(client, mock_matviews_qs):
-    mock_model_4 = MockModel(**subaward_12)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_4])
+def test_subaward_query_2(client):
+    create_subaward_test_data(subaward_12)
     resp = client.post(
         "/api/v2/subawards/",
         content_type="application/json",
@@ -59,10 +55,8 @@ def test_subaward_query_2(client, mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_subaward_query_3(client, mock_matviews_qs):
-    mock_model_4 = MockModel(**subaward_12)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_4])
+def test_subaward_query_3(client):
+    create_subaward_test_data(subaward_12)
     resp = client.post(
         "/api/v2/subawards/",
         content_type="application/json",

--- a/usaspending_api/awards/tests/test_awards_accounts_v2.py
+++ b/usaspending_api/awards/tests/test_awards_accounts_v2.py
@@ -39,7 +39,7 @@ class AwardAccountsTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None})
+        self._test_post({"award_id": "BOGUS_ID"})
 
     def test_sort_columns(self):
 

--- a/usaspending_api/awards/tests/test_awards_funding_rollup_v2.py
+++ b/usaspending_api/awards/tests/test_awards_funding_rollup_v2.py
@@ -67,4 +67,4 @@ class AwardFundingRollupTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None}, (0,))
+        self._test_post({"award_id": "BOGUS_ID"}, (0,))

--- a/usaspending_api/awards/tests/test_funding_v2.py
+++ b/usaspending_api/awards/tests/test_funding_v2.py
@@ -39,7 +39,7 @@ class AwardFundingTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None})
+        self._test_post({"award_id": "BOGUS_ID"})
 
     def test_sort_columns(self):
 

--- a/usaspending_api/awards/tests/unit/test_subawards.py
+++ b/usaspending_api/awards/tests/unit/test_subawards.py
@@ -1,35 +1,26 @@
-# Stdlib imports
+import datetime
+import pytest
 
-# Core Django imports
+from model_mommy import mommy
 
-# Third-party app imports
-from django_mock_queries.query import MockModel
-
-
-# Imports from your apps
-from usaspending_api.common.helpers.unit_test_helper import add_to_mock_objects
 from usaspending_api.awards.v2.views.subawards import SubawardsViewSet
 
 
+def create_subaward_test_data(*subawards_data_list):
+    mommy.make("awards.Award", id=88, generated_unique_award_id="generated_unique_award_id_for_88")
+    mommy.make("awards.Award", id=99, generated_unique_award_id="generated_unique_award_id_for_99")
+
+    for subaward in subawards_data_list:
+        mommy.make("awards.Subaward", **subaward)
+
+
 def strip_award_id(api_dict):
-    d = {k: v for k, v in api_dict.items() if k not in ("award_id", "generated_unique_award_id")}
-    return remap_subaward_id(d)
+    return {k: v for k, v in api_dict.items() if k not in ("award_id", "unique_award_key")}
 
 
-def remap_subaward_id(api_dict):
-    if "subaward_id" in api_dict:
-        api_dict["id"] = api_dict.pop("subaward_id")
-    else:
-        api_dict["subaward_id"] = api_dict.pop("id")
-    return api_dict
-
-
-def test_all_subawards(mock_matviews_qs):
-    mock_model_1 = MockModel(**subaward_1)
-    mock_model_2 = MockModel(**subaward_2)
-    mock_model_3 = MockModel(**subaward_3)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3])
+@pytest.mark.django_db
+def test_all_subawards():
+    create_subaward_test_data(subaward_1, subaward_2, subaward_3)
 
     test_payload = {"page": 1, "limit": 10, "order": "asc"}
     svs = SubawardsViewSet()
@@ -63,12 +54,9 @@ def request_with_sort(sort):
     return subawards_logic
 
 
-def test_specific_award(mock_matviews_qs):
-    mock_model_1 = MockModel(**subaward_10)
-    mock_model_2 = MockModel(**subaward_11)
-    mock_model_3 = MockModel(**subaward_12)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3])
+@pytest.mark.django_db
+def test_specific_award():
+    create_subaward_test_data(subaward_10, subaward_11, subaward_12)
 
     test_payload = {"award_id": 99}
 
@@ -82,7 +70,7 @@ def test_specific_award(mock_matviews_qs):
 
 
 subaward_1 = {
-    "subaward_id": 2,
+    "id": 2,
     "subaward_number": "000",
     "description": "Brunch chips craft direct fixie food gluten-free hoodie jean shorts keffiyeh lomo mumblecore"
     " readymade squid street stumptown thundercats viral wes you probably haven't heard of them. +1 bicycle biodiesel"
@@ -91,15 +79,15 @@ subaward_1 = {
     " chips cosby echo etsy forage future helvetica kale occupy salvia sartorial semiotics skateboard squid"
     " williamsburg yr. 8-bit banh beer before they sold out craft ethnic fingerstache fixie irony jean shorts"
     " life organic park photo booth retro salvia tattooed trade vhs williamsburg.",
-    "action_date": "2017-09-29",
-    "amount": "100",
+    "action_date": datetime.date(2017, 9, 29),
+    "amount": 100.0,
     "recipient_name": "ACME",
     "award_id": 99,
-    "generated_unique_award_id": "generated_unique_award_id_for_99",
+    "unique_award_key": "generated_unique_award_id_for_99",
 }
 
 subaward_2 = {
-    "subaward_id": 1,
+    "id": 1,
     "subaward_number": "001",
     "description": "Aesthetic bushwick chillwave chips cosby fanny pack four fund gentrify helvetica hoodie occupy pork"
     " raw salvia sartorial selvage stumptown sustainable tumblr vegan whatever wolf. American artisan authentic"
@@ -108,15 +96,15 @@ subaward_2 = {
     " seitan semiotics squid stumptown sweater trade vegan vhs vice. Aesthetic american beard chambray"
     " dreamcatcher echo gastropub hoodie next level pbr photo booth sartorial scenester terry thundercats"
     " truck trust typewriter you probably haven't heard of them.",
-    "action_date": "2017-09-30",
-    "amount": "200",
-    "recipient_name": "Tools",
+    "action_date": datetime.date(2017, 9, 30),
+    "amount": 200.0,
+    "recipient_name": "TOOLS",
     "award_id": 99,
-    "generated_unique_award_id": "generated_unique_award_id_for_99",
+    "unique_award_key": "generated_unique_award_id_for_99",
 }
 
 subaward_3 = {
-    "subaward_id": 3,
+    "id": 3,
     "subaward_number": "002",
     "description": "Ennui gluten-free keytar mixtape pitchfork selvage tattooed tofu viral yr. Austin banksy biodiesel"
     " carles fingerstache forage gentrify godard jean shorts kale sustainable terry vinyl. American bag"
@@ -127,42 +115,42 @@ subaward_3 = {
     " typewriter whatever williamsburg wolf. American banh before they sold out blog cray direct ethnic"
     " farm-to-table fingerstache food four freegan future gentrify kale life moon pour-over single-origin"
     " coffee small street trade twee umami wolf yr.",
-    "action_date": "2010-04-03",
-    "amount": "5000",
-    "recipient_name": "Inc",
+    "action_date": datetime.date(2010, 4, 3),
+    "amount": 5000.0,
+    "recipient_name": "INC",
     "award_id": 99,
-    "generated_unique_award_id": "generated_unique_award_id_for_99",
+    "unique_award_key": "generated_unique_award_id_for_99",
 }
 
 subaward_10 = {
-    "subaward_id": 10,
+    "id": 10,
     "subaward_number": "1234",
     "description": "Sub Award #10",
-    "action_date": "2010-04-03",
-    "amount": "5000",
-    "recipient_name": "Big",
+    "action_date": datetime.date(2010, 4, 3),
+    "amount": 5000.0,
+    "recipient_name": "BIG",
     "award_id": 99,
-    "generated_unique_award_id": "generated_unique_award_id_for_99",
+    "unique_award_key": "generated_unique_award_id_for_99",
 }
 
 subaward_11 = {
-    "subaward_id": 11,
+    "id": 11,
     "subaward_number": "1235",
     "description": "Sub Award #11",
-    "action_date": "2018-01-01",
-    "amount": "400",
-    "recipient_name": "Corp",
+    "action_date": datetime.date(2018, 1, 1),
+    "amount": 400.0,
+    "recipient_name": "CORP",
     "award_id": 99,
-    "generated_unique_award_id": "generated_unique_award_id_for_99",
+    "unique_award_key": "generated_unique_award_id_for_99",
 }
 
 subaward_12 = {
-    "subaward_id": 12,
+    "id": 12,
     "subaward_number": "1236",
     "description": "subaward_11",
-    "action_date": "2017-03-02",
-    "amount": "444",
-    "recipient_name": "First Tractor",
+    "action_date": datetime.date(2017, 3, 2),
+    "amount": 444.0,
+    "recipient_name": "FIRST TRACTOR",
     "award_id": 88,
-    "generated_unique_award_id": "generated_unique_award_id_for_88",
+    "unique_award_key": "generated_unique_award_id_for_88",
 }

--- a/usaspending_api/common/api_request_utils.py
+++ b/usaspending_api/common/api_request_utils.py
@@ -332,9 +332,9 @@ class FilterGenerator:
                 # Check if this field is a foreign key
                 if mf.get_internal_type() in ["ForeignKey", "ManyToManyField", "OneToOneField"]:
                     # Continue traversal
-                    related = getattr(mf, "rel", None)
+                    related = getattr(mf, "remote_field", None)
                     if related:
-                        model_to_check = related.to
+                        model_to_check = related.model
                     else:
                         model_to_check = mf.related_model
                 else:

--- a/usaspending_api/common/tests/unit/test_helpers.py
+++ b/usaspending_api/common/tests/unit/test_helpers.py
@@ -1,31 +1,22 @@
-# Stdlib imports
+import pytest
 from datetime import datetime
 
-# Core Django imports
+from model_mommy import mommy
 
-# Third-party app imports
-from django_mock_queries.query import MockModel
-from django_mock_queries.query import MockSet
-import pytest
-
-# Imports from your apps
 from usaspending_api.common.helpers.generic_helper import check_valid_toptier_agency
 from usaspending_api.common.helpers.generic_helper import generate_fiscal_period
 from usaspending_api.common.helpers.generic_helper import generate_fiscal_year
 
 
-# example of a mocked unit test
-def test_check_valid_toptier_agency_valid(monkeypatch):
-    agencies = MockSet()
-    monkeypatch.setattr("usaspending_api.references.models.Agency.objects", agencies)
-    agencies.add(MockModel(mock_name="toptier agency", id=12345, toptier_flag=True))
+@pytest.mark.django_db
+def test_check_valid_toptier_agency_valid():
+    mommy.make("references.Agency", id=12345, toptier_flag=True)
     assert check_valid_toptier_agency(12345)
 
 
-def test_check_valid_toptier_agency_invalid(monkeypatch):
-    agencies = MockSet()
-    monkeypatch.setattr("usaspending_api.references.models.Agency.objects", agencies)
-    agencies.add(MockModel(mock_name="subtier agency", id=54321, toptier_flag=False))
+@pytest.mark.django_db
+def test_check_valid_toptier_agency_invalid():
+    mommy.make("references.Agency", id=54321, toptier_flag=False)
     assert not check_valid_toptier_agency(54321)
 
 

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -7,7 +7,6 @@ import tempfile
 from django.conf import settings
 from django.db import connections
 from django.test import override_settings
-from django_mock_queries.query import MockSet
 from pathlib import Path
 
 from usaspending_api.common.elasticsearch.elasticsearch_sql_helpers import ensure_view_exists
@@ -17,7 +16,6 @@ from usaspending_api.common.sqs.sqs_handler import (
     _FakeUnitTestFileBackedSQSQueue,
 )
 from usaspending_api.common.helpers.generic_helper import generate_matviews
-from usaspending_api.common.matview_manager import MATERIALIZED_VIEWS
 from usaspending_api.conftest_helpers import (
     TestElasticSearchIndex,
     ensure_broker_server_dblink_exists,
@@ -26,148 +24,6 @@ from usaspending_api.conftest_helpers import (
 
 
 logger = logging.getLogger("console")
-
-
-@pytest.fixture()
-def mock_psc(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_psc_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.references.models.PSC.objects", mock_psc_qs)
-
-    yield mock_psc_qs
-
-    mock_psc_qs.delete()
-
-
-@pytest.fixture()
-def mock_cfda(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_cfda_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.references.models.Cfda.objects", mock_cfda_qs)
-
-    yield mock_cfda_qs
-
-    mock_cfda_qs.delete()
-
-
-@pytest.fixture()
-def mock_naics(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_naics_qs = MockSet()
-    monkeypatch.setattr("usaspending_api.references.models.NAICS.objects", mock_naics_qs)
-    yield mock_naics_qs
-    mock_naics_qs.delete()
-
-
-@pytest.fixture()
-def mock_federal_account(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_federal_accounts_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.accounts.models.FederalAccount.objects", mock_federal_accounts_qs)
-
-    yield mock_federal_accounts_qs
-
-    mock_federal_accounts_qs.delete()
-
-
-@pytest.fixture()
-def mock_tas(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_tas_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.accounts.models.TreasuryAppropriationAccount.objects", mock_tas_qs)
-
-    yield mock_tas_qs
-
-    mock_tas_qs.delete()
-
-
-@pytest.fixture()
-def mock_award(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_award_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.awards.models.Award.objects", mock_award_qs)
-
-    yield mock_award_qs
-
-    mock_award_qs.delete()
-
-
-@pytest.fixture()
-def mock_subaward(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_subaward_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.awards.models.Subaward.objects", mock_subaward_qs)
-
-    yield mock_subaward_qs
-
-    mock_subaward_qs.delete()
-
-
-@pytest.fixture()
-def mock_financial_account(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_financial_accounts_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.awards.models.FinancialAccountsByAwards.objects", mock_financial_accounts_qs)
-
-    yield mock_financial_accounts_qs
-
-    mock_financial_accounts_qs.delete()
-
-
-@pytest.fixture()
-def mock_transaction(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_transaciton_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.awards.models.TransactionNormalized.objects", mock_transaciton_qs)
-
-    yield mock_transaciton_qs
-
-    mock_transaciton_qs.delete()
-
-
-@pytest.fixture()
-def mock_agencies(monkeypatch):
-    """Mocks all agency querysets into a single mock"""
-    mock_agency_qs = MockSet()
-    mock_toptier_agency_qs = MockSet()
-    mock_subtier_agency_qs = MockSet()
-
-    monkeypatch.setattr("usaspending_api.references.models.Agency.objects", mock_agency_qs)
-    monkeypatch.setattr("usaspending_api.references.models.ToptierAgency.objects", mock_toptier_agency_qs)
-    monkeypatch.setattr("usaspending_api.references.models.SubtierAgency.objects", mock_subtier_agency_qs)
-
-    mocked_agencies = {
-        "agency": mock_agency_qs,
-        "toptier_agency": mock_toptier_agency_qs,
-        "subtier_agency": mock_subtier_agency_qs,
-    }
-
-    yield mocked_agencies
-
-    mock_agency_qs.delete()
-    mock_toptier_agency_qs.delete()
-    mock_subtier_agency_qs.delete()
-
-
-@pytest.fixture()
-def mock_matviews_qs(monkeypatch):
-    """Mocks all matvies to a single mock queryset"""
-    mock_qs = MockSet()  # mock queryset
-    for k, v in MATERIALIZED_VIEWS.items():
-        if k not in ["tas_autocomplete_matview"]:
-            monkeypatch.setattr("usaspending_api.search.models.{}.objects".format(v["model"].__name__), mock_qs)
-
-    yield mock_qs
-
-    mock_qs.delete()
 
 
 def pytest_configure():

--- a/usaspending_api/idvs/tests/test_awards_idvs_accounts_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_accounts_v2.py
@@ -39,7 +39,7 @@ class IDVAccountsTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None})
+        self._test_post({"award_id": "BOGUS_ID"})
 
     def test_sort_columns(self):
 

--- a/usaspending_api/idvs/tests/test_awards_idvs_activity_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_activity_v2.py
@@ -93,7 +93,7 @@ class IDVAwardsTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None}, (0, 10, 1))
+        self._test_post({"award_id": "BOGUS_ID"}, (0, 10, 1))
 
     def test_limit_values(self):
 

--- a/usaspending_api/idvs/tests/test_awards_idvs_awards_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_awards_v2.py
@@ -89,7 +89,7 @@ class IDVAwardsTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None}, (None, None, 1, False, False))
+        self._test_post({"award_id": "BOGUS_ID"}, (None, None, 1, False, False))
 
     def test_type(self):
 

--- a/usaspending_api/idvs/tests/test_awards_idvs_funding_rollup_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_funding_rollup_v2.py
@@ -70,7 +70,7 @@ class IDVFundingRollupTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None}, (0,))
+        self._test_post({"award_id": "BOGUS_ID"}, (0,))
 
     def test_null_agencies_accounts(self):
         """

--- a/usaspending_api/idvs/tests/test_awards_idvs_funding_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_funding_v2.py
@@ -95,7 +95,7 @@ class IDVFundingTestCase(TestCase):
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": None}, (None, None, 1, False, False))
+        self._test_post({"award_id": "BOGUS_ID"}, (None, None, 1, False, False))
 
     def test_piid_filter(self):
 

--- a/usaspending_api/search/models/base_award_search.py
+++ b/usaspending_api/search/models/base_award_search.py
@@ -19,7 +19,7 @@ class BaseAwardSearchModel(models.Model):
     award_ts_vector = SearchVectorField()
     recipient_name_ts_vector = SearchVectorField()
     treasury_account_identifiers = ArrayField(models.IntegerField(), default=None)
-    award = models.OneToOneField(Award, primary_key=True)
+    award = models.OneToOneField(Award, on_delete=models.DO_NOTHING, primary_key=True)
     category = models.TextField()
     type = models.TextField()
     type_description = models.TextField()

--- a/usaspending_api/search/models/subaward_view.py
+++ b/usaspending_api/search/models/subaward_view.py
@@ -23,7 +23,7 @@ class SubawardView(models.Model):
     award_report_fy_month = models.IntegerField()
     award_report_fy_year = models.IntegerField()
 
-    award = models.OneToOneField(Award, null=True)
+    award = models.OneToOneField(Award, on_delete=models.DO_NOTHING, null=True)
     generated_unique_award_id = models.TextField()
     awarding_agency_id = models.IntegerField()
     funding_agency_id = models.IntegerField()

--- a/usaspending_api/search/models/universal_transaction_matview.py
+++ b/usaspending_api/search/models/universal_transaction_matview.py
@@ -10,7 +10,7 @@ class UniversalTransactionView(models.Model):
     award_ts_vector = SearchVectorField()
     recipient_name_ts_vector = SearchVectorField()
     treasury_account_identifiers = ArrayField(models.IntegerField(), default=None)
-    transaction = models.OneToOneField(TransactionNormalized, primary_key=True)
+    transaction = models.OneToOneField(TransactionNormalized, on_delete=models.DO_NOTHING, primary_key=True)
     action_date = models.DateField(blank=True, null=False)
     last_modified_date = models.DateField(blank=True, null=False)
     fiscal_year = models.IntegerField()

--- a/usaspending_api/search/tests/unit/test_new_awards_over_time.py
+++ b/usaspending_api/search/tests/unit/test_new_awards_over_time.py
@@ -1,18 +1,12 @@
-# Stdlib imports
-from datetime import datetime
 import json
 import pytest
 
-# Core Django imports
+from datetime import datetime
+from model_mommy import mommy
 
-# Third-party app imports
-from django_mock_queries.query import MockModel, MockSet
-
-# Imports from your apps
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.exceptions import UnprocessableEntityException
 from usaspending_api.common.helpers.generic_helper import get_time_period_message
-from usaspending_api.common.helpers.unit_test_helper import add_to_mock_objects
 from usaspending_api.search.v2.views.new_awards_over_time import NewAwardsOverTimeVisualizationViewSet
 
 
@@ -41,70 +35,65 @@ def catch_filter_errors(viewset, filters, expected_exception):
 
 
 @pytest.fixture
-def add_award_recipients(monkeypatch):
-    mock_awards_recipients = MockSet()
-    monkeypatch.setattr("usaspending_api.recipient.models.SummaryAwardRecipient.objects", mock_awards_recipients)
-    mock_model_list = []
+def add_award_recipients(db):
     current_id = 1
     new_award_count = 12
     for i in range(current_id, current_id + new_award_count):
-        mock_model_list.append(
-            MockModel(
-                award_id=i,
-                recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
-                parent_recipient_unique_id=None,
-                action_date=datetime(2009, 5, 30),
-            )
+        mommy.make("awards.Award", id=i)
+        mommy.make(
+            "recipient.SummaryAwardRecipient",
+            award_id=i,
+            action_date=datetime(2009, 5, 30),
+            recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
+            parent_recipient_unique_id=None,
         )
     current_id += new_award_count
     new_award_count = 3
     for i in range(current_id, current_id + new_award_count):
-        mock_model_list.append(
-            MockModel(
-                award_id=i,
-                recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
-                parent_recipient_unique_id=None,
-                action_date=datetime(2009, 5, 1),
-            )
+        mommy.make("awards.Award", id=i)
+        mommy.make(
+            "recipient.SummaryAwardRecipient",
+            award_id=i,
+            action_date=datetime(2009, 5, 1),
+            recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
+            parent_recipient_unique_id=None,
         )
     current_id += new_award_count
     new_award_count = 1
     for i in range(current_id, current_id + new_award_count):
-        mock_model_list.append(
-            MockModel(
-                award_id=i,
-                recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
-                parent_recipient_unique_id=None,
-                action_date=datetime(2009, 7, 2),
-            )
+        mommy.make("awards.Award", id=i)
+        mommy.make(
+            "recipient.SummaryAwardRecipient",
+            award_id=i,
+            action_date=datetime(2009, 7, 2),
+            recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
+            parent_recipient_unique_id=None,
         )
     current_id += new_award_count
     new_award_count = 2
     for i in range(current_id, current_id + new_award_count):
-        mock_model_list.append(
-            MockModel(
-                award_id=i,
-                recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
-                parent_recipient_unique_id=None,
-                action_date=datetime(2008, 1, 10),
-            )
+        mommy.make("awards.Award", id=i)
+        mommy.make(
+            "recipient.SummaryAwardRecipient",
+            award_id=i,
+            action_date=datetime(2008, 1, 10),
+            recipient_hash="21a1b0df-e7cd-349b-b948-60ed0ac1e6a0",
+            parent_recipient_unique_id=None,
         )
     current_id += new_award_count
     new_award_count = 6
     for i in range(current_id, current_id + new_award_count):
-        mock_model_list.append(
-            MockModel(
-                award_id=i,
-                recipient_hash="4e418651-4b83-8722-ab4e-e68d80bfb3b3",
-                parent_recipient_unique_id=None,
-                action_date=datetime(2009, 7, 30),
-            )
+        mommy.make("awards.Award", id=i)
+        mommy.make(
+            "recipient.SummaryAwardRecipient",
+            award_id=i,
+            action_date=datetime(2009, 7, 30),
+            recipient_hash="4e418651-4b83-8722-ab4e-e68d80bfb3b3",
+            parent_recipient_unique_id=None,
         )
-    add_to_mock_objects(mock_awards_recipients, mock_model_list)
 
 
-@pytest.mark.django_db
-def test_new_awards_month(add_award_recipients, client):
+def test_new_awards_month(client, add_award_recipients):
     test_payload = {
         "group": "month",
         "filters": {
@@ -169,8 +158,7 @@ def test_new_awards_month(add_award_recipients, client):
     assert expected_response == resp.data
 
 
-@pytest.mark.django_db
-def test_new_awards_quarter(add_award_recipients, client):
+def test_new_awards_quarter(client, add_award_recipients):
     test_payload = {
         "group": "quarter",
         "filters": {
@@ -236,8 +224,7 @@ def test_new_awards_quarter(add_award_recipients, client):
     assert expected_response == resp.data
 
 
-@pytest.mark.django_db
-def test_new_awards_fiscal_year(add_award_recipients, client):
+def test_new_awards_fiscal_year(client, add_award_recipients):
     test_payload = {
         "group": "fiscal_year",
         "filters": {
@@ -276,8 +263,7 @@ def test_new_awards_fiscal_year(add_award_recipients, client):
     assert expected_response == resp.data
 
 
-@pytest.mark.django_db
-def test_new_awards_failures(add_award_recipients, client):
+def test_new_awards_failures(client, add_award_recipients):
     test_payload = {
         "group": "quarter",
         "filters": {
@@ -293,7 +279,6 @@ def test_new_awards_failures(add_award_recipients, client):
     assert resp.status_code == 400  # might reject text as non UUID in future?
 
 
-@pytest.mark.django_db
 def test_new_awards_filter_errors():
     new_awards_viewset = NewAwardsOverTimeVisualizationViewSet()
     filters = {"group": "baseball"}

--- a/usaspending_api/search/tests/unit/test_spending_by_category.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_category.py
@@ -1,354 +1,292 @@
 import pytest
 
-from decimal import Decimal
-from django_mock_queries.query import MockModel, MockSet
 from model_mommy import mommy
 
 from usaspending_api.common.helpers.generic_helper import get_time_period_message
-from usaspending_api.common.helpers.unit_test_helper import add_to_mock_objects
 from usaspending_api.search.v2.views.spending_by_category import BusinessLogic
 
 
-def test_category_awarding_agency_awards(mock_matviews_qs, mock_agencies):
-    mock_toptier = MockModel(toptier_agency_id=1, name="Department of Pizza", abbreviation="DOP")
-    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
-    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
-    mock_model_1 = MockModel(
-        awarding_agency_id=2,
-        awarding_toptier_agency_name="Department of Pizza",
-        awarding_toptier_agency_abbreviation="DOP",
-        generated_pragmatic_obligation=5,
+@pytest.fixture
+def psc_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+    mommy.make("awards.Award", id=3, latest_transaction_id=3)
+    mommy.make("awards.Award", id=4, latest_transaction_id=4)
+
+    mommy.make("awards.TransactionNormalized", id=1, award_id=1, federal_action_obligation=1, action_date="2020-01-01")
+    mommy.make("awards.TransactionNormalized", id=2, award_id=2, federal_action_obligation=1, action_date="2020-01-02")
+    mommy.make("awards.TransactionNormalized", id=3, award_id=3, federal_action_obligation=2, action_date="2020-01-03")
+    mommy.make("awards.TransactionNormalized", id=4, award_id=4, federal_action_obligation=2, action_date="2020-01-04")
+
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=1,
+        product_or_service_code="1234",
+        product_or_service_co_desc="PSC DESCRIPTION UP",
     )
-    mock_model_2 = MockModel(
-        awarding_agency_id=3,
-        awarding_toptier_agency_name="Department of Pizza",
-        awarding_toptier_agency_abbreviation="DOP",
-        generated_pragmatic_obligation=10,
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=2,
+        product_or_service_code="1234",
+        product_or_service_co_desc="PSC DESCRIPTION UP",
     )
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
-    add_to_mock_objects(mock_agencies["toptier_agency"], [mock_toptier])
-
-    test_payload = {"category": "awarding_agency", "subawards": False, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "awarding_agency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 15, "name": "Department of Pizza", "code": "DOP", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_awarding_agency_subawards(mock_matviews_qs, mock_agencies):
-    mock_toptier = MockModel(toptier_agency_id=1, name="Department of Pizza", abbreviation="DOP")
-    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
-    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
-    mock_model_1 = MockModel(
-        awarding_agency_id=2,
-        awarding_toptier_agency_name="Department of Pizza",
-        awarding_toptier_agency_abbreviation="DOP",
-        amount=5,
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=3,
+        product_or_service_code="9876",
+        product_or_service_co_desc="PSC DESCRIPTION DOWN",
     )
-    mock_model_2 = MockModel(
-        awarding_agency_id=3,
-        awarding_toptier_agency_name="Department of Pizza",
-        awarding_toptier_agency_abbreviation="DOP",
-        amount=10,
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=4,
+        product_or_service_code="9876",
+        product_or_service_co_desc="PSC DESCRIPTION DOWN",
     )
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
-
-    test_payload = {"category": "awarding_agency", "subawards": True, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "awarding_agency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 15, "name": "Department of Pizza", "code": "DOP", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
+    mommy.make("references.PSC", code="1234", description="PSC DESCRIPTION UP")
+    mommy.make("references.PSC", code="9876", description="PSC DESCRIPTION DOWN")
 
 
-def test_category_awarding_subagency_awards(mock_matviews_qs, mock_agencies):
-    mock_subtier = MockModel(subtier_agency_id=1, name="Department of Sub-pizza", abbreviation="DOSP")
-    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
-    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
-    mock_model_1 = MockModel(
-        awarding_agency_id=2,
-        awarding_subtier_agency_name="Department of Sub-pizza",
-        awarding_subtier_agency_abbreviation="DOSP",
-        generated_pragmatic_obligation=10,
+@pytest.fixture
+def cfda_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+
+    mommy.make(
+        "awards.Subaward", id=1, award_id=1, amount=1, cfda_id=1, cfda_number="CFDA1234", cfda_title="CFDA TITLE 1234"
     )
-    mock_model_2 = MockModel(
-        awarding_agency_id=3,
-        awarding_subtier_agency_name="Department of Sub-pizza",
-        awarding_subtier_agency_abbreviation="DOSP",
-        generated_pragmatic_obligation=10,
+    mommy.make(
+        "awards.Subaward", id=2, award_id=2, amount=1, cfda_id=1, cfda_number="CFDA1234", cfda_title="CFDA TITLE 1234"
     )
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
+    mommy.make("awards.TransactionNormalized", id=1, award_id=1, federal_action_obligation=1, action_date="2020-01-01")
+    mommy.make("awards.TransactionNormalized", id=2, award_id=2, federal_action_obligation=1, action_date="2020-01-02")
 
-    test_payload = {"category": "awarding_subagency", "subawards": False, "page": 1, "limit": 50}
+    mommy.make("awards.TransactionFABS", transaction_id=1, cfda_number="CFDA1234", cfda_title="CFDA TITLE 1234")
+    mommy.make("awards.TransactionFABS", transaction_id=2, cfda_number="CFDA1234", cfda_title="CFDA TITLE 1234")
 
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "awarding_subagency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 20, "name": "Department of Sub-pizza", "code": "DOSP", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
+    mommy.make("references.Cfda", id=1, program_number="CFDA1234", program_title="CFDA TITLE 1234")
 
 
-def test_category_awarding_subagency_subawards(mock_matviews_qs, mock_agencies):
-    mock_subtier = MockModel(subtier_agency_id=1, name="Department of Sub-pizza", abbreviation="DOSP")
-    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
-    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
-    mock_model_1 = MockModel(
-        awarding_agency_id=2,
-        awarding_subtier_agency_name="Department of Sub-pizza",
-        awarding_subtier_agency_abbreviation="DOSP",
-        amount=10,
-    )
-    mock_model_2 = MockModel(
-        awarding_agency_id=3,
-        awarding_subtier_agency_name="Department of Sub-pizza",
-        awarding_subtier_agency_abbreviation="DOSP",
-        amount=10,
-    )
+@pytest.fixture
+def naics_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+    mommy.make("awards.Award", id=3, latest_transaction_id=3)
+    mommy.make("awards.Award", id=4, latest_transaction_id=4)
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
+    mommy.make("awards.TransactionNormalized", id=1, award_id=1, federal_action_obligation=1, action_date="2020-01-01")
+    mommy.make("awards.TransactionNormalized", id=2, award_id=2, federal_action_obligation=1, action_date="2020-01-02")
+    mommy.make("awards.TransactionNormalized", id=3, award_id=3, federal_action_obligation=2, action_date="2020-01-03")
+    mommy.make("awards.TransactionNormalized", id=4, award_id=4, federal_action_obligation=2, action_date="2020-01-04")
 
-    test_payload = {"category": "awarding_subagency", "subawards": True, "page": 1, "limit": 50}
+    mommy.make("awards.TransactionFPDS", transaction_id=1, naics="NAICS 1234", naics_description="NAICS DESC 1234")
+    mommy.make("awards.TransactionFPDS", transaction_id=2, naics="NAICS 1234", naics_description="NAICS DESC 1234")
+    mommy.make("awards.TransactionFPDS", transaction_id=3, naics="NAICS 9876", naics_description="NAICS DESC 9876")
+    mommy.make("awards.TransactionFPDS", transaction_id=4, naics="NAICS 9876", naics_description="NAICS DESC 9876")
 
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "awarding_subagency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 20, "name": "Department of Sub-pizza", "code": "DOSP", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
+    mommy.make("references.NAICS", code="NAICS 1234", description="SOURCE NAICS DESC 1234", year=1955)
+    mommy.make("references.NAICS", code="NAICS 9876", description="SOURCE NAICS DESC 9876", year=1985)
 
 
-def test_category_funding_agency_awards(mock_matviews_qs, mock_agencies):
-    mock_toptier = MockModel(toptier_agency_id=1, name="Department of Calzone", abbreviation="DOC")
-    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
-    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
-    mock_model_1 = MockModel(
-        funding_agency_id=2,
-        funding_toptier_agency_name="Department of Calzone",
-        funding_toptier_agency_abbreviation="DOC",
-        generated_pragmatic_obligation=50,
-    )
-    mock_model_2 = MockModel(
-        funding_agency_id=3,
-        funding_toptier_agency_name="Department of Calzone",
-        funding_toptier_agency_abbreviation="DOC",
-        generated_pragmatic_obligation=50,
-    )
+@pytest.fixture
+def agency_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
-
-    test_payload = {"category": "funding_agency", "subawards": False, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "funding_agency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 100, "name": "Department of Calzone", "code": "DOC", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_funding_agency_subawards(mock_matviews_qs, mock_agencies):
-    mock_toptier = MockModel(toptier_agency_id=1, name="Department of Calzone", abbreviation="DOC")
-    mock_agency = MockModel(id=2, toptier_agency=mock_toptier, toptier_flag=True)
-    mock_agency_1 = MockModel(id=3, toptier_agency=mock_toptier, toptier_flag=False)
-    mock_model_1 = MockModel(
-        funding_agency_id=2,
-        funding_toptier_agency_name="Department of Calzone",
-        funding_toptier_agency_abbreviation="DOC",
+    mommy.make(
+        "awards.Subaward",
+        id=1,
+        latest_transaction_id=1,
         amount=50,
+        awarding_agency_id=1003,
+        funding_agency_id=1004,
+        awarding_toptier_agency_name="Awarding Toptier Agency 3",
+        awarding_subtier_agency_name="Awarding Subtier Agency 3",
+        funding_toptier_agency_name="Funding Toptier Agency 4",
+        funding_subtier_agency_name="Funding Subtier Agency 4",
+        awarding_toptier_agency_abbreviation="TA3",
+        awarding_subtier_agency_abbreviation="SA3",
+        funding_toptier_agency_abbreviation="TA4",
+        funding_subtier_agency_abbreviation="SA4",
     )
-    mock_model_2 = MockModel(
-        funding_agency_id=3,
-        funding_toptier_agency_name="Department of Calzone",
-        funding_toptier_agency_abbreviation="DOC",
-        amount=50,
-    )
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
-
-    test_payload = {"category": "funding_agency", "subawards": True, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "funding_agency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 100, "name": "Department of Calzone", "code": "DOC", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_funding_subagency_awards(mock_matviews_qs, mock_agencies):
-    mock_subtier = MockModel(subtier_agency_id=1, name="Department of Sub-calzone", abbreviation="DOSC")
-    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
-    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
-    mock_model_1 = MockModel(
-        funding_agency_id=2,
-        funding_subtier_agency_name="Department of Sub-calzone",
-        funding_subtier_agency_abbreviation="DOSC",
-        generated_pragmatic_obligation=5,
-    )
-    mock_model_2 = MockModel(
-        funding_agency_id=3,
-        funding_subtier_agency_name="Department of Sub-calzone",
-        funding_subtier_agency_abbreviation="DOSC",
-        generated_pragmatic_obligation=-5,
+    mommy.make(
+        "awards.Subaward",
+        id=2,
+        latest_transaction_id=2,
+        amount=100,
+        awarding_agency_id=1003,
+        funding_agency_id=1004,
+        awarding_toptier_agency_name="Awarding Toptier Agency 3",
+        awarding_subtier_agency_name="Awarding Subtier Agency 3",
+        funding_toptier_agency_name="Funding Toptier Agency 4",
+        funding_subtier_agency_name="Funding Subtier Agency 4",
+        awarding_toptier_agency_abbreviation="TA3",
+        awarding_subtier_agency_abbreviation="SA3",
+        funding_toptier_agency_abbreviation="TA4",
+        funding_subtier_agency_abbreviation="SA4",
     )
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
-
-    test_payload = {"category": "funding_subagency", "subawards": False, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "funding_subagency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 0, "name": "Department of Sub-calzone", "code": "DOSC", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_funding_subagency_subawards(mock_matviews_qs, mock_agencies):
-    mock_subtier = MockModel(subtier_agency_id=1, name="Department of Sub-calzone", abbreviation="DOSC")
-    mock_agency = MockModel(id=2, subtier_agency=mock_subtier, toptier_flag=False)
-    mock_agency_1 = MockModel(id=3, subtier_agency=mock_subtier, toptier_flag=True)
-    mock_model_1 = MockModel(
-        funding_agency_id=2,
-        funding_subtier_agency_name="Department of Sub-calzone",
-        funding_subtier_agency_abbreviation="DOSC",
-        amount=5,
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=1,
+        award_id=1,
+        awarding_agency_id=1001,
+        funding_agency_id=1002,
+        federal_action_obligation=5,
+        action_date="2020-01-01",
     )
-    mock_model_2 = MockModel(
-        funding_agency_id=3,
-        funding_subtier_agency_name="Department of Sub-calzone",
-        funding_subtier_agency_abbreviation="DOSC",
-        amount=-5,
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=2,
+        award_id=2,
+        awarding_agency_id=1001,
+        funding_agency_id=1002,
+        federal_action_obligation=10,
+        action_date="2020-01-02",
     )
 
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_agencies["agency"], [mock_agency, mock_agency_1])
+    mommy.make("references.ToptierAgency", toptier_agency_id=2001, name="Awarding Toptier Agency 1", abbreviation="TA1")
+    mommy.make("references.SubtierAgency", subtier_agency_id=3001, name="Awarding Subtier Agency 1", abbreviation="SA1")
+    mommy.make("references.ToptierAgency", toptier_agency_id=2003, name="Awarding Toptier Agency 3", abbreviation="TA3")
+    mommy.make("references.SubtierAgency", subtier_agency_id=3003, name="Awarding Subtier Agency 3", abbreviation="SA3")
 
-    test_payload = {"category": "funding_subagency", "subawards": True, "page": 1, "limit": 50}
+    mommy.make("references.ToptierAgency", toptier_agency_id=2002, name="Funding Toptier Agency 2", abbreviation="TA2")
+    mommy.make("references.SubtierAgency", subtier_agency_id=3002, name="Funding Subtier Agency 2", abbreviation="SA2")
+    mommy.make("references.ToptierAgency", toptier_agency_id=2004, name="Funding Toptier Agency 4", abbreviation="TA4")
+    mommy.make("references.SubtierAgency", subtier_agency_id=3004, name="Funding Subtier Agency 4", abbreviation="SA4")
 
-    spending_by_category_logic = BusinessLogic(test_payload).results()
+    mommy.make("references.Agency", id=1001, toptier_agency_id=2001, subtier_agency_id=3001, toptier_flag=True)
+    mommy.make("references.Agency", id=1002, toptier_agency_id=2002, subtier_agency_id=3002, toptier_flag=True)
 
-    expected_response = {
-        "category": "funding_subagency",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 0, "name": "Department of Sub-calzone", "code": "DOSC", "id": 2}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
+    mommy.make("references.Agency", id=1003, toptier_agency_id=2003, subtier_agency_id=3003, toptier_flag=True)
+    mommy.make("references.Agency", id=1004, toptier_agency_id=2004, subtier_agency_id=3004, toptier_flag=True)
 
 
-@pytest.mark.django_db
-def test_category_recipient_duns_awards(mock_matviews_qs):
-    mock_model_1 = MockModel(recipient_hash="59f9a646-cd1c-cbdc-63dd-1020fac59336", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(recipient_hash="59f9a646-cd1c-cbdc-63dd-1020fac59336", generated_pragmatic_obligation=1)
-    mock_model_3 = MockModel(recipient_hash="3725ba78-a607-7ab4-1cf6-2a08207bac3c", generated_pragmatic_obligation=1)
-    mock_model_4 = MockModel(recipient_hash="3725ba78-a607-7ab4-1cf6-2a08207bac3c", generated_pragmatic_obligation=10)
-    mock_model_5 = MockModel(recipient_hash="18569a71-3b0a-1586-50a9-cbb8bb070136", generated_pragmatic_obligation=15)
+@pytest.fixture
+def recipient_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+    mommy.make("awards.Award", id=3, latest_transaction_id=3)
+    mommy.make("awards.Award", id=4, latest_transaction_id=4)
+    mommy.make("awards.Award", id=5, latest_transaction_id=5)
+
+    mommy.make(
+        "awards.Subaward",
+        id=1,
+        award_id=1,
+        amount=1,
+        recipient_name="University of Pawnee",
+        recipient_unique_id="00UOP00",
+    )
+    mommy.make(
+        "awards.Subaward",
+        id=2,
+        award_id=2,
+        amount=1,
+        recipient_name="University of Pawnee",
+        recipient_unique_id="00UOP00",
+    )
+    mommy.make(
+        "awards.Subaward", id=3, award_id=3, amount=1, recipient_name="John Doe", recipient_unique_id="1234JD4321"
+    )
+    mommy.make(
+        "awards.Subaward", id=4, award_id=4, amount=10, recipient_name="John Doe", recipient_unique_id="1234JD4321"
+    )
+    mommy.make(
+        "awards.Subaward", id=5, award_id=5, amount=15, recipient_name="MULTIPLE RECIPIENTS", recipient_unique_id=None
+    )
+
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=1,
+        award_id=1,
+        federal_action_obligation=1,
+        action_date="2020-01-01",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=2,
+        award_id=2,
+        federal_action_obligation=1,
+        action_date="2020-01-02",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=3,
+        award_id=3,
+        federal_action_obligation=1,
+        action_date="2020-01-03",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=4,
+        award_id=4,
+        federal_action_obligation=10,
+        action_date="2020-01-04",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=5,
+        award_id=5,
+        federal_action_obligation=15,
+        action_date="2020-01-05",
+        is_fpds=True,
+    )
+
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=1,
+        awardee_or_recipient_legal="University of Pawnee",
+        awardee_or_recipient_uniqu="00UOP00",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=2,
+        awardee_or_recipient_legal="University of Pawnee",
+        awardee_or_recipient_uniqu="00UOP00",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=3,
+        awardee_or_recipient_legal="John Doe",
+        awardee_or_recipient_uniqu="1234JD4321",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=4,
+        awardee_or_recipient_legal="John Doe",
+        awardee_or_recipient_uniqu="1234JD4321",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=5,
+        awardee_or_recipient_legal="MULTIPLE RECIPIENTS",
+        awardee_or_recipient_uniqu=None,
+    )
 
     mommy.make(
         "recipient.RecipientLookup",
-        recipient_hash="3725ba78-a607-7ab4-1cf6-2a08207bac3c",
-        legal_business_name="John Doe",
-        duns="1234JD4321",
-    )
-    mommy.make(
-        "recipient.RecipientLookup",
-        recipient_hash="59f9a646-cd1c-cbdc-63dd-1020fac59336",
-        legal_business_name="University of Pawnee",
         duns="00UOP00",
+        legal_business_name="University of Pawnee",
+        recipient_hash="f9006d7e-fa6c-fa1c-6bc5-964fe524a948",
     )
     mommy.make(
         "recipient.RecipientLookup",
-        recipient_hash="18569a71-3b0a-1586-50a9-cbb8bb070136",
-        legal_business_name="MULTIPLE RECIPIENTS",
-        duns=None,
+        duns="1234JD4321",
+        legal_business_name="John Doe",
+        recipient_hash="f9006d7e-fa6c-fa1c-6bc5-964fe524a949",
     )
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4, mock_model_5])
-
-    test_payload = {"category": "recipient_duns", "subawards": False, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "recipient_duns",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [
-            {"amount": 15, "name": "MULTIPLE RECIPIENTS", "code": None, "recipient_id": None},
-            {"amount": 11, "name": "John Doe", "code": "1234JD4321", "recipient_id": None},
-            {"amount": 2, "name": "University of Pawnee", "code": "00UOP00", "recipient_id": None},
-        ],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-@pytest.mark.django_db
-def test_category_recipient_duns_subawards():
-
-    mommy.make("awards.Subaward", id=1, recipient_name="University of Pawnee", recipient_unique_id="00UOP00", amount=1)
-    mommy.make("awards.Subaward", id=2, recipient_name="University of Pawnee", recipient_unique_id="00UOP00", amount=1)
-    mommy.make("awards.Subaward", id=3, recipient_name="John Doe", recipient_unique_id="1234JD4321", amount=1)
-    mommy.make("awards.Subaward", id=4, recipient_name="John Doe", recipient_unique_id="1234JD4321", amount=10)
-    mommy.make("awards.Subaward", id=5, recipient_name="MULTIPLE RECIPIENTS", recipient_unique_id=None, amount=15)
-
-    mommy.make("recipient.RecipientLookup", duns="00UOP00", recipient_hash="f9006d7e-fa6c-fa1c-6bc5-964fe524a948")
-    mommy.make("recipient.RecipientLookup", duns="1234JD4321", recipient_hash="f9006d7e-fa6c-fa1c-6bc5-964fe524a949")
-    mommy.make("recipient.RecipientLookup", duns=None, recipient_hash="f9006d7e-fa6c-fa1c-6bc5-964fe524a940")
+    mommy.make(
+        "recipient.RecipientLookup",
+        duns=None,
+        legal_business_name="MULTIPLE RECIPIENTS",
+        recipient_hash="6dffe44a-554c-26b4-b7ef-44db50083732",
+    )
 
     mommy.make(
         "recipient.RecipientProfile",
@@ -368,10 +306,380 @@ def test_category_recipient_duns_subawards():
         "recipient.RecipientProfile",
         recipient_unique_id=None,
         recipient_level="R",
-        recipient_hash="f9006d7e-fa6c-fa1c-6bc5-964fe524a940",
+        recipient_hash="6dffe44a-554c-26b4-b7ef-44db50083732",
         recipient_name="MULTIPLE RECIPIENTS",
     )
 
+
+@pytest.fixture
+def geo_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+    mommy.make("awards.Award", id=3, latest_transaction_id=3)
+    mommy.make("awards.Award", id=4, latest_transaction_id=4)
+
+    mommy.make(
+        "awards.Subaward",
+        id=1,
+        award_id=1,
+        amount=1,
+        pop_country_name=None,
+        pop_country_code="US",
+        pop_state_code="XY",
+        pop_county_code="04",
+        pop_county_name="COUNTYSVILLE",
+        pop_zip4="12345",
+        pop_congressional_code="06",
+    )
+    mommy.make(
+        "awards.Subaward",
+        id=2,
+        award_id=2,
+        amount=1,
+        pop_country_name=None,
+        pop_country_code="US",
+        pop_state_code="XY",
+        pop_county_code="04",
+        pop_county_name="COUNTYSVILLE",
+        pop_zip4="12345",
+        pop_congressional_code="06",
+    )
+    mommy.make(
+        "awards.Subaward",
+        id=3,
+        award_id=3,
+        amount=1,
+        pop_country_name=None,
+        pop_country_code="US",
+        pop_state_code="XY",
+        pop_county_code="01",
+        pop_county_name="SOMEWHEREVILLE",
+        pop_zip4="98765",
+        pop_congressional_code="90",
+    )
+    mommy.make(
+        "awards.Subaward",
+        id=4,
+        award_id=4,
+        amount=1,
+        pop_country_name=None,
+        pop_country_code="US",
+        pop_state_code="XY",
+        pop_county_code="01",
+        pop_county_name="SOMEWHEREVILLE",
+        pop_zip4="98765",
+        pop_congressional_code="90",
+    )
+
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=1,
+        award_id=1,
+        federal_action_obligation=1,
+        action_date="2020-01-01",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=2,
+        award_id=2,
+        federal_action_obligation=1,
+        action_date="2020-01-02",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=3,
+        award_id=3,
+        federal_action_obligation=1,
+        action_date="2020-01-03",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=4,
+        award_id=4,
+        federal_action_obligation=1,
+        action_date="2020-01-04",
+        is_fpds=True,
+    )
+
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=1,
+        place_of_perform_country_n=None,
+        place_of_perform_country_c="US",
+        place_of_performance_state="XY",
+        place_of_perform_county_co="04",
+        place_of_perform_county_na="COUNTYSVILLE",
+        place_of_performance_zip5="12345",
+        place_of_performance_congr="06",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=2,
+        place_of_perform_country_n=None,
+        place_of_perform_country_c="US",
+        place_of_performance_state="XY",
+        place_of_perform_county_co="04",
+        place_of_perform_county_na="COUNTYSVILLE",
+        place_of_performance_zip5="12345",
+        place_of_performance_congr="06",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=3,
+        place_of_perform_country_n=None,
+        place_of_perform_country_c="US",
+        place_of_performance_state="XY",
+        place_of_perform_county_co="01",
+        place_of_perform_county_na="SOMEWHEREVILLE",
+        place_of_performance_zip5="98765",
+        place_of_performance_congr="90",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=4,
+        place_of_perform_country_n=None,
+        place_of_perform_country_c="US",
+        place_of_performance_state="XY",
+        place_of_perform_county_co="01",
+        place_of_perform_county_na="SOMEWHEREVILLE",
+        place_of_performance_zip5="98765",
+        place_of_performance_congr="90",
+    )
+
+    mommy.make("recipient.StateData", name="Test State", code="XY")
+    mommy.make("references.RefCountryCode", country_name="UNITED STATES", country_code="US")
+
+
+@pytest.fixture
+def federal_accounts_test_data(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=1,
+        award_id=1,
+        federal_action_obligation=1,
+        action_date="2020-01-01",
+        is_fpds=True,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=2,
+        award_id=2,
+        federal_action_obligation=2,
+        action_date="2020-01-02",
+        is_fpds=True,
+    )
+
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=1,
+        awardee_or_recipient_legal="Sample Recipient",
+        awardee_or_recipient_uniqu="000000000",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=2,
+        awardee_or_recipient_legal="Sample Recipient",
+        awardee_or_recipient_uniqu="000000000",
+    )
+
+    mommy.make(
+        "recipient.RecipientLookup",
+        duns="000000000",
+        legal_business_name="Sample Recipient",
+        recipient_hash="dece8b43-c2a8-d056-7e82-0fc2f1c7c4e4",
+    )
+
+    mommy.make(
+        "recipient.RecipientProfile",
+        recipient_unique_id="000000000",
+        recipient_level="R",
+        recipient_hash="dece8b43-c2a8-d056-7e82-0fc2f1c7c4e4",
+        recipient_name="Sample Recipient",
+    )
+
+    mommy.make("awards.FinancialAccountsByAwards", financial_accounts_by_awards_id=1, award_id=1, treasury_account_id=1)
+    mommy.make("awards.FinancialAccountsByAwards", financial_accounts_by_awards_id=2, award_id=2, treasury_account_id=1)
+
+    mommy.make(
+        "accounts.TreasuryAppropriationAccount", treasury_account_identifier=1, federal_account_id=10,
+    )
+
+    mommy.make(
+        "accounts.FederalAccount",
+        id=10,
+        agency_identifier="020",
+        main_account_code="0001",
+        account_title="Test Federal Account",
+    )
+
+
+def test_category_awarding_agency_awards(agency_test_data):
+    test_payload = {"category": "awarding_agency", "subawards": False, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "awarding_agency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 15, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_awarding_agency_subawards(agency_test_data):
+    test_payload = {"category": "awarding_agency", "subawards": True, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "awarding_agency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 150, "name": "Awarding Toptier Agency 3", "code": "TA3", "id": 1003}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_awarding_subagency_awards(agency_test_data):
+    test_payload = {"category": "awarding_subagency", "subawards": False, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "awarding_subagency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 15, "name": "Awarding Subtier Agency 1", "code": "SA1", "id": 1001}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_awarding_subagency_subawards(agency_test_data):
+    test_payload = {"category": "awarding_subagency", "subawards": True, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "awarding_subagency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 150, "name": "Awarding Subtier Agency 3", "code": "SA3", "id": 1003}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_funding_agency_awards(agency_test_data):
+    test_payload = {"category": "funding_agency", "subawards": False, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "funding_agency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 15, "name": "Funding Toptier Agency 2", "code": "TA2", "id": 1002}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_funding_agency_subawards(agency_test_data):
+    test_payload = {"category": "funding_agency", "subawards": True, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "funding_agency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 150, "name": "Funding Toptier Agency 4", "code": "TA4", "id": 1004}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_funding_subagency_awards(agency_test_data):
+    test_payload = {"category": "funding_subagency", "subawards": False, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "funding_subagency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 15, "name": "Funding Subtier Agency 2", "code": "SA2", "id": 1002}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+def test_category_funding_subagency_subawards(agency_test_data):
+    test_payload = {"category": "funding_subagency", "subawards": True, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "funding_subagency",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [{"amount": 150, "name": "Funding Subtier Agency 4", "code": "SA4", "id": 1004}],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+@pytest.mark.django_db
+def test_category_recipient_duns_awards(recipient_test_data):
+    test_payload = {"category": "recipient_duns", "subawards": False, "page": 1, "limit": 50}
+
+    spending_by_category_logic = BusinessLogic(test_payload).results()
+
+    expected_response = {
+        "category": "recipient_duns",
+        "limit": 50,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [
+            {"amount": 15, "name": "MULTIPLE RECIPIENTS", "code": None, "recipient_id": None},
+            {
+                "amount": 11,
+                "name": "John Doe",
+                "code": "1234JD4321",
+                "recipient_id": "f9006d7e-fa6c-fa1c-6bc5-964fe524a949-C",
+            },
+            {
+                "amount": 2,
+                "name": "University of Pawnee",
+                "code": "00UOP00",
+                "recipient_id": "f9006d7e-fa6c-fa1c-6bc5-964fe524a948-P",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+
+    assert expected_response == spending_by_category_logic
+
+
+@pytest.mark.django_db
+def test_category_recipient_duns_subawards(recipient_test_data):
     test_payload = {"category": "recipient_duns", "subawards": True, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -381,15 +689,15 @@ def test_category_recipient_duns_subawards():
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
         "results": [
-            {"amount": Decimal(15), "name": "MULTIPLE RECIPIENTS", "code": None, "recipient_id": None},
+            {"amount": 15, "name": "MULTIPLE RECIPIENTS", "code": None, "recipient_id": None},
             {
-                "amount": Decimal(11),
+                "amount": 11,
                 "name": "JOHN DOE",
                 "code": "1234JD4321",
                 "recipient_id": "f9006d7e-fa6c-fa1c-6bc5-964fe524a949-C",
             },
             {
-                "amount": Decimal(2),
+                "amount": 2,
                 "name": "UNIVERSITY OF PAWNEE",
                 "code": "00UOP00",
                 "recipient_id": "f9006d7e-fa6c-fa1c-6bc5-964fe524a948-P",
@@ -401,82 +709,7 @@ def test_category_recipient_duns_subawards():
     assert expected_response == spending_by_category_logic
 
 
-@pytest.mark.skip(reason="Currently not supporting recipient parent duns")
-def test_category_recipient_parent_duns_awards(mock_matviews_qs, mock_recipients):
-    mock_recipient_1 = MockModel(recipient_unique_id="00UOP00", legal_entity_id=1)
-    mock_recipient_2 = MockModel(recipient_unique_id="1234JD4321", legal_entity_id=2)
-    mock_model_1 = MockModel(
-        recipient_name="University of Pawnee", parent_recipient_unique_id="00UOP00", generated_pragmatic_obligation=1
-    )
-    mock_model_2 = MockModel(
-        recipient_name="University of Pawnee", parent_recipient_unique_id="00UOP00", generated_pragmatic_obligation=1
-    )
-    mock_model_3 = MockModel(
-        recipient_name="John Doe", parent_recipient_unique_id="1234JD4321", generated_pragmatic_obligation=1
-    )
-    mock_model_4 = MockModel(
-        recipient_name="John Doe", parent_recipient_unique_id="1234JD4321", generated_pragmatic_obligation=10
-    )
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_recipients, [mock_recipient_1, mock_recipient_2])
-
-    test_payload = {"category": "recipient_parent_duns", "subawards": False, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "recipient_parent_duns",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [
-            {"amount": 11, "name": "John Doe", "code": "1234JD4321", "id": 2},
-            {"amount": 2, "name": "University of Pawnee", "code": "00UOP00", "id": 1},
-        ],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-@pytest.mark.skip(reason="Currently not supporting recipient parent duns")
-def test_category_recipient_parent_duns_subawards(mock_matviews_qs, mock_recipients):
-    mock_recipient_1 = MockModel(recipient_unique_id="00UOP00", legal_entity_id=1)
-    mock_recipient_2 = MockModel(recipient_unique_id="1234JD4321", legal_entity_id=2)
-    mock_model_1 = MockModel(recipient_name="University of Pawnee", parent_recipient_unique_id="00UOP00", amount=1)
-    mock_model_2 = MockModel(recipient_name="University of Pawnee", parent_recipient_unique_id="00UOP00", amount=1)
-    mock_model_3 = MockModel(recipient_name="John Doe", parent_recipient_unique_id="1234JD4321", amount=1)
-    mock_model_4 = MockModel(recipient_name="John Doe", parent_recipient_unique_id="1234JD4321", amount=10)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_recipients, [mock_recipient_1, mock_recipient_2])
-
-    test_payload = {"category": "recipient_parent_duns", "subawards": True, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "recipient_parent_duns",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [
-            {"amount": 11, "name": "John Doe", "code": "1234JD4321", "id": 2},
-            {"amount": 2, "name": "University of Pawnee", "code": "00UOP00", "id": 1},
-        ],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_cfda_awards(mock_matviews_qs, mock_cfda):
-    mock_model_cfda = MockModel(program_title="CFDA TITLE 1234", program_number="CFDA1234", id=1)
-    mock_model_1 = MockModel(cfda_number="CFDA1234", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(cfda_number="CFDA1234", generated_pragmatic_obligation=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_cfda, [mock_model_cfda])
-
+def test_category_cfda_awards(cfda_test_data):
     test_payload = {"category": "cfda", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -492,14 +725,7 @@ def test_category_cfda_awards(mock_matviews_qs, mock_cfda):
     assert expected_response == spending_by_category_logic
 
 
-def test_category_cfda_subawards(mock_matviews_qs, mock_cfda):
-    mock_model_cfda = MockModel(program_title="CFDA TITLE 1234", program_number="CFDA1234", id=1)
-    mock_model_1 = MockModel(cfda_number="CFDA1234", amount=1)
-    mock_model_2 = MockModel(cfda_number="CFDA1234", amount=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-    add_to_mock_objects(mock_cfda, [mock_model_cfda])
-
+def test_category_cfda_subawards(cfda_test_data):
     test_payload = {"category": "cfda", "subawards": True, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -515,17 +741,7 @@ def test_category_cfda_subawards(mock_matviews_qs, mock_cfda):
     assert expected_response == spending_by_category_logic
 
 
-def test_category_psc_awards(mock_matviews_qs, mock_psc):
-    mock_psc_1 = MockModel(code="PSC 1234", description="PSC DESCRIPTION UP")
-    mock_psc_2 = MockModel(code="PSC 9876", description="PSC DESCRIPTION DOWN")
-    mock_model_1 = MockModel(product_or_service_code="PSC 1234", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(product_or_service_code="PSC 1234", generated_pragmatic_obligation=1)
-    mock_model_3 = MockModel(product_or_service_code="PSC 9876", generated_pragmatic_obligation=2)
-    mock_model_4 = MockModel(product_or_service_code="PSC 9876", generated_pragmatic_obligation=2)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_psc, [mock_psc_1, mock_psc_2])
-
+def test_category_psc_awards(psc_test_data):
     test_payload = {"category": "psc", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -535,8 +751,8 @@ def test_category_psc_awards(mock_matviews_qs, mock_psc):
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
         "results": [
-            {"amount": 4, "code": "PSC 9876", "id": None, "name": "PSC DESCRIPTION DOWN"},
-            {"amount": 2, "code": "PSC 1234", "id": None, "name": "PSC DESCRIPTION UP"},
+            {"amount": 4, "code": "9876", "id": None, "name": "PSC DESCRIPTION DOWN"},
+            {"amount": 2, "code": "1234", "id": None, "name": "PSC DESCRIPTION UP"},
         ],
         "messages": [get_time_period_message()],
     }
@@ -544,56 +760,7 @@ def test_category_psc_awards(mock_matviews_qs, mock_psc):
     assert expected_response == spending_by_category_logic
 
 
-@pytest.mark.skip(reason="Currently not supporting psc subawards")
-def test_category_psc_subawards(mock_matviews_qs, mock_psc):
-    mock_psc_1 = MockModel(code="PSC 1234", description="PSC DESCRIPTION UP")
-    mock_psc_2 = MockModel(code="PSC 9876", description="PSC DESCRIPTION DOWN")
-    mock_model_1 = MockModel(product_or_service_code="PSC 1234", amount=1)
-    mock_model_2 = MockModel(product_or_service_code="PSC 1234", amount=1)
-    mock_model_3 = MockModel(product_or_service_code="PSC 9876", amount=2)
-    mock_model_4 = MockModel(product_or_service_code="PSC 9876", amount=2)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_psc, [mock_psc_1, mock_psc_2])
-
-    test_payload = {"category": "psc", "subawards": True, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "psc",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [
-            {"amount": 4, "code": "PSC 9876", "id": None, "name": "PSC DESCRIPTION DOWN"},
-            {"amount": 2, "code": "PSC 1234", "id": None, "name": "PSC DESCRIPTION UP"},
-        ],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_naics_awards(mock_matviews_qs, mock_naics):
-    mock_model_1 = MockModel(
-        naics_code="NAICS 1234", naics_description="NAICS DESC 1234", generated_pragmatic_obligation=1
-    )
-    mock_model_2 = MockModel(
-        naics_code="NAICS 1234", naics_description="NAICS DESC 1234", generated_pragmatic_obligation=1
-    )
-    mock_model_3 = MockModel(
-        naics_code="NAICS 9876", naics_description="NAICS DESC 9876", generated_pragmatic_obligation=2
-    )
-    mock_model_4 = MockModel(
-        naics_code="NAICS 9876", naics_description="NAICS DESC 9876", generated_pragmatic_obligation=2
-    )
-
-    mock_naics_1 = MockModel(code="NAICS 1234", description="SOURCE NAICS DESC 1234", year=1955)
-    mock_naics_2 = MockModel(code="NAICS 9876", description="SOURCE NAICS DESC 9876", year=1985)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2, mock_model_3, mock_model_4])
-    add_to_mock_objects(mock_naics, [mock_naics_1, mock_naics_2])
-
+def test_category_naics_awards(naics_test_data):
     test_payload = {"category": "naics", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -612,12 +779,7 @@ def test_category_naics_awards(mock_matviews_qs, mock_naics):
     assert expected_response == spending_by_category_logic
 
 
-def test_category_county_awards(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_county_code="04", pop_county_name="COUNTYSVILLE", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(pop_county_code="04", pop_county_name="COUNTYSVILLE", generated_pragmatic_obligation=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_county_awards(geo_test_data):
     test_payload = {"category": "county", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -626,19 +788,17 @@ def test_category_county_awards(mock_matviews_qs):
         "category": "county",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "04", "name": "COUNTYSVILLE", "id": None}],
+        "results": [
+            {"amount": 2, "code": "001", "name": "SOMEWHEREVILLE", "id": None},
+            {"amount": 2, "code": "004", "name": "COUNTYSVILLE", "id": None},
+        ],
         "messages": [get_time_period_message()],
     }
 
     assert expected_response == spending_by_category_logic
 
 
-def test_category_county_subawards(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_county_code="04", pop_county_name="COUNTYSVILLE", amount=1)
-    mock_model_2 = MockModel(pop_county_code="04", pop_county_name="COUNTYSVILLE", amount=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_county_subawards(geo_test_data):
     test_payload = {"category": "county", "subawards": True, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -647,19 +807,17 @@ def test_category_county_subawards(mock_matviews_qs):
         "category": "county",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "04", "name": "COUNTYSVILLE", "id": None}],
+        "results": [
+            {"amount": 2, "code": "004", "name": "COUNTYSVILLE", "id": None},
+            {"amount": 2, "code": "001", "name": "SOMEWHEREVILLE", "id": None},
+        ],
         "messages": [get_time_period_message()],
     }
 
     assert expected_response == spending_by_category_logic
 
 
-def test_category_district_awards(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_congressional_code="06", pop_state_code="XY", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(pop_congressional_code="06", pop_state_code="XY", generated_pragmatic_obligation=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_district_awards(geo_test_data):
     test_payload = {"category": "district", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -668,40 +826,17 @@ def test_category_district_awards(mock_matviews_qs):
         "category": "district",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "06", "name": "XY-06", "id": None}],
+        "results": [
+            {"amount": 2, "code": "06", "name": "XY-06", "id": None},
+            {"amount": 2, "code": "90", "name": "XY-MULTIPLE DISTRICTS", "id": None},
+        ],
         "messages": [get_time_period_message()],
     }
 
     assert expected_response == spending_by_category_logic
 
 
-def test_category_district_awards_multiple_districts(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_congressional_code="90", pop_state_code="XY", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(pop_congressional_code="90", pop_state_code="XY", generated_pragmatic_obligation=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
-    test_payload = {"category": "district", "subawards": False, "page": 1, "limit": 50}
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "district",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "90", "name": "XY-MULTIPLE DISTRICTS", "id": None}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-def test_category_district_subawards(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_congressional_code="06", pop_state_code="XY", amount=1)
-    mock_model_2 = MockModel(pop_congressional_code="06", pop_state_code="XY", amount=1)
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_district_subawards(geo_test_data):
     test_payload = {"category": "district", "subawards": True, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -710,7 +845,10 @@ def test_category_district_subawards(mock_matviews_qs):
         "category": "district",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "06", "name": "XY-06", "id": None}],
+        "results": [
+            {"amount": 2, "code": "90", "name": "XY-MULTIPLE DISTRICTS", "id": None},
+            {"amount": 2, "code": "06", "name": "XY-06", "id": None},
+        ],
         "messages": [get_time_period_message()],
     }
 
@@ -718,13 +856,7 @@ def test_category_district_subawards(mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_category_state_territory(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_state_code="XY", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(pop_state_code="XY", generated_pragmatic_obligation=1)
-    mommy.make("recipient.StateData", name="Test State", code="XY")
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_state_territory(geo_test_data):
     test_payload = {"category": "state_territory", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -733,7 +865,7 @@ def test_category_state_territory(mock_matviews_qs):
         "category": "state_territory",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "XY", "name": "Test State", "id": None}],
+        "results": [{"amount": 4, "code": "XY", "name": "Test State", "id": None}],
         "messages": [get_time_period_message()],
     }
 
@@ -741,13 +873,7 @@ def test_category_state_territory(mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_category_state_territory_subawards(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_state_code="XY", amount=1)
-    mock_model_2 = MockModel(pop_state_code="XY", amount=1)
-    mommy.make("recipient.StateData", name="Test State", code="XY")
-
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_state_territory_subawards(geo_test_data):
     test_payload = {"category": "state_territory", "subawards": True, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -756,7 +882,7 @@ def test_category_state_territory_subawards(mock_matviews_qs):
         "category": "state_territory",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "XY", "name": "Test State", "id": None}],
+        "results": [{"amount": 4, "code": "XY", "name": "Test State", "id": None}],
         "messages": [get_time_period_message()],
     }
 
@@ -764,12 +890,7 @@ def test_category_state_territory_subawards(mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_category_country(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_country_code="US", generated_pragmatic_obligation=1)
-    mock_model_2 = MockModel(pop_country_code="US", generated_pragmatic_obligation=1)
-    mommy.make("references.RefCountryCode", country_name="UNITED STATES", country_code="US")
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_country(geo_test_data):
     test_payload = {"category": "country", "subawards": False, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -778,7 +899,7 @@ def test_category_country(mock_matviews_qs):
         "category": "country",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "US", "name": "UNITED STATES", "id": None}],
+        "results": [{"amount": 4, "code": "US", "name": "UNITED STATES", "id": None}],
         "messages": [get_time_period_message()],
     }
 
@@ -786,12 +907,7 @@ def test_category_country(mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_category_country_subawards(mock_matviews_qs):
-    mock_model_1 = MockModel(pop_country_code="US", amount=1)
-    mock_model_2 = MockModel(pop_country_code="US", amount=1)
-    mommy.make("references.RefCountryCode", country_name="UNITED STATES", country_code="US")
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_country_subawards(geo_test_data):
     test_payload = {"category": "country", "subawards": True, "page": 1, "limit": 50}
 
     spending_by_category_logic = BusinessLogic(test_payload).results()
@@ -800,7 +916,7 @@ def test_category_country_subawards(mock_matviews_qs):
         "category": "country",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "US", "name": "UNITED STATES", "id": None}],
+        "results": [{"amount": 4, "code": "US", "name": "UNITED STATES", "id": None}],
         "messages": [get_time_period_message()],
     }
 
@@ -808,29 +924,10 @@ def test_category_country_subawards(mock_matviews_qs):
 
 
 @pytest.mark.django_db
-def test_category_federal_accounts(mock_matviews_qs):
-
-    mock_model_1 = MockModel(
-        federal_account_id=10,
-        federal_account_display="020-0001",
-        account_title="Test Federal Account",
-        recipient_hash="00000-00000-00000-00000-00000",
-        parent_recipient_unique_id="000000",
-        generated_pragmatic_obligation=1,
-    )
-    mock_model_2 = MockModel(
-        federal_account_id=10,
-        federal_account_display="020-0001",
-        account_title="Test Federal Account",
-        recipient_hash="00000-00000-00000-00000-00000",
-        parent_recipient_unique_id="000000",
-        generated_pragmatic_obligation=2,
-    )
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
+def test_category_federal_accounts(federal_accounts_test_data):
     test_payload = {
         "category": "federal_account",
-        "filters": {"recipient_id": "00000-00000-00000-00000-00000-C"},
+        "filters": {"recipient_id": "dece8b43-c2a8-d056-7e82-0fc2f1c7c4e4-R"},
         "subawards": False,
         "page": 1,
         "limit": 50,
@@ -843,57 +940,6 @@ def test_category_federal_accounts(mock_matviews_qs):
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
         "results": [{"amount": 3, "code": "020-0001", "name": "Test Federal Account", "id": 10}],
-        "messages": [get_time_period_message()],
-    }
-
-    assert expected_response == spending_by_category_logic
-
-
-# Keeping this skipped until Recipient Hash gets included in the Subaward View
-@pytest.mark.skip
-def test_category_federal_accounts_subawards(
-    mock_matviews_qs, mock_federal_account, mock_tas, mock_award, mock_financial_account, mock_transaction
-):
-    fa = MockModel(id=10, agency_identifier="020", main_account_code="0001", account_title="Test Federal Account")
-    add_to_mock_objects(mock_federal_account, [fa])
-
-    tas = MockModel(treasury_account_identifier=2, federal_account_id=10)
-    add_to_mock_objects(mock_tas, [tas])
-
-    award = MockModel(id=3)
-    add_to_mock_objects(mock_award, [award])
-
-    fs = MockModel(financial_accounts_by_awards_id=4, submission_id=3, treasury_account=tas, award=award)
-    add_to_mock_objects(mock_financial_account, [fs])
-
-    award.financial_set = MockSet(fs)
-    t1 = MockModel(award=award, id=5)
-    t2 = MockModel(award=award, id=6)
-    add_to_mock_objects(mock_transaction, [t1, t2])
-
-    mock_model_1 = MockModel(
-        transaction=t1, recipient_hash="00000-00000-00000-00000-00000", parent_recipient_unique_id="000000", amount=1
-    )
-    mock_model_2 = MockModel(
-        transaction=t2, recipient_hash="00000-00000-00000-00000-00000", parent_recipient_unique_id="000000", amount=1
-    )
-    add_to_mock_objects(mock_matviews_qs, [mock_model_1, mock_model_2])
-
-    test_payload = {
-        "category": "federal_account",
-        "filters": {"recipient_id": "00000-00000-00000-00000-00000-C"},
-        "subawards": True,
-        "page": 1,
-        "limit": 50,
-    }
-
-    spending_by_category_logic = BusinessLogic(test_payload).results()
-
-    expected_response = {
-        "category": "federal_account",
-        "limit": 50,
-        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 2, "code": "020-0001", "name": "Test Federal Account", "id": 10}],
         "messages": [get_time_period_message()],
     }
 

--- a/usaspending_api/search/tests/unit/test_spending_over_time_details.py
+++ b/usaspending_api/search/tests/unit/test_spending_over_time_details.py
@@ -1,29 +1,81 @@
-# Stdlib imports
 import json
 import pytest
 
-from model_mommy import mommy
 from datetime import datetime
+from model_mommy import mommy
 from rest_framework import status
-from django_mock_queries.query import MockModel
 
 from usaspending_api.search.models import SummaryTransactionView
 from usaspending_api.common.helpers.generic_helper import get_time_period_message
-from usaspending_api.common.helpers.unit_test_helper import add_to_mock_objects
 
 
 @pytest.fixture
-def populate_models(mock_matviews_qs):
-    mock_0 = MockModel(action_date=datetime(2010, 3, 1), generated_pragmatic_obligation=100.0)
-    mock_1 = MockModel(action_date=datetime(2011, 3, 1), generated_pragmatic_obligation=110.0)
-    mock_2 = MockModel(action_date=datetime(2012, 3, 1), generated_pragmatic_obligation=120.0)
-    mock_3 = MockModel(action_date=datetime(2013, 3, 1), generated_pragmatic_obligation=130.0)
-    mock_4 = MockModel(action_date=datetime(2014, 3, 1), generated_pragmatic_obligation=140.0)
-    mock_5 = MockModel(action_date=datetime(2015, 3, 1), generated_pragmatic_obligation=150.0)
-    mock_6 = MockModel(action_date=datetime(2016, 3, 1), generated_pragmatic_obligation=160.0)
-    mock_7 = MockModel(action_date=datetime(2017, 3, 1), generated_pragmatic_obligation=170.0)
+def populate_models(db):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
+    mommy.make("awards.Award", id=2, latest_transaction_id=2)
+    mommy.make("awards.Award", id=3, latest_transaction_id=3)
+    mommy.make("awards.Award", id=4, latest_transaction_id=4)
+    mommy.make("awards.Award", id=5, latest_transaction_id=5)
+    mommy.make("awards.Award", id=6, latest_transaction_id=6)
+    mommy.make("awards.Award", id=7, latest_transaction_id=7)
+    mommy.make("awards.Award", id=8, latest_transaction_id=8)
 
-    add_to_mock_objects(mock_matviews_qs, [mock_0, mock_1, mock_2, mock_3, mock_4, mock_5, mock_6, mock_7])
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=1,
+        award_id=1,
+        action_date=datetime(2010, 3, 1),
+        federal_action_obligation=100.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=2,
+        award_id=2,
+        action_date=datetime(2011, 3, 1),
+        federal_action_obligation=110.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=3,
+        award_id=3,
+        action_date=datetime(2012, 3, 1),
+        federal_action_obligation=120.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=4,
+        award_id=4,
+        action_date=datetime(2013, 3, 1),
+        federal_action_obligation=130.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=5,
+        award_id=5,
+        action_date=datetime(2014, 3, 1),
+        federal_action_obligation=140.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=6,
+        award_id=6,
+        action_date=datetime(2015, 3, 1),
+        federal_action_obligation=150.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=7,
+        award_id=7,
+        action_date=datetime(2016, 3, 1),
+        federal_action_obligation=160.0,
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=8,
+        award_id=8,
+        action_date=datetime(2017, 3, 1),
+        federal_action_obligation=170.0,
+    )
 
 
 @pytest.fixture
@@ -93,8 +145,7 @@ def confirm_proper_ordering(group, results):
                 period = int(result["time_period"][group])
 
 
-@pytest.mark.django_db
-def test_spending_over_time_fy_ordering(populate_models, client, mock_matviews_qs):
+def test_spending_over_time_fy_ordering(client, populate_models):
     group = "fiscal_year"
     test_payload = {
         "group": group,
@@ -132,8 +183,7 @@ def test_spending_over_time_fy_ordering(populate_models, client, mock_matviews_q
     confirm_proper_ordering(group, resp.data["results"])
 
 
-@pytest.mark.django_db
-def test_spending_over_time_month_ordering(populate_models, client, mock_matviews_qs):
+def test_spending_over_time_month_ordering(client, populate_models):
     group = "month"
     test_payload = {
         "group": group,
@@ -197,8 +247,7 @@ def test_spending_over_time_month_ordering(populate_models, client, mock_matview
     confirm_proper_ordering(group, resp.data["results"])
 
 
-@pytest.mark.django_db
-def test_spending_over_time_funny_dates_ordering(populate_models, client, mock_matviews_qs):
+def test_spending_over_time_funny_dates_ordering(client, populate_models):
     group = "month"
     test_payload = {
         "group": group,


### PR DESCRIPTION
**Description:**
Made the necessary changes to upgrade Django to 2.2.X.

**Technical details:**
Not many code changes were needed for the upgrade. The most notable change is that `on_delete` is now required for ForeignKey, OneToOne, and ManyToMany. Older versions of Django [defaulted to CASCADE](https://docs.djangoproject.com/en/1.11/ref/models/fields/#arguments). This is why a lot of the models have been updated to explicitly say `on_delete=models.CASCADE`. The only exceptions are the matviews which are set to `on_delete=models.DO_NOTHING`. 

The majority of this PR is removing the use of MockModel and MockSet from `django-mock-queries` in favor of Model Mommy. Without getting into the weeds of re-writing every single test, an attempt was made to rewrite only the parts necessary for Model Mommy to be used.


**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-3074](https://federal-spending-transparency.atlassian.net/browse/DEV-3074):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
