### PR TITLE
[DEV-5428] Disaster Agency Count endpoint

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_disaster_agency_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_agency_count.py
@@ -1,0 +1,47 @@
+import pytest
+
+from rest_framework import status
+
+url = "/api/v2/disaster/agency/count/"
+
+
+@pytest.mark.django_db
+def test_agency_count_success(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
+
+    resp = helpers.post_for_count_endpoint(client, url, ["L", "M", "N", "O", "P"])
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 3
+
+    resp = helpers.post_for_count_endpoint(client, url, ["N", "O"])
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 2
+
+    resp = helpers.post_for_count_endpoint(client, url, ["P"])
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+
+    resp = helpers.post_for_count_endpoint(client, url, ["9"])
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_agency_count_invalid_defc(client, disaster_account_data, helpers):
+    resp = helpers.post_for_count_endpoint(client, url, ["ZZ"])
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.data["detail"] == "Field 'filter|def_codes' is outside valid values ['L', 'M', 'N', 'O', 'P', '9']"
+
+
+@pytest.mark.django_db
+def test_agency_count_invalid_defc_type(client, disaster_account_data, helpers):
+    resp = helpers.post_for_count_endpoint(client, url, "100")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.data["detail"] == "Invalid value in 'filter|def_codes'. '100' is not a valid type (array)"
+
+
+@pytest.mark.django_db
+def test_agency_count_missing_defc(client, disaster_account_data, helpers):
+    resp = helpers.post_for_count_endpoint(client, url)
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"

--- a/usaspending_api/disaster/v2/urls.py
+++ b/usaspending_api/disaster/v2/urls.py
@@ -1,9 +1,11 @@
 from django.conf.urls import url
 
+from usaspending_api.disaster.v2.views.agency.count import AgencyCountViewSet
 from usaspending_api.disaster.v2.views.federal_account.count import FederalAccountCountViewSet
 from usaspending_api.disaster.v2.views.spending import ExperimentalDisasterViewSet
 
 urlpatterns = [
+    url(r"^agency/count/$", AgencyCountViewSet.as_view()),
     url(r"^federal_account/count/$", FederalAccountCountViewSet.as_view()),
     url(r"^spending/$", ExperimentalDisasterViewSet.as_view()),
 ]

--- a/usaspending_api/disaster/v2/views/agency/count.py
+++ b/usaspending_api/disaster/v2/views/agency/count.py
@@ -1,0 +1,59 @@
+from django.db.models import OuterRef, Q, Exists
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.disaster.v2.views.disaster_base import DisasterBase
+from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
+from usaspending_api.references.models import ToptierAgency
+
+
+class AgencyCountViewSet(DisasterBase):
+    """
+    Obtain the count of Agencies related to supplied DEFC filter.
+    """
+
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/agency/count.md"
+
+    @cache_response()
+    def post(self, request: Request) -> Response:
+        filters = [
+            Q(treasury_account__funding_toptier_agency=OuterRef("pk")),
+            Q(disaster_emergency_fund__code__in=self.def_codes),
+            Q(submission__reporting_period_start__gte=self.reporting_period_min),
+            Q(
+                Q(
+                    submission__quarter_format_flag=True,
+                    submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
+                        "submission_fiscal_year"
+                    ),
+                    submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
+                        "submission_fiscal_quarter"
+                    ),
+                )
+                | Q(
+                    submission__quarter_format_flag=False,
+                    submission__reporting_fiscal_year__lte=self.last_closed_monthly_submission_dates.get(
+                        "submission_fiscal_year"
+                    ),
+                    submission__reporting_fiscal_period__lte=self.last_closed_monthly_submission_dates.get(
+                        "submission_fiscal_month"
+                    ),
+                )
+            ),
+            Q(
+                Q(obligations_incurred_by_program_object_class_cpe__gt=0)
+                | Q(obligations_incurred_by_program_object_class_cpe__lt=0)
+                | Q(gross_outlay_amount_by_program_object_class_cpe__gt=0)
+                | Q(gross_outlay_amount_by_program_object_class_cpe__lt=0)
+            ),
+        ]
+        count = (
+            ToptierAgency.objects.annotate(
+                include=Exists(FinancialAccountsByProgramActivityObjectClass.objects.filter(*filters).values("pk"))
+            )
+            .filter(include=True)
+            .values("pk")
+            .count()
+        )
+        return Response({"count": count})


### PR DESCRIPTION
**Description:**
New endpoint to return the count of the unique Agencies that match a list of DEF Code filters.

**Technical details:**
Implement new `v2/disaster/agency/count` endpoint that returns the count of unique Funding Toptier Agencies associated with File B matching the DEF Code filters supplied to the endpoint.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. N/A API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. N/A Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-5428](https://federal-spending-transparency.atlassian.net/browse/DEV-5428):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
