### PR TITLE
[DEV-4818] Fix sorting by Mod column on Keyword Search

### DIFF
--- a/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
+++ b/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
@@ -17,7 +17,7 @@ TRANSACTIONS_LOOKUP = {
     "Issued Date": "period_of_performance_start_date",
     "Loan Value": "face_value_loan_guarantee",
     "Subsidy Cost": "original_loan_subsidy_cost",
-    "Mod": "modification_number",
+    "Mod": "modification_number.keyword",
     "Award ID": "display_award_id",
     "awarding_agency_id": "awarding_agency_id",
     "internal_id": "award_id",

--- a/usaspending_api/etl/es_transaction_template.json
+++ b/usaspending_api/etl/es_transaction_template.json
@@ -48,7 +48,12 @@
         "index": false
       },
       "modification_number": {
-        "type": "text"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
       },
       "generated_unique_award_id": {
         "type": "keyword"

--- a/usaspending_api/search/tests/integration/test_spending_by_transaction.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_transaction.py
@@ -153,9 +153,9 @@ def test_subset_of_fields_returned(client, monkeypatch, transaction_data, elasti
 
 
 @pytest.mark.django_db
-def test_columns_can_be_sorted(client, transaction_data, elasticsearch_transaction_index):
-
-    elasticsearch_transaction_index.update_index()
+def test_columns_can_be_sorted(client, monkeypatch, transaction_data, elasticsearch_transaction_index):
+    logging_statements = []
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index, logging_statements)
 
     fields = [
         "Action Date",


### PR DESCRIPTION
**Description:**
A minor change from `integer` to `text` type resulted in an inability to sort by the Mod column on Keyword Search.

**Technical details:**
Add a `keyword` type for sorting and also fix the test case that should verify this ability to sort. Did verify that the test case now fails when the value does not support the `keyword` type.

Note: The test does not need the `logging_statements` variable, but this is being cleared up as part of moving Postgres functionality to Elasticsearch on numerous endpoints. 

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-4818](https://federal-spending-transparency.atlassian.net/browse/DEV-4818):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
