### PR TITLE
[UNTICKETED] Add Timer convenience classes

### DIFF
--- a/usaspending_api/awards/management/commands/load_subawards.py
+++ b/usaspending_api/awards/management/commands/load_subawards.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from pathlib import Path
 from usaspending_api.common.etl import ETLDBLinkTable, ETLTable, ETLTemporaryTable, operations, mixins
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 from usaspending_api.etl.operations.subaward.update_city_county import update_subaward_city_county
 
 

--- a/usaspending_api/common/etl/mixins.py
+++ b/usaspending_api/common/etl/mixins.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional, Union
 from usaspending_api.common.etl import ETLObjectBase
 from usaspending_api.common.etl.operations import delete_obsolete_rows, insert_missing_rows, update_changed_rows
 from usaspending_api.common.helpers.sql_helpers import execute_dml_sql
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 
 
 class ETLMixin:

--- a/usaspending_api/common/helpers/timing_helpers.py
+++ b/usaspending_api/common/helpers/timing_helpers.py
@@ -4,9 +4,7 @@ import math
 import time
 
 from datetime import timedelta
-
-
-logger = logging.getLogger("console")
+from typing import Callable, Optional
 
 
 @contextlib.contextmanager
@@ -65,7 +63,9 @@ class Timer:
 
     _formats = "{:,} d", "{} h", "{} m", "{} s", "{} ms"
 
-    def __init__(self, message=None, success_logger=logger.info, failure_logger=logger.error):
+    def __init__(
+        self, message: Optional[str] = None, success_logger: Callable = print, failure_logger: Callable = print
+    ):
         """
         For automatic logging, include a message.  By default, non-error messages
         are logged to the console info logger and errors are logged to the console
@@ -164,3 +164,25 @@ class Timer:
             " ".join(f.format(b) for f, b in zip(cls._formats, tuple(int(n) for n in (d, h, m, s, ms))) if b > 0)
             or "less than a millisecond"
         )
+
+
+class ConsoleTimer(Timer):
+    """
+    Convenience class to log to the Django "console" logs.  To use in standalone scripts you will need to
+    define your own "console" log handler.
+    """
+
+    def __init__(self, message=None):
+        logger = logging.getLogger("console")
+        super().__init__(message=message, success_logger=logger.info, failure_logger=logger.error)
+
+
+class ScriptTimer(Timer):
+    """
+    Convenience class to log to the Django "script" logs.  To use in standalone scripts you will need to
+    define your own "script" log handler.
+    """
+
+    def __init__(self, message=None):
+        logger = logging.getLogger("script")
+        super().__init__(message=message, success_logger=logger.info, failure_logger=logger.error)

--- a/usaspending_api/common/management/commands/matview_runner.py
+++ b/usaspending_api/common/management/commands/matview_runner.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 from pathlib import Path
 
 from usaspending_api.common.data_connectors.async_sql_query import async_run_creates
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 from usaspending_api.common.matview_manager import (
     DEFAULT_MATIVEW_DIR,
     DEPENDENCY_FILEPATH,

--- a/usaspending_api/database_scripts/job_archive/management/commands/dev_4109_repair_awards.py
+++ b/usaspending_api/database_scripts/job_archive/management/commands/dev_4109_repair_awards.py
@@ -17,7 +17,7 @@ from django.core.management.base import BaseCommand
 from django.db import connection
 from time import perf_counter
 
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 from usaspending_api.common.operations_reporter import OpsReporter
 
 

--- a/usaspending_api/etl/management/commands/submission_loader.py
+++ b/usaspending_api/etl/management/commands/submission_loader.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
 
 from usaspending_api.common.helpers.generic_helper import create_full_time_periods
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 
 logger = logging.getLogger("console")
 

--- a/usaspending_api/etl/transaction_loaders/fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/fpds_loader.py
@@ -25,7 +25,7 @@ from usaspending_api.etl.transaction_loaders.generic_loaders import (
     insert_transaction_fpds,
     insert_award,
 )
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 
 logger = logging.getLogger("console")
 

--- a/usaspending_api/references/management/commands/load_agencies.py
+++ b/usaspending_api/references/management/commands/load_agencies.py
@@ -11,7 +11,7 @@ from usaspending_api.common.csv_helpers import read_csv_file_as_list_of_dictiona
 from usaspending_api.common.etl import ETLQueryFile, ETLTable, mixins
 from usaspending_api.common.helpers.sql_helpers import get_connection
 from usaspending_api.common.helpers.text_helpers import standardize_nullable_whitespace as prep
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 
 logger = logging.getLogger("console")
 

--- a/usaspending_api/references/management/commands/load_city_county_state_code.py
+++ b/usaspending_api/references/management/commands/load_city_county_state_code.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from usaspending_api.common.etl import ETLTable, ETLTemporaryTable, operations
 from usaspending_api.common.helpers.sql_helpers import execute_dml_sql
-from usaspending_api.common.helpers.timing_helpers import Timer as OriginalTimer
+from usaspending_api.common.helpers.timing_helpers import ScriptTimer as Timer
 from usaspending_api.common.retrieve_file_from_uri import RetrieveFileFromUri
 from usaspending_api.common.zip import extract_single_file_zip
 from usaspending_api.etl.operations.subaward.update_city_county import update_subaward_city_county
@@ -19,13 +19,6 @@ logger = logging.getLogger("script")
 
 
 MAX_CHANGE_PERCENT = 20
-
-
-class Timer(OriginalTimer):
-    """ Override the default logging to use our new "script" logging. """
-
-    def __init__(self, message=None):
-        super().__init__(message=message, success_logger=logger.info, failure_logger=logger.error)
 
 
 class Command(BaseCommand):

--- a/usaspending_api/references/management/commands/load_object_classes.py
+++ b/usaspending_api/references/management/commands/load_object_classes.py
@@ -10,7 +10,7 @@ from usaspending_api.common.csv_helpers import read_csv_file_as_list_of_dictiona
 from usaspending_api.common.etl import ETLTable, mixins, ETLTemporaryTable
 from usaspending_api.common.etl.operations import insert_missing_rows, update_changed_rows
 from usaspending_api.common.helpers.sql_helpers import get_connection
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 from usaspending_api.references.models import ObjectClass
 
 

--- a/usaspending_api/references/management/commands/load_tas.py
+++ b/usaspending_api/references/management/commands/load_tas.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from usaspending_api.accounts.models import TreasuryAppropriationAccount
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
 from usaspending_api.common.retrieve_file_from_uri import RetrieveFileFromUri
 from usaspending_api.etl.management.load_base import load_data_into_model
 from usaspending_api.references.account_helpers import (

--- a/usaspending_api/transactions/agnostic_transaction_loader.py
+++ b/usaspending_api/transactions/agnostic_transaction_loader.py
@@ -11,7 +11,7 @@ from usaspending_api.broker.helpers.last_load_date import get_last_load_date, up
 from usaspending_api.common.etl import ETLDBLinkTable, ETLTable, operations
 from usaspending_api.common.helpers.date_helper import datetime_command_line_argument_type
 from usaspending_api.common.helpers.sql_helpers import get_broker_dsn_string
-from usaspending_api.common.helpers.timing_helpers import Timer
+from usaspending_api.common.helpers.timing_helpers import ScriptTimer as Timer
 from usaspending_api.common.retrieve_file_from_uri import SCHEMA_HELP_TEXT
 from usaspending_api.transactions.loader_functions import filepath_command_line_argument_type
 from usaspending_api.transactions.loader_functions import read_file_for_database_ids
@@ -75,7 +75,7 @@ class AgnosticTransactionLoader:
         )
 
     def handle(self, *args, **options):
-        with Timer(message=f"Script", success_logger=logger.info, failure_logger=logger.error):
+        with Timer(message="Script"):
             self.run_script(*args, **options)
 
     def run_script(self, *args, **options):
@@ -96,7 +96,7 @@ class AgnosticTransactionLoader:
                 raise RuntimeError("Fatal error. Problem with the deletes")
 
         try:
-            with Timer(message="Load Process", success_logger=logger.info, failure_logger=logger.error):
+            with Timer(message="Load Process"):
                 self.process()
             self.successful_run = True
         except (Exception, SystemExit, KeyboardInterrupt):
@@ -111,11 +111,11 @@ class AgnosticTransactionLoader:
         return dt
 
     def process(self) -> None:
-        with Timer(message="Compiling IDs to process", success_logger=logger.info, failure_logger=logger.error):
+        with Timer(message="Compiling IDs to process"):
             self.file_path, self.total_ids_to_process = self.compile_transactions_to_process()
 
         logger.info(f"{self.total_ids_to_process:,} IDs stored")
-        with Timer(message="Transfering Data", success_logger=logger.info, failure_logger=logger.error):
+        with Timer(message="Transfering Data"):
             self.copy_broker_table_data(self.broker_source_table_name, self.destination_table_name, self.shared_pk)
 
     def cleanup(self) -> None:
@@ -188,7 +188,7 @@ class AgnosticTransactionLoader:
         transactions_remaining_count = self.total_ids_to_process
 
         for id_list in read_file_for_database_ids(str(self.file_path), self.chunk_size, is_numeric=False):
-            with Timer(message="Batch upsert", success_logger=logger.info, failure_logger=logger.error):
+            with Timer(message="Batch upsert"):
                 if len(id_list) != 0:
                     predicate = self.extra_predicate + [{"field": primary_key, "op": "IN", "values": tuple(id_list)}]
                     record_count = operations.upsert_records_with_predicate(source, destination, predicate, primary_key)


### PR DESCRIPTION
**Description:**

Our Timer class allows us to log detailed timing information to Python logs (for example, how long unzipping a file takes).  When we added a new log level, it complicated the usage of the `Timer` class.  This pull request adds two new convenience classes that should re-simplify its usage.

**Technical details:**

The default behavior is now to just `print`.  Added a convenience class to log to the "console" logs (`ConsoleTimer`) and another to log to the "script" logs (`ScriptTimer`).  Of course, you can continue to override the default `Timer` if you wish something different.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Frontend unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] No ticket (although the annoyance was discovered during [DEV-3935](https://federal-spending-transparency.atlassian.net/browse/DEV-3935) if you really want to attach it to something).