### PR TITLE
[DEV-4972] Prevent FABS nightly loader skips

### DIFF
--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -21,7 +21,8 @@ from usaspending_api.transactions.transaction_delete_journal_helpers import retr
 logger = logging.getLogger("script")
 
 
-SUBMISSION_LOOKBACK_MINUTES = 15
+LAST_LOAD_LOOKBACK_MINUTES = 15
+UPDATED_AT_MODIFIER_MS = 1
 
 
 def get_incremental_load_start_datetime():
@@ -29,22 +30,29 @@ def get_incremental_load_start_datetime():
     This function is designed to help prevent two issues we've discovered with the FABS nightly
     pipline:
 
-     #1 We return the minimum of the last load date and the max transaction_fabs updated_at date
+     #1 LAST_LOAD_LOOKBACK_MINUTES are subtracted from last load datetime to counter a very rare
+        race condition where database commits are saved ever so slightly out of order when compared
+        to the last updated timestamp due to commit duration which can cause transactions to be
+        skipped.  The timestamp is set to when the commit begins, so if the commit starts before
+        the load but doesn't finish until after the load, the transactions saved as part of that
+        commit will never get picked up.  This has happened in the wild at least once and is not
+        all that hard to imagine if you consider that large submissions can take many minutes to
+        commit.  We do not currently have a good way to test this, but I've seen extremely large
+        transactions take an hour to commit.  I do not believe submissions currently get this large
+        but it's something to keep in mind.
+
+     #2 We use the minimum of the last load date or the max transaction_fabs updated_at date
         to prevent FABS transactions submitted between when the source records are copied from
         Broker and when FABS transactions are processed from being skipped.
 
-     #2 We then subtract SUBMISSION_LOOKBACK_MINUTES from #1 to counter a very rare race condition
-        where database commits are saved ever so slightly out of order when compared to the
-        updated_at timestamp due to commit duration which can cause specific transactions to be
-        skipped.
-
-    An unfortunate side effect is that some submissions will be processed more than once which
-    SHOULDN'T cause any problems but will add to the run time.  To minimize this, keep the
-    SUBMISSION_LOOKBACK_MINUTES value as small as possible while still preventing skips.  To be
+    An unfortunate side effect of the lookback is that some submissions may be processed more than
+    once.  This SHOULDN'T cause any problems since the FABS loader is designed to be able to reload
+    transactions, but it could add to the run time.  To minimize reprocessing, keep the
+    LAST_LOAD_LOOKBACK_MINUTES value as small as possible while still preventing skips.  To be
     clear, the original fabs loader did this as well, just in a way that did not always prevent
     skips (by always running since midnight - which had its own issues).
     """
-    last_load_date = get_last_load_date("fabs", SUBMISSION_LOOKBACK_MINUTES)
+    last_load_date = get_last_load_date("fabs", LAST_LOAD_LOOKBACK_MINUTES)
     if last_load_date is None:
         raise RuntimeError(
             f"Unable to find last_load_date in table {ExternalDataLoadDate.objects.model._meta.db_table} "
@@ -54,7 +62,14 @@ def get_incremental_load_start_datetime():
     max_updated_at = TransactionFABS.objects.aggregate(Max("updated_at"))["updated_at__max"]
     if max_updated_at is None:
         return last_load_date
-    return min((last_load_date, max_updated_at - timedelta(minutes=SUBMISSION_LOOKBACK_MINUTES)))
+
+    # We add a little tiny bit of time to the max_updated_at to prevent us from always reprocessing
+    # records since the SQL that grabs new records is using >= updated_at.  I realize this is a hack
+    # but the pipeline is already running for too long so anything we can do to prevent enlongating
+    # it should be welcome.
+    max_updated_at += timedelta(milliseconds=UPDATED_AT_MODIFIER_MS)
+
+    return min((last_load_date, max_updated_at))
 
 
 def _get_ids(sql, afa_ids, start_datetime, end_datetime):

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -64,7 +64,7 @@ def get_incremental_load_start_datetime():
         return last_load_date
 
     # We add a little tiny bit of time to the max_updated_at to prevent us from always reprocessing
-    # records since the SQL that grabs new records is using >= updated_at.  I realize this is a hack
+    # records since the SQL that grabs new records is using updated_at >=.  I realize this is a hack
     # but the pipeline is already running for too long so anything we can do to prevent enlongating
     # it should be welcome.
     max_updated_at += timedelta(milliseconds=UPDATED_AT_MODIFIER_MS)

--- a/usaspending_api/broker/tests/integration/test_incremental_load_start_datetime.py
+++ b/usaspending_api/broker/tests/integration/test_incremental_load_start_datetime.py
@@ -6,7 +6,8 @@ from usaspending_api.awards.models import TransactionFABS
 from usaspending_api.broker.lookups import EXTERNAL_DATA_TYPE_DICT
 from usaspending_api.broker.management.commands.fabs_nightly_loader import (
     get_incremental_load_start_datetime,
-    SUBMISSION_LOOKBACK_MINUTES,
+    LAST_LOAD_LOOKBACK_MINUTES,
+    UPDATED_AT_MODIFIER_MS,
 )
 from usaspending_api.broker.models import ExternalDataLoadDate
 
@@ -17,7 +18,8 @@ def test_get_incremental_load_start_datetime():
     may4 = datetime(2020, 5, 4, tzinfo=timezone.utc)
     may5 = datetime(2020, 5, 5, tzinfo=timezone.utc)
     may6 = datetime(2020, 5, 6, tzinfo=timezone.utc)
-    lookback_minutes = timedelta(minutes=SUBMISSION_LOOKBACK_MINUTES)
+    lookback_minutes = timedelta(minutes=LAST_LOAD_LOOKBACK_MINUTES)
+    updated_at_modifier = timedelta(milliseconds=UPDATED_AT_MODIFIER_MS)
 
     # With no data in the database, this should fail.
     with pytest.raises(RuntimeError):
@@ -33,7 +35,7 @@ def test_get_incremental_load_start_datetime():
 
     # Add a FABS updated_at that is older than last load date so it is chosen.
     mommy.make("awards.TransactionFABS", transaction__id=1, updated_at=may4)
-    assert get_incremental_load_start_datetime() == may4 - lookback_minutes
+    assert get_incremental_load_start_datetime() == may4 + updated_at_modifier
 
     # Make FABS updated_at newer so last load date is chosen.
     TransactionFABS.objects.filter(transaction_id=1).update(updated_at=may6)

--- a/usaspending_api/transactions/agnostic_transaction_loader.py
+++ b/usaspending_api/transactions/agnostic_transaction_loader.py
@@ -31,10 +31,7 @@ class AgnosticTransactionLoader:
         mutually_exclusive_group = parser.add_mutually_exclusive_group(required=True)
 
         mutually_exclusive_group.add_argument(
-            "--ids",
-            nargs="+",
-            type=int,
-            help=f"Load/Reload transactions using this {self.shared_pk} list (space-separated)",
+            "--ids", nargs="+", help=f"Load/Reload transactions using this {self.shared_pk} list (space-separated)",
         )
         mutually_exclusive_group.add_argument(
             "--date",


### PR DESCRIPTION
**Description:**

Currently, transactions submitted between when we copy transactions from Broker and when we process those transactions are never picked up by the nightly loader.  It's pretty rare for people to submit at 1am, but it has happened at least once.

This code adjusts the FABS nightly loader to use the lesser of last run or most recent `updated_at` in order to eliminate this gap

Also added support for AFA ids on the command line for the `fabs_nightly_loader` so we can more easily fix the skipped submission attached to the ticket.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] Operations ticket: [DEV-5092](https://federal-spending-transparency.atlassian.net/browse/DEV-5092)
8. [x] Jira Ticket [DEV-4972](https://federal-spending-transparency.atlassian.net/browse/DEV-4972):
    - [x] Link to this Pull-Request
