### PR TITLE
[DEV-4693] Prevent ES caching

### DIFF
--- a/usaspending_api/common/cache_decorator.py
+++ b/usaspending_api/common/cache_decorator.py
@@ -2,11 +2,18 @@
 import logging
 from rest_framework_extensions.cache.decorators import CacheResponse
 
+from usaspending_api.common.experimental_api_flags import is_experimental_elasticsearch_api
+
 logger = logging.getLogger("console")
 
 
 class CustomCacheResponse(CacheResponse):
     def process_cache_response(self, view_instance, view_method, request, args, kwargs):
+        if is_experimental_elasticsearch_api(request):
+            # bypass cache altogether
+            response = view_method(view_instance, request, *args, **kwargs)
+            response = view_instance.finalize_response(request, response, *args, **kwargs)
+            return response
         key = self.calculate_key(
             view_instance=view_instance, view_method=view_method, request=request, args=args, kwargs=kwargs
         )

--- a/usaspending_api/common/cache_decorator.py
+++ b/usaspending_api/common/cache_decorator.py
@@ -13,6 +13,7 @@ class CustomCacheResponse(CacheResponse):
             # bypass cache altogether
             response = view_method(view_instance, request, *args, **kwargs)
             response = view_instance.finalize_response(request, response, *args, **kwargs)
+            response["Cache-Trace"] = "no-cache"
             return response
         key = self.calculate_key(
             view_instance=view_instance, view_method=view_method, request=request, args=args, kwargs=kwargs


### PR DESCRIPTION
Prevents Elasticsearch requests from populating the cache. Same as https://github.com/fedspendingtransparency/usaspending-api/pull/2347.