### PR TITLE
Updating Dockerfile: Referenced public rpm no longer exists.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN yum -y install wget gcc openssl-devel bzip2-devel libffi libffi-devel zlib-d
 RUN yum -y groupinstall "Development Tools"
 
 ##### Install PostgreSQL 10 client (psql)
-RUN yum -y install https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-redhat10-10-2.noarch.rpm
+RUN yum -y install https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 RUN yum -y install postgresql10
 
 ##### Building python 3.7


### PR DESCRIPTION
rpm downloaded from download.postgresql.org no longer is available. referencing latest to increase our chances it will be available in the future.

**Description:**
When building the docker container, I could not build it because the rpm file on postgres' website was no longer available. This PR will update the referenced rpm file to the latest for the desired architecture.

**Technical details:**
can't build the docker container if the publicly hosted rpm is not available.

**Description:**
High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances
