### PR TITLE
[DEV-4795] Remove DOD subsumed agencies from agency/toptier tables

### DIFF
--- a/usaspending_api/references/management/commands/load_agencies.py
+++ b/usaspending_api/references/management/commands/load_agencies.py
@@ -12,7 +12,10 @@ from usaspending_api.common.etl import ETLQueryFile, ETLTable, mixins
 from usaspending_api.common.helpers.sql_helpers import get_connection, execute_sql
 from usaspending_api.common.helpers.text_helpers import standardize_nullable_whitespace as prep
 from usaspending_api.common.helpers.timing_helpers import ScriptTimer as Timer
-from usaspending_api.etl.operations.federal_account.update_agency import update_federal_account_agency
+from usaspending_api.etl.operations.federal_account.update_agency import (
+    DOD_SUBSUMED_AIDS,
+    update_federal_account_agency,
+)
 from usaspending_api.etl.operations.treasury_appropriation_account.update_agencies import (
     update_treasury_appropriation_account_agencies,
 )
@@ -172,7 +175,9 @@ class Command(mixins.ETLMixin, BaseCommand):
             self.etl_dml_sql_directory / "subtier_agency_query.sql", temp_table=TEMP_TABLE_NAME
         )
         toptier_agency_query = ETLQueryFile(
-            self.etl_dml_sql_directory / "toptier_agency_query.sql", temp_table=TEMP_TABLE_NAME
+            self.etl_dml_sql_directory / "toptier_agency_query.sql",
+            temp_table=TEMP_TABLE_NAME,
+            dod_subsumed=DOD_SUBSUMED_AIDS,
         )
 
         path = self._get_sql_directory_file_path("raw_agency_create_temp_table")

--- a/usaspending_api/references/management/commands/load_agencies_sql/toptier_agency_query.sql
+++ b/usaspending_api/references/management/commands/load_agencies_sql/toptier_agency_query.sql
@@ -23,7 +23,12 @@ from (
     where
         cgac_agency_code is not null and
         agency_name is not null and
-        is_frec is false
+        is_frec is false and
+        -- DOD subsumed agencies are still valid CGACs so they live in the CGAC table,
+        -- but they are no longer valid USAspending toptier agencies as of DEV-4795
+        -- (they never were, really - we just finally got around to cleaning up all
+        -- those account linkages).
+        cgac_agency_code not in {dod_subsumed}
     group by
         cgac_agency_code
 


### PR DESCRIPTION
**Description:**

Army, Navy, and Air Force are no longer required in the USAspending toptier agency table.  In order to prevent confusion and accidental linking, they have been removed.  If you need to look up official names or abbreviations, they do still exist in the CGAC table.

**Requirements for PR merge:**

1. [x] Tests unaffected
2. [x] API documentation unaffected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-4795](https://federal-spending-transparency.atlassian.net/browse/DEV-4795):
    - [x] Link to this Pull-Request