### PR TITLE
[DEV-4408] Changing unique field for new transaction loaders

### DIFF
--- a/usaspending_api/transactions/agnostic_transaction_deletes.py
+++ b/usaspending_api/transactions/agnostic_transaction_deletes.py
@@ -56,8 +56,10 @@ class AgnosticDeletes:
         connection = get_connection(read_only=False)
         with connection.cursor() as cursor:
             for date, ids in removed_records.items():
+                if len(ids) == 1:  # handle case with single-value Python tuples contain a trailing comma "(id,)"
+                    ids = ids + ids
                 sql = delete_template.format(
-                    table=self.destination_table_name, key=self.shared_pk, ids=tuple(ids), date=date
+                    table=self.destination_table_name, key=self.shared_unique_key, ids=tuple(ids), date=date
                 )
                 cursor.execute(sql)
                 logger.info(f"Removed {cursor.rowcount} rows from {date} delete records")

--- a/usaspending_api/transactions/agnostic_transaction_deletes.py
+++ b/usaspending_api/transactions/agnostic_transaction_deletes.py
@@ -59,7 +59,7 @@ class AgnosticDeletes:
                 if len(ids) == 1:  # handle case with single-value Python tuples contain a trailing comma "(id,)"
                     ids = ids + ids
                 sql = delete_template.format(
-                    table=self.destination_table_name, key=self.shared_unique_key, ids=tuple(ids), date=date
+                    table=self.destination_table_name, key=self.shared_pk, ids=tuple(ids), date=date
                 )
                 cursor.execute(sql)
                 logger.info(f"Removed {cursor.rowcount} rows from {date} delete records")

--- a/usaspending_api/transactions/agnostic_transaction_loader.py
+++ b/usaspending_api/transactions/agnostic_transaction_loader.py
@@ -147,7 +147,7 @@ class AgnosticTransactionLoader:
             ids = self.generate_ids_from_broker()
 
         file_name = f"{self.working_file_prefix}_{self.start_time.strftime('%Y%m%d_%H%M%S_%f')}"
-        return store_ids_in_file(ids, file_name)
+        return store_ids_in_file(ids, file_name, is_numeric=False)
 
     def generate_ids_from_broker(self):
         sql = self.combine_sql()
@@ -186,7 +186,7 @@ class AgnosticTransactionLoader:
         source = ETLDBLinkTable(source_tablename, "broker_server", destination.data_types)
         transactions_remaining_count = self.total_ids_to_process
 
-        for id_list in read_file_for_database_ids(str(self.file_path), self.chunk_size):
+        for id_list in read_file_for_database_ids(str(self.file_path), self.chunk_size, is_numeric=False):
             with Timer(message="Batch upsert", success_logger=logger.info, failure_logger=logger.error):
                 if len(id_list) != 0:
                     predicate = [{"field": primary_key, "op": "IN", "values": tuple(id_list)}]

--- a/usaspending_api/transactions/loader_functions.py
+++ b/usaspending_api/transactions/loader_functions.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 from usaspending_api.common.retrieve_file_from_uri import RetrieveFileFromUri
 
 
-def store_ids_in_file(id_iter: List, file_name: str = "temp_file") -> Tuple[Path, int]:
+def store_ids_in_file(id_iter: List, file_name: str = "temp_file", is_numeric: bool = True) -> Tuple[Path, int]:
     """Store the provided values in a file
         returning filepath and count of ids
     """
@@ -17,8 +17,11 @@ def store_ids_in_file(id_iter: List, file_name: str = "temp_file") -> Tuple[Path
             if not id_string:
                 continue
             total_ids += 1
-            int_characters = regex(r"\d+", str(id_string)).group()
-            f.writelines("{}\n".format(int_characters))
+            if is_numeric:
+                id_characters = regex(r"\d+", str(id_string)).group()
+            else:
+                id_characters = id_string
+            f.writelines("{}\n".format(id_characters))
 
     return file_path.resolve(), total_ids
 
@@ -32,16 +35,22 @@ def filepath_command_line_argument_type(chunk_count):
     return _filepath_command_line_argument_type
 
 
-def read_file_for_database_ids(provided_uri, chunk_count):
+def read_file_for_database_ids(provided_uri, chunk_count, is_numeric: bool = True):
     """wrapped generator to read file and stream IDs"""
+
+    use_binary = not is_numeric
     try:
-        with RetrieveFileFromUri(provided_uri).get_file_object() as file:
+        with RetrieveFileFromUri(provided_uri).get_file_object(text=use_binary) as file:
             chunk_list = []
             while True:
                 line = file.readline()
                 if not line:
                     break
-                chunk_list.append(int(line))
+                elif is_numeric:
+                    chunk_list.append(int(line))
+                else:
+                    chunk_list.append(line.strip())
+
                 if len(chunk_list) >= chunk_count:
                     yield chunk_list
                     chunk_list = []

--- a/usaspending_api/transactions/management/commands/transfer_assistance_records.py
+++ b/usaspending_api/transactions/management/commands/transfer_assistance_records.py
@@ -11,7 +11,7 @@ class Command(AgnosticTransactionLoader, BaseCommand):
     destination_table_name = SourceAssistanceTransaction().table_name
     last_load_record = "source_assistance_transaction"
     lookback_minutes = 15
-    shared_pk = "published_award_financial_assistance_id"
+    shared_pk = "afa_generated_unique"
     working_file_prefix = "assistance_load_ids"
     broker_full_select_sql = 'SELECT "{id}" FROM "{table}" WHERE "is_active" IS TRUE'
     broker_incremental_select_sql = """

--- a/usaspending_api/transactions/management/commands/transfer_procurement_records.py
+++ b/usaspending_api/transactions/management/commands/transfer_procurement_records.py
@@ -11,7 +11,7 @@ class Command(AgnosticTransactionLoader, BaseCommand):
     destination_table_name = SourceProcurementTransaction().table_name
     last_load_record = "source_procurement_transaction"
     lookback_minutes = 0
-    shared_pk = "detached_award_procurement_id"
+    shared_pk = "detached_award_proc_unique"
     working_file_prefix = "procurement_load_ids"
     broker_full_select_sql = 'SELECT "{id}" FROM "{table}"'
     broker_incremental_select_sql = 'SELECT "{id}" FROM "{table}" {optional_predicate}'

--- a/usaspending_api/transactions/migrations/0001_initial.py
+++ b/usaspending_api/transactions/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             name='SourceAssistanceTransaction',
             fields=[
                 ('published_award_financial_assistance_id', models.IntegerField(help_text='surrogate primary key defined in Broker', primary_key=True, serialize=False)),
-                ('afa_generated_unique', models.TextField(help_text='natural key defined in Broker')),
+                ('afa_generated_unique', models.TextField(help_text='natural key defined in Broker', unique=True)),
                 ('action_date', models.TextField(blank=True, null=True)),
                 ('action_type', models.TextField(blank=True, null=True)),
                 ('action_type_description', models.TextField(blank=True, null=True)),

--- a/usaspending_api/transactions/models/source_assistance_transaction.py
+++ b/usaspending_api/transactions/models/source_assistance_transaction.py
@@ -19,7 +19,7 @@ class SourceAssistanceTransaction(models.Model):
     published_award_financial_assistance_id = models.IntegerField(
         primary_key=True, help_text="surrogate primary key defined in Broker"
     )
-    afa_generated_unique = models.TextField(help_text="natural key defined in Broker")
+    afa_generated_unique = models.TextField(unique=True, help_text="natural key defined in Broker")
     action_date = models.TextField(blank=True, null=True)
     action_type = models.TextField(blank=True, null=True)
     action_type_description = models.TextField(blank=True, null=True)


### PR DESCRIPTION
**Description:**
Changing the unique field used for higher robustness and better data quality when loading data from Broker source system.

**Technical details:**

- Switching `published_award_financial_assistance_id` -> `afa_generated_unique` and `detached_award_procurement_id ` -> `detached_award_proc_unique `
    - This will incur a performance hit, but still much much higher than anything we currently have
- Added unique flag to migration so `afa_generated_unique` will be indexed
    - Manually added to staging

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4408](https://federal-spending-transparency.atlassian.net/browse/DEV-4408):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Script
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No edits to API or materialized views
```
