### PR TITLE
WARMFIX [DEV-4963] Sanitize elasticsearch text input

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -9,9 +9,18 @@ from elasticsearch_dsl import Q as ES_Q
 from usaspending_api.search.elasticsearch.filters.filter import _Filter, _QueryType
 from usaspending_api.search.elasticsearch.filters.naics import NaicsCodes
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 
 logger = logging.getLogger(__name__)
+
+
+def es_sanitize(input_string):
+    """ Escapes reserved elasticsearch characters and removes when necessary """
+
+    processed_string = re.sub(r'([-&!|{}()^~*?:\\/"+\[\]<>])', "", input_string)
+    if len(processed_string) != len(input_string):
+        msg = "Stripped characters from input string New: '{}' Original: '{}'"
+        logger.info(msg.format(processed_string, input_string))
+    return processed_string
 
 
 class _Keywords(_Filter):

--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -1,5 +1,4 @@
 import logging
-import re
 
 from django.conf import settings
 
@@ -9,18 +8,9 @@ from elasticsearch_dsl import Q as ES_Q
 from usaspending_api.search.elasticsearch.filters.filter import _Filter, _QueryType
 from usaspending_api.search.elasticsearch.filters.naics import NaicsCodes
 from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.search.v2.es_sanitization import es_sanitize
 
 logger = logging.getLogger(__name__)
-
-
-def es_sanitize(input_string):
-    """ Escapes reserved elasticsearch characters and removes when necessary """
-
-    processed_string = re.sub(r'([-&!|{}()^~*?:\\/"+\[\]<>])', "", input_string)
-    if len(processed_string) != len(input_string):
-        msg = "Stripped characters from input string New: '{}' Original: '{}'"
-        logger.info(msg.format(processed_string, input_string))
-    return processed_string
 
 
 class _Keywords(_Filter):

--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -1,7 +1,7 @@
 import logging
+import re
 
 from django.conf import settings
-
 
 from typing import List
 from elasticsearch_dsl import Q as ES_Q
@@ -9,6 +9,7 @@ from elasticsearch_dsl import Q as ES_Q
 from usaspending_api.search.elasticsearch.filters.filter import _Filter, _QueryType
 from usaspending_api.search.elasticsearch.filters.naics import NaicsCodes
 from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,9 @@ class _Keywords(_Filter):
             "description",
         ]
         for v in filter_values:
-            keyword_queries.append(ES_Q("query_string", query=v + "*", default_operator="AND", fields=fields))
+            keyword_queries.append(
+                ES_Q("query_string", query=es_sanitize(v) + "*", default_operator="AND", fields=fields)
+            )
 
         return ES_Q("dis_max", queries=keyword_queries)
 
@@ -165,7 +168,7 @@ class _RecipientSearchText(_Filter):
         fields = ["recipient_name"]
 
         for v in filter_values:
-            upper_recipient_string = v.upper()
+            upper_recipient_string = es_sanitize(v.upper())
             recipient_name_query = ES_Q(
                 "query_string", query=upper_recipient_string + "*", default_operator="AND", fields=fields
             )
@@ -311,7 +314,7 @@ class _AwardIds(_Filter):
         award_ids_query = []
 
         for v in filter_values:
-            award_ids_query.append(ES_Q("match", display_award_id=v))
+            award_ids_query.append(ES_Q("match", display_award_id=es_sanitize(v)))
 
         return ES_Q("bool", should=award_ids_query, minimum_should_match=1)
 

--- a/usaspending_api/references/v2/views/city.py
+++ b/usaspending_api/references/v2/views/city.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from usaspending_api.common.cache_decorator import cache_response
 
 from usaspending_api.common.elasticsearch.client import es_client_query
-from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
+from usaspending_api.search.v2.es_sanitization import es_sanitize
 from usaspending_api.common.validator.tinyshield import validate_post_request
 from usaspending_api.awards.v2.filters.location_filter_geocode import ALL_FOREIGN_COUNTRIES
 

--- a/usaspending_api/search/tests/unit/test_elasticsearch_helpers.py
+++ b/usaspending_api/search/tests/unit/test_elasticsearch_helpers.py
@@ -8,10 +8,10 @@ from usaspending_api.search.tests.integration.spending_by_category.utilities imp
 from usaspending_api.search.v2.elasticsearch_helper import (
     spending_by_transaction_count,
     get_download_ids,
-    es_sanitize,
     es_minimal_sanitize,
     swap_keys,
 )
+from usaspending_api.search.v2.es_sanitization import es_sanitize
 
 
 @pytest.fixture

--- a/usaspending_api/search/tests/unit/test_es_sanitize.py
+++ b/usaspending_api/search/tests/unit/test_es_sanitize.py
@@ -1,4 +1,4 @@
-from usaspending_api.search.v2.elasticsearch_helper import es_sanitize
+from usaspending_api.search.v2.es_sanitization import es_sanitize
 
 
 def test_sanitizer():

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -19,17 +19,6 @@ DOWNLOAD_QUERY_SIZE = settings.MAX_DOWNLOAD_LIMIT
 TRANSACTIONS_SOURCE_LOOKUP.update({v: k for k, v in TRANSACTIONS_SOURCE_LOOKUP.items()})
 
 
-def es_minimal_sanitize(keyword):
-    keyword = concat_if_array(keyword)
-    """Remove Lucene special characters instead of escaping for now"""
-    processed_string = re.sub(r"[%{}/:!^\[\]]", "", keyword)
-    if len(processed_string) != len(keyword):
-        msg = "Stripped characters from ES keyword search string New: '{}' Original: '{}'"
-        logger.info(msg.format(processed_string, keyword))
-        keyword = processed_string
-    return keyword
-
-
 def swap_keys(dictionary_):
     return dict(
         (TRANSACTIONS_SOURCE_LOOKUP.get(old_key, old_key), new_key) for (old_key, new_key) in dictionary_.items()

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from typing import Dict, Optional
 
 from django.conf import settings
@@ -12,6 +11,7 @@ from usaspending_api.awards.v2.lookups.elasticsearch_lookups import (
 from usaspending_api.common.data_classes import Pagination
 from usaspending_api.common.elasticsearch.search_wrappers import TransactionSearch
 from usaspending_api.common.query_with_filters import QueryWithFilters
+from usaspending_api.search.v2.es_sanitization import es_minimal_sanitize
 
 logger = logging.getLogger("console")
 
@@ -147,19 +147,6 @@ def get_sum_and_count_aggregation_results(keyword):
 
 def spending_by_transaction_sum_and_count(request_data):
     return get_sum_and_count_aggregation_results(request_data["filters"]["keywords"])
-
-
-def concat_if_array(data):
-    if isinstance(data, str):
-        return data
-    else:
-        if isinstance(data, list):
-            str_from_array = " ".join(data)
-            return str_from_array
-        else:
-            # This should never happen if TinyShield is functioning properly
-            logger.error("Keyword submitted was not a string or array")
-            return ""
 
 
 def get_number_of_unique_terms(filter_query: ES_Q, field: str) -> int:

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -19,16 +19,6 @@ DOWNLOAD_QUERY_SIZE = settings.MAX_DOWNLOAD_LIMIT
 TRANSACTIONS_SOURCE_LOOKUP.update({v: k for k, v in TRANSACTIONS_SOURCE_LOOKUP.items()})
 
 
-def es_sanitize(input_string):
-    """ Escapes reserved elasticsearch characters and removes when necessary """
-
-    processed_string = re.sub(r'([-&!|{}()^~*?:\\/"+\[\]<>])', "", input_string)
-    if len(processed_string) != len(input_string):
-        msg = "Stripped characters from input string New: '{}' Original: '{}'"
-        logger.info(msg.format(processed_string, input_string))
-    return processed_string
-
-
 def es_minimal_sanitize(keyword):
     keyword = concat_if_array(keyword)
     """Remove Lucene special characters instead of escaping for now"""

--- a/usaspending_api/search/v2/es_sanitization.py
+++ b/usaspending_api/search/v2/es_sanitization.py
@@ -1,9 +1,20 @@
 import logging
 import re
 
-from usaspending_api.search.v2.elasticsearch_helper import concat_if_array
-
 logger = logging.getLogger("console")
+
+
+def concat_if_array(data):
+    if isinstance(data, str):
+        return data
+    else:
+        if isinstance(data, list):
+            str_from_array = " ".join(data)
+            return str_from_array
+        else:
+            # This should never happen if TinyShield is functioning properly
+            logger.error("Keyword submitted was not a string or array")
+            return ""
 
 
 def es_sanitize(input_string):

--- a/usaspending_api/search/v2/es_sanitization.py
+++ b/usaspending_api/search/v2/es_sanitization.py
@@ -1,6 +1,8 @@
 import logging
 import re
 
+from usaspending_api.search.v2.elasticsearch_helper import concat_if_array
+
 logger = logging.getLogger("console")
 
 
@@ -12,3 +14,14 @@ def es_sanitize(input_string):
         msg = "Stripped characters from input string New: '{}' Original: '{}'"
         logger.info(msg.format(processed_string, input_string))
     return processed_string
+
+
+def es_minimal_sanitize(keyword):
+    keyword = concat_if_array(keyword)
+    """Remove Lucene special characters instead of escaping for now"""
+    processed_string = re.sub(r"[%{}/:!^\[\]]", "", keyword)
+    if len(processed_string) != len(keyword):
+        msg = "Stripped characters from ES keyword search string New: '{}' Original: '{}'"
+        logger.info(msg.format(processed_string, keyword))
+        keyword = processed_string
+    return keyword

--- a/usaspending_api/search/v2/es_sanitization.py
+++ b/usaspending_api/search/v2/es_sanitization.py
@@ -1,0 +1,14 @@
+import logging
+import re
+
+logger = logging.getLogger("console")
+
+
+def es_sanitize(input_string):
+    """ Escapes reserved elasticsearch characters and removes when necessary """
+
+    processed_string = re.sub(r'([-&!|{}()^~*?:\\/"+\[\]<>])', "", input_string)
+    if len(processed_string) != len(input_string):
+        msg = "Stripped characters from input string New: '{}' Original: '{}'"
+        logger.info(msg.format(processed_string, input_string))
+    return processed_string

--- a/usaspending_api/search/v2/views/search_elasticsearch.py
+++ b/usaspending_api/search/v2/views/search_elasticsearch.py
@@ -18,7 +18,8 @@ from usaspending_api.common.query_with_filters import QueryWithFilters
 from usaspending_api.common.validator.award_filter import AWARD_FILTER, AWARD_FILTER_NO_RECIPIENT_ID
 from usaspending_api.common.validator.pagination import PAGINATION
 from usaspending_api.common.validator.tinyshield import TinyShield
-from usaspending_api.search.v2.elasticsearch_helper import spending_by_transaction_count, es_minimal_sanitize
+from usaspending_api.search.v2.elasticsearch_helper import spending_by_transaction_count
+from usaspending_api.search.v2.es_sanitization import es_minimal_sanitize
 from usaspending_api.search.v2.elasticsearch_helper import spending_by_transaction_sum_and_count
 from usaspending_api.awards.v2.lookups.elasticsearch_lookups import TRANSACTIONS_SOURCE_LOOKUP, TRANSACTIONS_LOOKUP
 


### PR DESCRIPTION
**Description:**
Adds sanitization for elasticsearch text input to advanced search filters.

**Technical details:**
Strips all lucene special characters from the text entered into the advanced search filters. This is slightly different from the keyword search method, which strips only specific characters as the keyword search functionality allows using certain characters.

Additionally, for whatever reason importing the sanitization function from elasticsearch_helpers.py would not work in query_with_filters.py so we had to redefine it there.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [N/A] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-4963](https://federal-spending-transparency.atlassian.net/browse/DEV-4963):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to matviews, no ops tickets needed
```
