### PR TITLE
Reconfigure uwsgi.ini for a smaller server node

### DIFF
--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -26,7 +26,7 @@ cheaper-overload = 1
 cheaper = 50
 
 # Max Workers
-workers = 100
+workers = 200
 
 # Memory Limits
 # https://uwsgi-docs.readthedocs.io/en/latest/Cheaper.html

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -26,14 +26,16 @@ cheaper-overload = 1
 cheaper = 50
 
 # Max Workers
-workers = 200
+workers = 100
 
 # Memory Limits
 # https://uwsgi-docs.readthedocs.io/en/latest/Cheaper.html
-# Soft Limit of 80%; Hard Limit of 90% total memory
-# (Calculations are based on a m5.2xlarge w/ 32GB worker)
-cheaper-rss-limit-soft = 27487790694
-cheaper-rss-limit-hard = 30923764531
+#  (Calculations are based on a m5.large ec2 which has 8GB)
+#    Soft Limit of 80% total memory = ROUND(0.8*1024*1024*1024*8)
+#    Hard Limit of 90% total memory = ROUND(0.9*1024*1024*1024*8)
+
+cheaper-rss-limit-soft = 6871947674
+cheaper-rss-limit-hard = 7730941133
 
 # Configuration to limit the lifespan of a worker to mitigate the
 #  risk of memory leaks in the application or dependencies


### PR DESCRIPTION
**Description:**
Reducing the deployed API server node from 32GB of RAM to 8GB requires some changes to the uwsgi config

**Technical details:**
Comments in the file explain the details

**OPS link**
fedspendingtransparency/usaspending-config#686