### PR TITLE
[DEV-5041] Requested changes to submission loader

### DIFF
--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -184,9 +184,7 @@ def generate_treasury_account_query(queryset, account_type, tas_id):
         ),
         "submission_period": FiscalYearAndQuarter("reporting_period_end"),
         "last_modified_date"
-        + NAMING_CONFLICT_DISCRIMINATOR: Cast(
-            Max(Coalesce("submission__certified_date", "submission__published_date")), output_field=DateField()
-        ),
+        + NAMING_CONFLICT_DISCRIMINATOR: Cast(Max("submission__published_date"), output_field=DateField()),
     }
 
     # Derive recipient_parent_name
@@ -212,9 +210,7 @@ def generate_federal_account_query(queryset, account_type, tas_id):
         "agency_identifier_name": get_agency_name_annotation(tas_id, "agency_id"),
         "submission_period": FiscalYearAndQuarter("reporting_period_end"),
         "last_modified_date"
-        + NAMING_CONFLICT_DISCRIMINATOR: Cast(
-            Max(Coalesce("submission__certified_date", "submission__published_date")), output_field=DateField()
-        ),
+        + NAMING_CONFLICT_DISCRIMINATOR: Cast(Max("submission__published_date"), output_field=DateField()),
     }
 
     # Derive recipient_parent_name for award_financial downloads

--- a/usaspending_api/etl/management/commands/load_multiple_submissions.py
+++ b/usaspending_api/etl/management/commands/load_multiple_submissions.py
@@ -1,15 +1,16 @@
 import logging
 
+from collections import namedtuple
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
-from django.db import connection
 from usaspending_api.common.helpers.date_helper import datetime_command_line_argument_type
+from usaspending_api.common.helpers.sql_helpers import execute_sql_to_named_tuple
 from usaspending_api.etl.management.helpers.load_submission import (
     calculate_load_submissions_since_datetime,
     get_publish_history_table,
 )
-
+from usaspending_api.submissions.models import SubmissionAttributes
 
 logger = logging.getLogger("script")
 
@@ -41,27 +42,53 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        since_datetime = options.get("start_datetime") or calculate_load_submissions_since_datetime()
+        if since_datetime is None:
+            logger.info("No records found in submission_attributes.  Performing a full load.")
+        else:
+            logger.info(f"Performing incremental load starting from {since_datetime}.")
 
         if options["submission_ids"]:
-            submission_ids = options["submission_ids"]
+            certified_only_submission_ids, load_submission_ids = [], options["submission_ids"]
         else:
-            submission_ids = self.get_incremental_submission_ids(options.get("start_datetime"))
+            certified_only_submission_ids, load_submission_ids = self.get_incremental_submission_ids(since_datetime)
 
-        if submission_ids:
-            msg = f"{len(submission_ids):,} submissions will be created or updated"
-            if len(submission_ids) <= 1000:
-                logger.info(f"The following {msg}: {submission_ids}")
+        if certified_only_submission_ids:
+            msg = f"{len(certified_only_submission_ids):,} submissions will only receive certified_date updates"
+            if len(certified_only_submission_ids) <= 1000:
+                logger.info(f"The following {msg}: {[c.submission_id for c in certified_only_submission_ids]}")
             else:
                 logger.info(f"{msg}.")
-            if options["list_ids_only"]:
-                logger.info("Exiting script before data load occurs in accordance with the --list-ids-only flag.")
-                return
-        else:
-            logger.info("There are no new or updated submissions to load.")
+
+        if load_submission_ids:
+            msg = f"{len(load_submission_ids):,} submissions will be created or updated"
+            if len(load_submission_ids) <= 1000:
+                logger.info(f"The following {msg}: {load_submission_ids}")
+            else:
+                logger.info(f"{msg}.")
+
+        if not certified_only_submission_ids and not load_submission_ids:
+            logger.info("There are no new or updated submissions.")
+            return
+
+        if options["list_ids_only"]:
+            logger.info("Exiting script before data load occurs in accordance with the --list-ids-only flag.")
             return
 
         failed_submissions = []
-        for submission_id in submission_ids:
+
+        for submission in certified_only_submission_ids:
+            try:
+                rows_affected = SubmissionAttributes.objects.filter(submission_id=submission.submission_id).update(
+                    certified_date=submission.new_certified_date
+                )
+                if rows_affected < 1:
+                    raise RuntimeError(f"No rows affected for {submission.submission_id} when update was executed.")
+            except (Exception, SystemExit):
+                logger.exception(f"Submission {submission.submission_id} failed to update")
+                failed_submissions.append(submission.submission_id)
+
+        for submission_id in load_submission_ids:
             try:
                 call_command("load_submission", submission_id)
             except (Exception, SystemExit):
@@ -78,83 +105,108 @@ class Command(BaseCommand):
             logger.info("Script completed with no failures.")
 
     @staticmethod
-    def get_since_sql(start_datetime=None):
+    def get_since_sql(since_datetime=None):
         """
         For performance reasons, we intentionally use updated_at here even though we're comparing against
         published_date later.  submission.updated_at should always be greater than or equal to published_date.
         """
-        since = start_datetime or calculate_load_submissions_since_datetime()
-        if since is None:
-            logger.info("No records found in submission_attributes.  Performing a full load.")
-            since = ""
-        else:
-            logger.info(f"Performing incremental load starting from {since}.")
-            since = f"and s.updated_at >= ''{since}''::timestamp"
-        return since
+        if since_datetime is None:
+            return ""
+        return f"and s.updated_at >= ''{since_datetime}''::timestamp"
 
     @classmethod
-    def get_incremental_submission_ids(cls, start_datetime=None):
-        # Note that this is designed to work with our conservative lookback period by filtering
-        # out rows that haven't changed.  Look back as far as you want!
+    def get_incremental_submission_ids(cls, since_datetime=None):
+        """
+        Identifies Broker submissions that need to be created or updated in USAspending.  If supplied a
+        start_datetime, limits Broker rows to that date range.  If not, compares ALL Broker submissions.
+        Operates in two modes simultaneously:
+            MODE 1:  Detect when there are only changes in certification date.
+            MODE 2:  Detect when there are changes in any field other than certification date.
+        Certified-date-only changes do not require a full reload and thus provide us with a shortcut.
+        Note that this is designed to work with our conservative lookback period by filtering out rows
+        that haven't changed.  Look back as far as you want!
+
+        Returns two lists:
+            LIST 1:  Tuple of submission ids and new certified_date when only the certified_date has changed.
+            LIST 2:  Submission ids when anything other than just the certified_date has changed.
+        """
         sql = f"""
             select
-                bs.submission_id
-            from
-                dblink(
-                    '{settings.DATA_BROKER_DBLINK_NAME}',
-                    '
-                        select
-                            s.submission_id,
-                            (
-                                select  max(updated_at)
-                                from    {get_publish_history_table()}
-                                where   submission_id = s.submission_id
-                            ) as published_date,
-                            (
-                                select  max(updated_at)
-                                from    certify_history
-                                where   submission_id = s.submission_id
-                            ) as certified_date,
-                            coalesce(s.cgac_code, s.frec_code) as toptier_code,
-                            s.reporting_start_date,
-                            s.reporting_end_date,
-                            s.reporting_fiscal_year,
-                            s.reporting_fiscal_period,
-                            s.is_quarter_format
-                        from
-                            submission as s
-                        where
-                            s.d2_submission is false and
-                            s.publish_status_id in (2, 3)
-                            {cls.get_since_sql(start_datetime)}
-                    '
-                ) as bs (
-                    submission_id integer,
-                    published_date timestamp,
-                    certified_date timestamp,
-                    toptier_code text,
-                    reporting_start_date date,
-                    reporting_end_date date,
-                    reporting_fiscal_year integer,
-                    reporting_fiscal_period integer,
-                    is_quarter_format boolean
-                )
-                left outer join submission_attributes sa on
-                    sa.submission_id = bs.submission_id and
-                    sa.published_date::timestamp is not distinct from bs.published_date and
-                    sa.certified_date::timestamp is not distinct from bs.certified_date and
-                    sa.toptier_code is not distinct from bs.toptier_code and
-                    sa.reporting_period_start is not distinct from bs.reporting_start_date and
-                    sa.reporting_period_end is not distinct from bs.reporting_end_date and
-                    sa.reporting_fiscal_year is not distinct from bs.reporting_fiscal_year and
-                    sa.reporting_fiscal_period is not distinct from bs.reporting_fiscal_period and
-                    sa.quarter_format_flag is not distinct from bs.is_quarter_format
+                submission_id, new_certified_date, anything_other_than_certified_date_has_changed
+            from (
+                    select
+                        bs.submission_id,
+                        bs.published_date,
+                        case
+                            when sa.certified_date::timestamp is distinct from bs.certified_date then bs.certified_date
+                        end as new_certified_date,
+                        (
+                            sa.published_date::timestamp is distinct from bs.published_date or
+                            sa.toptier_code is distinct from bs.toptier_code or
+                            sa.reporting_period_start is distinct from bs.reporting_start_date or
+                            sa.reporting_period_end is distinct from bs.reporting_end_date or
+                            sa.reporting_fiscal_year is distinct from bs.reporting_fiscal_year or
+                            sa.reporting_fiscal_period is distinct from bs.reporting_fiscal_period or
+                            sa.quarter_format_flag is distinct from bs.is_quarter_format
+                        ) as anything_other_than_certified_date_has_changed
+                    from
+                        dblink(
+                            '{settings.DATA_BROKER_DBLINK_NAME}',
+                            '
+                                select
+                                    s.submission_id,
+                                    (
+                                        select  max(updated_at)
+                                        from    {get_publish_history_table()}
+                                        where   submission_id = s.submission_id
+                                    ) as published_date,
+                                    (
+                                        select  max(updated_at)
+                                        from    certify_history
+                                        where   submission_id = s.submission_id
+                                    ) as certified_date,
+                                    coalesce(s.cgac_code, s.frec_code) as toptier_code,
+                                    s.reporting_start_date,
+                                    s.reporting_end_date,
+                                    s.reporting_fiscal_year,
+                                    s.reporting_fiscal_period,
+                                    s.is_quarter_format
+                                from
+                                    submission as s
+                                where
+                                    s.d2_submission is false and
+                                    s.publish_status_id in (2, 3)
+                                    {cls.get_since_sql(since_datetime)}
+                            '
+                        ) as bs (
+                            submission_id integer,
+                            published_date timestamp,
+                            certified_date timestamp,
+                            toptier_code text,
+                            reporting_start_date date,
+                            reporting_end_date date,
+                            reporting_fiscal_year integer,
+                            reporting_fiscal_period integer,
+                            is_quarter_format boolean
+                        )
+                        left outer join submission_attributes sa on
+                            sa.submission_id = bs.submission_id
+                ) t
             where
-                sa.submission_id is null
+                new_certified_date is not null or
+                anything_other_than_certified_date_has_changed
             order by
-                bs.published_date,
-                bs.submission_id
+                published_date,
+                submission_id
         """
-        with connection.cursor() as cursor:
-            cursor.execute(sql)
-            return [s[0] for s in cursor.fetchall()]
+
+        Submission = namedtuple("Submission", ["submission_id", "new_certified_date"])
+        rows = execute_sql_to_named_tuple(sql)
+        return (
+            [
+                Submission(r.submission_id, r.new_certified_date)
+                for r in rows
+                if r.new_certified_date and not r.anything_other_than_certified_date_has_changed
+            ],
+            [r.submission_id for r in rows if r.anything_other_than_certified_date_has_changed],
+        )

--- a/usaspending_api/etl/management/commands/load_multiple_submissions.py
+++ b/usaspending_api/etl/management/commands/load_multiple_submissions.py
@@ -75,6 +75,10 @@ class Command(BaseCommand):
             logger.info("Exiting script before data load occurs in accordance with the --list-ids-only flag.")
             return
 
+        self.process_submissions(certified_only_submission_ids, load_submission_ids)
+
+    @staticmethod
+    def process_submissions(certified_only_submission_ids, load_submission_ids):
         failed_submissions = []
 
         for submission in certified_only_submission_ids:

--- a/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
+++ b/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
@@ -229,10 +229,10 @@ class TestWithMultipleDatabases(TestCase):
 
         assert expected_results == actual_results
 
-    def test_load_submission_file_c_zero_and_null_transaction_obligated_amount_ignored(self):
+    def test_load_submission_file_c_zero_and_null_amount_rows_ignored(self):
         """
-        Test that the 'certified_award_financial` rows that have a 'transaction_obligated_amou'
-        of zero or null are not loaded from Broker.
+        Test that 'certified_award_financial` rows that have a zero or null for both
+        'transaction_obligated_amou' and 'gross_outlay_amount_by_awa_cpe' are not loaded  from Broker.
         """
         call_command("load_submission", "-9999")
 


### PR DESCRIPTION
**Description:**

This pull request addresses some tweaks @kwhickey requested for the submission loader, specifically:

1. Use only `published_date` for `last_modified_date` in account downloads.
2. Add an optimized branch for updating `certified_date` that doesn't require reloading the entire submission.
3. Rename a test.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation unaffected
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-5041](https://federal-spending-transparency.atlassian.net/browse/DEV-5041):
    - [x] Link to this Pull-Request