### PR TITLE
WARMFIX: dev-4782 reject odd length naics codes

### DIFF
--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -264,13 +264,13 @@ def matview_search_filter(filters, model, for_downloads=False):
                         "NOT IMPLEMENTED: postgres endpoint does not currently support excluded naics!"
                     )
 
+            else:
+                raise InvalidParameterException("naics_codes must be an array or object")
+
             if [value for value in require if len(str(value)) not in [2, 4, 6]]:
                 raise InvalidParameterException(
                     "naics code filtering only supported for codes with lengths of 2, 4, and 6"
                 )
-
-            else:
-                raise InvalidParameterException("naics_codes must be an array or object")
 
             regex = f"^({'|'.join([str(elem) for elem in require])}).*"
             queryset = queryset.filter(naics_code__regex=regex)

--- a/usaspending_api/awards/v2/filters/matview_filters.py
+++ b/usaspending_api/awards/v2/filters/matview_filters.py
@@ -264,6 +264,11 @@ def matview_search_filter(filters, model, for_downloads=False):
                         "NOT IMPLEMENTED: postgres endpoint does not currently support excluded naics!"
                     )
 
+            if [value for value in require if len(str(value)) not in [2, 4, 6]]:
+                raise InvalidParameterException(
+                    "naics code filtering only supported for codes with lengths of 2, 4, and 6"
+                )
+
             else:
                 raise InvalidParameterException("naics_codes must be an array or object")
 

--- a/usaspending_api/search/elasticsearch/filters/naics.py
+++ b/usaspending_api/search/elasticsearch/filters/naics.py
@@ -18,6 +18,11 @@ class NaicsCodes(_Filter):
         else:
             raise InvalidParameterException(f"naics_codes must be an array or object")
 
+        if [value for value in require if len(str(value)) not in [2, 4, 6]] or [
+            value for value in exclude if len(str(value)) not in [2, 4, 6]
+        ]:
+            raise InvalidParameterException("naics code filtering only supported for codes with lengths of 2, 4, and 6")
+
         requires = [str(code) for code in require]
         exclude = [str(code) for code in exclude]
 
@@ -86,6 +91,7 @@ class _NaicsNode:
             retval += "*"
         if not self.positive:
             retval = f"NOT {retval}"
+        retval = f"({retval})"
 
         positive_child_query = " OR ".join([child.get_query() for child in self.children if child.positive])
         negative_child_query = " AND ".join([child.get_query() for child in self.children if not child.positive])

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -810,7 +810,7 @@ def _test_correct_response_for_naics_codes(client):
             {
                 "group": "fiscal_year",
                 "filters": {
-                    "naics_codes": {"require": ["8", "16", "26"]},
+                    "naics_codes": {"require": ["81", "16", "26"]},
                     "time_period": [{"start_date": "2007-10-01", "end_date": "2020-09-30"}],
                 },
             }

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -143,7 +143,7 @@ def spending_over_time_test_data():
                 legal_entity_congressional=f"{transaction_id:02d}",
                 legal_entity_zip5=f"le_zip5_{transaction_id}",
                 legal_entity_city_name=f"le_city_name_{transaction_id}",
-                naics=f"{transaction_id}",
+                naics=f"{transaction_id}{transaction_id}",
                 piid=f"piid_{transaction_id}",
                 place_of_perform_country_c="USA",
                 place_of_perf_country_desc="UNITED STATES",
@@ -810,7 +810,7 @@ def _test_correct_response_for_naics_codes(client):
             {
                 "group": "fiscal_year",
                 "filters": {
-                    "naics_codes": {"require": ["81", "16", "26"]},
+                    "naics_codes": {"require": ["88", "1616", "2626"]},
                     "time_period": [{"start_date": "2007-10-01", "end_date": "2020-09-30"}],
                 },
             }

--- a/usaspending_api/search/tests/unit/filters/naics.py
+++ b/usaspending_api/search/tests/unit/filters/naics.py
@@ -1,69 +1,72 @@
 from usaspending_api.search.elasticsearch.filters.naics import NaicsCodes
+from usaspending_api.common.exceptions import InvalidParameterException
+from pytest import raises
 
 
 def test_primative_naics_filter():
-    assert NaicsCodes._query_string(require=["11"], exclude=[]) == "(11*)"
+    assert NaicsCodes._query_string(require=["11"], exclude=[]) == "((11*))"
 
 
 def test_primative_negative_naics_filter():
-    assert NaicsCodes._query_string(require=[], exclude=["11"]) == "(NOT 11*)"
+    assert NaicsCodes._query_string(require=[], exclude=["11"]) == "((NOT 11*))"
 
 
 def test_positive_leaf_naics_filter():
-    assert NaicsCodes._query_string(require=["112233"], exclude=[]) == "(112233)"
+    assert NaicsCodes._query_string(require=["112233"], exclude=[]) == "((112233))"
 
 
 def test_negative_leaf_naics_filter():
-    assert NaicsCodes._query_string(require=[], exclude=["112233"]) == "(NOT 112233)"
+    assert NaicsCodes._query_string(require=[], exclude=["112233"]) == "((NOT 112233))"
 
 
 def test_two_positive_sibling_naics():
-    assert NaicsCodes._query_string(require=["11", "22"], exclude=[]) == "(11*) OR (22*)"
+    assert NaicsCodes._query_string(require=["11", "22"], exclude=[]) == "((11*)) OR ((22*))"
 
 
 def test_two_negative_sibling_naics():
-    assert NaicsCodes._query_string(require=[], exclude=["11", "22"]) == "(NOT 11*) AND (NOT 22*)"
+    assert NaicsCodes._query_string(require=[], exclude=["11", "22"]) == "((NOT 11*)) AND ((NOT 22*))"
 
 
 def test_simple_positive_hierarchy():
-    assert NaicsCodes._query_string(require=["11", "1111"], exclude=[]) == "(11*) AND ((1111*))"
+    assert NaicsCodes._query_string(require=["11", "1111"], exclude=[]) == "((11*) AND (((1111*))))"
 
 
 def test_simple_negative_hierarchy():
-    assert NaicsCodes._query_string(require=[], exclude=["11", "1111"]) == "(NOT 11*) OR ((NOT 1111*))"
+    assert NaicsCodes._query_string(require=[], exclude=["11", "1111"]) == "((NOT 11*) OR (((NOT 1111*))))"
 
 
 def test_positive_to_negative_cross_hierarchy():
-    assert NaicsCodes._query_string(require=["11"], exclude=["1111"]) == "(11*) AND ((NOT 1111*))"
+    assert NaicsCodes._query_string(require=["11"], exclude=["1111"]) == "((11*) AND (((NOT 1111*))))"
 
 
 def test_negative_to_positive_cross_hierarchy():
-    assert NaicsCodes._query_string(require=["1111"], exclude=["11"]) == "(NOT 11*) OR ((1111*))"
+    assert NaicsCodes._query_string(require=["1111"], exclude=["11"]) == "((NOT 11*) OR (((1111*))))"
 
 
 def test_positive_uncle_naics():
-    assert NaicsCodes._query_string(require=["11", "2211"], exclude=[]) == "(11*) OR (2211*)"
+    assert NaicsCodes._query_string(require=["11", "2211"], exclude=[]) == "((11*)) OR ((2211*))"
 
 
 def test_negative_uncle_naics():
-    assert NaicsCodes._query_string(require=[], exclude=["11", "2211"]) == "(NOT 11*) AND (NOT 2211*)"
+    assert NaicsCodes._query_string(require=[], exclude=["11", "2211"]) == "((NOT 11*)) AND ((NOT 2211*))"
 
 
 def test_competing_naics():
-    assert NaicsCodes._query_string(require=["11"], exclude=["11"]) == "(11*) AND (NOT 11*)"
+    assert NaicsCodes._query_string(require=["11"], exclude=["11"]) == "((11*)) AND ((NOT 11*))"
 
 
 def test_duplicate_positive_naics():
-    assert NaicsCodes._query_string(require=["11", "11"], exclude=[]) == "(11*) OR (11*)"
+    assert NaicsCodes._query_string(require=["11", "11"], exclude=[]) == "((11*)) OR ((11*))"
 
 
 def test_duplicate_negative_naics():
-    assert NaicsCodes._query_string(require=[], exclude=["11", "11"]) == "(NOT 11*) AND (NOT 11*)"
+    assert NaicsCodes._query_string(require=[], exclude=["11", "11"]) == "((NOT 11*)) AND ((NOT 11*))"
 
 
 def test_three_layer_naics():
     assert (
-        NaicsCodes._query_string(require=["11", "112233"], exclude=["1122"]) == "(11*) AND ((NOT 1122*) OR ((112233)))"
+        NaicsCodes._query_string(require=["11", "112233"], exclude=["1122"])
+        == "((11*) AND (((NOT 1122*) OR (((112233))))))"
     )
 
 
@@ -79,6 +82,16 @@ def test_large_negative_list():
     assert NaicsCodes._query_string(require=[], exclude=large_list) == " AND ".join(
         [NaicsCodes._query_string(require=[], exclude=[f"{i}"]) for i in range(10, 100, 5)]
     )
+
+
+def test_bad_require_naics():
+    with raises(InvalidParameterException):
+        NaicsCodes.generate_elasticsearch_query({"require": ["111"]}, None)
+
+
+def test_bad_exclude_naics():
+    with raises(InvalidParameterException):
+        NaicsCodes.generate_elasticsearch_query({"exclude": ["111"]}, None)
 
 
 def _large_naics_list(prefix):


### PR DESCRIPTION
**Description:**
Throws an error if a user attempts to filter on naics codes that are not 2, 4, or 6 digits long.

**Technical details:**
Extra set of parens added to ES query recursive logic, since sometimes a `NOT` could end up on the same level as an `AND` or `OR`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4782](https://federal-spending-transparency.atlassian.net/browse/DEV-4782):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
