### PR TITLE
[DEV-3074] Part 3: Fix some pytest warnings and code that will be rem…

### DIFF
--- a/usaspending_api/broker/tests/integration/test_broker_integration.py
+++ b/usaspending_api/broker/tests/integration/test_broker_integration.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 
 class BrokerIntegrationTestCase(TestCase):
-    multi_db = True
+    databases = {"default", "data_broker"}
     dummy_table_name = "dummy_broker_table_to_be_rolled_back"
 
     @classmethod

--- a/usaspending_api/common/management/commands/matview_runner.py
+++ b/usaspending_api/common/management/commands/matview_runner.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
     def generate_matview_sql(self):
         """Convert JSON definition files to SQL"""
         if self.matview_dir.exists():
-            logger.warn("Clearing dir {}".format(self.matview_dir))
+            logger.warning("Clearing dir {}".format(self.matview_dir))
             recursive_delete(self.matview_dir)
         self.matview_dir.mkdir()
 

--- a/usaspending_api/common/validator/helpers.py
+++ b/usaspending_api/common/validator/helpers.py
@@ -218,5 +218,7 @@ def validate_text(rule):
         #    ASCII escape characters
         val = rule["value"].translate(search_remap).strip()
         if val != rule["value"]:
-            logger.warn("Field {} value was changed from {} to {}".format(rule["key"], repr(rule["value"]), repr(val)))
+            logger.warning(
+                "Field {} value was changed from {} to {}".format(rule["key"], repr(rule["value"]), repr(val))
+            )
     return val

--- a/usaspending_api/etl/transaction_loaders/tests/integration/test_fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/tests/integration/test_fpds_loader.py
@@ -18,7 +18,7 @@ from usaspending_api.etl.transaction_loaders.data_load_helpers import format_bul
 
 class FPDSLoaderIntegrationTestCase(TestCase):
     logger = logging.getLogger(__name__)
-    multi_db = True
+    databases = {"default", "data_broker"}
 
     @classmethod
     def setUpClass(cls):

--- a/usaspending_api/recipient/v2/views/states.py
+++ b/usaspending_api/recipient/v2/views/states.py
@@ -67,7 +67,7 @@ def obtain_state_totals(fips, year=None, award_type_codes=None, subawards=False)
         return result
     except IndexError:
         # would prefer to catch an index error gracefully if the SQL query produces 0 rows
-        logger.warn("No results found for FIPS {} with filters: {}".format(fips, filters))
+        logger.warning("No results found for FIPS {} with filters: {}".format(fips, filters))
     return {"count": 0, "pop_state_code": None, "total": 0}
 
 


### PR DESCRIPTION
…oved in Django 3.0

**Description:**
Made some changes to support the future move to Django 3.0 and a small change to remove a large number of pytest warnings.

**Technical details:**
`multi_db` as part of TestCase is being removed in Django 3.0 and replaced by accessing the `databases` attribute. Additionally, a few places in the applications used `logger.warn` (which was deprecated and throwing warnings in pytest. This was updated to `logger.warning`.

Pytest now currently shows only 44 warnings. 
![Screen Shot 2020-01-24 at 10 34 23 AM](https://user-images.githubusercontent.com/40359517/73094692-fc2bce80-3e95-11ea-9a4e-31fd827baba1.png)


**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed (N/A)
6. [X] Data validation completed (N/A)
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-3074](https://federal-spending-transparency.atlassian.net/browse/DEV-3074):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
