### PR TITLE
[DEV-4340] Little bit of cleanup and consistency

### DIFF
--- a/usaspending_api/agency/tests/integration/test_agency_endpoint.py
+++ b/usaspending_api/agency/tests/integration/test_agency_endpoint.py
@@ -49,6 +49,7 @@ def test_happy_path(client, agency_data):
     assert resp.data["congressional_justification_url"] == "BECAUSE"
     assert resp.data["icon_filename"] == "HAI.jpg"
     assert resp.data["subtier_agency_count"] == 1
+    assert resp.data["messages"] == []
 
     resp = client.get(URL.format(code="001", filter=f"?fiscal_year={current_fiscal_year()}"))
     assert resp.status_code == status.HTTP_200_OK

--- a/usaspending_api/agency/tests/integration/test_agency_federal_account_count.py
+++ b/usaspending_api/agency/tests/integration/test_agency_federal_account_count.py
@@ -2,6 +2,8 @@ import pytest
 
 from rest_framework import status
 from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
+from usaspending_api.common.helpers.generic_helper import get_account_data_time_period_message
+
 
 url = "/api/v2/agency/{code}/federal_account/count/{filter}"
 
@@ -17,6 +19,12 @@ def test_federal_account_count_success(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["federal_account_count"] == 0
     assert resp.data["treasury_account_count"] == 0
+    assert resp.data["messages"] == []
+
+    resp = client.get(url.format(code="007", filter="?fiscal_year=2010"))
+    assert resp.data["federal_account_count"] == 0
+    assert resp.data["treasury_account_count"] == 0
+    assert resp.data["messages"] == [get_account_data_time_period_message()]
 
 
 @pytest.mark.django_db

--- a/usaspending_api/agency/v2/views/agency_base.py
+++ b/usaspending_api/agency/v2/views/agency_base.py
@@ -11,7 +11,7 @@ from usaspending_api.references.models import ToptierAgency
 
 
 class AgencyBase(APIView):
-    @cached_property
+    @property
     def toptier_code(self):
         # We don't have to do any validation here because Django has already checked this to be
         # either a three or four digit numeric string based on the regex pattern in our route url.

--- a/usaspending_api/agency/v2/views/agency_base.py
+++ b/usaspending_api/agency/v2/views/agency_base.py
@@ -1,22 +1,23 @@
-from re import fullmatch
-
 from django.conf import settings
+from django.utils.functional import cached_property
+from re import fullmatch
 from rest_framework.exceptions import NotFound
 from rest_framework.views import APIView
 from usaspending_api.common.exceptions import UnprocessableEntityException
 from usaspending_api.common.helpers.date_helper import fy
 from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
+from usaspending_api.common.helpers.generic_helper import get_account_data_time_period_message
 from usaspending_api.references.models import ToptierAgency
 
 
 class AgencyBase(APIView):
-    @property
+    @cached_property
     def toptier_code(self):
         # We don't have to do any validation here because Django has already checked this to be
         # either a three or four digit numeric string based on the regex pattern in our route url.
         return self.kwargs["toptier_code"]
 
-    @property
+    @cached_property
     def fiscal_year(self):
         fiscal_year = str(self.request.query_params.get("fiscal_year", current_fiscal_year()))
         if not fullmatch("[0-9]{4}", fiscal_year):
@@ -33,9 +34,13 @@ class AgencyBase(APIView):
             )
         return fiscal_year
 
-    @property
+    @cached_property
     def toptier_agency(self):
         toptier_agency = ToptierAgency.objects.account_agencies().filter(toptier_code=self.toptier_code).first()
         if not toptier_agency:
             raise NotFound(f"Agency with a toptier code of '{self.toptier_code}' does not exist")
         return toptier_agency
+
+    @property
+    def standard_response_messages(self):
+        return [get_account_data_time_period_message()] if self.fiscal_year < 2017 else []

--- a/usaspending_api/agency/v2/views/agency_overview.py
+++ b/usaspending_api/agency/v2/views/agency_overview.py
@@ -29,18 +29,19 @@ class AgencyOverview(AgencyBase):
                 "website": self.toptier_agency.website,
                 "congressional_justification_url": self.toptier_agency.justification,
                 "about_agency_data": self.toptier_agency.about_agency_data,
-                "subtier_agency_count": self._subtier_agency_count(),
+                "subtier_agency_count": self.get_subtier_agency_count(),
+                "messages": [],  # Currently no applicable messages
             }
         )
 
-    def _subtier_agency_count(self):
-        min_fiscal_year = fy(settings.API_SEARCH_MIN_DATE)
+    def get_subtier_agency_count(self):
         return (
             SubtierAgency.objects.filter(agency__toptier_agency=self.toptier_agency)
             .annotate(
                 was_an_awarding_agency=Exists(
                     TransactionNormalized.objects.filter(
-                        fiscal_year__gte=min_fiscal_year, awarding_agency__subtier_agency=OuterRef("pk")
+                        fiscal_year__gte=fy(settings.API_SEARCH_MIN_DATE),
+                        awarding_agency__subtier_agency=OuterRef("pk"),
                     ).values("pk")
                 )
             )

--- a/usaspending_api/agency/v2/views/budget_function_count.py
+++ b/usaspending_api/agency/v2/views/budget_function_count.py
@@ -2,10 +2,10 @@ from django.db.models import Exists, OuterRef
 from rest_framework.request import Request
 from rest_framework.response import Response
 from typing import Any
+from usaspending_api.accounts.models import TreasuryAppropriationAccount
 from usaspending_api.agency.v2.views.agency_base import AgencyBase
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
-from usaspending_api.accounts.models import TreasuryAppropriationAccount
 
 
 class BudgetFunctionCount(AgencyBase):
@@ -19,7 +19,7 @@ class BudgetFunctionCount(AgencyBase):
 
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        rows = list(self.budget_function_queryset())
+        rows = list(self.get_budget_function_queryset())
 
         return Response(
             {
@@ -27,10 +27,11 @@ class BudgetFunctionCount(AgencyBase):
                 "fiscal_year": self.fiscal_year,
                 "budget_function_count": len(set([row["budget_function_code"] for row in rows])),
                 "budget_sub_function_count": len(set([row["budget_subfunction_code"] for row in rows])),
+                "messages": self.standard_response_messages,
             }
         )
 
-    def budget_function_queryset(self):
+    def get_budget_function_queryset(self):
         return (
             TreasuryAppropriationAccount.objects.annotate(
                 include=Exists(

--- a/usaspending_api/agency/v2/views/federal_account_count.py
+++ b/usaspending_api/agency/v2/views/federal_account_count.py
@@ -2,11 +2,10 @@ from django.db.models import Exists, OuterRef
 from rest_framework.request import Request
 from rest_framework.response import Response
 from typing import Any
-
-from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.agency.v2.views.agency_base import AgencyBase
-from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 from usaspending_api.accounts.models import FederalAccount, TreasuryAppropriationAccount
+from usaspending_api.agency.v2.views.agency_base import AgencyBase
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 
 
 class FederalAccountCount(AgencyBase):
@@ -23,12 +22,13 @@ class FederalAccountCount(AgencyBase):
             {
                 "toptier_code": self.toptier_code,
                 "fiscal_year": self.fiscal_year,
-                "federal_account_count": self._federal_account_count(),
-                "treasury_account_count": self._treasury_account_count(),
+                "federal_account_count": self.get_federal_account_count(),
+                "treasury_account_count": self.get_treasury_account_count(),
+                "messages": self.standard_response_messages,
             }
         )
 
-    def _federal_account_count(self):
+    def get_federal_account_count(self):
         return (
             FederalAccount.objects.annotate(
                 include=Exists(
@@ -42,11 +42,10 @@ class FederalAccountCount(AgencyBase):
             )
             .filter(include=True)
             .values("pk")
-            .distinct()
             .count()
         )
 
-    def _treasury_account_count(self):
+    def get_treasury_account_count(self):
         return (
             TreasuryAppropriationAccount.objects.annotate(
                 include=Exists(
@@ -60,6 +59,5 @@ class FederalAccountCount(AgencyBase):
             )
             .filter(include=True)
             .values("pk")
-            .distinct()
             .count()
         )

--- a/usaspending_api/agency/v2/views/object_class_count.py
+++ b/usaspending_api/agency/v2/views/object_class_count.py
@@ -23,11 +23,12 @@ class ObjectClassCount(AgencyBase):
             {
                 "toptier_code": self.toptier_code,
                 "fiscal_year": self.fiscal_year,
-                "object_class_count": self.object_class_queryset().count(),
+                "object_class_count": self.get_object_class_count(),
+                "messages": self.standard_response_messages,
             }
         )
 
-    def object_class_queryset(self):
+    def get_object_class_count(self):
         return (
             ObjectClass.objects.annotate(
                 include=Exists(
@@ -41,4 +42,5 @@ class ObjectClassCount(AgencyBase):
             )
             .filter(include=True)
             .values("pk")
+            .count()
         )

--- a/usaspending_api/agency/v2/views/program_activity_count.py
+++ b/usaspending_api/agency/v2/views/program_activity_count.py
@@ -23,11 +23,12 @@ class ProgramActivityCount(AgencyBase):
             {
                 "toptier_code": self.toptier_code,
                 "fiscal_year": self.fiscal_year,
-                "program_activity_count": self._program_activity_count(),
+                "program_activity_count": self.get_program_activity_count(),
+                "messages": self.standard_response_messages,
             }
         )
 
-    def _program_activity_count(self):
+    def get_program_activity_count(self):
         return (
             RefProgramActivity.objects.annotate(
                 include=Exists(

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code.md
@@ -32,6 +32,8 @@ Returns some basic information regarding the agency for the fiscal year specifie
         + `congressional_justification_url` (required, string, nullable)
         + `about_agency_data` (required, string, nullable)
         + `subtier_agency_count` (required, number)
+        + `messages` (required, array[string])
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
     + Body
 
@@ -45,5 +47,6 @@ Returns some basic information regarding the agency for the fiscal year specifie
                 "website": "https://www.treasury.gov/",
                 "congressional_justification_url": "https://www.treasury.gov/cj",
                 "about_agency_data": null,
-                "subtier_agency_count": 10
+                "subtier_agency_count": 10,
+                "messages": []
             }

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/budget_function/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/budget_function/count.md
@@ -26,6 +26,8 @@ Returns the count of unique Budget Functions in the Agency's appropriations for 
         + `fiscal_year` (required, number)
         + `budget_function_count` (required, number)
         + `budget_sub_function_count` (required, number)
+        + `messages` (required, array[string])
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
     + Body
 
@@ -33,5 +35,6 @@ Returns the count of unique Budget Functions in the Agency's appropriations for 
                 "toptier_code": "012",
                 "fiscal_year": 2018,
                 "budget_function_count": 4,
-                "budget_sub_function_count": 17
+                "budget_sub_function_count": 17,
+                "messages": ["Account data powering this endpoint were first collected in FY2017 Q2..."]
             }

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/federal_account/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/federal_account/count.md
@@ -7,7 +7,6 @@ Returns the count of unique Federal Account and Treasury Account categories in t
 
 ## GET
 
-
 + Request (application/json)
     + Schema
 
@@ -27,6 +26,8 @@ Returns the count of unique Federal Account and Treasury Account categories in t
         + `fiscal_year` (required, number)
         + `federal_account_count` (required, number)
         + `treasury_account_count` (required, number)
+        + `messages` (required, array[string])
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
     + Body
 
@@ -34,5 +35,6 @@ Returns the count of unique Federal Account and Treasury Account categories in t
                 "toptier_code": 014,
                 "fiscal_year": 2018,
                 "federal_account_count": 7,
-                "treasury_account_count": 7
+                "treasury_account_count": 7,
+                "messages": ["Account data powering this endpoint were first collected in FY2017 Q2..."]
             }

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/object_class/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/object_class/count.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# Program Activity Count [/api/v2/agency/{toptier_code}/object_class/count/{?fiscal_year}]
+# Object Class Count [/api/v2/agency/{toptier_code}/object_class/count/{?fiscal_year}]
 
 Returns the count of Object Classes in the Agency's appropriations for a single fiscal year
 
@@ -25,11 +25,14 @@ Returns the count of Object Classes in the Agency's appropriations for a single 
         + `toptier_code` (required, string)
         + `fiscal_year` (required, number)
         + `object_class_count` (required, number)
+        + `messages` (required, array[string])
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
     + Body
 
             {
                 "toptier_code": "012",
                 "fiscal_year": 2018,
-                "object_class_count": 81
+                "object_class_count": 81,
+                "messages": ["Account data powering this endpoint were first collected in FY2017 Q2..."]
             }

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/program_activity/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/program_activity/count.md
@@ -25,11 +25,14 @@ Returns the count of Program Activity categories in the Agency's appropriations 
         + `toptier_code` (required, string)
         + `fiscal_year` (required, number)
         + `program_activity_count` (required, number)
+        + `messages` (required, array[string])
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
     + Body
 
             {
                 "toptier_code": "012",
                 "fiscal_year": 2020,
-                "program_activity_count": 7
+                "program_activity_count": 7,
+                "messages": ["Account data powering this endpoint were first collected in FY2017 Q2..."]
             }

--- a/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
@@ -34,3 +34,4 @@ This endpoint returns a list of toptier agencies, their budgetary resources, and
 + `outlay_amount` (required, number)
 + `percentage_of_total_budget_authority` (required, number)
     `percentage_of_total_budget_authority` is the percentage of the agency's budget authority compared to the total government budget authority, expressed as a decimal value.
++ `toptier_code` (required, string)

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -202,6 +202,13 @@ def unused_filters_message(filters):
     return f"The following filters from the request were not used: {filters}. See https://api.usaspending.gov/docs/endpoints for a list of appropriate filters"
 
 
+def get_account_data_time_period_message():
+    return (
+        f"Account data powering this endpoint were first collected in FY2017 Q2 under the DATA Act; "
+        f"as such, there are no data available for prior fiscal years."
+    )
+
+
 # Raw SQL run during a migration
 FY_PG_FUNCTION_DEF = """
     CREATE OR REPLACE FUNCTION fy(raw_date DATE)

--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -82,6 +82,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "obligated_amount": 2.0,
                 "outlay_amount": 2.0,
                 "percentage_of_total_budget_authority": 2.391930450298678e-13,
+                "toptier_code": "100",
             },
             {
                 "abbreviation": "tta_abrev_2",
@@ -95,6 +96,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "obligated_amount": 14.0,
                 "outlay_amount": 14.00,
                 "percentage_of_total_budget_authority": 1.6743513152090746e-12,
+                "toptier_code": "200",
             },
         ]
     }
@@ -115,6 +117,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "obligated_amount": 14.0,
                 "outlay_amount": 14.0,
                 "percentage_of_total_budget_authority": 1.6743513152090746e-12,
+                "toptier_code": "200",
             },
             {
                 "abbreviation": "tta_abrev",
@@ -128,6 +131,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "obligated_amount": 2.0,
                 "outlay_amount": 2.0,
                 "percentage_of_total_budget_authority": 2.391930450298678e-13,
+                "toptier_code": "100",
             },
         ]
     }

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -107,6 +107,7 @@ class ToptierAgenciesViewSet(APIView):
             response["results"].append(
                 {
                     "agency_id": agency.id,
+                    "toptier_code": toptier_agency.toptier_code,
                     "abbreviation": abbreviation,
                     "agency_name": toptier_agency.name,
                     "congressional_justification_url": cj,


### PR DESCRIPTION
**Description:**

A little post-PTO cleanup and consistency.

Highlights:
- Added `messages` to responses for new agency endpoints so we can document data limitations for consumers (e.g. account data only goes back to 2017).
- Cached properties on the base class.  An unfortunate side effect of a last minute tweak added to the pull request was that it was pinging the database about a dozen times to fill in response objects.  This way the database is only called once.
- Added `toptier_code` to agency list endpoint so front end will be able to link to Agency 2.0 pages when the cutover happens.
- Tried to add a little consistency to method names.  I guess one of the downsides of splitting up endpoint development is that you end up with different styles depending on who's working on what.  Or maybe that's a plus.  Who am I to judge, really.
- Minor fix to a contract (copy paste error).

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-4340](https://federal-spending-transparency.atlassian.net/browse/DEV-4340):
    - [x] Link to this Pull-Request