### PR TITLE
[OPS] Removing truncate from SQL scripts

### DIFF
--- a/usaspending_api/broker/management/sql/restock_duns.sql
+++ b/usaspending_api/broker/management/sql/restock_duns.sql
@@ -68,7 +68,7 @@ CREATE TABLE public.temporary_restock_duns AS (
 );
 
 BEGIN;
-TRUNCATE TABLE public.duns RESTART IDENTITY;
+DELETE FROM public.duns;
 INSERT INTO public.duns SELECT * FROM public.temporary_restock_duns;
 DROP TABLE public.temporary_restock_duns;
 COMMIT;

--- a/usaspending_api/recipient/management/sql/restock_recipient_lookup.sql
+++ b/usaspending_api/recipient/management/sql/restock_recipient_lookup.sql
@@ -423,7 +423,7 @@ ON CONFLICT (recipient_hash) DO NOTHING;
 VACUUM ANALYZE public.temporary_restock_recipient_lookup;
 DO $$ BEGIN RAISE NOTICE 'Step 6: Restocking destination table: recipient_lookup'; END $$;
 BEGIN;
-TRUNCATE TABLE public.recipient_lookup RESTART IDENTITY;
+DELETE FROM public.recipient_lookup;
 INSERT INTO public.recipient_lookup (
     recipient_hash, legal_business_name, duns, address_line_1, address_line_2,
     city, state, zip5, zip4, country_code,

--- a/usaspending_api/recipient/management/sql/restock_recipient_profile.sql
+++ b/usaspending_api/recipient/management/sql/restock_recipient_profile.sql
@@ -313,7 +313,7 @@ DELETE FROM public.temporary_restock_recipient_profile WHERE unused = true;
 DO $$ BEGIN RAISE NOTICE 'Step 10: restocking destination table'; END $$;
 
 BEGIN;
-TRUNCATE TABLE public.recipient_profile RESTART IDENTITY;
+DELETE FROM public.recipient_profile;
 INSERT INTO public.recipient_profile (
     recipient_level, recipient_hash, recipient_unique_id,
     recipient_name, recipient_affiliations, award_types, last_12_months,

--- a/usaspending_api/recipient/management/sql/restock_summary_award_recipient.sql
+++ b/usaspending_api/recipient/management/sql/restock_summary_award_recipient.sql
@@ -28,7 +28,7 @@ CREATE TABLE public.earliest_transaction_temp AS (
 DO $$ BEGIN RAISE NOTICE 'Step 2: Create summary_award_recipient'; END $$;
 
 BEGIN;
-TRUNCATE TABLE public.summary_award_recipient RESTART IDENTITY;
+DELETE FROM public.summary_award_recipient;
 INSERT INTO public.summary_award_recipient
   (award_id, action_date, recipient_hash, parent_recipient_unique_id)
   SELECT


### PR DESCRIPTION
**Description:**
Truncate has a few nice benefits. Unfortunately, when run within a lengthly transaction block it completely locks the table to reads.

**Technical details:**
[TRUNCATE](https://www.postgresql.org/docs/10/sql-truncate.html) vs [DELETE FROM](https://www.postgresql.org/docs/10/sql-delete.html)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Operations
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Minor SQL tweaks for ETL scripts
```
