### PR TITLE
[DEV-3997 HOTFIX]: Temporarily remove account rollups

### DIFF
--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -30,9 +30,11 @@ from usaspending_api.awards.v2.filters.matview_filters import (
 )
 from usaspending_api.awards.v2.filters.sub_award import subaward_download
 from usaspending_api.awards.v2.lookups.lookups import award_type_mapping
-from usaspending_api.download.filestreaming.generate_export_query import (
-    generate_file_b_custom_account_download_export_query,
-)
+
+# Temporary hotfix to get custom award downloads working until a permanent solution can be found
+# from usaspending_api.download.filestreaming.generate_export_query import (
+#     generate_file_b_custom_account_download_export_query,
+# )
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 from usaspending_api.download.helpers.download_annotation_functions import (
     universal_transaction_matview_annotations,
@@ -112,7 +114,8 @@ VALUE_MAPPINGS = {
         "download_name": "{data_quarters}_{agency}_{level}_AccountBreakdownByPA-OC_{timestamp}",
         "zipfile_template": "{data_quarters}_{agency}_{level}_AccountBreakdownByPA-OC_{timestamp}",
         "filter_function": account_download_filter,
-        "export_query_function": generate_file_b_custom_account_download_export_query,
+        # Temporary hotfix to get custom award downloads working until a permanent solution can be found
+        # "export_query_function": generate_file_b_custom_account_download_export_query,
     },
     "award_financial": {
         "source_type": "account",

--- a/usaspending_api/download/tests/integration/test_download_accounts_dev_3997.py
+++ b/usaspending_api/download/tests/integration/test_download_accounts_dev_3997.py
@@ -48,6 +48,8 @@ def get_csv_contents_and_clean_up(zip_file_path):
     return [{k: v for k, v in r.items() if k in important_columns} for r in csv_reader]
 
 
+# Temporary hotfix to get custom award downloads working until a permanent solution can be found
+@pytest.mark.skip
 @pytest.mark.django_db(transaction=True)
 def test_download_accounts_dev_3997(client):
     """


### PR DESCRIPTION
HOTFIX to temporarily remove account rollups until such time as we can make them not require a temporary table.