### PR TITLE
[DEV-4430] Change some logic to work with Download SQS Handler

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -159,7 +159,7 @@ def get_download_sources(json_request: dict, origination: Optional[str] = None):
             )
 
             queryset = filter_function(filters)
-            if origination == "bulk_download":
+            if filters.get("prime_and_sub_award_types") is not None:
                 award_type_codes = set(filters["prime_and_sub_award_types"][download_type])
             else:
                 award_type_codes = set(filters["award_type_codes"])

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -31,7 +31,7 @@ from usaspending_api.download.v2.request_validations import (
 class BaseDownloadViewSet(APIView):
     def post(self, request: Request, request_type: str = "award", origination: Optional[str] = None):
         if request_type == "award":
-            json_request = validate_award_request(request.data, origination)
+            json_request = validate_award_request(request.data)
         elif request_type == "idv":
             json_request = validate_idv_request(request.data)
         elif request_type == "contract":
@@ -66,14 +66,14 @@ class BaseDownloadViewSet(APIView):
         )
 
         log_new_download_job(request, download_job)
-        self.process_request(download_job, origination)
+        self.process_request(download_job)
 
         return self.get_download_response(file_name=final_output_zip_name)
 
-    def process_request(self, download_job: DownloadJob, origination: Optional[str] = None):
+    def process_request(self, download_job: DownloadJob):
         if settings.IS_LOCAL and settings.RUN_LOCAL_DOWNLOAD_IN_PROCESS:
             # Eagerly execute the download in this running process
-            download_generation.generate_download(download_job, origination)
+            download_generation.generate_download(download_job)
         else:
             # Send a SQS message that will be processed by another server which will eventually run
             # download_generation.generate_download(download_source) (see download_sqs_worker.py)

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -1,6 +1,4 @@
 from copy import deepcopy
-from typing import Optional
-
 from django.conf import settings
 
 from usaspending_api.awards.models import Award
@@ -28,7 +26,7 @@ from usaspending_api.download.lookups import (
 )
 
 
-def validate_award_request(request_data: dict, origination: Optional[str] = None):
+def validate_award_request(request_data: dict):
     """Analyze request and raise any formatting errors as Exceptions"""
 
     _validate_required_parameters(request_data, ["filters"])

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -45,7 +45,7 @@ def validate_award_request(request_data: dict, origination: Optional[str] = None
     check_types_and_assign_defaults(filters, json_request["filters"], SHARED_AWARD_FILTER_DEFAULTS)
 
     # Award type validation depends on the
-    if origination == "bulk_download":
+    if filters.get("prime_and_sub_award_types") is not None:
         json_request["filters"]["prime_and_sub_award_types"] = _validate_award_and_subaward_types(filters)
     else:
         json_request["filters"]["award_type_codes"] = _validate_award_type_codes(filters)


### PR DESCRIPTION
**Description:**
Forgot that we use an SQS Handler for download jobs that are not local. As a result, part of the logic that allows the new custom award download changes is not being hit when a non-local environment performs a download.

**Technical details:**
Checking for when the new `prime_and_sub_award_types` filter is present instead of the `origination` since the latter is not being provided by the SQS Handler.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4430](https://federal-spending-transparency.atlassian.net/browse/DEV-4430):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
