### PR TITLE
Set Elasticsearch Downloads Shard Size

### DIFF
--- a/usaspending_api/download/helpers/elasticsearch_download_functions.py
+++ b/usaspending_api/download/helpers/elasticsearch_download_functions.py
@@ -33,12 +33,18 @@ class _ElasticsearchDownload(metaclass=ABCMeta):
         max_iterations = settings.MAX_DOWNLOAD_LIMIT // size
         req_iterations = (total // size) + 1
         num_iterations = min(max(1, req_iterations), max_iterations)
+
+        # Setting the shard_size below works in this case because we are aggregating on a unique field. Otherwise, this
+        # would not work due to the number of records. Other places this is set are in the different spending_by
+        # endpoints which are either routed or contain less than 10k unique values, both allowing for the shard
+        # size to be manually set to 10k.
         for iteration in range(num_iterations):
             aggregation = A(
                 "terms",
                 field=cls._source_field,
                 include={"partition": iteration, "num_partitions": num_iterations},
                 size=size,
+                shard_size=size,
             )
             search.aggs.bucket("results", aggregation)
             response = search.handle_execute(retries=max_retries).to_dict()

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -110,7 +110,12 @@ def get_download_ids(keyword, field, size=10000):
             {"keyword_search": [es_minimal_sanitize(keyword)]}
         )
         search = TransactionSearch().filter(filter_query)
-        group_by_agg_key_values = {"field": field, "include": {"partition": i, "num_partitions": n_iter}, "size": size}
+        group_by_agg_key_values = {
+            "field": field,
+            "include": {"partition": i, "num_partitions": n_iter},
+            "size": size,
+            "shard_size": size,
+        }
         aggs = A("terms", **group_by_agg_key_values)
         search.aggs.bucket("results", aggs)
         response = search.handle_execute()


### PR DESCRIPTION
**Description:**
Manually set the shard size for downloads with Elasticsearch.

**Technical details:**
The shard_size is automatically calculated as part of Elasticsearch query unless it is manually set in a query. This poses a problem when the values reach above 10k since 10k is the maximum size for the cluster. To prevent this the shard_size is manually set to be equal to the size (which defaults to 10k). There are issues around setting shard_size for aggregations since it can omit documents on another shard when performing aggregations, but in the case of downloads, we are using aggregations purely for the pagination aspect. A unique value is used and thus the issue of not finding documents is not a concern. 

**Requirements for PR merge:**

1. [X] Unit & integration tests updated (N/A)
2. [X] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created  (N/A)
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Kirk noticed this while testing Advanced Search and so this PR was put together to go out with the Prod deploy as a warmfix. Currently, there is no ticket associated with this bug. 
```
