### PR TITLE
[DEV-4790] Add Owning Agency to downloads

### DIFF
--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -133,8 +133,6 @@ def get_agency_name_annotation(relation_name: str, cgac_column_name: str) -> Sub
 
 def generate_treasury_account_query(queryset, account_type, tas_id):
     """ Derive necessary fields for a treasury account-grouped query """
-    # Derive treasury_account_symbol, allocation_transfer_agency_name, agency_name, and federal_account_symbol
-    # for all account types
     derived_fields = {
         "last_reported_submission_period": FiscalYearAndQuarter("reporting_period_end"),
         # treasury_account_symbol: [ATA-]AID-BPOA/EPOA-MAC-SAC or [ATA-]AID-"X"-MAC-SAC
@@ -166,8 +164,10 @@ def generate_treasury_account_query(queryset, account_type, tas_id):
             "{}__sub_account_code".format(tas_id),
             output_field=CharField(),
         ),
-        "allocation_transfer_agency_name": get_agency_name_annotation(tas_id, "allocation_transfer_agency_id"),
-        "agency_name": get_agency_name_annotation(tas_id, "agency_id"),
+        "allocation_transfer_agency_identifer_name": get_agency_name_annotation(
+            tas_id, "allocation_transfer_agency_id"
+        ),
+        "agency_identifier_name": get_agency_name_annotation(tas_id, "agency_id"),
         # federal_account_symbol: fed_acct_AID-fed_acct_MAC
         "federal_account_symbol": Concat(
             "{}__federal_account__agency_identifier".format(tas_id),
@@ -195,7 +195,7 @@ def generate_federal_account_query(queryset, account_type, tas_id):
             Value("-"),
             "{}__federal_account__main_account_code".format(tas_id),
         ),
-        "agency_name": get_agency_name_annotation(tas_id, "agency_id"),
+        "agency_identifier_name": get_agency_name_annotation(tas_id, "agency_id"),
         "submission_period": FiscalYearAndQuarter("reporting_period_end"),
         "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR: Max("submission__certified_date"),
     }

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1450,13 +1450,17 @@ query_paths = {
     "account_balances": {
         "treasury_account": OrderedDict(
             [
+                ("owning_agency_name", "treasury_account_identifier__funding_toptier_agency__name"),
                 ("reporting_agency_name", "submission__reporting_agency_name"),
                 (
                     "last_reported_submission_period",
                     "last_reported_submission_period",
                 ),  # Column is appended to in account_download.py
-                ("allocation_transfer_agency_identifier", "treasury_account_identifier__allocation_transfer_agency_id"),
-                ("agency_identifier", "treasury_account_identifier__agency_id"),
+                (
+                    "allocation_transfer_agency_identifer_code",
+                    "treasury_account_identifier__allocation_transfer_agency_id",
+                ),
+                ("agency_identifier_code", "treasury_account_identifier__agency_id"),
                 ("beginning_period_of_availability", "treasury_account_identifier__beginning_period_of_availability"),
                 ("ending_period_of_availability", "treasury_account_identifier__ending_period_of_availability"),
                 ("availability_type_code", "treasury_account_identifier__availability_type_code"),
@@ -1464,10 +1468,10 @@ query_paths = {
                 ("sub_account_code", "treasury_account_identifier__sub_account_code"),
                 ("treasury_account_symbol", "treasury_account_symbol"),  # Column is appended to in account_download.py
                 ("treasury_account_name", "treasury_account_identifier__account_title"),
-                ("agency_name", "agency_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
                 (
-                    "allocation_transfer_agency_name",
-                    "allocation_transfer_agency_name",
+                    "allocation_transfer_agency_identifer_name",
+                    "allocation_transfer_agency_identifer_name",
                 ),  # Column is appended to in account_download.py
                 ("budget_function", "treasury_account_identifier__budget_function_title"),
                 ("budget_subfunction", "treasury_account_identifier__budget_subfunction_title"),
@@ -1503,6 +1507,7 @@ query_paths = {
         ),
         "federal_account": OrderedDict(
             [
+                ("owning_agency_name", "treasury_account_identifier__federal_account__parent_toptier_agency__name"),
                 ("reporting_agency_name", "reporting_agency_name"),  # Column is appended to in account_download.py
                 (
                     "last_reported_submission_period",
@@ -1510,7 +1515,7 @@ query_paths = {
                 ),  # Column is appended to in account_download.py
                 ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
                 ("federal_account_name", "treasury_account_identifier__federal_account__account_title"),
-                ("agency_name", "agency_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
                 ("budget_function", "treasury_account_identifier__budget_function_title"),
                 ("budget_subfunction", "treasury_account_identifier__budget_subfunction_title"),
                 (
@@ -1548,13 +1553,14 @@ query_paths = {
     "object_class_program_activity": {
         "treasury_account": OrderedDict(
             [
+                ("owning_agency_name", "treasury_account__funding_toptier_agency__name"),
                 ("reporting_agency_name", "submission__reporting_agency_name"),
                 (
                     "last_reported_submission_period",
                     "last_reported_submission_period",
                 ),  # Column is appended to in account_download.py
-                ("allocation_transfer_agency_identifier", "treasury_account__allocation_transfer_agency_id"),
-                ("agency_identifier", "treasury_account__agency_id"),
+                ("allocation_transfer_agency_identifer_code", "treasury_account__allocation_transfer_agency_id"),
+                ("agency_identifier_code", "treasury_account__agency_id"),
                 ("beginning_period_of_availability", "treasury_account__beginning_period_of_availability"),
                 ("ending_period_of_availability", "treasury_account__ending_period_of_availability"),
                 ("availability_type_code", "treasury_account__availability_type_code"),
@@ -1562,10 +1568,10 @@ query_paths = {
                 ("sub_account_code", "treasury_account__sub_account_code"),
                 ("treasury_account_symbol", "treasury_account_symbol"),  # Column is appended to in account_download.py
                 ("treasury_account_name", "treasury_account__account_title"),
-                ("agency_name", "agency_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
                 (
-                    "allocation_transfer_agency_name",
-                    "allocation_transfer_agency_name",
+                    "allocation_transfer_agency_identifer_name",
+                    "allocation_transfer_agency_identifer_name",
                 ),  # Column is appended to in account_download.py
                 ("budget_function", "treasury_account__budget_function_title"),
                 ("budget_subfunction", "treasury_account__budget_subfunction_title"),
@@ -1587,6 +1593,7 @@ query_paths = {
         ),
         "federal_account": OrderedDict(
             [
+                ("owning_agency_name", "treasury_account__federal_account__parent_toptier_agency__name"),
                 ("reporting_agency_name", "submission__reporting_agency_name"),
                 (
                     "last_reported_submission_period",
@@ -1594,7 +1601,7 @@ query_paths = {
                 ),  # Column is appended to in account_download.py
                 ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
                 ("federal_account_name", "treasury_account__federal_account__account_title"),
-                ("agency_name", "agency_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
                 ("budget_function", "treasury_account__budget_function_title"),
                 ("budget_subfunction", "treasury_account__budget_subfunction_title"),
                 ("program_activity_code", "program_activity__program_activity_code"),
@@ -1619,10 +1626,11 @@ query_paths = {
     "award_financial": {
         "treasury_account": OrderedDict(
             [
+                ("owning_agency_name", "treasury_account__funding_toptier_agency__name"),
                 ("reporting_agency_name", "submission__reporting_agency_name"),
                 ("submission_period", "submission_period"),  # Column is appended to in account_download.py
-                ("allocation_transfer_agency_identifier", "treasury_account__allocation_transfer_agency_id"),
-                ("agency_identifier", "treasury_account__agency_id"),
+                ("allocation_transfer_agency_identifer_code", "treasury_account__allocation_transfer_agency_id"),
+                ("agency_identifier_code", "treasury_account__agency_id"),
                 ("beginning_period_of_availability", "treasury_account__beginning_period_of_availability"),
                 ("ending_period_of_availability", "treasury_account__ending_period_of_availability"),
                 ("availability_type_code", "treasury_account__availability_type_code"),
@@ -1630,10 +1638,10 @@ query_paths = {
                 ("sub_account_code", "treasury_account__sub_account_code"),
                 ("treasury_account_symbol", "treasury_account_symbol"),  # Column is appended to in account_download.py
                 ("treasury_account_name", "treasury_account__account_title"),
-                ("agency_name", "agency_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
                 (
-                    "allocation_transfer_agency_name",
-                    "allocation_transfer_agency_name",
+                    "allocation_transfer_agency_identifer_name",
+                    "allocation_transfer_agency_identifer_name",
                 ),  # Column is appended to in account_download.py
                 ("budget_function", "treasury_account__budget_function_title"),
                 ("budget_subfunction", "treasury_account__budget_subfunction_title"),
@@ -1716,11 +1724,12 @@ query_paths = {
         ),
         "federal_account": OrderedDict(
             [
+                ("owning_agency_name", "treasury_account__federal_account__parent_toptier_agency__name"),
                 ("reporting_agency_name", "submission__reporting_agency_name"),
                 ("submission_period", "submission_period"),  # Column is appended to in account_download.py
                 ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
                 ("federal_account_name", "treasury_account__federal_account__account_title"),
-                ("agency_name", "agency_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
                 ("budget_function", "treasury_account__budget_function_title"),
                 ("budget_subfunction", "treasury_account__budget_subfunction_title"),
                 ("program_activity_code", "program_activity__program_activity_code"),


### PR DESCRIPTION
**Description:**

We added an Owning Agency column to Account Download files and renamed a handful of other columns.

**Requirements for PR merge:**

1. [x] Tests unaffected
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations tickets required
8. [x] Jira Ticket [DEV-4790](https://federal-spending-transparency.atlassian.net/browse/DEV-4790):
    - [x] Link to this Pull-Request