### PR TITLE
[DEV-4430] Split up the "Other" Award Type category for bulk award download

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -25,8 +25,8 @@ This route sends a request to the backend to begin generating a zipfile of award
             {
                 "filters": {
                     "agency": 50,
-                    "prime_award_types": ["contracts", "grants"],
-                    "sub_award_types": ["procurement"],
+                    "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
+                    "sub_award_types": ["procurement"]
                     "date_range": {
                         "start_date": "2019-01-01",
                         "end_date": "2019-12-31"
@@ -69,16 +69,10 @@ This route sends a request to the backend to begin generating a zipfile of award
                                 "type": "awarding"
                             }
                         ],
-                        "award_type_codes": [
-                            "02",
-                            "03",
-                            "04",
-                            "05",
-                            "A",
-                            "B",
-                            "C",
-                            "D"
-                        ],
+                        "prime_and_sub_award_types": {
+                            "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
+                            "sub_award_types": ["procurement"]
+                        },
                         "time_period": [
                             {
                                 "date_type": "action_date",
@@ -100,12 +94,28 @@ This route sends a request to the backend to begin generating a zipfile of award
     Agency database id to include, 'all' is also an option to include all agencies
 + `prime_award_types` (optional, array[enum[string]])
     + Members
-        + `contracts`
-        + `direct_payments`
-        + `grants`
-        + `idvs`
-        + `loans`
-        + `other_financial_assistance`
+        + `IDV_A`
+        + `IDV_B`
+        + `IDV_B_A`
+        + `IDV_B_B`
+        + `IDV_B_C`
+        + `IDV_C`
+        + `IDV_D`
+        + `IDV_E`
+        + `02`
+        + `03`
+        + `04`
+        + `05`
+        + `06`
+        + `07`
+        + `08`
+        + `09`
+        + `10`
+        + `11`
+        + `A`
+        + `B`
+        + `C`
+        + `D`
 + `date_range` (required, TimePeriod, fixed-type)
     Object with start and end dates
 + `date_type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -26,7 +26,7 @@ This route sends a request to the backend to begin generating a zipfile of award
                 "filters": {
                     "agency": 50,
                     "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
-                    "sub_award_types": ["procurement"]
+                    "sub_award_types": ["procurement"],
                     "date_range": {
                         "start_date": "2019-01-01",
                         "end_date": "2019-12-31"


### PR DESCRIPTION
**Description:**
User has the ability to select `Insurance` from the `Other` grouping by itself.

**Technical details:**
To accommodate the ability to select only `Insurance` the actual Award Type Codes are expected instead of the category that they fall in to on other pages. This allows for the `Other` category to be split into `Insurance` and `Other Financial Assistance`.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4430](https://federal-spending-transparency.atlassian.net/browse/DEV-4430):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
