### PR TITLE
[DEV-4872] Change FPDS loader to consistently use natural key for updates

### DIFF
--- a/usaspending_api/etl/transaction_loaders/generic_loaders.py
+++ b/usaspending_api/etl/transaction_loaders/generic_loaders.py
@@ -10,8 +10,8 @@ def insert_award(cursor, load_object):
 
 def update_transaction_fpds(cursor, load_object):
     columns, values, pairs = format_insert_or_update_column_sql(cursor, load_object, "transaction_fpds")
-    transaction_fpds_sql = "UPDATE transaction_fpds SET {} where detached_award_procurement_id = {}".format(
-        pairs, load_object["transaction_fpds"]["detached_award_procurement_id"]
+    transaction_fpds_sql = "UPDATE transaction_fpds SET {} where detached_award_proc_unique = '{}'".format(
+        pairs, load_object["transaction_fpds"]["detached_award_proc_unique"]
     )
     cursor.execute(transaction_fpds_sql)
 


### PR DESCRIPTION
**Description:**

This is a very minor fix for a very fringe case problem.  Because the FPDS loader looks up differences by `detached_award_proc_unique` then later attempts to update them by `detached_award_procurement_id`, there's a slight chance that records won't get updated if the `detached_award_procurement_id` changes (which happens fairly frequently).  This is really only an issue when deletes are not picked up correctly, so it only expresses itself due to another bug, but it compounds the mess that is created by the other bug making it significantly harder to clean up afterwards.

**Requirements for PR merge:**

1. [x] Unit & integration unaffected
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-4872](https://federal-spending-transparency.atlassian.net/browse/DEV-4872):
    - [x] Link to this Pull-Request
