### PR TITLE
Add info logging for USAspending-API modules

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -318,6 +318,8 @@ LOGGING = {
     "loggers": {
         # The root logger; i.e. "all modules"
         "": {"handlers": ["console", "console_file"], "level": "WARNING", "propagate": False},
+        # The "root" logger for all usaspending_api modules
+        "usaspending_api": {"handlers": ["console", "console_file"], "level": "INFO", "propagate": False},
         # Logger for Django API requests via middleware. See logging.py
         "server": {"handlers": ["server"], "level": "INFO", "propagate": False},
         # Catch-all logger (over)used for non-Django-API commands that output to the console

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -328,9 +328,6 @@ LOGGING = {
         "script": {"handlers": ["script"], "level": "INFO", "propagate": False},
         # Logger used to specifically record exceptions
         "exceptions": {"handlers": ["console", "console_file"], "level": "ERROR", "propagate": False},
-        # ======== Module-specific loggers ========
-        "usaspending_api.common.sqs": {"handlers": ["console", "console_file"], "level": "INFO", "propagate": False},
-        "usaspending_api.download": {"handlers": ["console", "console_file"], "level": "INFO", "propagate": False},
     },
 }
 


### PR DESCRIPTION
**Description:**
Add info logging for USAspending-API modules to be able to track them in Kibana.

**Technical details:**
A "root" logger for the USAspending-API modules so that we can track Info logs in Kibana.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed (N/A)
6. [X] Data validation completed (N/A)
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [X] Link to this Pull-Request (N/A)
    - [X] Performance evaluation of affected (API | Script | Download) (N/A)
    - [X] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```

```
