### PR TITLE
[DEV-4531] Trim hashes to remove byte literal

### DIFF
--- a/usaspending_api/database_scripts/job_archive/dev-4531-fix-hashes.sql
+++ b/usaspending_api/database_scripts/job_archive/dev-4531-fix-hashes.sql
@@ -1,8 +1,0 @@
--- Jira Ticket Number: DEV-4531
--- Expected CLI: psql -v ON_ERROR_STOP=1 -c '\timing' -f dev-4531-fix-hashes.sql $DATABASE_URL
---
--- Purpose: Remove the "b''" byte literal from hashes in the filter_hash table
-
-DELETE FROM filter_hash where id in (SELECT b.id FROM filter_hash a INNER JOIN filter_hash b ON a.hash = trim(both '\''' from trim(leading 'b' from b.hash)) WHERE b.hash LIKE 'b\''%\''');
-
-UPDATE filter_hash SET hash = TRIM(both '\''' from trim(leading 'b' from hash)) WHERE hash LIKE 'b\''%\'''; 

--- a/usaspending_api/database_scripts/job_archive/dev-4531-fix-hashes.sql
+++ b/usaspending_api/database_scripts/job_archive/dev-4531-fix-hashes.sql
@@ -1,0 +1,8 @@
+-- Jira Ticket Number: DEV-4531
+-- Expected CLI: psql -v ON_ERROR_STOP=1 -c '\timing' -f dev-4531-fix-hashes.sql $DATABASE_URL
+--
+-- Purpose: Remove the "b''" byte literal from hashes in the filter_hash table
+
+DELETE FROM filter_hash where id in (SELECT b.id FROM filter_hash a INNER JOIN filter_hash b ON a.hash = trim(both '\''' from trim(leading 'b' from b.hash)) WHERE b.hash LIKE 'b\''%\''');
+
+UPDATE filter_hash SET hash = TRIM(both '\''' from trim(leading 'b' from hash)) WHERE hash LIKE 'b\''%\'''; 

--- a/usaspending_api/references/v1/views.py
+++ b/usaspending_api/references/v1/views.py
@@ -27,6 +27,7 @@ class FilterEndpoint(APIView):
         m = hashlib.md5()
         m.update(json_req)
         hash = m.hexdigest().encode("utf8")
+        hash = str(hash)[2:-1]
         # check for hash in db, store if not in db
         try:
             fh = FilterHash.objects.get(hash=hash)

--- a/usaspending_api/references/v1/views.py
+++ b/usaspending_api/references/v1/views.py
@@ -27,7 +27,8 @@ class FilterEndpoint(APIView):
         m = hashlib.md5()
         m.update(json_req)
         hash = m.hexdigest().encode("utf8")
-        hash = str(hash)[2:-1]
+        if len(str(hash)) > 2 and str(hash)[:2] == "b'":
+            hash = str(hash)[2:-1]
         # check for hash in db, store if not in db
         try:
             fh = FilterHash.objects.get(hash=hash)


### PR DESCRIPTION
**Description:**
Fixes the issue with the filter hashes on Advanced Search not functioning properly.

**Technical details:**
Trims the hash being stored in postgres to remove the python byte literal `b''` from the string.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created [DEV-4624](https://federal-spending-transparency.atlassian.net/browse/DEV-4624)
8. [X] Jira Ticket [DEV-4531](https://federal-spending-transparency.atlassian.net/browse/DEV-4531):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to matviews.
```

