### PR TITLE
Fix Child Counts of TAS Filter Tree

### DIFF
--- a/usaspending_api/references/tests/integration/filter_tree/conftest.py
+++ b/usaspending_api/references/tests/integration/filter_tree/conftest.py
@@ -6,6 +6,7 @@ from usaspending_api.references.tests.integration.filter_tree.tas.tas_data_fixtu
     multiple_federal_accounts,
     agency_with_unsupported_fa,
     multiple_tas,
+    fa_with_multiple_tas,
     fa_with_unsupported_tas,
 )
 
@@ -18,5 +19,6 @@ __all__ = [
     "multiple_federal_accounts",
     "agency_with_unsupported_fa",
     "multiple_tas",
+    "fa_with_multiple_tas",
     "fa_with_unsupported_tas",
 ]

--- a/usaspending_api/references/tests/integration/filter_tree/tas/tas_data_fixtures.py
+++ b/usaspending_api/references/tests/integration/filter_tree/tas/tas_data_fixtures.py
@@ -47,6 +47,11 @@ def multiple_tas(db, basic_agency):
 
 
 @pytest.fixture
+def fa_with_multiple_tas(db, multiple_tas):
+    _setup_fa(1, 1)
+
+
+@pytest.fixture
 def agency_with_unsupported_fa(db):
     _setup_agency(1)
     _setup_fa(1, 1)

--- a/usaspending_api/references/tests/integration/filter_tree/tas/test_level_1_tas.py
+++ b/usaspending_api/references/tests/integration/filter_tree/tas/test_level_1_tas.py
@@ -8,7 +8,7 @@ common_query = base_query + "?depth=0"
 def test_one_fa(client, basic_agency):
     resp = _call_and_expect_200(client, common_query)
     assert resp.json() == {
-        "results": [{"id": "001", "ancestors": ["001"], "description": "Fed Account 001", "count": 0, "children": None}]
+        "results": [{"id": "001", "ancestors": ["001"], "description": "Fed Account 001", "count": 1, "children": None}]
     }
 
 

--- a/usaspending_api/references/tests/integration/filter_tree/tas/test_level_1_tas.py
+++ b/usaspending_api/references/tests/integration/filter_tree/tas/test_level_1_tas.py
@@ -18,6 +18,13 @@ def test_multiple_fa(client, multiple_federal_accounts):
     assert len(resp.json()["results"]) == 4
 
 
+# Will the count be greater than one if there are multiple  children?
+def test_multiple_children(client, fa_with_multiple_tas):
+    resp = _call_and_expect_200(client, common_query)
+    assert len(resp.json()["results"]) == 1
+    assert resp.json()["results"][0]["count"] == 4
+
+
 # Does the endpoint only return federal accounts with file D data?
 def test_unsupported_fa(client, agency_with_unsupported_fa):
     resp = _call_and_expect_200(client, common_query)

--- a/usaspending_api/references/tests/integration/filter_tree/tas/test_toptier_tas.py
+++ b/usaspending_api/references/tests/integration/filter_tree/tas/test_toptier_tas.py
@@ -10,7 +10,7 @@ common_query = base_query + "?depth=0"
 def test_one_agency(client, basic_agency):
     resp = _call_and_expect_200(client, common_query)
     assert resp.json() == {
-        "results": [{"id": "001", "ancestors": [], "description": "Agency 001", "count": 0, "children": None}]
+        "results": [{"id": "001", "ancestors": [], "description": "Agency 001", "count": 1, "children": None}]
     }
 
 

--- a/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
@@ -63,16 +63,16 @@ class TASFilterTree(FilterTree):
             )
 
     def _generate_agency_node(self, ancestors, data, child_layers):
+        raw_children = self._fa_given_agency(data["toptier_code"])
         if child_layers:
-            raw_children = self._fa_given_agency(data["toptier_code"])
             generated_children = [
                 self.construct_node_from_raw(1, ancestors + [data["toptier_code"]], elem, child_layers - 1).to_JSON()
                 for elem in raw_children
             ]
-            count = len(generated_children)
         else:
             generated_children = None
-            count = DEFAULT_CHILDREN
+
+        count = len(raw_children)
 
         return Node(
             id=data["toptier_code"],
@@ -83,18 +83,18 @@ class TASFilterTree(FilterTree):
         )
 
     def _generate_federal_account_node(self, ancestors, data, child_layers):
+        raw_children = self._tas_given_fa(ancestors[0], data.federal_account_code)
         if child_layers:
-            raw_children = self._tas_given_fa(ancestors[0], data.federal_account_code)
             generated_children = [
                 self.construct_node_from_raw(
                     2, ancestors + [data.federal_account_code], elem, child_layers - 1
                 ).to_JSON()
                 for elem in raw_children
             ]
-            count = len(generated_children)
         else:
             generated_children = None
-            count = DEFAULT_CHILDREN
+
+        count = len(raw_children)
 
         return Node(
             id=data.federal_account_code,


### PR DESCRIPTION
**Description:**
Old implementation was returning counts of children in the provided tree, not the "true" tree. 

**Technical details:**
The need to always make an extra query slows down the searches slightly, but local testing stayed well within 15 second parameters

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)

**Area for explaining above N/A when needed:**
```
```
