### PR TITLE
Correct travis command that runs integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
   - python manage.py check_for_endpoint_documentation
   - dredd > dredd-results.txt && echo '! grep -E "^[warn:|error:]" dredd-results.txt' | bash
   - pytest --durations 50 --ignore-glob='**/tests/integration/*' --cov=usaspending_api --cov-report= --reuse-db -rsx
-  - pytest --durations 50 --override-ini=python_files='**/tests/integration/test_*.py **/tests/integration/*_test.py' --cov=usaspending_api --cov-append --cov-report term --cov-report xml:coverage.xml --reuse-db -rsx
+  - pytest --durations 50 --override-ini=python_files='**/tests/integration/*' --cov=usaspending_api --cov-append --cov-report term --cov-report xml:coverage.xml --reuse-db -rsx
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT


### PR DESCRIPTION
**Description:**
Travis is not running integration tests that live in a sub-folder and not immediately under a `*/tests/integration/` directory.

**Technical details:**
The command to run integration tests will run all integration tests under a `*/tests/integration` folder. Some stats to prove this out:

* Total Tests: 724
* Total Unit Tests (or non-Integration Tests): 489
* Total Integration Tests (before fix): 206
* Total Integration Tests (after fix): 235

(Will note that the stats above are from a feature branch where this was noticed so they are off by about six tests from current state of DEV. Also, the numbers do not count skipped tests.)

**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed (N/A)
6. [X] Data validation completed (N/A)
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123): (N/A)
    - [X] Link to this Pull-Request (N/A)
    - [X] Performance evaluation of affected (API | Script | Download) (N/A)
    - [X] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
```
