### PR TITLE
[WARMFIX] Fix agency codes

### DIFF
--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -347,6 +347,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
 
         return response
 
+    # For an unknown reason, ES tends to return the awarding agency toptier codes as integers or floats, instead of as
+    # text. This function casts the code back to a string and appends any leading zeroes that were lost.
     def get_agency_database_id(self, code):
         if len(str(int(code))) < 3:
             code = "{zeroes}{code}".format(zeroes=("0" * (3 - len(str(int(code))))), code=int(code))

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -348,9 +348,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
         return response
 
     def get_agency_database_id(self, code):
-        if len(str(code)) < 3:
-            code = "{zeroes}{code}".format(zeroes=("0" * (3 - len(str(code)))), code=code)
-
+        if len(str(int(code))) < 3:
+            code = "{zeroes}{code}".format(zeroes=("0" * (3 - len(str(int(code))))), code=int(code))
         agency_id = Agency.objects.filter(toptier_agency__toptier_code=code, toptier_flag=True).first()
         submission = SubmissionAttributes.objects.filter(toptier_code=code).first()
         if submission is None or agency_id is None:


### PR DESCRIPTION
**Description:**
Fixes issue where agency ids were not returning.

**Technical details:**
Adjust method of formatting agency codes to account of Elasticsearch sometimes returning the agency code as a `float` instead of an `int`

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-3986](https://federal-spending-transparency.atlassian.net/browse/DEV-3986):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
