### PR TITLE
[DEV-3478] Add CFDA number to transactions endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/transactions.md
+++ b/usaspending_api/api_contracts/contracts/v2/transactions.md
@@ -64,7 +64,8 @@ This endpoint returns a list of transactions, their amount, type, action date, a
                         "description": "GRANT TO LOCAL GOVERNMENT FOR REPAIR OR REPLACEMENT OF DISASTER DAMAGED FACILITIES",
                         "federal_action_obligation": 11041.0,
                         "face_value_loan_guarantee": null,
-                        "original_loan_subsidy_cost": null
+                        "original_loan_subsidy_cost": null,
+                        "cfda_number": "12.345"
                     }
                 ]
             }
@@ -90,6 +91,7 @@ This endpoint returns a list of transactions, their amount, type, action date, a
 + `type` (required, string)
     Award type code
 + `type_description` (required, string, nullable)
++ `cfda_number` (optional, string, nullable)
 
 ## PageMetaDataObject (object)
 + `page` (required, number)

--- a/usaspending_api/awards/tests/integration/test_transactions_v2.py
+++ b/usaspending_api/awards/tests/integration/test_transactions_v2.py
@@ -25,7 +25,13 @@ def cfda_transactions(db):
         "face_value_loan_guarantee": "10.00",
         "original_loan_subsidy_cost": "10.00",
     }
-    trx_fabs_1 = {"pk": 1, "transaction_id": 1, "cfda_number": 12.345, "cfda_title": "Shiloh", "afa_generated_unique": "Q25B9A1MQ0"}
+    trx_fabs_1 = {
+        "pk": 1,
+        "transaction_id": 1,
+        "cfda_number": 12.345,
+        "cfda_title": "Shiloh",
+        "afa_generated_unique": "Q25B9A1MQ0",
+    }
 
     mommy.make("awards.Award", **award_1)
     mommy.make("awards.TransactionNormalized", **trx_norm_1)
@@ -34,24 +40,24 @@ def cfda_transactions(db):
 
 def test_transaction_cfda(client, cfda_transactions):
     expected_response = {
-            "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-            "results": [
-                {
-                    "id": "ASST_TX_Q25B9A1MQ0",
-                    "type": "02",
-                    "type_description": "Green",
-                    "action_date": "2008-11-22",
-                    "action_type": None,
-                    "action_type_description": "grant",
-                    "modification_number": "0",
-                    "description": "ligula in lacus curabitur at ipsum ac tellus semper interdum mauris",
-                    "federal_action_obligation": 10.00,
-                    "face_value_loan_guarantee": 10.00,
-                    "original_loan_subsidy_cost": 10.00,
-                    "cfda_number": "12.345",
-                }
-            ],
-        }
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [
+            {
+                "id": "ASST_TX_Q25B9A1MQ0",
+                "type": "02",
+                "type_description": "Green",
+                "action_date": "2008-11-22",
+                "action_type": None,
+                "action_type_description": "grant",
+                "modification_number": "0",
+                "description": "ligula in lacus curabitur at ipsum ac tellus semper interdum mauris",
+                "federal_action_obligation": 10.00,
+                "face_value_loan_guarantee": 10.00,
+                "original_loan_subsidy_cost": 10.00,
+                "cfda_number": "12.345",
+            }
+        ],
+    }
 
     resp = client.post(
         "/api/v2/transactions/",

--- a/usaspending_api/awards/tests/integration/test_transactions_v2.py
+++ b/usaspending_api/awards/tests/integration/test_transactions_v2.py
@@ -1,0 +1,62 @@
+import pytest
+import json
+import datetime
+
+from model_mommy import mommy
+from rest_framework import status
+
+
+@pytest.fixture
+def cfda_transactions(db):
+    award_1 = {"pk": 1, "category": "grant", "generated_unique_award_id": "whatever"}
+    trx_norm_1 = {
+        "pk": 1,
+        "award_id": 1,
+        "is_fpds": False,
+        "transaction_unique_id": "Q25B9A1MQ0",
+        "type": "02",
+        "type_description": "Green",
+        "action_date": datetime.date(2008, 11, 22),
+        "action_type": None,
+        "action_type_description": "grant",
+        "modification_number": "0",
+        "description": "ligula in lacus curabitur at ipsum ac tellus semper interdum mauris",
+        "federal_action_obligation": "10.00",
+        "face_value_loan_guarantee": "10.00",
+        "original_loan_subsidy_cost": "10.00",
+    }
+    trx_fabs_1 = {"pk": 1, "transaction_id": 1, "cfda_number": 12.345, "cfda_title": "Shiloh", "afa_generated_unique": "Q25B9A1MQ0"}
+
+    mommy.make("awards.Award", **award_1)
+    mommy.make("awards.TransactionNormalized", **trx_norm_1)
+    mommy.make("awards.TransactionFABS", **trx_fabs_1)
+
+
+def test_transaction_cfda(client, cfda_transactions):
+    expected_response = {
+            "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+            "results": [
+                {
+                    "id": "ASST_TX_Q25B9A1MQ0",
+                    "type": "02",
+                    "type_description": "Green",
+                    "action_date": "2008-11-22",
+                    "action_type": None,
+                    "action_type_description": "grant",
+                    "modification_number": "0",
+                    "description": "ligula in lacus curabitur at ipsum ac tellus semper interdum mauris",
+                    "federal_action_obligation": 10.00,
+                    "face_value_loan_guarantee": 10.00,
+                    "original_loan_subsidy_cost": 10.00,
+                    "cfda_number": "12.345",
+                }
+            ],
+        }
+
+    resp = client.post(
+        "/api/v2/transactions/",
+        content_type="application/json",
+        data=json.dumps({"award_id": 1, "page": 1, "sort": "modification_number", "order": "asc", "limit": 15}),
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert json.loads(resp.content.decode("utf-8")) == expected_response

--- a/usaspending_api/awards/v2/views/transactions.py
+++ b/usaspending_api/awards/v2/views/transactions.py
@@ -88,7 +88,7 @@ class TransactionViewSet(APIView):
         results = []
         for row in rows:
             unique_prefix = "ASST_TX"
-            result = {k: row[v] for k, v in self.transaction_lookup.items() if k != "award_id"}
+            result = {k: row.get(v) for k, v in self.transaction_lookup.items() if k != "award_id"}
             if result["is_fpds"]:
                 unique_prefix = "CONT_TX"
                 del result["cfda_number"]


### PR DESCRIPTION
**Description:**
Adds the CFDA number for the transaction to the api/v2/transactions endpoint for assistance transactions to support the addition of the CFDA to the  
**Technical details:**
Annotates the TransactionNormalized query with a subquery to TransactionFABS.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-3478](https://federal-spending-transparency.atlassian.net/browse/DEV-3478):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No change to matviews, no ops tickets needed
```
