### PR TITLE
Fix JSON aggregation in award_delta_view 

### DIFF
--- a/usaspending_api/database_scripts/etl/award_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/award_delta_view.sql
@@ -94,7 +94,7 @@ SELECT
   SELECT
     faba.award_id,
     JSONB_AGG(
-      JSONB_BUILD_OBJECT(
+      DISTINCT JSONB_BUILD_OBJECT(
         'aid', taa.agency_id,
         'ata', taa.allocation_transfer_agency_id,
         'main', taa.main_account_code,


### PR DESCRIPTION
**Description:**
Adds `DISTINCT` to the json aggregation in award delta view to prevent overrunning the csv field limit.