### PR TITLE
Increase memory allocated to Elasticsearch on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ before_script:
   # Run elasticsearch
   - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
   - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
-  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
-  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
+  - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
+  - sudo sed -i.old 's/-Xmx1g/-Xmx512m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch


### PR DESCRIPTION
**Description:**
Elasticsearch tests will occasionally fail due to memory issues.

**Technical details:**
The current settings for `Xmx` and `Xms` are causing Elasticsearch tests to occasionally fail due to issues with memory. This increases those values to avoid random test failures on Travis runs.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed (N/A)
6. [X] Data validation completed (N/A)
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123): (N/A)
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
