### PR TITLE
[DEV-4649] Remove ES page jumping

### DIFF
--- a/usaspending_api/search/v2/views/search_elasticsearch.py
+++ b/usaspending_api/search/v2/views/search_elasticsearch.py
@@ -56,7 +56,7 @@ class SpendingByTransactionVisualizationViewSet(APIView):
         record_num = (validated_payload["page"] - 1) * validated_payload["limit"]
         if record_num >= settings.ES_TRANSACTIONS_MAX_RESULT_WINDOW:
             raise UnprocessableEntityException(
-                "Accessing page {page} with limit {limit} exceeds the Elasticsearch limit of {es_limit}. Please use downloads to access the full set of results.".format(
+                "Page #{page} of size {limit} is over the maximum result limit ({es_limit}). Consider using custom data downloads to obtain large data sets.".format(
                     page=validated_payload["page"],
                     limit=validated_payload["limit"],
                     es_limit=settings.ES_TRANSACTIONS_MAX_RESULT_WINDOW,

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -326,13 +326,12 @@ class SpendingByAwardVisualizationViewSet(APIView):
             self.last_record_unique_id is None and self.last_record_sort_value is None
         ):
             raise UnprocessableEntityException(
-                "Accessing page {page} with limit {limit} exceeds the Elasticsearch limit of {es_limit}. Please provide the 'last_record_sort_value' and 'last_record_unique_id' to paginate sequentially.".format(
+                "Page #{page} with limit {limit} is over the maximum result limit {es_limit}. Please provide the 'last_record_sort_value' and 'last_record_unique_id' to paginate sequentially.".format(
                     page=self.pagination["page"],
                     limit=self.pagination["limit"],
                     es_limit=settings.ES_AWARDS_MAX_RESULT_WINDOW,
                 )
             )
-        # es_limit=settings.ES_AWARDS_MAX_RESULT_WINDOW,
         # Search_after values are provided in the API request - use search after
         if self.last_record_sort_value is not None and self.last_record_unique_id is not None:
             search = (

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -57,6 +57,7 @@ from usaspending_api.common.validator.award_filter import AWARD_FILTER_NO_RECIPI
 from usaspending_api.common.validator.pagination import PAGINATION
 from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.common.recipient_lookups import annotate_recipient_id, annotate_prime_award_recipient_id
+from usaspending_api.common.exceptions import UnprocessableEntityException
 
 logger = logging.getLogger("console")
 
@@ -321,6 +322,17 @@ class SpendingByAwardVisualizationViewSet(APIView):
             raise Exception(
                 "Using search_after functionality in Elasticsearch requires both last_record_sort_value and last_record_unique_id."
             )
+        if record_num >= settings.ES_AWARDS_MAX_RESULT_WINDOW and (
+            self.last_record_unique_id is None and self.last_record_sort_value is None
+        ):
+            raise UnprocessableEntityException(
+                "Accessing page {page} with limit {limit} exceeds the Elasticsearch limit of {es_limit}. Please provide the 'last_record_sort_value' and 'last_record_unique_id' to paginate sequentially.".format(
+                    page=self.pagination["page"],
+                    limit=self.pagination["limit"],
+                    es_limit=settings.ES_AWARDS_MAX_RESULT_WINDOW,
+                )
+            )
+        # es_limit=settings.ES_AWARDS_MAX_RESULT_WINDOW,
         # Search_after values are provided in the API request - use search after
         if self.last_record_sort_value is not None and self.last_record_unique_id is not None:
             search = (

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -313,7 +313,7 @@ class SpendingByAwardVisualizationViewSet(APIView):
         sort_field = self.get_elastic_sort_by_fields()
         sorts = [{field: self.pagination["sort_order"]} for field in sort_field]
         record_num = (self.pagination["page"] - 1) * self.pagination["limit"]
-
+        # random page jumping was removed due to performance concerns
         if (self.last_record_sort_value is None and self.last_record_unique_id is not None) or (
             self.last_record_sort_value is not None and self.last_record_unique_id is None
         ):


### PR DESCRIPTION
**Description:**
Removes the "jumping" feature on spending_by_award when using Elasticsearch due to performance issues.

**Technical details:**
The "jumping" worked by determining the correct record based on the page number and the limit, then doing a postgres search to get the value of the records preceding the desired first record, then querying elasticsearch using the `search_after`. The performance for this was bad. 

Note: Removing this code will require using a different API request for spending_by_award, but only after query through 50,000 records. I.E. - for pages 1-833 of the advanced search page (using limit: 60), the API will return fine. After that, you will have to use the last_record_unique_id" and "last_record_sort_value" to get the correct results.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-4649](https://federal-spending-transparency.atlassian.net/browse/DEV-4649):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to matview, no ops tickets needed
```
