### PR TITLE
dev-4964 added deprecation flag

### DIFF
--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -7,6 +7,8 @@ from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.references.models import Cfda, Definition, NAICS, PSC
 from usaspending_api.references.v2.views.glossary import DefinitionSerializer
 from usaspending_api.search.models import AgencyAutocompleteMatview
+from usaspending_api.common.api_versioning import deprecated
+from django.utils.decorators import method_decorator
 
 
 class BaseAutocompleteViewSet(APIView):
@@ -142,6 +144,7 @@ class NAICSAutocompleteViewSet(BaseAutocompleteViewSet):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/naics.md"
 
+    @method_decorator(deprecated, name="list")
     @cache_response()
     def post(self, request):
         """Return all NAICS table entries matching the provided search text"""


### PR DESCRIPTION
**Description:**
With the rise of Elasticsearch, NAICS autocomplete will be going away with DEV-3674. Seemed fair to give them fair warning first.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed 
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [ ] Jira Ticket [DEV-4964](https://federal-spending-transparency.atlassian.net/browse/DEV-4964):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
