### PR TITLE
[DEV-4155] Removed all references to nested type with ES

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -375,25 +375,25 @@ class _TasCodes(_Filter):
         tas_codes_query = []
 
         for v in filter_values:
-            code_query = []
             code_lookup = {
-                "aid": v.get("aid"),
-                "ata": v.get("ata"),
-                "main": v.get("main"),
-                "sub": v.get("sub"),
-                "bpoa": v.get("bpoa"),
-                "epoa": v.get("epoa"),
-                "a": v.get("a"),
+                "aid": v.get("aid", ".*"),
+                "ata": v.get("ata", ".*"),
+                "main": v.get("main", ".*"),
+                "sub": v.get("sub", ".*"),
+                "bpoa": v.get("bpoa", ".*"),
+                "epoa": v.get("epoa", ".*"),
+                "a": v.get("a", ".*"),
             }
-
-            for code_key, code_value in code_lookup.items():
-                if code_value is not None:
-                    code_query.append(ES_Q("match", **{f"treasury_accounts__{code_key}": code_value}))
-
+            search_regex = (
+                '\\"a\\": \\"{a}\\", \\"aid\\": \\"{aid}\\", \\"ata\\": \\"{ata}\\",'
+                ' \\"sub\\": \\"{sub}\\", \\"bpoa\\": \\"{bpoa}\\", \\"epoa\\": \\"{epoa}\\",'
+                ' \\"main\\": \\"{main}\\"'.format(**code_lookup)
+            )
+            search_regex = "{" + search_regex + "}"
+            code_query = ES_Q("regexp", treasury_accounts={"value": search_regex})
             tas_codes_query.append(ES_Q("bool", must=code_query))
 
-        nested_query = ES_Q("bool", should=tas_codes_query, minimum_should_match=1)
-        return ES_Q("nested", path="treasury_accounts", query=nested_query)
+        return ES_Q("bool", should=tas_codes_query, minimum_should_match=1)
 
 
 class QueryWithFilters:

--- a/usaspending_api/database_scripts/etl/award_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/award_delta_view.sql
@@ -80,20 +80,36 @@ SELECT
   vw_award_search.product_or_service_description,
   vw_award_search.naics_code,
   vw_award_search.naics_description,
-  TREASURY_ACCT.treasury_account_identifiers as treasury_accounts
-  FROM vw_award_search
-  INNER JOIN awards a ON a.id = vw_award_search.award_id
-  LEFT JOIN
-  (SELECT
+  TREASURY_ACCT.treasury_accounts
+FROM vw_award_search
+INNER JOIN awards a ON (a.id = vw_award_search.award_id)
+LEFT JOIN (
+  SELECT
     recipient_hash,
     legal_business_name AS recipient_name,
     duns
-  FROM recipient_lookup AS rlv
-  ) recipient_lookup ON recipient_lookup.duns = vw_award_search.recipient_unique_id AND vw_award_search.recipient_unique_id IS NOT NULL
-  LEFT OUTER JOIN (
-    SELECT
+  FROM
+    recipient_lookup AS rlv
+) recipient_lookup ON (recipient_lookup.duns = vw_award_search.recipient_unique_id AND vw_award_search.recipient_unique_id IS NOT NULL)
+LEFT JOIN (
+  SELECT
     faba.award_id,
-    ARRAY_AGG(DISTINCT tas.tas_rendering_label) AS treasury_account_identifiers
-  FROM financial_accounts_by_awards faba
-  INNER JOIN treasury_appropriation_account tas ON faba.treasury_account_id = tas.treasury_account_identifier
-  WHERE faba.award_id IS NOT NULL GROUP BY faba.award_id) TREASURY_ACCT ON (TREASURY_ACCT.award_id = vw_award_search.award_id);
+    JSONB_AGG(
+      DISTINCT JSONB_BUILD_OBJECT(
+        'aid', taa.agency_id,
+        'ata', taa.allocation_transfer_agency_id,
+        'main', taa.main_account_code,
+        'sub', taa.sub_account_code,
+        'bpoa', taa.beginning_period_of_availability,
+        'epoa', taa.ending_period_of_availability,
+        'a', taa.availability_type_code
+       )
+     ) treasury_accounts
+ FROM
+   treasury_appropriation_account taa
+   INNER JOIN financial_accounts_by_awards faba ON (taa.treasury_account_identifier = faba.treasury_account_id)
+ WHERE
+   faba.award_id IS NOT NULL
+ GROUP BY
+   faba.award_id
+) TREASURY_ACCT ON (TREASURY_ACCT.award_id = vw_award_search.award_id);

--- a/usaspending_api/database_scripts/etl/transaction_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/transaction_delta_view.sql
@@ -137,8 +137,7 @@ LEFT JOIN (
        )
      ) treasury_accounts
  FROM
-   federal_account fa
-   INNER JOIN treasury_appropriation_account taa ON (fa.id = taa.federal_account_id)
+   treasury_appropriation_account taa
    INNER JOIN financial_accounts_by_awards faba ON (taa.treasury_account_identifier = faba.treasury_account_id)
  WHERE
    faba.award_id IS NOT NULL

--- a/usaspending_api/etl/es_award_template.json
+++ b/usaspending_api/etl/es_award_template.json
@@ -23,400 +23,377 @@
     }
   },
   "mappings": {
-      "properties": {
-        "award_id": {
-          "type": "integer"
-        },
-        "generated_unique_award_id": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "display_award_id": {
-          "type": "keyword"
-        },
-        "category": {
-          "type": "text"
-        },
-        "type": {
-          "type": "keyword",
-          "null_value": "NULL"
-        },
-        "type_description": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "piid": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "fain": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "uri": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "total_obligation": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "description": {
-          "type": "text",
-          "analyzer": "stemmer_analyzer"
-        },
-        "total_obl_bin": {
-          "type": "keyword"
-        },
-        "total_subsidy_cost": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "total_loan_value": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "recipient_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_unique_id": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_hash": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "parent_recipient_unique_id": {
-          "type": "keyword",
-          "null_value": "NULL"
-        },
-        "business_categories": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "action_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "fiscal_year": {
-          "type": "integer"
-        },
-        "last_modified_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
-        },
-        "update_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
-        },
-        "period_of_performance_start_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "period_of_performance_current_end_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "date_signed": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "ordering_period_end_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "original_loan_subsidy_cost": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "face_value_loan_guarantee": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "awarding_agency_id": {
-          "type": "integer"
-        },
-        "funding_agency_id": {
-          "type": "integer"
-        },
-        "awarding_toptier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_toptier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_subtier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_subtier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_toptier_agency_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_toptier_agency_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_subtier_agency_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_subtier_agency_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_location_country_code": {
-          "type": "keyword"
-        },
-        "recipient_location_country_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_location_state_code": {
-          "type": "keyword"
-        },
-        "recipient_location_county_code": {
-          "type": "keyword"
-        },
-        "recipient_location_county_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_location_zip5": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_location_congressional_code": {
-          "type": "keyword"
-        },
-        "recipient_location_city_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "pop_country_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "pop_country_code": {
-          "type": "keyword"
-        },
-        "pop_state_code": {
-          "type": "keyword"
-        },
-        "pop_county_code": {
-          "type": "keyword"
-        },
-        "pop_county_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "pop_zip5": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "pop_congressional_code": {
-          "type": "keyword"
-        },
-        "pop_city_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "cfda_number": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "sai_number": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "type_of_contract_pricing": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "type_set_aside": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "extent_competed": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "product_or_service_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "product_or_service_description": {
-          "type": "text"
-        },
-        "naics_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "naics_description": {
-          "type": "text"
-        },
-        "treasury_accounts": {
-          "type": "nested",
-          "properties": {
-            "aid": {
-              "type": "integer"
-            },
-            "ata": {
-              "type": "integer"
-            },
-            "main": {
-              "type": "integer"
-            },
-            "sub": {
-              "type": "integer"
-            },
-            "bpoa": {
-              "type": "integer"
-            },
-            "epoa": {
-              "type": "integer"
-            },
-            "a": {
-              "type": "text"
-            }
+    "properties": {
+      "award_id": {
+        "type": "integer"
+      },
+      "generated_unique_award_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
           }
         }
+      },
+      "display_award_id": {
+        "type": "keyword"
+      },
+      "category": {
+        "type": "text"
+      },
+      "type": {
+        "type": "keyword",
+        "null_value": "NULL"
+      },
+      "type_description": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "piid": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "fain": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "uri": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "total_obligation": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "stemmer_analyzer"
+      },
+      "total_obl_bin": {
+        "type": "keyword"
+      },
+      "total_subsidy_cost": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "total_loan_value": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "recipient_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_unique_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_hash": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "parent_recipient_unique_id": {
+        "type": "keyword",
+        "null_value": "NULL"
+      },
+      "business_categories": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "action_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "fiscal_year": {
+        "type": "integer"
+      },
+      "last_modified_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+      },
+      "update_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+      },
+      "period_of_performance_start_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "period_of_performance_current_end_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "date_signed": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "ordering_period_end_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "original_loan_subsidy_cost": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "face_value_loan_guarantee": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "awarding_agency_id": {
+        "type": "integer"
+      },
+      "funding_agency_id": {
+        "type": "integer"
+      },
+      "awarding_toptier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_toptier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_subtier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_subtier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_toptier_agency_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_toptier_agency_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_subtier_agency_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_subtier_agency_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_location_country_code": {
+        "type": "keyword"
+      },
+      "recipient_location_country_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_location_state_code": {
+        "type": "keyword"
+      },
+      "recipient_location_county_code": {
+        "type": "keyword"
+      },
+      "recipient_location_county_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_location_zip5": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_location_congressional_code": {
+        "type": "keyword"
+      },
+      "recipient_location_city_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pop_country_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pop_country_code": {
+        "type": "keyword"
+      },
+      "pop_state_code": {
+        "type": "keyword"
+      },
+      "pop_county_code": {
+        "type": "keyword"
+      },
+      "pop_county_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pop_zip5": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pop_congressional_code": {
+        "type": "keyword"
+      },
+      "pop_city_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "cfda_number": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "sai_number": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "type_of_contract_pricing": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "type_set_aside": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "extent_competed": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "product_or_service_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "product_or_service_description": {
+        "type": "text"
+      },
+      "naics_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "naics_description": {
+        "type": "text"
+      },
+      "treasury_accounts": {
+        "type": "keyword"
       }
+    }
   }
 }

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import boto3
 import json
 import os
@@ -235,7 +237,7 @@ class DataJob:
 # ==============================================================================
 
 
-def convert_postgres_array_as_string_to_list(array_as_string: str) -> list:
+def convert_postgres_array_as_string_to_list(array_as_string: str) -> Optional[list]:
     """
         Postgres arrays are stored in CSVs as strings. Elasticsearch is able to handle lists of items, but needs to
         be passed a list instead of a string. In the case of an empty array, return null.
@@ -244,13 +246,24 @@ def convert_postgres_array_as_string_to_list(array_as_string: str) -> list:
     return array_as_string[1:-1].split(",") if len(array_as_string) > 2 else None
 
 
-def convert_postgres_json_array_as_string_to_json(json_array_as_string: str) -> dict:
+def convert_postgres_json_array_as_string_to_list(json_array_as_string: str) -> Optional[dict]:
     """
-        Postgres JSON arrays (jsonb) are stored in CSVs as strings. Elasticsearch is able to handle
-        JSON arrays with nested types, but needs to be passed a list JSON instead of a string.
-        In the case of an empty array, return null.
+        Postgres JSON arrays (jsonb) are stored in CSVs as strings. Since we want to avoid nested types
+        in Elasticsearch the JSON arrays are converted to dictionaries to make parsing easier and then
+        converted back into a formatted string.
     """
-    return json.loads(json_array_as_string) if json_array_as_string else None
+    if json_array_as_string is None or len(json_array_as_string) == 0:
+        return None
+    result = []
+    json_array = json.loads(json_array_as_string)
+    for j in json_array:
+        for key, value in j.items():
+            if value is None:
+                j[key] = ""
+            else:
+                j[key] = str(value)
+        result.append(json.dumps(j))
+    return result
 
 
 def process_guarddog(process_list):
@@ -385,8 +398,8 @@ def csv_chunk_gen(filename, chunksize, job_id, awards):
     # Need a specific converter to handle converting strings to correct data types (e.g. string -> array)
     converters = {
         "business_categories": convert_postgres_array_as_string_to_list,
-        "treasury_accounts": convert_postgres_json_array_as_string_to_json,
-        "federal_accounts": convert_postgres_json_array_as_string_to_json,
+        "treasury_accounts": convert_postgres_json_array_as_string_to_list,
+        "federal_accounts": convert_postgres_json_array_as_string_to_list,
     }
     # Panda's data type guessing causes issues for Elasticsearch. Explicitly cast using dictionary
     dtype = {k: str for k in VIEW_COLUMNS if k not in converters}

--- a/usaspending_api/etl/es_transaction_template.json
+++ b/usaspending_api/etl/es_transaction_template.json
@@ -23,389 +23,374 @@
     }
   },
   "mappings": {
-      "properties": {
-        "transaction_id": {
-          "type": "integer"
-        },
-        "detached_award_proc_unique": {
-          "type": "text"
-        },
-        "afa_generated_unique": {
-          "type": "text"
-        },
-        "generated_unique_transaction_id": {
-          "type": "text"
-        },
-        "display_award_id": {
-          "type": "keyword"
-        },
-        "update_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
-          "index": false
-        },
-        "modification_number": {
-          "type": "integer"
-        },
-        "generated_unique_award_id": {
-          "type": "keyword"
-        },
-        "award_id": {
-          "type": "integer"
-        },
-        "piid": {
-          "type": "keyword"
-        },
-        "fain": {
-          "type": "keyword"
-        },
-        "uri": {
-          "type": "keyword"
-        },
-        "award_description": {
-          "type": "text",
-          "analyzer": "stemmer_analyzer"
-        },
-        "product_or_service_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
+    "properties": {
+      "transaction_id": {
+        "type": "integer"
+      },
+      "detached_award_proc_unique": {
+        "type": "text"
+      },
+      "afa_generated_unique": {
+        "type": "text"
+      },
+      "generated_unique_transaction_id": {
+        "type": "text"
+      },
+      "display_award_id": {
+        "type": "keyword"
+      },
+      "update_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
+        "index": false
+      },
+      "modification_number": {
+        "type": "integer"
+      },
+      "generated_unique_award_id": {
+        "type": "keyword"
+      },
+      "award_id": {
+        "type": "integer"
+      },
+      "piid": {
+        "type": "keyword"
+      },
+      "fain": {
+        "type": "keyword"
+      },
+      "uri": {
+        "type": "keyword"
+      },
+      "award_description": {
+        "type": "text",
+        "analyzer": "stemmer_analyzer"
+      },
+      "product_or_service_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
           }
-        },
-        "product_or_service_description": {
-          "type": "text"
-        },
-        "naics_code": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "naics_description": {
-          "type": "text"
-        },
-        "type_description": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "award_category": {
-          "type": "keyword"
-        },
-        "recipient_unique_id": {
-          "type": "keyword"
-        },
-        "recipient_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_hash": {
-          "type": "keyword"
-        },
-        "parent_recipient_unique_id": {
-          "type": "keyword",
-          "null_value": "NULL"
-        },
-        "parent_recipient_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "parent_recipient_hash": {
-          "type": "keyword"
-        },
-        "action_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "fiscal_action_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "period_of_performance_start_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "period_of_performance_current_end_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "ordering_period_end_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "transaction_fiscal_year": {
-          "type": "integer"
-        },
-        "award_fiscal_year": {
-          "type": "integer"
-        },
-        "award_amount": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "transaction_amount": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "face_value_loan_guarantee": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "original_loan_subsidy_cost": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "generated_pragmatic_obligation": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        },
-        "awarding_agency_id": {
-          "type": "integer"
-        },
-        "funding_agency_id": {
-          "type": "integer"
-        },
-        "awarding_toptier_agency_id": {
-          "type": "integer"
-        },
-        "awarding_subtier_agency_id": {
-          "type": "integer"
-        },
-        "funding_toptier_agency_id": {
-          "type": "integer"
-        },
-        "funding_subtier_agency_id": {
-          "type": "integer"
-        },
-        "awarding_toptier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_toptier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_subtier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_subtier_agency_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_toptier_agency_abbreviation": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_toptier_agency_abbreviation": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_subtier_agency_abbreviation": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "funding_subtier_agency_abbreviation": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "awarding_toptier_agency_code": {
-          "type": "keyword"
-        },
-        "funding_toptier_agency_code": {
-          "type": "keyword"
-        },
-        "awarding_subtier_agency_code": {
-          "type": "keyword"
-        },
-        "funding_subtier_agency_code": {
-          "type": "keyword"
-        },
-        "cfda_id": {
-          "type": "integer"
-        },
-        "cfda_number": {
-          "type": "keyword"
-        },
-        "cfda_title": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "cfda_popular_name": {
-          "type": "text",
-          "index": false
-        },
-        "type_of_contract_pricing": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "type_set_aside": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "extent_competed": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "type": {
-          "type": "keyword",
-          "null_value": "NULL"
-        },
-        "pop_country_code": {
-          "type": "keyword"
-        },
-        "pop_country_name": {
-          "type": "text"
-        },
-        "pop_state_code": {
-          "type": "keyword"
-        },
-        "pop_county_code": {
-          "type": "keyword"
-        },
-        "pop_county_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "pop_zip5": {
-          "type": "text"
-        },
-        "pop_congressional_code": {
-          "type": "keyword"
-        },
-        "pop_city_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_location_country_code": {
-          "type": "keyword"
-        },
-        "recipient_location_country_name": {
-          "type": "text"
-        },
-        "recipient_location_state_code": {
-          "type": "keyword"
-        },
-        "recipient_location_county_code": {
-          "type": "keyword"
-        },
-        "recipient_location_county_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "recipient_location_zip5": {
-          "type": "text"
-        },
-        "recipient_location_congressional_code": {
-          "type": "keyword"
-        },
-        "recipient_location_city_name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
-        "treasury_accounts": {
-          "type": "nested",
-          "properties": {
-            "aid": {"type": "keyword"},
-            "ata": {"type": "keyword"},
-            "main": {"type": "keyword"},
-            "sub": {"type": "keyword"},
-            "bpoa": {"type": "keyword"},
-            "epoa": {"type": "keyword"},
-            "a": {"type": "keyword"}
-          }
-        },
-        "federal_accounts": {
-          "type": "nested",
-          "properties": {
-            "id": {"type": "integer"},
-            "account_title": {"type": "keyword"},
-            "federal_account_code": {"type": "keyword"}
-          }
-        },
-        "business_categories": {
-          "type": "keyword"
         }
+      },
+      "product_or_service_description": {
+        "type": "text"
+      },
+      "naics_code": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "naics_description": {
+        "type": "text"
+      },
+      "type_description": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "award_category": {
+        "type": "keyword"
+      },
+      "recipient_unique_id": {
+        "type": "keyword"
+      },
+      "recipient_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_hash": {
+        "type": "keyword"
+      },
+      "parent_recipient_unique_id": {
+        "type": "keyword",
+        "null_value": "NULL"
+      },
+      "parent_recipient_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "parent_recipient_hash": {
+        "type": "keyword"
+      },
+      "action_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "fiscal_action_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "period_of_performance_start_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "period_of_performance_current_end_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "ordering_period_end_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "transaction_fiscal_year": {
+        "type": "integer"
+      },
+      "award_fiscal_year": {
+        "type": "integer"
+      },
+      "award_amount": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "transaction_amount": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "face_value_loan_guarantee": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "original_loan_subsidy_cost": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "generated_pragmatic_obligation": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "awarding_agency_id": {
+        "type": "integer"
+      },
+      "funding_agency_id": {
+        "type": "integer"
+      },
+      "awarding_toptier_agency_id": {
+        "type": "integer"
+      },
+      "awarding_subtier_agency_id": {
+        "type": "integer"
+      },
+      "funding_toptier_agency_id": {
+        "type": "integer"
+      },
+      "funding_subtier_agency_id": {
+        "type": "integer"
+      },
+      "awarding_toptier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_toptier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_subtier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_subtier_agency_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_toptier_agency_abbreviation": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_toptier_agency_abbreviation": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_subtier_agency_abbreviation": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "funding_subtier_agency_abbreviation": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "awarding_toptier_agency_code": {
+        "type": "keyword"
+      },
+      "funding_toptier_agency_code": {
+        "type": "keyword"
+      },
+      "awarding_subtier_agency_code": {
+        "type": "keyword"
+      },
+      "funding_subtier_agency_code": {
+        "type": "keyword"
+      },
+      "cfda_id": {
+        "type": "integer"
+      },
+      "cfda_number": {
+        "type": "keyword"
+      },
+      "cfda_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "cfda_popular_name": {
+        "type": "text",
+        "index": false
+      },
+      "type_of_contract_pricing": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "type_set_aside": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "extent_competed": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "type": {
+        "type": "keyword",
+        "null_value": "NULL"
+      },
+      "pop_country_code": {
+        "type": "keyword"
+      },
+      "pop_country_name": {
+        "type": "text"
+      },
+      "pop_state_code": {
+        "type": "keyword"
+      },
+      "pop_county_code": {
+        "type": "keyword"
+      },
+      "pop_county_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pop_zip5": {
+        "type": "text"
+      },
+      "pop_congressional_code": {
+        "type": "keyword"
+      },
+      "pop_city_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_location_country_code": {
+        "type": "keyword"
+      },
+      "recipient_location_country_name": {
+        "type": "text"
+      },
+      "recipient_location_state_code": {
+        "type": "keyword"
+      },
+      "recipient_location_county_code": {
+        "type": "keyword"
+      },
+      "recipient_location_county_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "recipient_location_zip5": {
+        "type": "text"
+      },
+      "recipient_location_congressional_code": {
+        "type": "keyword"
+      },
+      "recipient_location_city_name": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "treasury_accounts": {
+        "type": "keyword"
+      },
+      "federal_accounts": {
+        "type": "keyword"
+      },
+      "business_categories": {
+        "type": "keyword"
       }
-
+    }
   }
 }

--- a/usaspending_api/tests/test_award_index_elasticsearch.py
+++ b/usaspending_api/tests/test_award_index_elasticsearch.py
@@ -102,38 +102,38 @@ def test_date_range(award_data_fixture, elasticsearch_award_index):
 
 def test_tas(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
-    should = {
-        "nested": {
-            "path": "treasury_accounts",
-            "query": {
-                "bool": {
-                    "should": [
-                        {"match": {"treasury_accounts.aid": "097"}},
-                        {"match": {"treasury_accounts.main": "4930"}},
-                    ],
-                    "minimum_should_match": 2,
-                }
-            },
-        }
+    search_regex = (
+        '\\"a\\": \\"{a}\\", \\"aid\\": \\"{aid}\\", \\"ata\\": \\"{ata}\\",'
+        ' \\"sub\\": \\"{sub}\\", \\"bpoa\\": \\"{bpoa}\\", \\"epoa\\": \\"{epoa}\\",'
+        ' \\"main\\": \\"{main}\\"'
+    )
+
+    tas_code_regexes1 = {
+        "aid": "097",
+        "ata": ".*",
+        "main": "4930",
+        "sub": ".*",
+        "bpoa": ".*",
+        "epoa": ".*",
+        "a": ".*",
     }
+    value_regex1 = "{" + search_regex.format(**tas_code_regexes1) + "}"
+    should = {"regexp": {"treasury_accounts": {"value": value_regex1}}}
     query = create_query(should)
     client = elasticsearch_award_index.client
     response = client.search(index=elasticsearch_award_index.index_name, body=query)
     assert response["hits"]["total"]["value"] == 1
-    should = {
-        "nested": {
-            "path": "treasury_accounts",
-            "query": {
-                "bool": {
-                    "should": [
-                        {"match": {"treasury_accounts.aid": "028"}},
-                        {"match": {"treasury_accounts.main": "8006"}},
-                    ],
-                    "minimum_should_match": 2,
-                }
-            },
-        }
+    tas_code_regexes2 = {
+        "aid": "028",
+        "ata": ".*",
+        "main": "8006",
+        "sub": ".*",
+        "bpoa": ".*",
+        "epoa": ".*",
+        "a": ".*",
     }
+    value_regex2 = "{" + search_regex.format(**tas_code_regexes2) + "}"
+    should = {"regexp": {"treasury_accounts": {"value": value_regex2}}}
     query = create_query(should)
     response = client.search(index=elasticsearch_award_index.index_name, body=query)
     assert response["hits"]["total"]["value"] == 0


### PR DESCRIPTION
**Description:**
Removed Nested Types from Transaction and Award ES indexes.

**Technical details:**
Did not change the View SQL that makes the JSON Array in Postgres, but instead added to the ETL so that it will parse the JSON Array and create a list of formatted strings. Made updates to the TAS filter to use `regexp` query since TAS and Federal Account records will be stored as a list of formatted strings in Elasticsearch.

Here is a sample query run on Kibana against Elasticsearch: 
```
{
  "query": {
    "regexp": {
      "treasury_accounts": {
        "value": """{\"a\": \".*\", \"aid\": \"097\", \"ata\": \".*\", \"sub\": \".*\", \"bpoa\": \".*\", \"epoa\": \".*\", \"main\": \"4930\"}"""
      }
    }
  }
}
```

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4155](https://federal-spending-transparency.atlassian.net/browse/DEV-4155):
    - [X] Link to this Pull-Request (N/A)
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No link on the JIRA Ticket since this goes into the current open PR.
```
