### PR TITLE
[DEV-3935] Prevent linking to agencies without agency pages

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
+++ b/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
@@ -771,6 +771,7 @@ This endpoint returns a list of data that is associated with the award profile p
 
 ## Agency (object)
 + `id` (required, number)
++ `has_agency_page` (required, boolean)
 + `toptier_agency` (required, TopTierAgency, nullable)
 + `subtier_agency` (required, SubTierAgency, nullable)
 + `office_agency_name` (required, string, nullable)

--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -979,12 +979,14 @@ expected_response_asst = {
     "transaction_obligated_amount": None,
     "awarding_agency": {
         "id": 1,
+        "has_agency_page": False,
         "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "awarding_office",
     },
     "funding_agency": {
         "id": 1,
+        "has_agency_page": False,
         "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "funding_office",
@@ -1058,12 +1060,14 @@ expected_response_cont = {
     "description": "lorem ipsum",
     "awarding_agency": {
         "id": 1,
+        "has_agency_page": False,
         "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "awarding_office",
     },
     "funding_agency": {
         "id": 1,
+        "has_agency_page": False,
         "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "funding_office",

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -3,7 +3,7 @@ import logging
 
 from collections import OrderedDict
 from decimal import Decimal
-from django.db.models import Sum, F
+from django.db.models import Sum, F, Subquery
 from typing import Optional
 
 from usaspending_api.awards.models import (
@@ -26,6 +26,8 @@ from usaspending_api.common.helpers.data_constants import state_code_from_name, 
 from usaspending_api.common.helpers.date_helper import get_date_from_datetime
 from usaspending_api.common.recipient_lookups import obtain_recipient_uri
 from usaspending_api.references.models import Agency, Cfda, PSC, NAICS, SubtierAgency
+from usaspending_api.submissions.models import SubmissionAttributes
+
 
 logger = logging.getLogger("console")
 
@@ -359,6 +361,12 @@ def fetch_latest_ec_details(award_id: int, mapper: OrderedDict, transaction_type
     return retval.first()
 
 
+def agency_has_file_c_submission(agency_id):
+    return SubmissionAttributes.objects.filter(
+        toptier_code=Subquery(Agency.objects.filter(id=agency_id).values("toptier_agency__toptier_code")[:1])
+    ).exists()
+
+
 def fetch_agency_details(agency_id: int) -> Optional[dict]:
     values = [
         "toptier_agency__toptier_code",
@@ -374,6 +382,7 @@ def fetch_agency_details(agency_id: int) -> Optional[dict]:
     if agency:
         agency_details = {
             "id": agency_id,
+            "has_agency_page": agency_has_file_c_submission(agency_id),
             "toptier_agency": {
                 "name": agency["toptier_agency__name"],
                 "code": agency["toptier_agency__toptier_code"],

--- a/usaspending_api/idvs/tests/test_awards_idv_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idv_v2.py
@@ -369,12 +369,14 @@ expected_response_idv = {
     },
     "awarding_agency": {
         "id": 1,
+        "has_agency_page": False,
         "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "abc"},
         "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "def"},
         "office_agency_name": "awarding_office",
     },
     "funding_agency": {
         "id": 1,
+        "has_agency_page": False,
         "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "abc"},
         "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "def"},
         "office_agency_name": "funding_office",


### PR DESCRIPTION
**Description:**

Today, when an award is viewed that was awarded by an agency that has no agency page in USAspending, users are taken to a 404 page when they click on the agency link.  This pull request is the backend bit that provides the frontend with the information needed to determine whether or not an agency has an agency page.

Paired with [FRONTEND #1532](https://github.com/fedspendingtransparency/usaspending-website/pull/1532) although, **TECHNICALLY**, this change can be pushed without impacting the front end since it is additive.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend
4. [x] Materialized views unaffected
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-3935](https://federal-spending-transparency.atlassian.net/browse/DEV-3935):
    - [x] Link to this Pull-Request