### PR TITLE
[DEV-4943] Use file epoch instead of S3 last modified for filtering delete files

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -150,6 +150,7 @@ class Command(BaseCommand):
         with timer("obtaining delete records", logger.info):
             delete_records = retrieve_deleted_fabs_transactions(start_datetime, end_datetime)
             ids_to_delete = [item for sublist in delete_records.values() for item in sublist if item]
+        logger.info(f"{len(ids_to_delete):,} delete ids found in total")
 
         with timer("retrieving/diff-ing FABS Data", logger.info):
             ids_to_upsert = get_fabs_transaction_ids(afa_ids, start_datetime, end_datetime)

--- a/usaspending_api/common/helpers/s3_helpers.py
+++ b/usaspending_api/common/helpers/s3_helpers.py
@@ -1,36 +1,25 @@
 import boto3
 import io
 import logging
-import re
 
-from typing import Optional, List
-
+from typing import List
 from usaspending_api import settings
+
 
 logger = logging.getLogger("script")
 
 
-def access_s3_object_list(
-    bucket_name: str, regex_pattern: Optional[str] = None
-) -> List["boto3.resources.factory.s3.ObjectSummary"]:
-    """Find all S3 objects in provided bucket.
-
-    If regex is passed, only keys which match the regex are returned
-    """
-
-    logger.info("Gathering all deleted transactions from S3")
+def retrieve_s3_bucket_object_list(bucket_name: str) -> List["boto3.resources.factory.s3.ObjectSummary"]:
     try:
         bucket = get_s3_bucket(bucket_name=bucket_name)
         bucket_objects = list(bucket.objects.all())
-        logger.info(f"{len(bucket_objects):,} files found in bucket.")
-    except Exception:
-        logger.exception("Most likely the AWS region or bucket name are configured incorrectly")
-        bucket_objects = None
-
-    if regex_pattern and bucket_objects:
-        bucket_objects = [obj for obj in bucket_objects if re.search(regex_pattern, obj.key)]
-        logger.info(f"{len(bucket_objects):,} files matched file pattern.")
-
+    except Exception as e:
+        message = (
+            f"Problem accessing S3 bucket '{bucket_name}' for deleted records.  Most likely the "
+            f"AWS region or bucket name is configured incorrectly."
+        )
+        logger.exception(message)
+        raise RuntimeError(message) from e
     return bucket_objects
 
 

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -15,7 +15,7 @@ from time import perf_counter, sleep
 
 from usaspending_api.awards.v2.lookups.elasticsearch_lookups import INDEX_ALIASES_TO_AWARD_TYPES
 from usaspending_api.common.csv_helpers import count_rows_in_delimited_file
-from usaspending_api.common.helpers.s3_helpers import access_s3_object_list, access_s3_object
+from usaspending_api.common.helpers.s3_helpers import retrieve_s3_bucket_object_list, access_s3_object
 from usaspending_api.common.helpers.sql_helpers import get_database_dsn_string
 
 # ==============================================================================
@@ -637,9 +637,8 @@ def gather_deleted_ids(config):
     printf({"msg": "Gathering all deleted transactions from S3"})
     start = perf_counter()
 
-    bucket_objects = access_s3_object_list(bucket_name=config["s3_bucket"])
-    if bucket_objects is None:
-        raise Exception(f"Issue connecting to {config['s3_bucket']} in s3")
+    bucket_objects = retrieve_s3_bucket_object_list(bucket_name=config["s3_bucket"])
+    printf({"msg": f"{len(bucket_objects):,} files found in bucket '{config['s3_bucket']}'."})
 
     if config["verbose"]:
         printf({"msg": f"CSV data from {config['starting_date']} to now"})

--- a/usaspending_api/transactions/transaction_delete_journal_helpers.py
+++ b/usaspending_api/transactions/transaction_delete_journal_helpers.py
@@ -1,12 +1,13 @@
 import csv
 import logging
+import re
 
 from collections import defaultdict
 from datetime import datetime
 from typing import Optional, List
 from usaspending_api import settings
-from usaspending_api.common.helpers.date_helper import cast_datetime_to_naive, datetime_is_ge, datetime_is_lt
-from usaspending_api.common.helpers.s3_helpers import access_s3_object, access_s3_object_list
+from usaspending_api.common.helpers.date_helper import datetime_is_ge, datetime_is_lt
+from usaspending_api.common.helpers.s3_helpers import access_s3_object, retrieve_s3_bucket_object_list
 from usaspending_api.common.helpers.timing_helpers import ScriptTimer as Timer
 
 
@@ -14,65 +15,62 @@ logger = logging.getLogger("script")
 
 
 def retrieve_deleted_fabs_transactions(start_datetime: datetime, end_datetime: Optional[datetime] = None) -> dict:
-    FABS_regex = ".*_FABSdeletions_.*"
-    date_format = "%Y-%m-%d"
-    return retrieve_deleted_transactions(FABS_regex, date_format, start_datetime, end_datetime)
+    FABS_regex = r".*_FABSdeletions_(?P<epoch>\d+)\.csv"
+    return retrieve_deleted_transactions(FABS_regex, start_datetime, end_datetime)
 
 
 def retrieve_deleted_fpds_transactions(start_datetime: datetime, end_datetime: Optional[datetime] = None) -> dict:
-    FPDS_regex = ".*_delete_records_(IDV|award).*"
-    date_format = "%m-%d-%Y"
-    return retrieve_deleted_transactions(FPDS_regex, date_format, start_datetime, end_datetime)
+    FPDS_regex = r".*_delete_records_(IDV|award)_(?P<epoch>\d+)\.csv"
+    return retrieve_deleted_transactions(FPDS_regex, start_datetime, end_datetime)
 
 
 def retrieve_deleted_transactions(
-    regex: str, date_fmt: str, start_datetime: datetime, end_datetime: Optional[datetime] = None
+    regex: str, start_datetime: datetime, end_datetime: Optional[datetime] = None
 ) -> dict:
     with Timer("Obtaining S3 Object list"):
-        logger.info(f"file regex pattern: {regex}")
-        logger.info(f"date format: {date_fmt}")
-        logger.info(f"start date: {start_datetime}")
-        logger.info(f"end date: {end_datetime}")
-        logger.info(f"S3 bucket name: {settings.DELETED_TRANSACTION_JOURNAL_FILES}")
-        objects = access_s3_object_list(settings.DELETED_TRANSACTION_JOURNAL_FILES, regex_pattern=regex)
-        if objects is None:
-            raise Exception("Problem accessing S3 for deleted records")
-        objects = limit_objects_to_date_range(objects, date_fmt, start_datetime, end_datetime)
-        logger.info(f"{len(objects):,} files found in date range.")
+        objects = retrieve_s3_bucket_object_list(settings.DELETED_TRANSACTION_JOURNAL_FILES)
+        logger.info(f"{len(objects):,} files found in bucket '{settings.DELETED_TRANSACTION_JOURNAL_FILES}'.")
+        objects = [o for o in objects if re.fullmatch(regex, o.key) is not None]
+        logger.info(f"{len(objects):,} files match file pattern '{regex}'.")
+        objects = limit_objects_to_date_range(objects, regex, start_datetime, end_datetime)
+        logger.info(
+            f"{len(objects):,} files found in date range {start_datetime} through {end_datetime or 'the end of time'}."
+        )
 
     deleted_records = defaultdict(list)
     for obj in objects:
-        with Timer(f"Read delete ids from {obj.key}"):
-            object_data = access_s3_object(settings.DELETED_TRANSACTION_JOURNAL_FILES, obj)
-            reader = csv.reader(object_data.read().decode("utf-8").splitlines())
-            next(reader)  # skip the header
+        object_data = access_s3_object(settings.DELETED_TRANSACTION_JOURNAL_FILES, obj)
+        reader = csv.reader(object_data.read().decode("utf-8").splitlines())
+        next(reader)  # skip the header
 
-            transaction_id_list = [rows[0] for rows in reader]
-            logger.info(f"{len(transaction_id_list):,} delete ids found")
+        transaction_id_list = [rows[0] for rows in reader]
+        logger.info(f"{len(transaction_id_list):,} delete ids found in {obj.key}")
 
-            if transaction_id_list:
-                file_date = obj.key[: obj.key.find("_")]
-                deleted_records[file_date].extend(transaction_id_list)
+        if transaction_id_list:
+            file_date = obj.key[: obj.key.find("_")]
+            deleted_records[file_date].extend(transaction_id_list)
 
     return deleted_records
 
 
 def limit_objects_to_date_range(
     objects: List["boto3.resources.factory.s3.ObjectSummary"],
-    date_format: str,
+    regex_pattern: str,
     start_datetime: datetime,
     end_datetime: Optional[datetime] = None,
 ) -> List["boto3.resources.factory.s3.ObjectSummary"]:
     results = []
     for obj in objects or []:
 
-        file_last_modified = cast_datetime_to_naive(obj.last_modified)
+        match = re.fullmatch(regex_pattern, obj.key)
+        file_datetime = datetime.utcfromtimestamp(int(match["epoch"]))
 
-        # Only keep S3 objects which fall between the provided dates
-        if datetime_is_lt(file_last_modified, start_datetime):
+        # Only keep S3 objects that fall between the provided dates
+        if datetime_is_lt(file_datetime, start_datetime):
             continue
-        if end_datetime and datetime_is_ge(file_last_modified, end_datetime):
+        if end_datetime and datetime_is_ge(file_datetime, end_datetime):
             continue
+
         results.append(obj)
 
     return results


### PR DESCRIPTION
**Description:**

Last sprint we introduced a hotfix to use S3 last modified date when filtering FPDS/FABS delete files.  This will work right up until we move the files somewhere else.  Thankfully, the original developers added the file creation time epoch to the file name so we are able to persistently determine when those files were created.

This pull request converts the S3 code to use that epoch instead of the last modified date.  It also cleans up some of the logging we added when trying to track down the problem.  Finally it attempts to simplify a couple of the lower level functions.

**Requirements for PR merge:**

1. [x] Unit & integration tests unaffected
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-4943](https://federal-spending-transparency.atlassian.net/browse/DEV-4943):
    - [x] Link to this Pull-Request