### PR TITLE
Updated ES Mappings for Recipient Unique ID

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -163,9 +163,13 @@ class _RecipientId(_Filter):
         if filter_value.endswith("P"):
             return ES_Q("match", parent_recipient_hash=recipient_hash)
         elif filter_value.endswith("C"):
-            return ES_Q("match", recipient_hash=recipient_hash) & ~ES_Q("match", parent_recipient_unique_id="NULL")
+            return ES_Q("match", recipient_hash=recipient_hash) & ~ES_Q(
+                "match", parent_recipient_unique_id__keyword="NULL"
+            )
         else:
-            return ES_Q("match", recipient_hash=recipient_hash) & ES_Q("match", parent_recipient_unique_id="NULL")
+            return ES_Q("match", recipient_hash=recipient_hash) & ES_Q(
+                "match", parent_recipient_unique_id__keyword="NULL"
+            )
 
 
 class _RecipientScope(_Filter):

--- a/usaspending_api/etl/es_award_template.json
+++ b/usaspending_api/etl/es_award_template.json
@@ -142,8 +142,13 @@
           }
         },
         "parent_recipient_unique_id": {
-          "type": "keyword",
-          "null_value": "NULL"
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "null_value": "NULL"
+            }
+          }
         },
         "business_categories": {
           "type": "text",

--- a/usaspending_api/etl/es_transaction_template.json
+++ b/usaspending_api/etl/es_transaction_template.json
@@ -112,7 +112,12 @@
           "type": "keyword"
         },
         "recipient_unique_id": {
-          "type": "keyword"
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
         },
         "recipient_name": {
           "type": "text",
@@ -126,8 +131,13 @@
           "type": "keyword"
         },
         "parent_recipient_unique_id": {
-          "type": "keyword",
-          "null_value": "NULL"
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "null_value": "NULL"
+            }
+          }
         },
         "parent_recipient_name": {
           "type": "text",


### PR DESCRIPTION
**Description:**
Two fields on the ES Index were changed a few sprints ago from Text to Keyword. Since Text type allows partial matches and Keyword does not it no longer allowed a user to supply a series of search terms (such as a DUNS seperated by commas). This PR reverts that change and makes small additional changes to keep expected functionality.

**Technical details:**
A problem was found where previously a user could pass in a list of DUNS using Keyword Search and it would return all Awards that have match any of those DUNS. A little while back this was removed when `recipient_unique_id` and `parent_recipient_unique_id` were changed from Text to Keyword type in the Elasticsearch Index. 

Below is an example from my Local that shows current functionality. When searching for a series of three numbers only one result is returned. That is because (as the second screenshot shows) the middle number is not paired with a DUNS from an Award, but instead a partial match to the Award Description.

![Screen Shot 2020-02-25 at 3 04 15 PM](https://user-images.githubusercontent.com/40359517/75297105-d28efb80-57e3-11ea-828a-cb4690aefde9.png)

![Screen Shot 2020-02-25 at 3 04 26 PM](https://user-images.githubusercontent.com/40359517/75297301-5a750580-57e4-11ea-8c35-746cdc1b7332.png)

To return to previous functionality the `recipient_unique_id` and `parent_recipient_unique_id` fields were changed to allow Text and Keyword matches, or partial and exact matches. Now when a user supplies a series of DUNS seperated by commas all Awards with a DUNS that has been provided will be returned. The screenshots below demonstrate different combinations of DUNS and the results to showcase that it is working.

![Screen Shot 2020-02-25 at 3 25 32 PM](https://user-images.githubusercontent.com/40359517/75297095-d02ca180-57e3-11ea-980d-0bea50506cbc.png)
![Screen Shot 2020-02-25 at 3 25 23 PM](https://user-images.githubusercontent.com/40359517/75297098-d15dce80-57e3-11ea-8be2-a1538a3e9c4a.png)
![Screen Shot 2020-02-25 at 3 25 10 PM](https://user-images.githubusercontent.com/40359517/75297100-d15dce80-57e3-11ea-9b13-71edf25f9c3b.png)
![Screen Shot 2020-02-25 at 3 24 58 PM](https://user-images.githubusercontent.com/40359517/75297102-d1f66500-57e3-11ea-995d-591e06ecfd7f.png)
**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed (N/A)
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4614](https://federal-spending-transparency.atlassian.net/browse/DEV-4614):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
