### PR TITLE
[DEV-4685] Route transaction documents to shards by recipient_hash

### DIFF
--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -394,7 +394,7 @@ def download_csv(count_sql, copy_sql, filename, job_id, skip_counts, verbose):
     return count
 
 
-def csv_chunk_gen(filename, chunksize, job_id, awards):
+def csv_chunk_gen(filename, chunksize, job_id, load_type):
     printf({"msg": "Opening {} (batch size = {})".format(filename, chunksize), "job": job_id, "f": "ES Ingest"})
     # Need a specific converter to handle converting strings to correct data types (e.g. string -> array)
     converters = {
@@ -406,9 +406,13 @@ def csv_chunk_gen(filename, chunksize, job_id, awards):
     dtype = {k: str for k in VIEW_COLUMNS if k not in converters}
     for file_df in pd.read_csv(filename, dtype=dtype, converters=converters, header=0, chunksize=chunksize):
         file_df = file_df.where(cond=(pd.notnull(file_df)), other=None)
-        # Route all documents with the same recipient to the same shard
-        # ES helper will pop any "meta" fields like "routing" from provided data dict and use them in the action
-        file_df["routing"] = file_df["recipient_hash"]
+        if load_type != "awards":
+            # Route all transaction documents with the same recipient to the same shard
+            # This allows for accuracy and early-termination of "top N" recipient category aggregation queries
+            # Recipient is are highest-cardinality category with over 2M unique values to aggregate against,
+            # and this is needed for performance
+            # ES helper will pop any "meta" fields like "routing" from provided data dict and use them in the action
+            file_df["routing"] = file_df["recipient_hash"]
         yield file_df.to_dict(orient="records")
 
 

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -406,7 +406,7 @@ def csv_chunk_gen(filename, chunksize, job_id, load_type):
     dtype = {k: str for k in VIEW_COLUMNS if k not in converters}
     for file_df in pd.read_csv(filename, dtype=dtype, converters=converters, header=0, chunksize=chunksize):
         file_df = file_df.where(cond=(pd.notnull(file_df)), other=None)
-        if load_type != "awards":
+        if load_type == "transactions":
             # Route all transaction documents with the same recipient to the same shard
             # This allows for accuracy and early-termination of "top N" recipient category aggregation queries
             # Recipient is are highest-cardinality category with over 2M unique values to aggregate against,

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -406,6 +406,9 @@ def csv_chunk_gen(filename, chunksize, job_id, awards):
     dtype = {k: str for k in VIEW_COLUMNS if k not in converters}
     for file_df in pd.read_csv(filename, dtype=dtype, converters=converters, header=0, chunksize=chunksize):
         file_df = file_df.where(cond=(pd.notnull(file_df)), other=None)
+        # Route all documents with the same recipient to the same shard
+        # ES helper will pop any "meta" fields like "routing" from provided data dict and use them in the action
+        file_df["routing"] = file_df["recipient_hash"]
         yield file_df.to_dict(orient="records")
 
 


### PR DESCRIPTION
**Description:**
Use a routing key technique to put all the same transaction documents in the transactions ES index on the same physical shard.

**Technical details:**
TL;DR - this makes our high-cardinality (2M unique recipients to sum data for) queries performant and accurate, where they were not before. Further, this redistribution of data does not seem to hurt performance of other queries.
- See detailed explanations and background and conclusions here. 
    - https://federal-spending-transparency.atlassian.net/browse/DEV-4538
    - https://federal-spending-transparency.atlassian.net/browse/DEV-4685
    - https://discuss.elastic.co/t/high-cardinality-aggregation-alternate-approaches-2-million-buckets/222814

**NOTE: It will require a reindex after deploy to staging and production for each of those clusters.**

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-4685](https://federal-spending-transparency.atlassian.net/browse/DEV-4685):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Data level change only, with no change to end user.
```
