### PR TITLE
[DEV-4506] Obtain recipient_id when record doesn't contain DUNS

### DIFF
--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -151,12 +151,21 @@ def annotate_recipient_id(field_name, queryset):
                 recipient_profile rp
                 inner join recipient_lookup rl on rl.recipient_hash = rp.recipient_hash
             where
-                rl.duns = {outer_table}.recipient_unique_id and
-                rp.recipient_level = case
+                (
+                    (
+                        {outer_table}.recipient_unique_id is null
+                        and rl.duns is null
+                        and {outer_table}.recipient_name = rl.legal_business_name
+                    ) or (
+                        {outer_table}.recipient_unique_id is not null
+                        and rl.duns is not null
+                        and rl.duns = {outer_table}.recipient_unique_id
+                    )
+                )
+                and rp.recipient_level = case
                     when {outer_table}.parent_recipient_unique_id is null then 'R'
-                    else 'C'
-                end and
-                rp.recipient_name not in {special_cases}
+                    else 'C' end
+                and rp.recipient_name not in {special_cases}
         )""",
     )
 


### PR DESCRIPTION
**Description:**
Original SQL only worked when both the award's latest transaction and the recipient lookup record contained a DUNS. Now, in the event of no DUNS in the transaction/award the lookup will be performed using the name and null DUNS

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-4506](https://federal-spending-transparency.atlassian.net/browse/DEV-4506):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Changes simply increase the results which contain a populated `recipient_id` value
```
