### PR TITLE
Mod/dev 5180 add columns account downloads

### DIFF
--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -16,7 +16,6 @@ from usaspending_api.references.models import CGAC, ToptierAgency
 from usaspending_api.settings import HOST
 
 
-
 AWARD_URL = f"{HOST}/#/award/" if "localhost" in HOST else f"https://{HOST}/#/award/"
 
 """
@@ -101,11 +100,10 @@ def account_download_filter(account_type, download_table, filters, account_level
             ],
         }
 
-        ## DEV-5180
+        # DEV-5180
         if settings.ENABLE_CARES_ACT_FEATURES is True:
-            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code__code")
-            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code__name") ## ?
-
+            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund__code")
+            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund__title")
 
         distinct_cols = unique_columns_mapping[account_type]
         order_by_cols = distinct_cols + ["-reporting_period_start", "-pk"]

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -91,8 +91,6 @@ def account_download_filter(account_type, download_table, filters, account_level
             "object_class_program_activity": "financial_accounts_by_program_activity_object_class_id",
         }
 
-        ###
-
         unique_columns_mapping = {
             "account_balances": ["treasury_account_identifier__tas_rendering_label"],
             "object_class_program_activity": [
@@ -103,12 +101,10 @@ def account_download_filter(account_type, download_table, filters, account_level
             ],
         }
 
-        ##
+        ## DEV-5180
         if settings.ENABLE_CARES_ACT_FEATURES is True:
             unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code")
             unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_name")
-
-
 
 
         distinct_cols = unique_columns_mapping[account_type]

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -3,6 +3,7 @@ import datetime
 from django.contrib.postgres.aggregates import StringAgg
 from django.db.models import Case, CharField, Max, OuterRef, Subquery, Sum, When, Func, F, Value
 from django.db.models.functions import Concat, Coalesce
+from django.conf import settings
 
 from usaspending_api.accounts.helpers import start_and_end_dates_from_fyq
 from usaspending_api.accounts.models import FederalAccount
@@ -13,6 +14,8 @@ from usaspending_api.download.filestreaming import NAMING_CONFLICT_DISCRIMINATOR
 from usaspending_api.download.v2.download_column_historical_lookups import query_paths
 from usaspending_api.references.models import CGAC, ToptierAgency
 from usaspending_api.settings import HOST
+
+
 
 AWARD_URL = f"{HOST}/#/award/" if "localhost" in HOST else f"https://{HOST}/#/award/"
 
@@ -87,6 +90,9 @@ def account_download_filter(account_type, download_table, filters, account_level
             "account_balances": "appropriation_account_balances_id",
             "object_class_program_activity": "financial_accounts_by_program_activity_object_class_id",
         }
+
+        ###
+
         unique_columns_mapping = {
             "account_balances": ["treasury_account_identifier__tas_rendering_label"],
             "object_class_program_activity": [
@@ -96,6 +102,15 @@ def account_download_filter(account_type, download_table, filters, account_level
                 "object_class__direct_reimbursable",
             ],
         }
+
+        ##
+        if settings.ENABLE_CARES_ACT_FEATURES is True:
+            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code")
+            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_name")
+
+
+
+
         distinct_cols = unique_columns_mapping[account_type]
         order_by_cols = distinct_cols + ["-reporting_period_start", "-pk"]
         latest_ids_q = (

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -103,8 +103,8 @@ def account_download_filter(account_type, download_table, filters, account_level
 
         ## DEV-5180
         if settings.ENABLE_CARES_ACT_FEATURES is True:
-            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code")
-            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_name")
+            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code__code")
+            unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund_code__name") ## ?
 
 
         distinct_cols = unique_columns_mapping[account_type]

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -100,7 +100,7 @@ def account_download_filter(account_type, download_table, filters, account_level
             ],
         }
 
-        # DEV-5180
+        # DEV-5180 check if cares act features are enabled in production yet
         if settings.ENABLE_CARES_ACT_FEATURES is True:
             unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund__code")
             unique_columns_mapping["object_class_program_activity"].append("disaster_emergency_fund__title")

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -130,10 +130,6 @@ VALUE_MAPPINGS = {
         "zipfile_template": "{data_quarters}_{agency}_{level}_AccountBalances_{timestamp}",
         "filter_function": account_download_filter,
     },
-
-    ####### DEV-5180
-
-
     # Object Class Program Activity Account Data
     "object_class_program_activity": {
         "source_type": "account",
@@ -151,10 +147,6 @@ VALUE_MAPPINGS = {
         "zipfile_template": "{data_quarters}_{agency}_{level}_AccountBreakdownByAward_{timestamp}",
         "filter_function": account_download_filter,
     },
-
-    ####### DEV-5180
-
-
     "idv_orders": {
         "source_type": "award",
         "table": Award,

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -130,6 +130,9 @@ VALUE_MAPPINGS = {
         "zipfile_template": "{data_quarters}_{agency}_{level}_AccountBalances_{timestamp}",
         "filter_function": account_download_filter,
     },
+
+    #######
+
     # Object Class Program Activity Account Data
     "object_class_program_activity": {
         "source_type": "account",
@@ -147,6 +150,13 @@ VALUE_MAPPINGS = {
         "zipfile_template": "{data_quarters}_{agency}_{level}_AccountBreakdownByAward_{timestamp}",
         "filter_function": account_download_filter,
     },
+
+    #######
+
+
+
+
+
     "idv_orders": {
         "source_type": "award",
         "table": Award,

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -131,7 +131,8 @@ VALUE_MAPPINGS = {
         "filter_function": account_download_filter,
     },
 
-    #######
+    ####### DEV-5180
+
 
     # Object Class Program Activity Account Data
     "object_class_program_activity": {
@@ -151,10 +152,7 @@ VALUE_MAPPINGS = {
         "filter_function": account_download_filter,
     },
 
-    #######
-
-
-
+    ####### DEV-5180
 
 
     "idv_orders": {

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1906,7 +1906,7 @@ query_paths = {
 }
 
 
-# check the ENABLE_CARES_ACT_FEATURES and delete keys if necessary
+# check the ENABLE_CARES_ACT_FEATURES and delete keys if necessary DEV-5180
 if settings.ENABLE_CARES_ACT_FEATURES is False:
     query_paths["object_class_program_activity"]["treasury_account"].pop("disaster_emergency_fund_code")
     query_paths["object_class_program_activity"]["federal_account"].pop("disaster_emergency_fund_code")

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1684,11 +1684,7 @@ query_paths = {
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
-                #
-                #
-                # ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
-                #
-                #
+                ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_by_award_cpe"),
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
                 ("award_type", "award_type"),  # Column is appended to in account_download.py
@@ -1783,11 +1779,7 @@ query_paths = {
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
-                # find out if this is the difference betweend fyb and cpe
-                #
-                # ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
-                #
-                #
+                ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_by_award_cpe"),
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
                 ("award_type", "award_type"),  # Column is appended to in account_download.py
@@ -1871,8 +1863,8 @@ if settings.ENABLE_CARES_ACT_FEATURES is False:
     query_paths["award_financial"]["treasury_account"].pop("disaster_emergency_fund_name")
     query_paths["award_financial"]["federal_account"].pop("disaster_emergency_fund_name")
 
-    # query_paths["award_financial"]["treasury_account"].pop("gross_outlay_amount_fyb_to_period_end")
-    # query_paths["award_financial"]["federal_account"].pop("gross_outlay_amount_fyb_to_period_end")
+    query_paths["award_financial"]["treasury_account"].pop("gross_outlay_amount_fyb_to_period_end")
+    query_paths["award_financial"]["federal_account"].pop("gross_outlay_amount_fyb_to_period_end")
 
 
 # IDV Orders are nearly identical to awards but start from the Awards table

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+
+from usaspending_api import settings
 from usaspending_api.download.filestreaming import NAMING_CONFLICT_DISCRIMINATOR
 
 """
@@ -1593,6 +1595,17 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
+
+
+                #
+                #
+
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+
+                #
+                #
+
                 ("obligations_incurred", "obligations_incurred_by_program_object_class_cpe"),
                 (
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
@@ -1620,6 +1633,18 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
+
+
+                #
+                #
+
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+
+                #
+                #
+
+
                 ("obligations_incurred", "obligations_incurred"),
                 (
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
@@ -1663,6 +1688,18 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
+
+
+                #
+                #
+
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+
+                #
+                #
+
+
                 ("award_id_piid", "piid"),
                 ("parent_award_id_piid", "parent_award_id"),
                 ("award_id_fain", "fain"),
@@ -1676,6 +1713,14 @@ query_paths = {
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
+
+                #
+                #
+                ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
+                #
+                #
+
+
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
                 ("award_type", "award_type"),  # Column is appended to in account_download.py
@@ -1755,6 +1800,20 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
+
+
+
+                #
+                #
+
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+
+                #
+                #
+
+
+
                 ("award_id_piid", "piid"),
                 ("parent_award_id_piid", "parent_award_id"),
                 ("award_id_fain", "fain"),
@@ -1768,6 +1827,14 @@ query_paths = {
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
+
+
+                #
+                #
+                ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
+                #
+                #
+
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
                 ("award_type", "award_type"),  # Column is appended to in account_download.py
@@ -1837,6 +1904,25 @@ query_paths = {
         ),
     },
 }
+
+
+# check the ENABLE_CARES_ACT_FEATURES and delete keys if necessary
+if settings.ENABLE_CARES_ACT_FEATURES is False:
+    query_paths["object_class_program_activity"]["treasury_account"].pop("disaster_emergency_fund_code")
+    query_paths["object_class_program_activity"]["federal_account"].pop("disaster_emergency_fund_code")
+
+    query_paths["object_class_program_activity"]["treasury_account"].pop("disaster_emergency_fund_name")
+    query_paths["object_class_program_activity"]["federal_account"].pop("disaster_emergency_fund_name")
+
+    query_paths["award_financial"]["treasury_account"].pop("disaster_emergency_fund_code")
+    query_paths["award_financial"]["federal_account"].pop("disaster_emergency_fund_code")
+
+    query_paths["award_financial"]["treasury_account"].pop("disaster_emergency_fund_name")
+    query_paths["award_financial"]["federal_account"].pop("disaster_emergency_fund_name")
+
+    query_paths["award_financial"]["treasury_account"].pop("gross_outlay_amount_fyb_to_period_end")
+    query_paths["award_financial"]["federal_account"].pop("gross_outlay_amount_fyb_to_period_end")
+
 
 # IDV Orders are nearly identical to awards but start from the Awards table
 # instead of from UniversalAwardView materialized view so we need to lop off

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1910,13 +1910,11 @@ query_paths = {
 if settings.ENABLE_CARES_ACT_FEATURES is False:
     query_paths["object_class_program_activity"]["treasury_account"].pop("disaster_emergency_fund_code")
     query_paths["object_class_program_activity"]["federal_account"].pop("disaster_emergency_fund_code")
-
-    query_paths["object_class_program_activity"]["treasury_account"].pop("disaster_emergency_fund_name")
-    query_paths["object_class_program_activity"]["federal_account"].pop("disaster_emergency_fund_name")
-
     query_paths["award_financial"]["treasury_account"].pop("disaster_emergency_fund_code")
     query_paths["award_financial"]["federal_account"].pop("disaster_emergency_fund_code")
 
+    query_paths["object_class_program_activity"]["treasury_account"].pop("disaster_emergency_fund_name")
+    query_paths["object_class_program_activity"]["federal_account"].pop("disaster_emergency_fund_name")
     query_paths["award_financial"]["treasury_account"].pop("disaster_emergency_fund_name")
     query_paths["award_financial"]["federal_account"].pop("disaster_emergency_fund_name")
 

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1600,8 +1600,8 @@ query_paths = {
                 #
                 #
 
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
 
                 #
                 #
@@ -1638,8 +1638,8 @@ query_paths = {
                 #
                 #
 
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
 
                 #
                 #
@@ -1693,8 +1693,8 @@ query_paths = {
                 #
                 #
 
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
 
                 #
                 #
@@ -1806,8 +1806,8 @@ query_paths = {
                 #
                 #
 
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_title"),
+                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
 
                 #
                 #

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1595,17 +1595,8 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
-
-
-                #
-                #
-
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
-
-                #
-                #
-
+                ("disaster_emergency_fund_code", "disaster_emergency_fund__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund__title"),
                 ("obligations_incurred", "obligations_incurred_by_program_object_class_cpe"),
                 (
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
@@ -1633,18 +1624,8 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
-
-
-                #
-                #
-
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
-
-                #
-                #
-
-
+                ("disaster_emergency_fund_code", "disaster_emergency_fund__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund__title"),
                 ("obligations_incurred", "obligations_incurred"),
                 (
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
@@ -1688,18 +1669,8 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
-
-
-                #
-                #
-
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
-
-                #
-                #
-
-
+                ("disaster_emergency_fund_code", "disaster_emergency_fund__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund__title"),
                 ("award_id_piid", "piid"),
                 ("parent_award_id_piid", "parent_award_id"),
                 ("award_id_fain", "fain"),
@@ -1713,14 +1684,11 @@ query_paths = {
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
-
                 #
                 #
-                ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
+                # ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
                 #
                 #
-
-
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
                 ("award_type", "award_type"),  # Column is appended to in account_download.py
@@ -1800,20 +1768,8 @@ query_paths = {
                 ("object_class_code", "object_class__object_class"),
                 ("object_class_name", "object_class__object_class_name"),
                 ("direct_or_reimbursable_funding_source", "object_class__direct_reimbursable"),
-
-
-
-                #
-                #
-
-                ("disaster_emergency_fund_code", "disaster_emergency_fund_code__code"),
-                ("disaster_emergency_fund_name", "disaster_emergency_fund_code__title"),
-
-                #
-                #
-
-
-
+                ("disaster_emergency_fund_code", "disaster_emergency_fund__code"),
+                ("disaster_emergency_fund_name", "disaster_emergency_fund__title"),
                 ("award_id_piid", "piid"),
                 ("parent_award_id_piid", "parent_award_id"),
                 ("award_id_fain", "fain"),
@@ -1827,14 +1783,11 @@ query_paths = {
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
-
-
+                # find out if this is the difference betweend fyb and cpe
+                #
+                # ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
                 #
                 #
-                ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_fyb_to_period_end"),
-                #
-                #
-
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
                 ("award_type", "award_type"),  # Column is appended to in account_download.py
@@ -1918,8 +1871,8 @@ if settings.ENABLE_CARES_ACT_FEATURES is False:
     query_paths["award_financial"]["treasury_account"].pop("disaster_emergency_fund_name")
     query_paths["award_financial"]["federal_account"].pop("disaster_emergency_fund_name")
 
-    query_paths["award_financial"]["treasury_account"].pop("gross_outlay_amount_fyb_to_period_end")
-    query_paths["award_financial"]["federal_account"].pop("gross_outlay_amount_fyb_to_period_end")
+    # query_paths["award_financial"]["treasury_account"].pop("gross_outlay_amount_fyb_to_period_end")
+    # query_paths["award_financial"]["federal_account"].pop("gross_outlay_amount_fyb_to_period_end")
 
 
 # IDV Orders are nearly identical to awards but start from the Awards table

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -11,8 +11,6 @@ from django.utils.crypto import get_random_string
 from pathlib import Path
 from ddtrace import patch_all
 
-# ENABLE_CARES_ACT_FEATURES = True
-
 # All paths inside the project should be additive to BASE_DIR or APP_DIR
 APP_DIR = Path(__file__).resolve().parent
 BASE_DIR = APP_DIR.parent
@@ -34,7 +32,7 @@ API_SEARCH_MIN_DATE = "2007-10-01"  # Beginning of FY2008
 # This flag is used to control dark release features for the CARES Act initiative.  Set this to True
 # for testing and once the CARES Act features go live.  Remove all references to this global once
 # we have finished fully rolling out all CARES Act features.
-ENABLE_CARES_ACT_FEATURES = False
+ENABLE_CARES_ACT_FEATURES = True
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -11,6 +11,8 @@ from django.utils.crypto import get_random_string
 from pathlib import Path
 from ddtrace import patch_all
 
+# ENABLE_CARES_ACT_FEATURES = True
+
 # All paths inside the project should be additive to BASE_DIR or APP_DIR
 APP_DIR = Path(__file__).resolve().parent
 BASE_DIR = APP_DIR.parent


### PR DESCRIPTION
**Description:**
Add new CARES Act columns to AccountBreakdownByPA-OC and AccountBreakdownByAward Account Downloads

**Technical details:**
Columns added:
- disaster_emergency_fund_code 
- disaster_emergency_fund_name
- gross_outlay_amount_fyb_to_period_end
- check ENABLE_CARES_ACT_FEATURES to only include columns if CARES Act features are enabled in production

**Requirements for PR merge:**

1. [x] Unit & integration tests updated - tests were not required to be updated 
2. [x] API documentation updated - API documentiation not updated 
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed - Matviews not affected
5. [x] Frontend impact assessment completed - Frontend not affexted 
6. [x] Data validation completed - new columns tested, all data validated 
7. [x] Appropriate Operations ticket(s) created - None created
8. [x] Jira Ticket [DEV-5180](https://federal-spending-transparency.atlassian.net/browse/DEV-5180):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
