### PR TITLE
[DEV-4329] Implement new filter for array of submission types

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/download/accounts.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/accounts.md
@@ -33,7 +33,7 @@ Generate files and return metadata using filters on custom account
                 "filters": {
                     "fy": "2018",
                     "quarter": "1",
-                    "submission_type": "account_balances"
+                    "submission_types": ["account_balances", "award_financial"]
                 }
             }
 
@@ -51,14 +51,15 @@ Generate files and return metadata using filters on custom account
 
             {
                 "status_url": "http://localhost:8000/api/v2/download/status?file_name=FY2018Q1_All_TAS_AccountBalances_2020-01-13_H21M00S18407575.zip",
-                "file_name": "FY2018Q1_All_TAS_AccountBalances_2020-01-13_H21M00S18407575.zip",
-                "file_url": "/csv_downloads/FY2018Q1_All_TAS_AccountBalances_2020-01-13_H21M00S18407575.zip",
+                "file_name": "FY2018Q1_All_TAS_AccountData_2020-01-13_H21M00S18407575.zip",
+                "file_url": "/csv_downloads/FY2018Q1_All_TAS_AccountData_2020-01-13_H21M00S18407575.zip",
                 "download_request": {
                     "account_level": "treasury_account",
                     "agency": "all",
                     "columns": [],
                     "download_types": [
-                        "account_balances"
+                        "account_balances",
+                        "award_financial"
                     ],
                     "file_format": "csv",
                     "filters": {
@@ -68,7 +69,7 @@ Generate files and return metadata using filters on custom account
                     "request_type": "account"
                 }
             }
-            
+
 
 
 # Data Structures
@@ -79,8 +80,8 @@ Generate files and return metadata using filters on custom account
     + Default: `all`
 + `federal_account`(optional, string)
     This field is an internal id.
-+ `submission_type` (required, enum[string])
-    + Members
++ `submission_types` (required, array)
+    + (enum[string])
         + `account_balances`
         + `object_class_program_activity`
         + `award_financial`

--- a/usaspending_api/download/download_utils.py
+++ b/usaspending_api/download/download_utils.py
@@ -42,8 +42,8 @@ def create_unique_filename(json_request, origination=None):
 
 def obtain_zip_filename_format(download_types):
     if len(download_types) > 1:
-        raise NotImplementedError
-    return VALUE_MAPPINGS[download_types[0]]["zipfile_template"] + ".zip"
+        return "{data_quarters}_{agency}_{level}_AccountData_{timestamp}.zip"
+    return f"{VALUE_MAPPINGS[download_types[0]]['zipfile_template']}.zip"
 
 
 def obtain_filename_prefix_from_agency_id(request_agency):

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -312,3 +312,5 @@ FILE_FORMATS = {
     "tsv": {"delimiter": "\t", "extension": "tsv", "options": r"WITH CSV DELIMITER E'\t' HEADER"},
     "pstxt": {"delimiter": "|", "extension": "txt", "options": "WITH CSV DELIMITER '|' HEADER"},
 }
+
+VALID_ACCOUNT_SUBMISSION_TYPES = ("account_balances", "object_class_program_activity", "award_financial")

--- a/usaspending_api/download/tests/integration/test_download_accounts_dev_3997.py
+++ b/usaspending_api/download/tests/integration/test_download_accounts_dev_3997.py
@@ -310,7 +310,7 @@ def test_download_accounts_dev_3997(client):
                 "filters": {
                     "budget_function": "all",
                     "agency": "all",
-                    "submission_type": "object_class_program_activity",
+                    "submission_types": ["object_class_program_activity"],
                     "fy": "2018",
                     "quarter": "4",
                 },
@@ -443,7 +443,7 @@ def test_download_accounts_dev_3997(client):
                 "filters": {
                     "budget_function": "all",
                     "agency": "all",
-                    "submission_type": "object_class_program_activity",
+                    "submission_types": ["object_class_program_activity"],
                     "fy": "2018",
                     "quarter": "4",
                 },

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -164,17 +164,12 @@ def validate_assistance_request(request_data):
 def validate_account_request(request_data):
     json_request = {"columns": request_data.get("columns", []), "filters": {}}
 
-    _validate_submission_type(request_data)
     _validate_required_parameters(request_data, ["account_level", "filters"])
     json_request["account_level"] = _validate_account_level(request_data, ["federal_account", "treasury_account"])
 
     filters = _validate_filters(request_data)
 
-    json_request["download_types"] = request_data["filters"]["submission_types"]
-    json_request["agency"] = request_data["filters"]["agency"] if request_data["filters"].get("agency") else "all"
-
     json_request["file_format"] = str(request_data.get("file_format", "csv")).lower()
-
     _validate_file_format(json_request)
 
     # Validate required filters
@@ -191,6 +186,11 @@ def validate_account_request(request_data):
     # Validate fiscal_quarter
     if json_request["filters"]["quarter"] not in [1, 2, 3, 4]:
         raise InvalidParameterException("quarter filter must be a valid fiscal quarter (1, 2, 3, or 4)")
+
+    _validate_submission_type(filters)
+
+    json_request["download_types"] = request_data["filters"]["submission_types"]
+    json_request["agency"] = request_data["filters"]["agency"] if request_data["filters"].get("agency") else "all"
 
     # Validate the rest of the filters
     check_types_and_assign_defaults(filters, json_request["filters"], ACCOUNT_FILTER_DEFAULTS)
@@ -296,31 +296,34 @@ def _validate_file_format(json_request: dict) -> None:
         raise InvalidParameterException(msg)
 
 
-def _validate_submission_type(json_request: dict) -> None:
+def _validate_submission_type(filters: dict) -> None:
     """Validate submission_type/submission_types parameter
 
     In February 2020 submission_type became the legacy filter, replaced by submission_types
     submission_type was left in-place for backward compatibility but hidden in API Contract and error messages
     """
-    legacy_submission_type = json_request.get("filters").get("submission_type", ...)
-    submission_types = json_request.get("filters").get("submission_types", ...)
+    legacy_submission_type = filters.get("submission_type", ...)
+    submission_types = filters.get("submission_types", ...)
 
     if submission_types == ... and legacy_submission_type == ...:
         raise InvalidParameterException("Missing required filter: submission_types")
 
     elif submission_types == ... and legacy_submission_type != ...:
-        del json_request["filters"]["submission_type"]
-        if not isinstance(legacy_submission_type, list):
-            submission_types = [legacy_submission_type]
+        del filters["submission_type"]
+        if isinstance(legacy_submission_type, list):
+            raise InvalidParameterException("Use filter `submission_types` to request multiple submission types")
         else:
-            submission_types = legacy_submission_type
+            submission_types = [legacy_submission_type]
     else:
         if not isinstance(submission_types, list):
             submission_types = [submission_types]
 
-    for submission_type in submission_types:
-        if submission_type not in VALID_ACCOUNT_SUBMISSION_TYPES:
-            msg = f"Invalid value for submission_type: `{submission_type}` not in {VALID_ACCOUNT_SUBMISSION_TYPES}"
-            raise InvalidParameterException(msg)
+    if len(submission_types) == 0:
+        msg = f"Provide at least one value in submission_types: {' '.join(VALID_ACCOUNT_SUBMISSION_TYPES)}"
+        raise InvalidParameterException(msg)
 
-    json_request["filters"]["submission_types"] = list(set(submission_types))
+    if any(True for submission_type in submission_types if submission_type not in VALID_ACCOUNT_SUBMISSION_TYPES):
+        msg = f"Invalid value in submission_types. Options: [{', '.join(VALID_ACCOUNT_SUBMISSION_TYPES)}]"
+        raise InvalidParameterException(msg)
+
+    filters["submission_types"] = list(set(submission_types))


### PR DESCRIPTION
**Description:**
To facilitate multiple Submission types in a single Account Download request, `submission_type` is being replaced by `submission_types`. While `submission_type` is legacy and removed from the API Contract, it remains in place for backward compatibility.

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4329](https://federal-spending-transparency.atlassian.net/browse/DEV-4329):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Download
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to the database
```
