### PR TITLE
seperated awards from ref data

### DIFF
--- a/usaspending_api/search/tests/conftest.py
+++ b/usaspending_api/search/tests/conftest.py
@@ -1,8 +1,16 @@
 from usaspending_api.search.tests.data.spending_by_award_test_data import spending_by_award_test_data
 from usaspending_api.search.tests.integration.spending_by_category.spending_test_fixtures import (
     basic_agencies,
+    basic_award,
     agencies_with_subagencies,
+    subagency_award,
 )
 
 
-__all__ = ["spending_by_award_test_data", "basic_agencies", "agencies_with_subagencies"]
+__all__ = [
+    "spending_by_award_test_data",
+    "basic_agencies",
+    "basic_award",
+    "agencies_with_subagencies",
+    "subagency_award",
+]

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -8,8 +8,10 @@ def basic_agencies(db):
 
     _setup_agency(4, [], "Funding")
 
-    mommy.make("awards.Award", id=1, latest_transaction_id=1)
 
+@pytest.fixture
+def basic_award(db, basic_agencies):
+    mommy.make("awards.Award", id=1, latest_transaction_id=1)
     mommy.make(
         "awards.TransactionNormalized",
         id=1,
@@ -28,6 +30,9 @@ def agencies_with_subagencies(db):
 
     _setup_agency(2, [6], "Funding")
 
+
+@pytest.fixture
+def subagency_award(db, agencies_with_subagencies):
     mommy.make("awards.Award", id=2, latest_transaction_id=2)
 
     mommy.make(

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
@@ -16,7 +16,7 @@ the endpoint these tests should be updated to reflect the change.
 """
 
 
-def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_agencies):
+def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_award):
     """
     General test to make sure that all groups respond with a Status Code of 200 regardless of the filters.
     """
@@ -35,7 +35,7 @@ def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction
 
 
 def test_correct_response_with_more_awards(
-    client, monkeypatch, elasticsearch_transaction_index, basic_agencies, agencies_with_subagencies
+    client, monkeypatch, elasticsearch_transaction_index, basic_award, subagency_award
 ):
 
     logging_statements = []
@@ -62,7 +62,7 @@ def test_correct_response_with_more_awards(
     assert resp.json() == expected_response
 
 
-def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, basic_agencies):
+def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, basic_award):
 
     logging_statements = []
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_subagency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_subagency.py
@@ -18,7 +18,7 @@ the endpoint these tests should be updated to reflect the change.
 
 
 @pytest.mark.django_db
-def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_agencies):
+def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_award):
     """
     General test to make sure that all groups respond with a Status Code of 200 regardless of the filters.
     """
@@ -37,9 +37,7 @@ def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction
 
 
 @pytest.mark.django_db
-def test_correct_response(
-    client, monkeypatch, elasticsearch_transaction_index, basic_agencies, agencies_with_subagencies
-):
+def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, basic_award, subagency_award):
 
     logging_statements = []
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_funding_agency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_funding_agency.py
@@ -18,7 +18,7 @@ the endpoint these tests should be updated to reflect the change.
 
 
 @pytest.mark.django_db
-def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_agencies):
+def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_award):
     """
     General test to make sure that all groups respond with a Status Code of 200 regardless of the filters.
     """
@@ -37,9 +37,7 @@ def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction
 
 
 @pytest.mark.django_db
-def test_correct_response(
-    client, monkeypatch, elasticsearch_transaction_index, basic_agencies, agencies_with_subagencies
-):
+def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, basic_award, subagency_award):
 
     logging_statements = []
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_funding_subagency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_funding_subagency.py
@@ -18,7 +18,7 @@ the endpoint these tests should be updated to reflect the change.
 
 
 @pytest.mark.django_db
-def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_agencies):
+def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, basic_award):
     """
     General test to make sure that all groups respond with a Status Code of 200 regardless of the filters.
     """
@@ -37,9 +37,7 @@ def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction
 
 
 @pytest.mark.django_db
-def test_correct_response(
-    client, monkeypatch, elasticsearch_transaction_index, basic_agencies, agencies_with_subagencies
-):
+def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, basic_award, subagency_award):
 
     logging_statements = []
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)


### PR DESCRIPTION
**Description:**
Since we all have to add different aspects to these transactions and awards, splitting that off from the ref data will avoid a lot of conflicts