### PR TITLE
[DEV-5170] Ensure Spending Explorer doesn't explode with the introduction of monthly submissions

### DIFF
--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -1,7 +1,8 @@
-import json
 import copy
-
+import json
 import pytest
+
+from datetime import datetime, timezone
 from model_mommy import mommy
 from rest_framework import status
 
@@ -13,13 +14,29 @@ from usaspending_api.financial_activities.models import (
 )
 from usaspending_api.accounts.models import FederalAccount
 from usaspending_api.references.models import Agency, GTASSF133Balances, ToptierAgency, ObjectClass
+from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
 ENDPOINT_URL = "/api/v2/spending/"
 CONTENT_TYPE = "application/json"
 GLOBAL_MOCK_DICT = [
+    {
+        "model": DABSSubmissionWindowSchedule,
+        "period_end_date": datetime(1599, 12, 31, tzinfo=timezone.utc),
+        "submission_fiscal_year": 1600,
+        "submission_fiscal_quarter": 1,
+        "submission_fiscal_month": 3,
+        "submission_reveal_date": datetime(1600, 1, 28, tzinfo=timezone.utc),
+        "is_quarter": True,
+    },
     {"model": ObjectClass, "id": 1},
-    {"model": GTASSF133Balances, "fiscal_year": 1600, "fiscal_period": 1, "obligations_incurred_total_cpe": -10},
-    {"model": SubmissionAttributes, "submission_id": -1, "reporting_fiscal_year": 1600, "reporting_fiscal_quarter": 1},
+    {"model": GTASSF133Balances, "fiscal_year": 1600, "fiscal_period": 3, "obligations_incurred_total_cpe": -10},
+    {
+        "model": SubmissionAttributes,
+        "submission_id": -1,
+        "reporting_fiscal_year": 1600,
+        "reporting_fiscal_period": 3,
+        "reporting_fiscal_quarter": 1,
+    },
     {
         "model": ToptierAgency,
         "toptier_agency_id": -1,
@@ -112,12 +129,22 @@ def test_unreported_data_actual_value_file_b(client):
 @pytest.mark.django_db
 def test_unreported_data_actual_value_file_c(client):
     models_to_mock = [
+        {
+            "model": DABSSubmissionWindowSchedule,
+            "period_end_date": datetime(1599, 12, 31, tzinfo=timezone.utc),
+            "submission_fiscal_year": 1600,
+            "submission_fiscal_quarter": 1,
+            "submission_fiscal_month": 3,
+            "submission_reveal_date": datetime(1600, 1, 28, tzinfo=timezone.utc),
+            "is_quarter": True,
+        },
         {"model": GTASSF133Balances, "fiscal_year": 1600, "fiscal_period": 3, "obligations_incurred_total_cpe": -10},
         {
             "model": SubmissionAttributes,
             "submission_id": -1,
             "reporting_fiscal_year": 1600,
             "reporting_fiscal_quarter": 1,
+            "reporting_fiscal_period": 3,
         },
         {
             "model": ToptierAgency,
@@ -238,7 +265,7 @@ def test_budget_function_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "budget_function", "filters": {"fy": "2017"}}),
+        data=json.dumps({"type": "budget_function", "filters": {"fy": "2017", "quarter": 1}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -246,7 +273,7 @@ def test_budget_function_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "federal_account", "filters": {"fy": "2017", "budget_function": "050"}}),
+        data=json.dumps({"type": "federal_account", "filters": {"fy": "2017", "quarter": 1, "budget_function": "050"}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -257,7 +284,7 @@ def test_budget_function_filter_success(client):
         data=json.dumps(
             {
                 "type": "federal_account",
-                "filters": {"fy": "2017", "budget_function": "050", "budget_subfunction": "053"},
+                "filters": {"fy": "2017", "quarter": 1, "budget_function": "050", "budget_subfunction": "053"},
             }
         ),
     )
@@ -272,6 +299,7 @@ def test_budget_function_filter_success(client):
                 "type": "program_activity",
                 "filters": {
                     "fy": "2017",
+                    "quarter": 1,
                     "budget_function": "050",
                     "budget_subfunction": "053",
                     "federal_account": 2715,
@@ -290,6 +318,7 @@ def test_budget_function_filter_success(client):
                 "type": "object_class",
                 "filters": {
                     "fy": "2017",
+                    "quarter": 1,
                     "budget_function": "050",
                     "budget_subfunction": "053",
                     "federal_account": 2715,
@@ -309,6 +338,7 @@ def test_budget_function_filter_success(client):
                 "type": "recipient",
                 "filters": {
                     "fy": "2017",
+                    "quarter": 1,
                     "budget_function": "050",
                     "budget_subfunction": "053",
                     "federal_account": 2715,
@@ -329,6 +359,7 @@ def test_budget_function_filter_success(client):
                 "type": "award",
                 "filters": {
                     "fy": "2017",
+                    "quarter": 1,
                     "budget_function": "050",
                     "budget_subfunction": "053",
                     "federal_account": 2715,
@@ -357,7 +388,7 @@ def test_object_class_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "object_class", "filters": {"fy": "2017"}}),
+        data=json.dumps({"type": "object_class", "filters": {"fy": "2017", "quarter": 1}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -365,7 +396,7 @@ def test_object_class_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "agency", "filters": {"fy": "2017", "object_class": "20"}}),
+        data=json.dumps({"type": "agency", "filters": {"fy": "2017", "quarter": 1, "object_class": "20"}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -373,7 +404,7 @@ def test_object_class_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "federal_account", "filters": {"fy": "2017", "object_class": "20"}}),
+        data=json.dumps({"type": "federal_account", "filters": {"fy": "2017", "quarter": 1, "object_class": "20"}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -382,7 +413,10 @@ def test_object_class_filter_success(client):
         "/api/v2/spending/",
         content_type="application/json",
         data=json.dumps(
-            {"type": "program_activity", "filters": {"fy": "2017", "object_class": "20", "federal_account": 2358}}
+            {
+                "type": "program_activity",
+                "filters": {"fy": "2017", "quarter": 1, "object_class": "20", "federal_account": 2358},
+            }
         ),
     )
     assert resp.status_code == status.HTTP_200_OK
@@ -394,7 +428,13 @@ def test_object_class_filter_success(client):
         data=json.dumps(
             {
                 "type": "recipient",
-                "filters": {"fy": "2017", "object_class": "20", "federal_account": 2358, "program_activity": 15103},
+                "filters": {
+                    "fy": "2017",
+                    "quarter": 1,
+                    "object_class": "20",
+                    "federal_account": 2358,
+                    "program_activity": 15103,
+                },
             }
         ),
     )
@@ -409,6 +449,7 @@ def test_object_class_filter_success(client):
                 "type": "award",
                 "filters": {
                     "fy": "2017",
+                    "quarter": 1,
                     "object_class": "20",
                     "federal_account": 2358,
                     "program_activity": 15103,
@@ -435,7 +476,7 @@ def test_agency_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "agency", "filters": {"fy": "2017"}}),
+        data=json.dumps({"type": "agency", "filters": {"fy": "2017", "quarter": 1}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -451,7 +492,7 @@ def test_agency_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "federal_account", "filters": {"fy": "2017"}}),
+        data=json.dumps({"type": "federal_account", "filters": {"fy": "2017", "quarter": 1}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -459,7 +500,7 @@ def test_agency_filter_success(client):
     resp = client.post(
         "/api/v2/spending/",
         content_type="application/json",
-        data=json.dumps({"type": "program_activity", "filters": {"fy": "2017", "federal_account": 1500}}),
+        data=json.dumps({"type": "program_activity", "filters": {"fy": "2017", "quarter": 1, "federal_account": 1500}}),
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -468,7 +509,10 @@ def test_agency_filter_success(client):
         "/api/v2/spending/",
         content_type="application/json",
         data=json.dumps(
-            {"type": "object_class", "filters": {"fy": "2017", "federal_account": 1500, "program_activity": 12697}}
+            {
+                "type": "object_class",
+                "filters": {"fy": "2017", "quarter": 1, "federal_account": 1500, "program_activity": 12697},
+            }
         ),
     )
     assert resp.status_code == status.HTTP_200_OK
@@ -480,7 +524,13 @@ def test_agency_filter_success(client):
         data=json.dumps(
             {
                 "type": "recipient",
-                "filters": {"fy": "2017", "federal_account": 1500, "program_activity": 12697, "object_class": "40"},
+                "filters": {
+                    "fy": "2017",
+                    "quarter": 1,
+                    "federal_account": 1500,
+                    "program_activity": 12697,
+                    "object_class": "40",
+                },
             }
         ),
     )
@@ -495,6 +545,7 @@ def test_agency_filter_success(client):
                 "type": "award",
                 "filters": {
                     "fy": "2017",
+                    "quarter": 1,
                     "federal_account": 1500,
                     "program_activity": 12697,
                     "object_class": "40",

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -1,12 +1,13 @@
+from datetime import datetime, timezone
 from django.db.models import Sum
-
 from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.common.helpers.fiscal_year_helpers import generate_last_completed_fiscal_quarter
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 from usaspending_api.references.models import GTASSF133Balances
 from usaspending_api.spending_explorer.v2.filters.explorer import Explorer
 from usaspending_api.spending_explorer.v2.filters.spending_filter import spending_filter
+from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
+
 
 UNREPORTED_DATA_NAME = "Unreported Data"
 VALID_UNREPORTED_DATA_TYPES = ["agency", "budget_function", "object_class"]
@@ -14,7 +15,7 @@ VALID_UNREPORTED_FILTERS = ["fy", "quarter"]
 
 
 def get_unreported_data_obj(
-    queryset, filters, limit, spending_type, actual_total, fiscal_year, fiscal_quarter
+    queryset, filters, limit, spending_type, actual_total, fiscal_year, fiscal_period
 ) -> (list, float):
     """ Returns the modified list of result objects including the object corresponding to the unreported amount, only
         if applicable. If the unreported amount does not fit within the limit of results provided, it will not be added.
@@ -26,7 +27,7 @@ def get_unreported_data_obj(
             spending_type: spending explorer category
             actual_total: total calculated based on results in `queryset`
             fiscal_year: fiscal year from request
-            fiscal_quarter: fiscal quarter from request
+            fiscal_period: final fiscal period for fiscal quarter requested
 
         Returns:
             result_set: modified (if applicable) result set as a list
@@ -46,13 +47,10 @@ def get_unreported_data_obj(
         result_set.append(condensed_entry)
 
     expected_total = (
-        GTASSF133Balances.objects.filter(
-            fiscal_year=fiscal_year,
-            fiscal_period__gt=((fiscal_quarter - 1) * 3),
-            fiscal_period__lte=fiscal_quarter * 3,
-        )
-        .order_by("fiscal_period")
-        .values_list("obligations_incurred_total_cpe", flat=True)
+        GTASSF133Balances.objects.filter(fiscal_year=fiscal_year, fiscal_period=fiscal_period)
+        .values("fiscal_year", "fiscal_period")
+        .annotate(Sum("obligations_incurred_total_cpe"))
+        .values_list("obligations_incurred_total_cpe__sum", flat=True)
         .first()
     )
 
@@ -74,10 +72,6 @@ def get_unreported_data_obj(
 
 
 def type_filter(_type, filters, limit=None):
-    fiscal_year = None
-    fiscal_quarter = None
-    fiscal_date = None
-
     _types = [
         "budget_function",
         "budget_subfunction",
@@ -106,43 +100,50 @@ def type_filter(_type, filters, limit=None):
     if filters is None:
         raise InvalidParameterException('Missing Required Request Parameter, "filters": { "filter_options" }')
 
-    # Get fiscal_date and fiscal_quarter
-    for key, value in filters.items():
-        if key == "fy":
-            try:
-                fiscal_year = int(value)
-                if fiscal_year < 1000 or fiscal_year > 9999:
-                    raise InvalidParameterException('Incorrect Fiscal Year Parameter, "fy": "YYYY"')
-            except ValueError:
-                raise InvalidParameterException('Incorrect or Missing Fiscal Year Parameter, "fy": "YYYY"')
-        elif key == "quarter":
-            if value in ("1", "2", "3", "4"):
-                fiscal_quarter = int(value)
-            else:
-                raise InvalidParameterException(
-                    "Incorrect value provided for quarter parameter. Must be a string between 1 and 4"
-                )
+    if "fy" not in filters:
+        raise InvalidParameterException('Missing required parameter "fy".')
 
-    if fiscal_year:
-        fiscal_date, fiscal_quarter = generate_last_completed_fiscal_quarter(
-            fiscal_year=fiscal_year, fiscal_quarter=fiscal_quarter
-        )
+    if "quarter" not in filters:
+        raise InvalidParameterException('Missing required parameter "quarter".')
 
-    # Recipient, Award Queryset
+    try:
+        fiscal_year = int(filters["fy"])
+        if fiscal_year < 1000 or fiscal_year > 9999:
+            raise InvalidParameterException('Incorrect Fiscal Year Parameter, "fy": "YYYY"')
+    except ValueError:
+        raise InvalidParameterException('Incorrect or Missing Fiscal Year Parameter, "fy": "YYYY"')
+
+    if filters["quarter"] not in ("1", "2", "3", "4", 1, 2, 3, 4):
+        raise InvalidParameterException("Incorrect value provided for quarter parameter. Must be between 1 and 4")
+    fiscal_quarter = int(filters["quarter"])
+
+    submission_window = DABSSubmissionWindowSchedule.objects.filter(
+        submission_fiscal_year=fiscal_year,
+        submission_fiscal_quarter=fiscal_quarter,
+        is_quarter=True,
+        submission_reveal_date__lte=datetime.now(timezone.utc),
+    ).first()
+    if submission_window is None:
+        raise InvalidParameterException(f"No submission data available for FY{fiscal_year}Q{fiscal_quarter}.")
+
+    fiscal_date = submission_window.period_end_date
+    fiscal_period = submission_window.submission_fiscal_month
+
+    # transaction_obligated_amount is summed across all periods in the year up to and including the requested quarter.
     alt_set = (
-        FinancialAccountsByAwards.objects.all()
-        .exclude(transaction_obligated_amount__isnull=True)
+        FinancialAccountsByAwards.objects.exclude(transaction_obligated_amount__isnull=True)
         .exclude(transaction_obligated_amount="NaN")
-        .filter(submission__reporting_fiscal_quarter=fiscal_quarter)
+        .filter(submission__reporting_fiscal_quarter__lte=fiscal_quarter)
         .filter(submission__reporting_fiscal_year=fiscal_year)
         .annotate(amount=Sum("transaction_obligated_amount"))
     )
 
-    # Base Queryset
+    # obligations_incurred_by_program_object_class_cpe is picked from the final period of the quarter.
     queryset = (
-        FinancialAccountsByProgramActivityObjectClass.objects.all()
-        .exclude(obligations_incurred_by_program_object_class_cpe__isnull=True)
-        .filter(submission__reporting_fiscal_quarter=fiscal_quarter)
+        FinancialAccountsByProgramActivityObjectClass.objects.exclude(
+            obligations_incurred_by_program_object_class_cpe__isnull=True
+        )
+        .filter(submission__reporting_fiscal_period=fiscal_period)
         .filter(submission__reporting_fiscal_year=fiscal_year)
         .annotate(amount=Sum("obligations_incurred_by_program_object_class_cpe"))
     )
@@ -210,7 +211,7 @@ def type_filter(_type, filters, limit=None):
             spending_type=_type,
             actual_total=actual_total,
             fiscal_year=fiscal_year,
-            fiscal_quarter=fiscal_quarter,
+            fiscal_period=fiscal_period,
         )
 
         results = {"total": expected_total, "end_date": fiscal_date, "results": result_set}


### PR DESCRIPTION
**Description:**

Ensure Spending Explorer continues to function in a world with monthly submissions.  Cleaned up some other stuff in the process.
- Still operates on quarters.
- Validates requested FYQ against new submission window table.
- Better handling of missing required filters (no longer 500s).
- Fixed a bug that was looking only at the quarter requested when summing transaction obligated amount instead of across all quarters for the year.
- Fixed a couple of small issues with the GTAS query.

**Requirements for PR merge:**

1. [x] Unit tests unaffected
2. [x] API documentation unaffected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Front end unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-5170](https://federal-spending-transparency.atlassian.net/browse/DEV-5170):
    - [x] Link to this Pull-Request