### PR TITLE
[DEV-3140] Add recipient hash to spending explorer response

### DIFF
--- a/usaspending_api/common/recipient_lookups.py
+++ b/usaspending_api/common/recipient_lookups.py
@@ -141,10 +141,15 @@ def _annotate_recipient_id(alias_name, queryset, annotation_sql):
 
 
 def annotate_recipient_id(alias_name, queryset, id_lookup=None, parent_id_lookup=None, name_lookup=None):
-    if not all([v is not None for v in [id_lookup, parent_id_lookup, name_lookup]]):
+    param_check = [v is not None for v in [id_lookup, parent_id_lookup, name_lookup]]
+    if sum(param_check) == 0:
         id_lookup = "{outer_table}.recipient_unique_id"
         parent_id_lookup = "{outer_table}.parent_recipient_unique_id"
         name_lookup = "{outer_table}.recipient_name"
+    elif sum(param_check) < 3:
+        raise Exception(
+            "Invalid parameters for 'annotate_recipient_id'; requires all or just 'alias_name' and 'queryset'"
+        )
 
     return _annotate_recipient_id(
         alias_name,


### PR DESCRIPTION
**Description:**
Added the recipient hash to the spending explorer response.

**Technical details:**
The old response:
```
{
    "total": 49994182133.32,
    "end_date": "2018-12-31",
    "results": [
        {
            "amount": 8855926130.78,
            "id": "LOCKHEED MARTIN CORPORATION",
            "type": "recipient",
            "name": "LOCKHEED MARTIN CORPORATION",
            "code": "LOCKHEED MARTIN CORPORATION",
            "total": 8855926130.78
        }
   ]
}
```

The new response:
```
{
    "total": 21212437.87,
    "end_date": "2018-12-31",
    "results": [
        {
            "amount": 2779216.32,
            "type": "recipient",
            "name": "REHABILITATION SERVICES, ALABAMA DEPT OF",
            "code": "958175390",
            "id": "4b42d753-2c1e-4815-a13a-0ec1ac0f3af1-C",
            "total": 2779216.32
        }
   ]
}
```

After looking closer it was noticed that this will cause some Recipients to be broken up into their Recipient and Child levels. Below is a sample from my local DB to demonstrate this difference.

Request Body:
```
{
    "type": "recipient",
    "filters": {
        "fy": "2018",
        "quarter": "4",
        "agency": 731
    }
}
```

Part of old response:
```
{
            "amount": 229540.0,
            "id": "EXECUTIVE OFFICE OF THE COMMONWEALTH OF KENTUCKY",
            "type": "recipient",
            "name": "EXECUTIVE OFFICE OF THE COMMONWEALTH OF KENTUCKY",
            "code": "EXECUTIVE OFFICE OF THE COMMONWEALTH OF KENTUCKY",
            "total": 229540.0
        },
        {
            "amount": 196200.0,
            "id": "CITY OF CUSHING",
            "type": "recipient",
            "name": "CITY OF CUSHING",
            "code": "CITY OF CUSHING",
            "total": 196200.0
        },
        {
            "amount": 196000.0,
            "id": "TRANSPORTATION TECHNOLOGY CENTER, INC.",
            "type": "recipient",
            "name": "TRANSPORTATION TECHNOLOGY CENTER, INC.",
            "code": "TRANSPORTATION TECHNOLOGY CENTER, INC.",
            "total": 196000.0
        },
        {
            "amount": 176098.44,
            "id": "HAVASUPAI TRIBE",
            "type": "recipient",
            "name": "HAVASUPAI TRIBE",
            "code": "HAVASUPAI TRIBE",
            "total": 176098.44
        },
        {
            "amount": 129470.0,
            "id": "U.S. PAN AMERICAN SOLUTIONS LLC",
            "type": "recipient",
            "name": "U.S. PAN AMERICAN SOLUTIONS LLC",
            "code": "U.S. PAN AMERICAN SOLUTIONS LLC",
            "total": 129470.0
        },
```

Part of new response:
```{
            "amount": 229540.0,
            "type": "recipient",
            "name": "EXECUTIVE OFFICE OF THE COMMONWEALTH OF KENTUCKY",
            "code": "188593644",
            "id": "a84895ec-f2d1-a728-4ef5-5d3eb5fa2456-C",
            "total": 229540.0
        },
        {
            "amount": 200000.0,
            "type": "recipient",
            "name": "TRANSPORTATION, VIRGINIA DEPARTMENT OF",
            "code": "809875263",
            "id": "77ca521d-b25c-c2bf-43c3-73188fde9d1c-R",
            "total": 200000.0
        },
        {
            "amount": 196200.0,
            "type": "recipient",
            "name": "CITY OF CUSHING",
            "code": "074274762",
            "id": "40a8fb83-2db0-41ac-7ea3-819552d4d502-C",
            "total": 196200.0
        },
        {
            "amount": 196000.0,
            "type": "recipient",
            "name": "TRANSPORTATION TECHNOLOGY CENTER, INC.",
            "code": "969546407",
            "id": "8592b4b7-6e13-d2b2-01e1-43b34e58a325-C",
            "total": 196000.0
        },
        {
            "amount": 176098.44,
            "type": "recipient",
            "name": "HAVASUPAI TRIBE",
            "code": "145306817",
            "id": "73c89d04-2794-e64b-3015-e43ff6ee44c9-C",
            "total": 176098.44
        },
        {
            "amount": 135540.33,
            "type": "recipient",
            "name": "TRANSPORTATION, VIRGINIA DEPARTMENT OF",
            "code": "809875263",
            "id": "77ca521d-b25c-c2bf-43c3-73188fde9d1c-C",
            "total": 135540.33
        },
        {
            "amount": 129470.0,
            "type": "recipient",
            "name": "U.S. PAN AMERICAN SOLUTIONS LLC",
            "code": "079433916",
            "id": "710ae966-318b-b71e-6553-89584964b76c-C",
            "total": 129470.0
        },
```

In this sample `TRANSPORTATION, VIRGINIA DEPARTMENT OF` is broken into two different Recipients due to their levels. Further up there is an entry for Virginia DOT that has an amount equal to the two previous entries combined since it a combination of the `-R` and `-C` level.

```
{
            "amount": 335540.33,
            "id": "TRANSPORTATION, VIRGINIA DEPARTMENT OF",
            "type": "recipient",
            "name": "TRANSPORTATION, VIRGINIA DEPARTMENT OF",
            "code": "TRANSPORTATION, VIRGINIA DEPARTMENT OF",
            "total": 335540.33
        },
```

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-3140](https://federal-spending-transparency.atlassian.net/browse/DEV-3140):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
This change did not break any currently existing tests.
```
