### PR TITLE
[FIX] SpendingByAward was unintentionally running an extra SQL

### DIFF
--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -197,7 +197,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
 
     def create_response(self, queryset):
         results = []
-        for record in queryset[: self.pagination["limit"]]:
+        rows = list(queryset)
+        for record in rows[: self.pagination["limit"]]:
             row = {k: record[v] for k, v in self.constants["internal_id_fields"].items()}
 
             for field in self.fields:
@@ -214,7 +215,7 @@ class SpendingByAwardVisualizationViewSet(APIView):
 
         results = self.add_award_generated_id_field(results)
 
-        return self.populate_response(results=results, has_next=len(queryset) > self.pagination["limit"])
+        return self.populate_response(results=results, has_next=len(rows) > self.pagination["limit"])
 
     def add_award_generated_id_field(self, records):
         """Obtain the generated_unique_award_id and add to response"""


### PR DESCRIPTION
**Description:**
The business logic to calculate if there was a next page was making a DB call instead of using a pre-run list of results

**Technical details:**
Django Querysets are lazily loaded, but they will run SQL everytime an operator is determining state. In this case, `len(queryset)` needed to run SQL to determine how many results were being returned. This is unnecessary since the DB rows were already returned to create the response JSON.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Minor edit to business logic to prevent running a nearly-identical SQL statement twice
```

### Before
```console
2020-02-26 15:46:52.924 UTC [44] LOG:  statement: SELECT "mv_contract_award_search"."fain", "mv_contract_award_search"."recipient_name", "mv_contract_award_search"."piid", "mv_contract_award_search"."awarding_toptier_agency_name", "mv_contract_award_search"."awarding_subtier_agency_name", "mv_contract_award_search"."type", "mv_contract_award_search"."period_of_performance_current_end_date", "mv_contract_award_search"."uri", "mv_contract_award_search"."award_id", "mv_contract_award_search"."period_of_performance_start_date", "mv_contract_award_search"."type_description", "mv_contract_award_search"."total_obligation" FROM "mv_contract_award_search" WHERE ("mv_contract_award_search"."type" IN ('A', 'B', 'C', 'D') AND "mv_contract_award_search"."recipient_name_ts_vector" @@ (plainto_tsquery('FREEDOM')) = true AND "mv_contract_award_search"."action_date" >= '2012-10-01'::date AND "mv_contract_award_search"."date_signed" <= '2019-09-30'::date AND "mv_contract_award_search"."awarding_toptier_agency_name" = 'All') ORDER BY "mv_contract_award_search"."total_obligation" DESC NULLS LAST LIMIT 60
2020-02-26 15:46:53.005 UTC [44] LOG:  statement: SELECT "mv_contract_award_search"."fain", "mv_contract_award_search"."recipient_name", "mv_contract_award_search"."piid", "mv_contract_award_search"."awarding_toptier_agency_name", "mv_contract_award_search"."awarding_subtier_agency_name", "mv_contract_award_search"."type", "mv_contract_award_search"."period_of_performance_current_end_date", "mv_contract_award_search"."uri", "mv_contract_award_search"."award_id", "mv_contract_award_search"."period_of_performance_start_date", "mv_contract_award_search"."type_description", "mv_contract_award_search"."total_obligation" FROM "mv_contract_award_search" WHERE ("mv_contract_award_search"."type" IN ('A', 'B', 'C', 'D') AND "mv_contract_award_search"."recipient_name_ts_vector" @@ (plainto_tsquery('FREEDOM')) = true AND "mv_contract_award_search"."action_date" >= '2012-10-01'::date AND "mv_contract_award_search"."date_signed" <= '2019-09-30'::date AND "mv_contract_award_search"."awarding_toptier_agency_name" = 'All') ORDER BY "mv_contract_award_search"."total_obligation" DESC NULLS LAST LIMIT 61
```

### After
```console
2020-02-26 16:09:59.063 UTC [187] LOG:  statement: SELECT "mv_contract_award_search"."award_id", "mv_contract_award_search"."awarding_toptier_agency_name", "mv_contract_award_search"."awarding_subtier_agency_name", "mv_contract_award_search"."total_obligation", "mv_contract_award_search"."piid", "mv_contract_award_search"."period_of_performance_current_end_date", "mv_contract_award_search"."fain", "mv_contract_award_search"."type", "mv_contract_award_search"."type_description", "mv_contract_award_search"."uri", "mv_contract_award_search"."recipient_name", "mv_contract_award_search"."period_of_performance_start_date" FROM "mv_contract_award_search" WHERE ("mv_contract_award_search"."type" IN ('A', 'B', 'C', 'D') AND "mv_contract_award_search"."recipient_name_ts_vector" @@ (plainto_tsquery('FREEDOM')) = true AND "mv_contract_award_search"."action_date" >= '2011-10-01'::date AND "mv_contract_award_search"."date_signed" <= '2019-09-30'::date AND "mv_contract_award_search"."awarding_toptier_agency_name" = 'All') ORDER BY "mv_contract_award_search"."total_obligation" DESC NULLS LAST  LIMIT 61
```
