### PR TITLE
[DEV-4430] Fix logic around scope filters

### DIFF
--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -36,9 +36,6 @@ def matview_search_filter_determine_award_matview_model(filters):
 def matview_search_filter(filters, model, for_downloads=False):
     queryset = model.objects.all()
 
-    recipient_scope_q = Q(recipient_location_country_code="USA") | Q(recipient_location_country_name="UNITED STATES")
-    pop_scope_q = Q(pop_country_code="USA") | Q(pop_country_name="UNITED STATES")
-
     faba_flag = False
     faba_queryset = FinancialAccountsByAwards.objects.filter(award__isnull=False)
 
@@ -218,6 +215,10 @@ def matview_search_filter(filters, model, for_downloads=False):
             queryset = queryset.filter(filter_obj)
 
         elif key == "recipient_scope":
+            recipient_scope_q = (
+                Q(recipient_location_country_code__isnull=False) & Q(recipient_location_country_code="USA")
+            ) | (Q(recipient_location_country_name__isnull=False) & Q(recipient_location_country_name="UNITED STATES"))
+
             if value == "domestic":
                 queryset = queryset.filter(recipient_scope_q)
             elif value == "foreign":
@@ -233,6 +234,10 @@ def matview_search_filter(filters, model, for_downloads=False):
                 queryset = queryset.filter(business_categories__overlap=value)
 
         elif key == "place_of_performance_scope":
+            pop_scope_q = (Q(pop_country_code__isnull=False) & Q(pop_country_code="USA")) | (
+                Q(pop_country_name__isnull=False) & Q(pop_country_name="UNITED STATES")
+            )
+
             if value == "domestic":
                 queryset = queryset.filter(pop_scope_q)
             elif value == "foreign":

--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -25,9 +25,6 @@ def subaward_filter(filters, for_downloads=False):
 
     queryset = SubawardView.objects.all()
 
-    recipient_scope_q = Q(recipient_location_country_code="USA") | Q(recipient_location_country_name="UNITED STATES")
-    pop_scope_q = Q(pop_country_code="USA") | Q(pop_country_name="UNITED STATES")
-
     for key, value in filters.items():
 
         if value is None:
@@ -183,6 +180,10 @@ def subaward_filter(filters, for_downloads=False):
             queryset = queryset.filter(filter_obj)
 
         elif key == "recipient_scope":
+            recipient_scope_q = (
+                Q(recipient_location_country_code__isnull=False) & Q(recipient_location_country_code="USA")
+            ) | (Q(recipient_location_country_name__isnull=False) & Q(recipient_location_country_name="UNITED STATES"))
+
             if value == "domestic":
                 queryset = queryset.filter(recipient_scope_q)
             elif value == "foreign":
@@ -198,6 +199,10 @@ def subaward_filter(filters, for_downloads=False):
                 queryset = queryset.filter(business_categories__overlap=value)
 
         elif key == "place_of_performance_scope":
+            pop_scope_q = (Q(pop_country_code__isnull=False) & Q(pop_country_code="USA")) | (
+                Q(pop_country_name__isnull=False) & Q(pop_country_name="UNITED STATES")
+            )
+
             if value == "domestic":
                 queryset = queryset.filter(pop_scope_q)
             elif value == "foreign":

--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -195,9 +195,7 @@ def award_data(transactional_db):
         transaction_id=1,
         piid="tc1piid",
         unique_award_key="TEST_AWARD_1",
-        legal_entity_country_code="USA",
         legal_entity_country_name="UNITED STATES",
-        place_of_perform_country_c="USA",
         place_of_perform_country_n="UNITED STATES",
     )
     mommy.make(
@@ -226,9 +224,7 @@ def award_data(transactional_db):
         piid="tc7piid",
         unique_award_key="TEST_AWARD_7",
         legal_entity_country_code="CAN",
-        legal_entity_country_name="CANADA",
         place_of_perform_country_c="CAN",
-        place_of_perform_country_n="CANADA",
     )
 
     # Create TransactionAssistance
@@ -362,9 +358,7 @@ def award_data(transactional_db):
         prime_id=4,
         action_date="2018-01-15",
         subaward_type="sub-contract",
-        legal_entity_country_code="USA",
         legal_entity_country_name="UNITED STATES",
-        place_of_perform_country_co="USA",
         place_of_perform_country_na="UNITED STATES",
     )
     mommy.make(
@@ -396,9 +390,7 @@ def award_data(transactional_db):
         action_date="2017-01-15",
         subaward_type="sub-contract",
         legal_entity_country_code="USA",
-        legal_entity_country_name="UNITED STATES",
         place_of_perform_country_co="USA",
-        place_of_perform_country_na="UNITED STATES",
     )
     mommy.make(
         BrokerSubaward,
@@ -418,9 +410,7 @@ def award_data(transactional_db):
         action_date="2017-06-15",
         subaward_type="sub-grant",
         legal_entity_country_code="CAN",
-        legal_entity_country_name="CANADA",
         place_of_perform_country_co="CAN",
-        place_of_perform_country_na="CANADA",
     )
 
     # Set latest_award for each award


### PR DESCRIPTION
**Description:**
It was noticed while testing DEV-4430 that the way `All Foreign Countries` filter is handled results in incorrect results. This PR fixes the logic around the recipient_location and place_of_performance scope filters to make sure the correct results are returned.

**Technical details:**
The reason that the old logic was causing issues is due to the way Postgres handles `Null` values in boolean comparison. A comparison operator used between a non-null value and null results in a value of null (https://www.postgresql.org/docs/9.0/functions-comparison.html). The second part has to do with logical operators. A nice chart for different cases is shown here: https://www.postgresql.org/docs/9.1/functions-logical.html. Below is an example of the old logic and new logic for foreign scope.

Old SQL:
```
where 
   not (utm.pop_country_code = 'USA' or utm.pop_country_name = 'UNITED STATES')
```

Old Logic:
|Country Code|Country Name|Breakdown|Result|
|:---|:---|:---:|:---:|
|USA|UNITED STATES|Not True and Not True|False|
|USA|null|Not True and Not Null|False|
|null|UNITED STATES|Not Null and Not True|False|
|CAN|CANADA|Not False and Not False|True|
|CAN|null|Not False and Not Null|Null|
|null|CANADA|Not Null and Not False|Null|
|null|null|Not Null and Not Null|Null|


New SQL:
```
where 
   not (
      (utm."pop_country_code" is not null and utm."pop_country_code" = 'USA')
      or (utm."pop_country_name" is not null and utm."pop_country_name" = 'UNITED STATES')
   )
```

New Logic:
|Country Code|Country Name|Breakdown|Result|
|:---|:---|:---:|:---:|
|USA|UNITED STATES|Not (True and True) and Not (True and True)|False|
|USA|null|Not (True and True) and Not (False and Null)|False|
|null|UNITED STATES|Not (False and Null) and Not (True and True)|False|
|CAN|CANADA|Not (True and False) and Not (True and False)|True|
|CAN|null|Not (True and False) and Not (False and Null|True|
|null|CANADA|Not (False and Null) and Not (True and False)|True|
|null|null|Not (False and Null) and Not (False and Null)|True|

**NOTE:** The case of `null` for both country_code and country_name does not appear in the API since a null country_code is filled with `USA`.

Using the old logic only the case of a non-null country_code and country_name would return foreign country records if they do not match `USA` and `UNITED STATES` respectively.

Also, updated test cases to reflect this possible data state.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-4430](https://federal-spending-transparency.atlassian.net/browse/DEV-4430):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
