### PR TITLE
Update es_sanitization.py

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -174,9 +174,7 @@ class _RecipientSearchText(_Filter):
             query = es_sanitize(upper_recipient_string) + "*"
             if "\\" in es_sanitize(upper_recipient_string):
                 query = es_sanitize(upper_recipient_string) + r"\*"
-            recipient_name_query = ES_Q(
-                "query_string", query=query, default_operator="AND", fields=fields
-            )
+            recipient_name_query = ES_Q("query_string", query=query, default_operator="AND", fields=fields)
 
             if len(upper_recipient_string) == 9 and upper_recipient_string[:5].isnumeric():
                 recipient_duns_query = ES_Q("match", recipient_unique_id=upper_recipient_string)

--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -171,8 +171,11 @@ class _RecipientSearchText(_Filter):
 
         for v in filter_values:
             upper_recipient_string = es_sanitize(v.upper())
+            query = es_sanitize(upper_recipient_string) + "*"
+            if "\\" in es_sanitize(upper_recipient_string):
+                query = es_sanitize(upper_recipient_string) + r"\*"
             recipient_name_query = ES_Q(
-                "query_string", query=upper_recipient_string + "*", default_operator="AND", fields=fields
+                "query_string", query=query, default_operator="AND", fields=fields
             )
 
             if len(upper_recipient_string) == 9 and upper_recipient_string[:5].isnumeric():

--- a/usaspending_api/search/tests/unit/test_elasticsearch_helpers.py
+++ b/usaspending_api/search/tests/unit/test_elasticsearch_helpers.py
@@ -112,17 +112,16 @@ def test_es_sanitize():
     test_string = '+&|()[]{}*?:"<>\\'
     processed_string = es_sanitize(test_string)
     assert processed_string == ""
-    test_string = '!-^~/'
+    test_string = "!-^~/"
     processed_string = es_sanitize(test_string)
     assert processed_string == r"\!\-\^\~\/"
-
 
 
 def test_es_minimal_sanitize():
     test_string = "https://www.localhost:8000/"
     processed_string = es_minimal_sanitize(test_string)
     assert processed_string == r"https\/\/www.localhost8000\/"
-    test_string = '!-^~/'
+    test_string = "!-^~/"
     processed_string = es_minimal_sanitize(test_string)
     assert processed_string == r"\!\-\^\~\/"
 

--- a/usaspending_api/search/tests/unit/test_elasticsearch_helpers.py
+++ b/usaspending_api/search/tests/unit/test_elasticsearch_helpers.py
@@ -112,12 +112,19 @@ def test_es_sanitize():
     test_string = '+&|()[]{}*?:"<>\\'
     processed_string = es_sanitize(test_string)
     assert processed_string == ""
+    test_string = '!-^~/'
+    processed_string = es_sanitize(test_string)
+    assert processed_string == r"\!\-\^\~\/"
+
 
 
 def test_es_minimal_sanitize():
     test_string = "https://www.localhost:8000/"
     processed_string = es_minimal_sanitize(test_string)
     assert processed_string == r"https\/\/www.localhost8000\/"
+    test_string = '!-^~/'
+    processed_string = es_minimal_sanitize(test_string)
+    assert processed_string == r"\!\-\^\~\/"
 
 
 def test_swap_keys():

--- a/usaspending_api/search/tests/unit/test_es_sanitize.py
+++ b/usaspending_api/search/tests/unit/test_es_sanitize.py
@@ -1,7 +1,0 @@
-from usaspending_api.search.v2.es_sanitization import es_sanitize
-
-
-def test_sanitizer():
-    test_string = '+&|()[]{}*?:"<>\\'
-    processed_string = es_sanitize(test_string)
-    assert processed_string == ""

--- a/usaspending_api/search/v2/es_sanitization.py
+++ b/usaspending_api/search/v2/es_sanitization.py
@@ -24,6 +24,7 @@ def es_sanitize(input_string):
     processed_string = re.sub(r"[\^]", r"\^", processed_string)
     processed_string = re.sub(r"[~]", r"\~", processed_string)
     processed_string = re.sub(r"[/]", r"\/", processed_string)
+    processed_string = re.sub(r"[!]", r"\!", processed_string)
     if len(processed_string) != len(input_string):
         msg = "Stripped characters from input string New: '{}' Original: '{}'"
         logger.info(msg.format(processed_string, input_string))
@@ -38,6 +39,7 @@ def es_minimal_sanitize(keyword):
     processed_string = re.sub(r"[\^]", r"\^", processed_string)
     processed_string = re.sub(r"[~]", r"\~", processed_string)
     processed_string = re.sub(r"[/]", r"\/", processed_string)
+    processed_string = re.sub(r"[!]", r"\!", processed_string)
     if len(processed_string) != len(keyword):
         msg = "Stripped characters from ES keyword search string New: '{}' Original: '{}'"
         logger.info(msg.format(processed_string, keyword))


### PR DESCRIPTION
**Description:**
Discovered that the `!` wasn't being escaped when escaping characters for the ES sanitization, also fixed same escape issue as previous fix with recipient names

**Technical details:**
Wasn't escaping `!`, also needed to escape the wildcard in recipient names. If you're wondering why I didn't catch that the first time, I'm as confused as you are because `!` is in my list of recipient names and award ids to check and yet I still missed it.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-5252](https://federal-spending-transparency.atlassian.net/browse/DEV-5252):
    - [X] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
