### PR TITLE
[DEV-5323/5324] FABS delete bugs warmfix

### DIFF
--- a/usaspending_api/broker/helpers/delete_fabs_transactions.py
+++ b/usaspending_api/broker/helpers/delete_fabs_transactions.py
@@ -1,16 +1,15 @@
 import logging
 
-from usaspending_api.common.helpers.timing_helpers import timer
+from django.db import connections
 from usaspending_api.broker.helpers.delete_stale_fabs import delete_stale_fabs
+from usaspending_api.common.helpers.timing_helpers import timer
 
 
 logger = logging.getLogger("console")
 
 
 def delete_fabs_transactions(ids_to_delete):
-    """
-    ids_to_delete are afa_generated_unique ids
-    """
+    """ids_to_delete are published_award_financial_assistance_ids"""
     if ids_to_delete:
         with timer(f"deleting {len(ids_to_delete)} stale FABS data", logger.info):
             update_award_ids = delete_stale_fabs(ids_to_delete)
@@ -20,3 +19,31 @@ def delete_fabs_transactions(ids_to_delete):
         logger.info("Nothing to delete...")
 
     return update_award_ids
+
+
+def get_delete_pks_for_afa_keys(afa_ids_to_delete):
+    """
+    When we read from FABS delete files, we are only reading in afa_generated_unique keys (AFA).  Unfortunately,
+    AFAs on their own do not give us enough information to delete records since AFAs are reused in Broker.  This
+    function converts AFAs into a list of published_award_financial_assistance_id primary keys that should no
+    longer exist in USAspending for the supplied set of AFAs.  Notice that published_award_financial_assistance
+    records marked as is_active will not be deleted since they are the current, active, non-deleted version of
+    the FABS record for that AFA.
+    """
+    if not afa_ids_to_delete:
+        return []
+
+    uppercased = tuple(afa.upper() for afa in afa_ids_to_delete)
+
+    sql = """
+    select  published_award_financial_assistance_id
+    from    published_award_financial_assistance
+    where   upper(afa_generated_unique) in %s and
+            is_active is not true
+    """
+
+    with connections["data_broker"].cursor() as cursor:
+        cursor.execute(sql, [uppercased])
+        rows = cursor.fetchall()
+
+    return [row[0] for row in rows]

--- a/usaspending_api/broker/helpers/delete_stale_fabs.py
+++ b/usaspending_api/broker/helpers/delete_stale_fabs.py
@@ -12,12 +12,15 @@ logger = logging.getLogger("console")
 
 @transaction.atomic
 def delete_stale_fabs(ids_to_delete):
+    """ids_to_delete are published_award_financial_assistance_ids"""
     logger.info("Starting deletion of stale FABS data")
 
     if not ids_to_delete:
         return []
 
-    transactions = TransactionNormalized.objects.filter(assistance_data__afa_generated_unique__in=ids_to_delete)
+    transactions = TransactionNormalized.objects.filter(
+        assistance_data__published_award_financial_assistance_id__in=ids_to_delete
+    )
     update_award_ids, delete_award_ids = find_related_awards(transactions)
 
     delete_transaction_ids = [delete_result[0] for delete_result in transactions.values_list("id")]

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -7,7 +7,10 @@ from django.db.models import Max
 
 from usaspending_api.awards.models import TransactionFABS
 from usaspending_api.broker import lookups
-from usaspending_api.broker.helpers.delete_fabs_transactions import delete_fabs_transactions
+from usaspending_api.broker.helpers.delete_fabs_transactions import (
+    delete_fabs_transactions,
+    get_delete_pks_for_afa_keys,
+)
 from usaspending_api.broker.helpers.last_load_date import get_last_load_date
 from usaspending_api.broker.helpers.last_load_date import update_last_load_date
 from usaspending_api.broker.helpers.upsert_fabs_transactions import upsert_fabs_transactions
@@ -186,6 +189,7 @@ class Command(BaseCommand):
             with timer("obtaining delete records", logger.info):
                 delete_records = retrieve_deleted_fabs_transactions(start_datetime, end_datetime)
                 ids_to_delete = [item for sublist in delete_records.values() for item in sublist if item]
+                ids_to_delete = get_delete_pks_for_afa_keys(ids_to_delete)
             logger.info(f"{len(ids_to_delete):,} delete ids found in total")
 
         with timer("retrieving/diff-ing FABS Data", logger.info):

--- a/usaspending_api/broker/tests/integration/test_delete_fabs.py
+++ b/usaspending_api/broker/tests/integration/test_delete_fabs.py
@@ -12,7 +12,9 @@ def test_delete_fabs_success():
     # Award/Transaction deleted based on 1-1 transaction
     mommy.make(Award, id=1, latest_transaction_id=1, generated_unique_award_id="TEST_AWARD_1")
     mommy.make(TransactionNormalized, id=1, award_id=1, unique_award_key="TEST_AWARD_1")
-    mommy.make(TransactionFABS, transaction_id=1, afa_generated_unique="A", unique_award_key="TEST_AWARD_1")
+    mommy.make(
+        TransactionFABS, transaction_id=1, published_award_financial_assistance_id=301, unique_award_key="TEST_AWARD_1"
+    )
 
     # Award kept despite having one of their associated transactions removed
     mommy.make(Award, id=2, latest_transaction_id=2, generated_unique_award_id="TEST_AWARD_2")
@@ -22,16 +24,22 @@ def test_delete_fabs_success():
     mommy.make(
         TransactionNormalized, id=3, award_id=2, action_date="2019-01-02", unique_award_key="TEST_AWARD_2",
     )
-    mommy.make(TransactionFABS, transaction_id=2, afa_generated_unique="B", unique_award_key="TEST_AWARD_2")
-    mommy.make(TransactionFABS, transaction_id=3, afa_generated_unique="C", unique_award_key="TEST_AWARD_2")
+    mommy.make(
+        TransactionFABS, transaction_id=2, published_award_financial_assistance_id=302, unique_award_key="TEST_AWARD_2"
+    )
+    mommy.make(
+        TransactionFABS, transaction_id=3, published_award_financial_assistance_id=303, unique_award_key="TEST_AWARD_2"
+    )
 
-    # Award/Transaction/LE/Locations untouched at all for control
+    # Award/Transaction untouched at all as control
     mommy.make(Award, id=3, latest_transaction_id=4, generated_unique_award_id="TEST_AWARD_3")
     mommy.make(TransactionNormalized, id=4, award_id=3, unique_award_key="TEST_AWARD_3")
-    mommy.make(TransactionFABS, transaction_id=4, afa_generated_unique="D", unique_award_key="TEST_AWARD_3")
+    mommy.make(
+        TransactionFABS, transaction_id=4, published_award_financial_assistance_id=304, unique_award_key="TEST_AWARD_3"
+    )
 
     # Main call
-    updated_awards = delete_stale_fabs(["A", "B"])
+    updated_awards = delete_stale_fabs([301, 302])
     expected_update_awards = [2]
     assert updated_awards == expected_update_awards
 
@@ -56,8 +64,8 @@ def test_delete_fabs_success():
     # Transaction FABS
     transactions_fabs_left = TransactionFABS.objects.all()
 
-    transaction_fabs_afas_left = set(
-        [transaction_fabs.afa_generated_unique for transaction_fabs in transactions_fabs_left]
+    transaction_fabs_left = set(
+        [transaction_fabs.published_award_financial_assistance_id for transaction_fabs in transactions_fabs_left]
     )
-    expected_transaction_fabs_afas_left = {"C", "D"}
-    assert expected_transaction_fabs_afas_left == transaction_fabs_afas_left
+    expected_transaction_fabs_left = {303, 304}
+    assert expected_transaction_fabs_left == transaction_fabs_left

--- a/usaspending_api/broker/tests/integration/test_get_delete_pks_for_afa_keys.py
+++ b/usaspending_api/broker/tests/integration/test_get_delete_pks_for_afa_keys.py
@@ -29,11 +29,12 @@ class TestThingWithMultipleDatabases(TestCase):
                     (5, 'xYz', false),
                     (6, 'XYZ', false),
                     (7, 'lmn', false),
-                    (8, 'opq', false)
+                    (8, 'opq', true)
                 )
                 """
             )
 
     def test_get_delete_pks_for_afa_keys(self):
         assert get_delete_pks_for_afa_keys(None) == []
+        assert get_delete_pks_for_afa_keys([]) == []
         assert set(get_delete_pks_for_afa_keys(["abc", "xyZ"])) == {1, 2, 4, 5, 6}

--- a/usaspending_api/broker/tests/integration/test_get_delete_pks_for_afa_keys.py
+++ b/usaspending_api/broker/tests/integration/test_get_delete_pks_for_afa_keys.py
@@ -1,0 +1,39 @@
+import pytest
+
+from django.db import connections
+from django.test import TestCase
+from usaspending_api.broker.helpers.delete_fabs_transactions import get_delete_pks_for_afa_keys
+
+
+@pytest.mark.usefixtures("broker_db_setup")
+class TestThingWithMultipleDatabases(TestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        connection = connections["data_broker"]
+        with connection.cursor() as cursor:
+
+            cursor.execute("select count(*) from published_award_financial_assistance")
+            assert cursor.fetchone()[0] == 0, "Another test somewhere is leaking data"
+
+            cursor.execute(
+                """
+                insert into published_award_financial_assistance (
+                    published_award_financial_assistance_id, afa_generated_unique, is_active
+                ) (values
+                    (1, 'abc', false),
+                    (2, 'aBc', false),
+                    (3, 'ABC', true),
+                    (4, 'xyz', false),
+                    (5, 'xYz', false),
+                    (6, 'XYZ', false),
+                    (7, 'lmn', false),
+                    (8, 'opq', false)
+                )
+                """
+            )
+
+    def test_get_delete_pks_for_afa_keys(self):
+        assert get_delete_pks_for_afa_keys(None) == []
+        assert set(get_delete_pks_for_afa_keys(["abc", "xyZ"])) == {1, 2, 4, 5, 6}

--- a/usaspending_api/transactions/agnostic_transaction_deletes.py
+++ b/usaspending_api/transactions/agnostic_transaction_deletes.py
@@ -63,7 +63,7 @@ class AgnosticDeletes:
             self.store_delete_records(removed_records)
 
     def delete_rows(self, removed_records: dict) -> None:
-        delete_template = "DELETE FROM {table} WHERE {key} IN {ids} AND updated_at < '{date}'::date"
+        delete_template = "DELETE FROM {table} WHERE {key} IN {ids}"
         connection = get_connection(read_only=False)
         with connection.cursor() as cursor:
             for date, ids in removed_records.items():
@@ -73,9 +73,7 @@ class AgnosticDeletes:
                 if len(ids) == 0:
                     logger.warning(f"No records to delete for '{date}'")
                 else:
-                    sql = delete_template.format(
-                        table=self.destination_table_name, key=self.shared_pk, ids=tuple(ids), date=date
-                    )
+                    sql = delete_template.format(table=self.destination_table_name, key=self.shared_pk, ids=tuple(ids))
                     cursor.execute(sql)
                     logger.info(f"Removed {cursor.rowcount} rows previous to '{date}'")
 

--- a/usaspending_api/transactions/management/commands/delete_assistance_records.py
+++ b/usaspending_api/transactions/management/commands/delete_assistance_records.py
@@ -25,14 +25,14 @@ class Command(AgnosticDeletes, BaseCommand):
 
         sql = """
         select  published_award_financial_assistance_id
-        from    published_award_financial_assistance p
-        where   UPPER(correction_delete_indicatr) = 'D' and
-                not exists (
-                    select  *
+        from    published_award_financial_assistance
+        where   afa_generated_unique in (
+                    select  afa_generated_unique
                     from    published_award_financial_assistance
-                    where   afa_generated_unique = p.afa_generated_unique and is_active is true
-                )
-                and updated_at >= %s
+                    where   updated_at >= %s and
+                            upper(correction_delete_indicatr) = 'D'
+                ) and
+                is_active is not true
         """
         with connections["data_broker"].cursor() as cursor:
             cursor.execute(sql, [date_time])

--- a/usaspending_api/transactions/management/commands/transfer_assistance_records.py
+++ b/usaspending_api/transactions/management/commands/transfer_assistance_records.py
@@ -16,17 +16,14 @@ class Command(AgnosticTransactionLoader, BaseCommand):
     working_file_prefix = "assistance_load_ids"
     broker_full_select_sql = 'SELECT "{id}" FROM "{table}" WHERE "is_active" IS TRUE'
     broker_incremental_select_sql = """
-SELECT "{id}"
-FROM   "{table}"
-WHERE
-  "is_active" IS TRUE
-  AND
-    "submission_id" IN (
-      SELECT "submission_id"
-      FROM   "submission"
-      WHERE
-        "d2_submission" IS TRUE
-        AND "publish_status_id" IN (2, 3)
-        {optional_predicate}
-  )
-"""
+        select  "{id}"
+        from    "{table}"
+        where   "is_active" is true and
+                "submission_id" in (
+                    select  "submission_id"
+                    from    "submission"
+                    where   "d2_submission" is true and
+                            "publish_status_id" in (2, 3)
+                            {optional_predicate}
+                )
+    """


### PR DESCRIPTION
**Description:**

Cleaned up some code in an effort to stamp out some more pesky FABS delete issues.  Should also rectify a minor FPDS delete issue.

Bug 1 was an issue where `afa_generated_unique` values were being stored in delete files in mixed case, which is what we want, but the FABS loader wasn't updated to match so it was attempting to find uppercased `afa_generated_uniques` using mixed case values which resulted in many missed deletes.

Bug 2 was an issue where we were attempting to delete FABS records based solely on `afa_generated_unique` which is not possible to do correctly.  Added some code to look up the `published_award_financial_assistance_ids` that need to be deleted for the `afa_generated_uniques` provided.

Bug 3 affected both FABS and FPDS.  We were filtering deletes on the last run date which was unnecessary and causing skips.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-5323](https://federal-spending-transparency.atlassian.net/browse/DEV-5323):
    - [x] Link to this Pull-Request
9. [x] Jira Ticket [DEV-5324](https://federal-spending-transparency.atlassian.net/browse/DEV-5324):
    - [x] Link to this Pull-Request