### PR TITLE
Ensure readonly user has read access to vw_award_search

### DIFF
--- a/usaspending_api/database_scripts/matviews/vw_award_search.sql
+++ b/usaspending_api/database_scripts/matviews/vw_award_search.sql
@@ -15,3 +15,5 @@ CREATE VIEW vw_award_search AS (
   UNION ALL
   SELECT * FROM mv_pre2008_award_search
 );
+
+GRANT SELECT ON vw_award_search TO readonly;


### PR DESCRIPTION
**Description:**
The SQL view is being dropped and recreated when materialized views are recreated during deploys (and other operations reasons). In production envs this is a problem since the readonly user loses access to the view

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Minor edit to operations SQL script
```
