### PR TITLE
[DEV-4070] Spending by PSC

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md
@@ -1,0 +1,196 @@
+FORMAT: 1A
+HOST: https://api.usaspending.gov
+
+# Spending By PSC [/api/v2/search/spending_by_category/psc/]
+
+This endpoint supports the advanced search page and allow for complex filtering for specific subsets of spending data.
+
+## POST
+
+This endpoint returns a list of the top results of PSC sorted by the total amounts in descending order.
+
++ Request (application/json)
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object"
+            }
+
+    + Attributes (object)
+        + `filters` (required, FilterObject)
+            The filters to find with said category
+        + `limit`: 5 (optional, number)
+            The number of results to include per page
+        + `page`: 1 (optional, number)
+            The page of results to return based on the limit
+        + `subawards` (optional, boolean)
+            Determines whether Prime Awards or Sub Awards are searched
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `category`: `psc` (required, string)
+        + `results` (required, array[CategoryResult], fixed-type)
+        + `limit`: 10 (required, number)
+        + `page_metadata` (PageMetadataObject)
+        + `messages` (optional, array[string])
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
+    + Body
+
+            {
+                "category": "psc",
+                "limit": 10,
+                "page_metadata": {
+                    "page": 1,
+                    "next": 2,
+                    "previous": null,
+                    "hasNext": false,
+                    "hasPrevious": false
+                },
+                "results": [
+                    {
+                        "amount": 17334384477.7,
+                        "code": "AC15",
+                        "id": null,
+                        "name": "R&D- DEFENSE SYSTEM: AIRCRAFT (OPERATIONAL SYSTEMS DEVELOPMENT)"
+                    },
+                    {
+                        "amount": 983942189.45,
+                        "code": "Y142",
+                        "id": null,
+                        "name": "CONSTRUCT/LABORATORIES & CLINICS"
+                    }
+                ],
+                "messages": [
+                    "For searches, time period start and end dates are currently limited to an earliest date of 2007-10-01.  For data going back to 2000-10-01, use either the Custom Award Download feature on the website or one of our download or bulk_download API endpoints as listed on https://api.usaspending.gov/docs/endpoints."
+                ]
+            }
+
+# Data Structures
+
+## CategoryResult (object)
++ `id` (required, number)
+    The id is the database key.
++ `name` (required, string, nullable)
++ `code` (required, string, nullable)
+    `code` is a user-displayable code (such as a program activity or NAICS code, but **not** a database ID). When no such code is relevant, return a `null`.
++ `amount` (required, number)
+
+## PageMetadataObject (object)
++ `page` (required, number)
++ `hasNext` (required, boolean)
+
+## Filter Objects
+### FilterObject (object)
++ `keywords` : `transport` (optional, array[string])
++ `time_period` (optional, array[TimePeriodObject], fixed-type)
++ `place_of_performance_scope` (optional, enum[string])
+    + Members
+        + `domestic`
+        + `foreign`
++ `place_of_performance_locations` (optional, array[LocationObject], fixed-type)
++ `agencies` (optional, array[AgencyObject], fixed-type)
++ `recipient_search_text`: `Hampton` (optional, array[string])
++ `recipient_id` (optional, string)
+    A unique identifier for the recipient which includes the recipient hash and level.
++ `recipient_scope` (optional, enum[string])
+    + Members
+        + `domestic`
+        + `foreign`
++ `recipient_locations` (optional, array[LocationObject], fixed-type)
++ `recipient_type_names`: `category_business` (optional, array[string])
++ `award_type_codes` (optional, FilterObjectAwardTypes)
++ `award_ids`: `SPE30018FLGFZ`, `SPE30018FLJFN` (optional, array[string])
+    Award IDs surrounded by double quotes (e.g. `"SPE30018FLJFN"`) will perform exact matches as opposed to the default, fuzzier full text matches.  Useful for Award IDs that contain spaces or other word delimiters.
++ `award_amounts` (optional, array[AwardAmounts], fixed-type)
++ `program_numbers`: `10.331` (optional, array[string])
++ `naics_codes`: `311812` (optional, array[string])
++ `psc_codes`: `8940`, `8910` (optional, array[string])
++ `contract_pricing_type_codes`: `J` (optional, array[string])
++ `set_aside_type_codes`: `NONE` (optional, array[string])
++ `extent_competed_type_codes`: `A` (optional, array[string])
++ `tas_codes` (optional, array[TASCodeObject], fixed-type)
+
+### TimePeriodObject (object)
++ `start_date`: `2017-10-01` (required, string)
+    Currently limited to an earliest date of `2007-10-01` (FY2008).  For data going back to `2000-10-01` (FY2001), use either the Custom Award Download
+    feature on the website or one of our `download` or `bulk_download` API endpoints.
++ `end_date`: `2018-09-30` (required, string)
+    Currently limited to an earliest date of `2007-10-01` (FY2008).  For data going back to `2000-10-01` (FY2001), use either the Custom Award Download
+    feature on the website or one of our `download` or `bulk_download` API endpoints.
++ `date_type` (optional, enum[string])
+    + Members
+        + `action_date`
+        + `last_modified_date`
+
+### LocationObject (object)
++ `country`: `USA` (required, string)
++ `state`: `VA` (optional, string)
++ `county` (optional, string)
++ `city` (optional, string)
++ `district` (optional, string)
++ `zip` (optional, string)
+
+### AgencyObject (object)
++ `type` (required, enum[string])
+    + Members
+        + `awarding`
+        + `funding`
++ `tier` (required, enum[string])
+    + Members
+        + `toptier`
+        + `subtier`
++ `name`: `Department of Defense` (required, string)
+
+### AwardAmounts (object)
++ `lower_bound` (optional, number)
++ `upper_bound`: 1000000 (optional, number)
+
+### TASCodeObject (object)
++ `ata` (optional, string, nullable)
+    Allocation Transfer Agency Identifier - three characters
++ `aid` (required, string)
+    Agency Identifier - three characters
++ `bpoa` (optional, string, nullable)
+    Beginning Period of Availability - four digits
++ `epoa` (optional, string, nullable)
+    Ending Period of Availability - four digits
++ `a` (optional, string, nullable)
+    Availability Type Code - X or null
++ `main` (required, string)
+    Main Account Code - four digits
++ `sub` (optional, string, nullable)
+    Sub-Account Code - three digits
+
+### FilterObjectAwardTypes (array)
+List of filterable award types
+
+#### Sample
+- `A`
+- `B`
+- `C`
+- `D`
+
+#### Default
+- `02`
+- `03`
+- `04`
+- `05`
+- `06`
+- `07`
+- `08`
+- `09`
+- `10`
+- `11`
+- `A`
+- `B`
+- `C`
+- `D`
+- `IDV_A`
+- `IDV_B`
+- `IDV_B_A`
+- `IDV_B_B`
+- `IDV_B_C`
+- `IDV_C`
+- `IDV_D`
+- `IDV_E`

--- a/usaspending_api/database_scripts/etl/transaction_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/transaction_delta_view.sql
@@ -30,6 +30,10 @@ SELECT
 
   UTM.product_or_service_code,
   UTM.product_or_service_description,
+  CASE
+    WHEN UTM.product_or_service_code IS NOT NULL THEN CONCAT('{"code":"', UTM.product_or_service_code, '","description":"', UTM.product_or_service_description, '","id":"', NULL, '"}')
+    ELSE NULL
+  END AS psc_agg_key,
   UTM.naics_code,
   UTM.naics_description,
   AWD.type_description,

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -38,6 +38,7 @@ VIEW_COLUMNS = [
     "award_description",
     "product_or_service_code",
     "product_or_service_description",
+    "psc_agg_key",
     "naics_code",
     "naics_description",
     "type_description",

--- a/usaspending_api/etl/es_transaction_template.json
+++ b/usaspending_api/etl/es_transaction_template.json
@@ -80,6 +80,15 @@
         "product_or_service_description": {
           "type": "text"
         },
+      "psc_agg_key": {
+          "type": "keyword",
+          "eager_global_ordinals": true,
+          "fields": {
+            "hash": {
+              "type": "murmur3"
+            }
+          }
+        },
         "naics_code": {
           "type": "text",
           "fields": {

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -176,6 +176,8 @@ def awards_and_transactions(db):
         place_of_performance_state="WA",
         place_of_perform_county_co="005",
         place_of_perform_county_na="TEST NAME",
+        product_or_service_code="1005",
+        product_or_service_co_desc="PSC 1",
     )
     mommy.make(
         "awards.TransactionFPDS",
@@ -184,6 +186,8 @@ def awards_and_transactions(db):
         place_of_performance_state="SC",
         place_of_perform_county_co="001",
         place_of_perform_county_na="CHARLESTON",
+        product_or_service_code="M123",
+        product_or_service_co_desc="PSC 2",
     )
     mommy.make(
         "awards.TransactionFPDS",
@@ -197,3 +201,7 @@ def awards_and_transactions(db):
     # References CFDA
     mommy.make("references.Cfda", id=100, program_number="10.100", program_title="CFDA 1")
     mommy.make("references.Cfda", id=200, program_number="20.200", program_title="CFDA 2")
+
+    # PSC
+    mommy.make("references.PSC", code="1005", description="PSC 1")
+    mommy.make("references.PSC", code="M123", description="PSC 2")

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_psc.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_psc.py
@@ -1,0 +1,84 @@
+import json
+
+from rest_framework import status
+
+from usaspending_api.common.experimental_api_flags import ELASTICSEARCH_HEADER_VALUE, EXPERIMENTAL_API_HEADER
+from usaspending_api.common.helpers.generic_helper import get_time_period_message
+from usaspending_api.search.tests.data.search_filters_test_data import non_legacy_filters
+from usaspending_api.search.tests.integration.spending_by_category.utilities import setup_elasticsearch_test
+
+
+"""
+As of 03/17/2020 these are intended for the experimental Elasticsearch functionality that lives alongside the Postgres
+implementation. These tests verify that ES performs as expected, but that it also respects the header put in place
+to trigger the experimental functionality. When ES for spending_by_category is used as the primary implementation for
+the endpoint these tests should be updated to reflect the change.
+"""
+
+
+def test_success_with_all_filters(client, monkeypatch, elasticsearch_transaction_index, awards_and_transactions):
+    """
+    General test to make sure that all groups respond with a Status Code of 200 regardless of the filters.
+    """
+
+    logging_statements = []
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)
+
+    resp = client.post(
+        "/api/v2/search/spending_by_category/psc/",
+        content_type="application/json",
+        data=json.dumps({"filters": non_legacy_filters()}),
+        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+    )
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+    assert len(logging_statements) == 1, "Expected one logging statement"
+
+
+def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, awards_and_transactions):
+
+    logging_statements = []
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)
+
+    resp = client.post(
+        "/api/v2/search/spending_by_category/psc/",
+        content_type="application/json",
+        data=json.dumps({"filters": {"time_period": [{"start_date": "2007-10-01", "end_date": "2020-09-30"}]}}),
+        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+    )
+    expected_response = {
+        "category": "psc",
+        "limit": 10,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [
+            {"amount": 50000.0, "code": "M123", "id": None, "name": "PSC 2"},
+            {"amount": 5000.0, "code": "1005", "id": None, "name": "PSC 1"},
+        ],
+        "messages": [get_time_period_message()],
+    }
+    print(resp.json())
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+    assert len(logging_statements) == 1, "Expected one logging statement"
+    assert resp.json() == expected_response
+
+
+def test_correct_response_of_empty_list(client, monkeypatch, elasticsearch_transaction_index, awards_and_transactions):
+
+    logging_statements = []
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)
+
+    resp = client.post(
+        "/api/v2/search/spending_by_category/psc",
+        content_type="application/json",
+        data=json.dumps({"filters": {"time_period": [{"start_date": "2008-10-01", "end_date": "2009-09-30"}]}}),
+        **{EXPERIMENTAL_API_HEADER: ELASTICSEARCH_HEADER_VALUE},
+    )
+    expected_response = {
+        "category": "psc",
+        "limit": 10,
+        "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
+        "results": [],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+    assert len(logging_statements) == 1, "Expected one logging statement"
+    assert resp.json() == expected_response

--- a/usaspending_api/search/v2/urls_spending_by_category.py
+++ b/usaspending_api/search/v2/urls_spending_by_category.py
@@ -6,7 +6,10 @@ from usaspending_api.search.v2.views.spending_by_category_views.spending_by_agen
     FundingAgencyViewSet,
     FundingSubagencyViewSet,
 )
-from usaspending_api.search.v2.views.spending_by_category_views.spending_by_industry_codes import CfdaViewSet
+from usaspending_api.search.v2.views.spending_by_category_views.spending_by_industry_codes import (
+    CfdaViewSet,
+    PSCViewSet,
+)
 from usaspending_api.search.v2.views.spending_by_category_views.spending_by_locations import CountyViewSet
 
 urlpatterns = [
@@ -16,4 +19,5 @@ urlpatterns = [
     url(r"^county", CountyViewSet.as_view()),
     url(r"^funding_agency", FundingAgencyViewSet.as_view()),
     url(r"^funding_subagency", FundingSubagencyViewSet.as_view()),
+    url(r"^psc", PSCViewSet.as_view()),
 ]

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -36,7 +36,8 @@ from usaspending_api.search.v2.views.spending_by_category_views.spending_by_agen
     FundingAgencyViewSet,
     FundingSubagencyViewSet,
 )
-from usaspending_api.search.v2.views.spending_by_category_views.spending_by_industry_codes import CfdaViewSet
+from usaspending_api.search.v2.views.spending_by_category_views.spending_by_industry_codes import CfdaViewSet, \
+    PSCViewSet
 from usaspending_api.search.v2.views.spending_by_category_views.spending_by_locations import CountyViewSet
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,8 @@ class SpendingByCategoryVisualizationViewSet(APIView):
             response = FundingAgencyViewSet().perform_search(validated_payload, original_filters)
         elif validated_payload["category"] == "funding_subagency":
             response = FundingSubagencyViewSet().perform_search(validated_payload, original_filters)
+        elif validated_payload["category"] == "psc":
+            response = PSCViewSet().perform_search(validated_payload, original_filters)
         else:
             response = BusinessLogic(validated_payload, original_filters).results()
 

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_industry_codes.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_industry_codes.py
@@ -85,3 +85,14 @@ class CfdaViewSet(AbstractIndustryCodeViewSet):
 
     industry_code_type = IndustryCodeType.CFDA
     category = Category(name="cfda", agg_key="cfda_agg_key")
+
+
+class PSCViewSet(AbstractIndustryCodeViewSet):
+    """
+    This route takes award filters and returns spending by PSC.
+    """
+
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md"
+
+    industry_code_type = IndustryCodeType.PSC
+    category = Category(name="psc", agg_key="psc_agg_key")


### PR DESCRIPTION
**Description:**
Adds `spending_by_category/psc/` endpoint to the API which utilizes Elasticsearch.
**Technical details:**
Uses the same setup as spending_by_category/cfda.
**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [X] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-4070](https://federal-spending-transparency.atlassian.net/browse/DEV-4070):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
