### PR TITLE
[DEV-3932] Enable and fix tests

### DIFF
--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -1,9 +1,8 @@
 import json
+import pytest
 
 from model_mommy import mommy
-import pytest
 from rest_framework import status
-
 from usaspending_api.awards.models import TransactionNormalized, TransactionFABS, TransactionFPDS
 from usaspending_api.download.lookups import JOB_STATUS
 from usaspending_api.etl.award_helpers import update_awards
@@ -18,6 +17,7 @@ def award_data(db):
     # Create Awarding Top Agency
     ata1 = mommy.make(
         "references.ToptierAgency",
+        toptier_agency_id=1,
         name="Bureau of Things",
         toptier_code="100",
         website="http://test.com",
@@ -26,6 +26,7 @@ def award_data(db):
     )
     ata2 = mommy.make(
         "references.ToptierAgency",
+        toptier_agency_id=2,
         name="Bureau of Stuff",
         toptier_code="101",
         website="http://test.com",
@@ -34,12 +35,16 @@ def award_data(db):
     )
 
     # Create Awarding subs
-    asa1 = mommy.make("references.SubtierAgency", name="Bureau of Things")
-    asa2 = mommy.make("references.SubtierAgency", name="Bureau of Stuff")
+    asa1 = mommy.make("references.SubtierAgency", name="SubBureau of Things")
+    asa2 = mommy.make("references.SubtierAgency", name="SubBureau of Stuff")
 
     # Create Awarding Agencies
-    aa1 = mommy.make("references.Agency", toptier_agency=ata1, subtier_agency=asa1, toptier_flag=False)
-    aa2 = mommy.make("references.Agency", toptier_agency=ata2, subtier_agency=asa2, toptier_flag=False)
+    aa1 = mommy.make(
+        "references.Agency", toptier_agency=ata1, subtier_agency=asa1, toptier_flag=False, user_selectable=True
+    )
+    aa2 = mommy.make(
+        "references.Agency", toptier_agency=ata2, subtier_agency=asa2, toptier_flag=False, user_selectable=True
+    )
 
     # Create Funding Top Agency
     fta = mommy.make(
@@ -159,59 +164,31 @@ def test_download_status_nonexistent_file_404(client):
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def sort_function(agency):
-    return agency["toptier_code"]
-
-
-@pytest.mark.skip
 def test_list_agencies(client, award_data):
     """Test transaction list agencies endpoint"""
-    resp = client.post("/api/v2/bulk_download/list_agencies", content_type="application/json", data=json.dumps({}))
+    resp = client.post(
+        "/api/v2/bulk_download/list_agencies",
+        content_type="application/json",
+        data=json.dumps({"type": "award_agencies"}),
+    )
 
-    all_toptiers = [
-        {"name": "Bureau of Things", "toptier_code": "100"},
-        {"name": "Bureau of Stuff", "toptier_code": "101"},
-        {"name": "Bureau of Money", "toptier_code": "102"},
-    ]
-
-    index = 0
-    agency_ids = []
-    for toptier in sorted(resp.json()["agencies"]["other_agencies"], key=sort_function):
-        assert toptier["name"] == all_toptiers[index]["name"]
-        assert toptier["toptier_code"] == all_toptiers[index]["toptier_code"]
-        agency_ids.append(toptier["toptier_agency_id"])
-        index += 1
-    assert resp.json()["sub_agencies"] == []
-    assert resp.json()["federal_accounts"] == []
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data == {
+        "agencies": {
+            "cfo_agencies": [],
+            "other_agencies": [
+                {"name": "Bureau of Stuff", "toptier_agency_id": 2, "toptier_code": "101"},
+                {"name": "Bureau of Things", "toptier_agency_id": 1, "toptier_code": "100"},
+            ],
+        },
+        "sub_agencies": [],
+    }
 
     resp = client.post(
         "/api/v2/bulk_download/list_agencies",
         content_type="application/json",
-        data=json.dumps({"agency": agency_ids[0]}),
+        data=json.dumps({"type": "award_agencies", "agency": 2}),
     )
 
-    assert resp.json()["agencies"] == []
-    assert resp.json()["sub_agencies"] == [{"subtier_agency_name": "Bureau of Things", "subtier_agency_id": 1}]
-    assert resp.json()["federal_accounts"] == []
-
-    resp = client.post(
-        "/api/v2/bulk_download/list_agencies",
-        content_type="application/json",
-        data=json.dumps({"agency": agency_ids[1]}),
-    )
-
-    assert resp.json()["agencies"] == []
-    assert resp.json()["sub_agencies"] == [{"subtier_agency_name": "Bureau of Stuff", "subtier_agency_id": 2}]
-    assert resp.json()["federal_accounts"] == []
-
-    resp = client.post(
-        "/api/v2/bulk_download/list_agencies",
-        content_type="application/json",
-        data=json.dumps({"agency": agency_ids[2]}),
-    )
-
-    assert resp.json()["agencies"] == []
-    assert resp.json()["sub_agencies"] == [{"subtier_agency_name": "Bureau of Things", "subtier_agency_id": 3}]
-    assert resp.json()["federal_accounts"] == [
-        {"federal_account_name": "Compensation to Accounts", "federal_account_id": 1}
-    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data == {"agencies": [], "sub_agencies": [{"subtier_agency_name": "SubBureau of Stuff"}]}

--- a/usaspending_api/database_scripts/tests/test_custom_sql_functions.py
+++ b/usaspending_api/database_scripts/tests/test_custom_sql_functions.py
@@ -49,6 +49,8 @@ def test_urlencoding_no_change(add_fun_awards):
 
     for i in range(4):
         print(results[i][0], results[i][1])
+
+    for i in range(4):
         assert results[i][0] == results[i][1], "Safe ASCII characters were incorrectly modified!"
 
 

--- a/usaspending_api/database_scripts/tests/test_custom_sql_functions.py
+++ b/usaspending_api/database_scripts/tests/test_custom_sql_functions.py
@@ -10,45 +10,51 @@ URLENCODE_FUNCTION_NAME = "urlencode"
 
 @pytest.fixture()
 def add_fun_awards(db):
-    mommy.make("awards.award", generated_unique_award_id="CONT_IDV_ABCDEFG_0123456")
-    mommy.make("awards.award", generated_unique_award_id="CONT_IDV_abcdefg_9876543")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_._.._..._....")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_-_--_---_----")
-    mommy.make("awards.award", generated_unique_award_id="ASST_AGG_1008DRCATTHP  01^~@01906470531201403_7022")
-    mommy.make("awards.award", generated_unique_award_id="ASST_AGG_12C30000000000006122970000  121/21000_12C3")
-    mommy.make("awards.award", generated_unique_award_id="ASST_AGG_17.302-MARYLAND-PRINCE GEORGE'S-20081231-10_1635")
-    mommy.make("awards.award", generated_unique_award_id="ASST_NON_30180J015 MOD#2_1448")
-    mommy.make("awards.award", generated_unique_award_id="ASST_NON_5% RECAP_8630")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_GS30FY0027QP0019405Â_4732_GS30FY0027_4732")
-    mommy.make("awards.award", generated_unique_award_id="ASST_NON_R!D1102A37    10_12E2")
-    mommy.make("awards.award", generated_unique_award_id="CONT_IDV_[_]_test")
-    mommy.make("awards.award", generated_unique_award_id="CONT_IDV_(_)_test")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_(())_[[]]_test")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_==_++_test")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_?_??_test")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_^_^^_^^^")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_::_;;_:::;;;")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_,_,,_,,,")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_$_$$_$$$")
-    mommy.make("awards.award", generated_unique_award_id="CONT_AWD_%_%%_%%%%")
-    mommy.make("awards.award", generated_unique_award_id="☰☱☳☲☶☴ ൠൠൠ ☴☶☲☳☱☰")
-    mommy.make("awards.award", generated_unique_award_id="❋❋❋ ALL YOUR BASE ARE BELONG TO US ❋❋❋")
-    mommy.make("awards.award", generated_unique_award_id="⎺╲_❪ツ❫_╱⎺")
-    mommy.make("awards.award", generated_unique_award_id="питон е јазик на компјутер и змија")
-    mommy.make("awards.award", generated_unique_award_id="如果科羅拉多被鋪平會比得克薩斯州大")
-    mommy.make("awards.award", generated_unique_award_id="епстеин се није убио")
-    mommy.make("awards.award", generated_unique_award_id="kjo frazë nuk bën mirëkuptim")
-    mommy.make("awards.award", generated_unique_award_id="何者なにものかによって、爆発物ばくはつぶつが仕掛しかけられたようです。")
+    generated_unique_award_ids = [
+        "CONT_IDV_ABCDEFG_0123456",
+        "CONT_IDV_abcdefg_9876543",
+        "CONT_AWD_._.._..._....",
+        "CONT_AWD_-_--_---_----",
+        "ASST_AGG_1008DRCATTHP  01^~@01906470531201403_7022",
+        "ASST_AGG_12C30000000000006122970000  121/21000_12C3",
+        "ASST_AGG_17.302-MARYLAND-PRINCE GEORGE'S-20081231-10_1635",
+        "ASST_NON_30180J015 MOD#2_1448",
+        "ASST_NON_5% RECAP_8630",
+        "CONT_AWD_GS30FY0027QP0019405Â_4732_GS30FY0027_4732",
+        "ASST_NON_R!D1102A37    10_12E2",
+        "CONT_IDV_[_]_test",
+        "CONT_IDV_(_)_test",
+        "CONT_AWD_(())_[[]]_test",
+        "CONT_AWD_==_++_test",
+        "CONT_AWD_?_??_test",
+        "CONT_AWD_^_^^_^^^",
+        "CONT_AWD_::_;;_:::;;;",
+        "CONT_AWD_,_,,_,,,",
+        "CONT_AWD_$_$$_$$$",
+        "CONT_AWD_%_%%_%%%%",
+        "☰☱☳☲☶☴ ൠൠൠ ☴☶☲☳☱☰",
+        "❋❋❋ ALL YOUR BASE ARE BELONG TO US ❋❋❋",
+        "⎺╲_❪ツ❫_╱⎺",
+        "питон е јазик на компјутер и змија",
+        "如果科羅拉多被鋪平會比得克薩斯州大",
+        "епстеин се није убио",
+        "kjo frazë nuk bën mirëkuptim",
+        "何者なにものかによって、爆発物ばくはつぶつが仕掛しかけられたようです。",
+    ]
+    for id_, generated_unique_award_id in enumerate(generated_unique_award_ids):
+        mommy.make("awards.award", id=id_, generated_unique_award_id=generated_unique_award_id)
 
 
 def test_urlencoding_no_change(add_fun_awards):
-    test_sql = f"SELECT generated_unique_award_id, {URLENCODE_FUNCTION_NAME}(generated_unique_award_id) from awards"
+    test_sql = f"""
+        SELECT      generated_unique_award_id,
+                    {URLENCODE_FUNCTION_NAME}(generated_unique_award_id)
+        from        awards
+        order by    id
+    """
     with connection.cursor() as cursor:
         cursor.execute(test_sql)
         results = cursor.fetchall()
-
-    for i in range(4):
-        print(results[i][0], results[i][1])
 
     for i in range(4):
         assert results[i][0] == results[i][1], "Safe ASCII characters were incorrectly modified!"

--- a/usaspending_api/database_scripts/tests/test_custom_sql_functions.py
+++ b/usaspending_api/database_scripts/tests/test_custom_sql_functions.py
@@ -48,6 +48,7 @@ def test_urlencoding_no_change(add_fun_awards):
         results = cursor.fetchall()
 
     for i in range(4):
+        print(results[i][0], results[i][1])
         assert results[i][0] == results[i][1], "Safe ASCII characters were incorrectly modified!"
 
 


### PR DESCRIPTION
**DO NOT MERGE:** Until downmerge #2316 has been completed.

**Description:**

This pull request fixes and enables the `test_list_agencies` test and fixes the `test_urlencoding_no_change` test which was adversely affected by the repairs to the `test_list_agencies` test.

**Technical details:**

`test_urlencoding_no_change` was assuming the insertion order would be the same as the return order which you cannot reliably do in a SQL database without an `order by` clause.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Frontend unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-3932](https://federal-spending-transparency.atlassian.net/browse/DEV-3932):
    - [x] Link to this Pull-Request
