### PR TITLE
[DEV-3932] Adjust download agency list

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md
@@ -16,7 +16,7 @@ requests it returns a list of all user selectable flagged subtier agencies.
             + Members
                 + `account_agencies`
                 + `award_agencies`
-        + `agency` (required, optional)
+        + `agency` (optional, number)
 
 + Response 200 (application/json)
     + Attributes (object)

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md
@@ -5,30 +5,36 @@ HOST: https://api.usaspending.gov
 
 ## POST
 
-This route lists all the agencies and the subagencies or federal accounts associated under specific agencies.
-        
+This route returns one of three result set flavors.  For "account_agencies" requests, it returns a list
+of all toptier agencies with at least one DABS submission.  For "award_agencies" requests, it returns a
+list of all user selectable flagged toptier agencies with at least one subtier agency.  For specific agency
+requests it returns a list of all user selectable flagged subtier agencies.
+
 + Request (application/json)
     + Attributes (object)
-        + `agency` (required, number)
+        + `type` (required, enum[string])
+            + Members
+                + `account_agencies`
+                + `award_agencies`
+        + `agency` (required, optional)
 
 + Response 200 (application/json)
     + Attributes (object)
         + `agencies` (required, object)
             + `cfo_agencies` (required, array[Agency], fixed-type)
             + `other_agencies` (required, array[Agency], fixed-type)
-        + `federal_accounts` (required, array[FederalAgency], fixed-type)
         + `sub_agencies` (required, array[SubAgency], fixed-type)
 
 # Data Structures
 
 ## Agency (object)
+For "account_agencies" requests, it returns a list of all toptier agencies with at least one DABS submission.
+For "award_agencies" requests, it returns a list of all user selectable flagged toptier agencies with at least
+one subtier agency. 
 + `toptier_code` (required, string)
 + `name` (required, string)
 + `toptier_agency_id` (required, number)
 
-## FederalAgency (object)
-+ `federal_account_id` (required, number)
-+ `federal_account_name` (required, string)
-
 ## SubAgency (object)
+Returns a list of all user selectable flagged subtier agencies for the agency specified in the request.
 + `subtier_agency_name` (required, string)

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md
@@ -5,8 +5,8 @@ HOST: https://api.usaspending.gov
 
 ## POST
 
-This route returns one of three result set flavors.  For "account_agencies" requests, it returns a list
-of all toptier agencies with at least one DABS submission.  For "award_agencies" requests, it returns a
+This route returns one of three result set flavors.  For "account_agencies" requests it returns a list
+of all toptier agencies with at least one DABS submission.  For "award_agencies" requests it returns a
 list of all user selectable flagged toptier agencies with at least one subtier agency.  For specific agency
 requests it returns a list of all user selectable flagged subtier agencies.
 
@@ -28,13 +28,9 @@ requests it returns a list of all user selectable flagged subtier agencies.
 # Data Structures
 
 ## Agency (object)
-For "account_agencies" requests, it returns a list of all toptier agencies with at least one DABS submission.
-For "award_agencies" requests, it returns a list of all user selectable flagged toptier agencies with at least
-one subtier agency. 
 + `toptier_code` (required, string)
 + `name` (required, string)
 + `toptier_agency_id` (required, number)
 
 ## SubAgency (object)
-Returns a list of all user selectable flagged subtier agencies for the agency specified in the request.
 + `subtier_agency_name` (required, string)

--- a/usaspending_api/download/v2/download_list_agencies.py
+++ b/usaspending_api/download/v2/download_list_agencies.py
@@ -1,52 +1,61 @@
-from django.db.models import F
+from django.db.models import Exists, F, OuterRef
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from usaspending_api.accounts.models import FederalAccount
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.download.lookups import CFO_CGACS
-from usaspending_api.references.models import Agency
-from usaspending_api.references.models import SubtierAgency, ToptierAgency
+from usaspending_api.references.models import Agency, SubtierAgency, ToptierAgency
 from usaspending_api.submissions.models import SubmissionAttributes
+
+
+ACCOUNT_AGENCIES = "account_agencies"
+AWARD_AGENCIES = "award_agencies"
+AGENCY_LIST_TYPES = (ACCOUNT_AGENCIES, AWARD_AGENCIES)
 
 
 class DownloadListAgenciesViewSet(APIView):
     """
-    This route lists all the agencies and the subagencies or federal accounts associated under specific agencies.
+    This route returns one of three result set flavors.  For "account_agencies" requests, it returns a list
+    of all toptier agencies with at least one DABS submission.  For "award_agencies" requests, it returns a
+    list of all user selectable flagged toptier agencies with at least one subtier agency.  For specific agency
+    requests it returns a list of all user selectable flagged subtier agencies.
     """
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md"
-    sub_agencies_map = {}
-
-    def pull_modified_agencies_cgacs_subtiers(self):
-        self.sub_agencies_map = {
-            sa["subtier_code"]: sa["agency__toptier_agency__toptier_code"]
-            for sa in SubtierAgency.objects.filter(agency__user_selectable=True).values(
-                "subtier_code", "agency__toptier_agency__toptier_code"
-            )
-        }
 
     def post(self, request):
-        """Return list of agencies if no POST data is provided.
-        Otherwise, returns sub_agencies/federal_accounts associated with the agency provided"""
-        response_data = {"agencies": [], "sub_agencies": [], "federal_accounts": []}
 
-        agency_id = None
-        post_data = request.data
-        if post_data:
-            if "agency" not in post_data:
-                raise InvalidParameterException("Missing one or more required body parameters: agency")
-            agency_id = post_data["agency"]
+        post_data = request.data or {}
+        toptier_agency_id = post_data.get("agency")
+        list_type = post_data.get("type")
+        if list_type not in AGENCY_LIST_TYPES:
+            raise InvalidParameterException(f"type must be one of: {AGENCY_LIST_TYPES}")
 
-        # Get all the top tier agencies that have submissions.
-        submitters = SubmissionAttributes.objects.filter(toptier_code__isnull=False).distinct().values("toptier_code")
-        toptier_agencies = list(
-            ToptierAgency.objects.filter(toptier_code__in=submitters).values(
-                "name", "toptier_agency_id", "toptier_code"
+        if list_type == ACCOUNT_AGENCIES:
+            # Get toptier agencies that have DABS submissions.  As per discussion with PO, these are not
+            # subject to user selectable flag.
+            toptier_agencies = ToptierAgency.objects.filter(
+                toptier_code__in=SubmissionAttributes.objects.filter(toptier_code__isnull=False)
+                .distinct()
+                .values("toptier_code")
             )
-        )
 
-        if not agency_id:
-            # Return all the agencies if no agency id provided
+        else:  # AWARD_AGENCIES
+            # Get toptier agencies that have a subtier and for which the user_selectable flag is True.
+            toptier_agencies = ToptierAgency.objects.annotate(
+                include_agency=Exists(
+                    Agency.objects.filter(
+                        user_selectable=True, subtier_agency_id__isnull=False, toptier_agency_id=OuterRef("pk")
+                    ).values("pk")
+                )
+            ).filter(include_agency=True)
+
+        toptier_agencies = toptier_agencies.values("name", "toptier_agency_id", "toptier_code")
+        response_data = {"agencies": [], "sub_agencies": []}
+
+        if not toptier_agency_id:
+            # Convert to list since we'll be iterating over the results twice which would otherwise run the query twice.
+            toptier_agencies = list(toptier_agencies)
+
             cfo_agencies = sorted(
                 [a for a in toptier_agencies if a["toptier_code"] in CFO_CGACS],
                 key=lambda a: CFO_CGACS.index(a["toptier_code"]),
@@ -55,41 +64,27 @@ class DownloadListAgenciesViewSet(APIView):
                 [a for a in toptier_agencies if a["toptier_code"] not in CFO_CGACS], key=lambda a: a["name"]
             )
             response_data["agencies"] = {"cfo_agencies": cfo_agencies, "other_agencies": other_agencies}
-        else:
-            if not self.sub_agencies_map:
-                # populate the sub_agencies dictionary
-                self.pull_modified_agencies_cgacs_subtiers()
 
-            # Get the top tier agency object based on the agency id provided
-            top_tier_agency = list(filter(lambda toptier: toptier["toptier_agency_id"] == agency_id, toptier_agencies))
-            if not top_tier_agency:
+        else:
+            # Get the top tier agency object based on the agency id provided.  It must still meet all of the
+            # account/award type filtering above.
+            toptier_agency = toptier_agencies.filter(pk=toptier_agency_id).first()
+            if not toptier_agency:
                 raise InvalidParameterException("Agency ID not found")
-            top_tier_agency = top_tier_agency[0]
-            # Get the sub agencies and federal accounts associated with that top tier agency
-            # Removed distinct subtier_agency_name since removing subtiers with multiple codes that aren't in the
-            # modified list
-            response_data["sub_agencies"] = (
-                Agency.objects.filter(toptier_agency_id=agency_id)
-                .values(
-                    subtier_agency_name=F("subtier_agency__name"), subtier_agency_code=F("subtier_agency__subtier_code")
+
+            # Get the subtier agencies associated with the toptier agency but only if they're user selectable.
+            response_data["sub_agency"] = (
+                SubtierAgency.objects.annotate(
+                    include_agency=Exists(
+                        Agency.objects.filter(
+                            user_selectable=True, subtier_agency_id=OuterRef("pk"), toptier_agency_id=toptier_agency_id
+                        ).values("pk")
+                    )
                 )
+                .filter(include_agency=True)
+                .values(subtier_agency_name=F("name"))
+                .distinct()
                 .order_by("subtier_agency_name")
             )
-            # Tried converting this to queryset filtering but ran into issues trying to
-            # double check the right used subtier_agency by cross checking the toptier_code
-            # see the last 2 lines of the list comprehension below
-            response_data["sub_agencies"] = [
-                subagency
-                for subagency in response_data["sub_agencies"]
-                if subagency["subtier_agency_code"] in self.sub_agencies_map
-                and self.sub_agencies_map[subagency["subtier_agency_code"]] == top_tier_agency["toptier_code"]
-            ]
-            for subagency in response_data["sub_agencies"]:
-                del subagency["subtier_agency_code"]
 
-            response_data["federal_accounts"] = (
-                FederalAccount.objects.filter(agency_identifier=top_tier_agency["toptier_code"])
-                .values(federal_account_name=F("account_title"), federal_account_id=F("id"))
-                .order_by("federal_account_name")
-            )
         return Response(response_data)

--- a/usaspending_api/download/v2/download_list_agencies.py
+++ b/usaspending_api/download/v2/download_list_agencies.py
@@ -14,8 +14,8 @@ AGENCY_LIST_TYPES = (ACCOUNT_AGENCIES, AWARD_AGENCIES)
 
 class DownloadListAgenciesViewSet(APIView):
     """
-    This route returns one of three result set flavors.  For "account_agencies" requests, it returns a list
-    of all toptier agencies with at least one DABS submission.  For "award_agencies" requests, it returns a
+    This route returns one of three result set flavors.  For "account_agencies" requests it returns a list
+    of all toptier agencies with at least one DABS submission.  For "award_agencies" requests it returns a
     list of all user selectable flagged toptier agencies with at least one subtier agency.  For specific agency
     requests it returns a list of all user selectable flagged subtier agencies.
     """


### PR DESCRIPTION
**NOTE:**  Merge this at the same time as [FRONTEND 1524](https://github.com/fedspendingtransparency/usaspending-website/pull/1524)

**Description:**

How we return agencies for account downloads vs award downloads have diverged.  This code supports that divergence.  Also removed an unused response array/list.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend
4. [x] Materialized views unaffected
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-3932](https://federal-spending-transparency.atlassian.net/browse/DEV-3932):
    - [x] Link to this Pull-Request