### PR TITLE
[DEV-4443] AC 1 - Don't carry forward TAS in account downloads

### DIFF
--- a/usaspending_api/agency/v2/views/agency_base.py
+++ b/usaspending_api/agency/v2/views/agency_base.py
@@ -9,7 +9,7 @@ from usaspending_api.common.exceptions import UnprocessableEntityException
 from usaspending_api.common.helpers.date_helper import fy
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     calculate_last_completed_fiscal_quarter,
-    convert_fiscal_quarter_to_fiscal_period,
+    get_final_period_of_quarter,
     current_fiscal_year,
 )
 from usaspending_api.common.helpers.generic_helper import get_account_data_time_period_message
@@ -48,7 +48,7 @@ class AgencyBase(APIView):
         self.fiscal_year.  If it's prior to Q1 submission window close date, we will return
         quarter 1 anyhow and just show what we have (which will likely be incomplete).
         """
-        return convert_fiscal_quarter_to_fiscal_period(calculate_last_completed_fiscal_quarter(self.fiscal_year)) or 3
+        return get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(self.fiscal_year)) or 3
 
     @cached_property
     def toptier_agency(self):

--- a/usaspending_api/agency/v2/views/budgetary_resources.py
+++ b/usaspending_api/agency/v2/views/budgetary_resources.py
@@ -5,7 +5,7 @@ from usaspending_api.agency.v2.views.agency_base import AgencyBase
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     calculate_last_completed_fiscal_quarter,
-    convert_fiscal_quarter_to_fiscal_period,
+    get_final_period_of_quarter,
 )
 
 
@@ -63,7 +63,7 @@ class BudgetaryResources(AgencyBase):
         even though we're in FY2000 Q1.
         """
         prior_fiscal_year = self.fiscal_year - 1
-        prior_fiscal_year_last_completed_fiscal_period = convert_fiscal_quarter_to_fiscal_period(
+        prior_fiscal_year_last_completed_fiscal_period = get_final_period_of_quarter(
             calculate_last_completed_fiscal_quarter(prior_fiscal_year)
         )
         return AppropriationAccountBalances.objects.filter(

--- a/usaspending_api/api_contracts/contracts/v2/download/accounts.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/accounts.md
@@ -95,14 +95,14 @@ Generate files and return metadata using filters on custom account
 + `fy` (required, string)
     The fiscal year to filter by in the format `YYYY`
 + `quarter` (optional, enum[string])
-    Either `quarter` or `period` is required.  Do not supply both.
+    Either `quarter` or `period` is required.  Do not supply both.   Note that both monthly and quarterly submissions will be included in the resulting download file even if only `quarter` is provided.
     + Members
         + `1`
         + `2`
         + `3`
         + `4`
 + `period` (optional, enum[string])
-    Either `quarter` or `period` is required.  Do not supply both.  Agencies cannot submit data for period 1 so it is disallowed as a query filter.
+    Either `quarter` or `period` is required.  Do not supply both.  Agencies cannot submit data for period 1 so it is disallowed as a query filter.   Note that both monthly and quarterly submissions will be included in the resulting download file even if only `period` is provided.
     + Members
         + `2`
         + `3`

--- a/usaspending_api/api_contracts/contracts/v2/download/accounts.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/accounts.md
@@ -94,9 +94,24 @@ Generate files and return metadata using filters on custom account
         + `award_financial`
 + `fy` (required, string)
     The fiscal year to filter by in the format `YYYY`
-+ `quarter` (required, enum[string])
++ `quarter` (optional, enum[string])
+    Either `quarter` or `period` is required.  Do not supply both.
     + Members
         + `1`
         + `2`
         + `3`
         + `4`
++ `period` (optional, enum[string])
+    Either `quarter` or `period` is required.  Do not supply both.  Agencies cannot submit data for period 1 so it is disallowed as a query filter.
+    + Members
+        + `2`
+        + `3`
+        + `4`
+        + `5`
+        + `6`
+        + `7`
+        + `8`
+        + `9`
+        + `10`
+        + `11`
+        + `12`

--- a/usaspending_api/common/helpers/fiscal_year_helpers.py
+++ b/usaspending_api/common/helpers/fiscal_year_helpers.py
@@ -48,7 +48,7 @@ def generate_fiscal_year(date):
     return year
 
 
-def generate_fiscal_period(date):
+def generate_fiscal_month(date):
     """ Generate fiscal period based on the date provided """
     validate_date(date)
 
@@ -99,7 +99,7 @@ def generate_fiscal_date_range(min_date: datetime, max_date: datetime, frequency
             {
                 "fiscal_year": generate_fiscal_year(current_date),
                 "fiscal_quarter": generate_fiscal_quarter(current_date),
-                "fiscal_month": generate_fiscal_period(current_date),
+                "fiscal_month": generate_fiscal_month(current_date),
             }
         )
         current_date = current_date + relativedelta(months=interval)
@@ -114,8 +114,8 @@ def create_full_time_periods(min_date, max_date, group, columns):
         return [{**cols, **{"time_period": {"fy": str(fy)}}} for fy in fiscal_years]
 
     if group == "month":
-        period = generate_fiscal_period(min_date)
-        ending = generate_fiscal_period(max_date)
+        period = generate_fiscal_month(min_date)
+        ending = generate_fiscal_month(max_date)
         rollover = 12
     else:  # quarter
         period = generate_fiscal_quarter(min_date)

--- a/usaspending_api/common/helpers/fiscal_year_helpers.py
+++ b/usaspending_api/common/helpers/fiscal_year_helpers.py
@@ -1,7 +1,9 @@
 import logging
 
+from datetime import datetime, MAXYEAR, MINYEAR, timedelta
 from dateutil.relativedelta import relativedelta
-from fiscalyear import FiscalDate, FiscalDateTime, datetime
+from fiscalyear import FiscalDate, FiscalDateTime
+from typing import Optional, Tuple
 from usaspending_api.common.helpers.generic_helper import validate_date, min_and_max_from_date_ranges
 
 
@@ -46,7 +48,7 @@ def generate_fiscal_year(date):
     return year
 
 
-def generate_fiscal_month(date):
+def generate_fiscal_period(date):
     """ Generate fiscal period based on the date provided """
     validate_date(date)
 
@@ -97,7 +99,7 @@ def generate_fiscal_date_range(min_date: datetime, max_date: datetime, frequency
             {
                 "fiscal_year": generate_fiscal_year(current_date),
                 "fiscal_quarter": generate_fiscal_quarter(current_date),
-                "fiscal_month": generate_fiscal_month(current_date),
+                "fiscal_month": generate_fiscal_period(current_date),
             }
         )
         current_date = current_date + relativedelta(months=interval)
@@ -112,8 +114,8 @@ def create_full_time_periods(min_date, max_date, group, columns):
         return [{**cols, **{"time_period": {"fy": str(fy)}}} for fy in fiscal_years]
 
     if group == "month":
-        period = generate_fiscal_month(min_date)
-        ending = generate_fiscal_month(max_date)
+        period = generate_fiscal_period(min_date)
+        ending = generate_fiscal_period(max_date)
         rollover = 12
     else:  # quarter
         period = generate_fiscal_quarter(min_date)
@@ -174,7 +176,7 @@ def calculate_last_completed_fiscal_quarter(fiscal_year, as_of_date=current_fisc
     """
 
     # Get the current fiscal year so that it can be compared against the FY in the request.
-    day_difference = as_of_date - datetime.timedelta(days=SUBMISSION_WINDOW_DAYS)
+    day_difference = as_of_date - timedelta(days=SUBMISSION_WINDOW_DAYS)
     current_fiscal_date_adjusted = FiscalDateTime(day_difference.year, day_difference.month, day_difference.day)
 
     if fiscal_year == current_fiscal_date_adjusted.fiscal_year:
@@ -195,10 +197,31 @@ def calculate_last_completed_fiscal_quarter(fiscal_year, as_of_date=current_fisc
     return fiscal_quarter
 
 
-def convert_fiscal_quarter_to_fiscal_period(fiscal_quarter):
-    """ Returns None if fiscal_quarter is invalid or not a number. """
-    return {1: 3, 2: 6, 3: 9, 4: 12}.get(fiscal_quarter)
+def is_valid_period(period: int) -> bool:
+    """ There is no period 1. """
+    return isinstance(period, int) and 2 <= period <= 12
 
 
-# aliasing the generate_fiscal_month function to the more appropriate function name
-generate_fiscal_period = generate_fiscal_month
+def is_valid_quarter(quarter: int) -> bool:
+    return isinstance(quarter, int) and 1 <= quarter <= 4
+
+
+def is_valid_year(year: int) -> bool:
+    return isinstance(year, int) and MINYEAR <= year <= MAXYEAR
+
+
+def is_final_period_of_quarter(period: int, quarter: int) -> bool:
+    return is_valid_period(period) and is_valid_quarter(quarter) and period == get_final_period_of_quarter(quarter)
+
+
+def get_final_period_of_quarter(quarter: int) -> Optional[int]:
+    return get_periods_in_quarter(quarter)[-1] if is_valid_quarter(quarter) else None
+
+
+def get_periods_in_quarter(quarter: int) -> Optional[Tuple[int]]:
+    """ There is no period 1. """
+    return {1: (2, 3), 2: (4, 5, 6), 3: (7, 8, 9), 4: (10, 11, 12)}[quarter] if is_valid_quarter(quarter) else None
+
+
+def get_quarter_from_period(period: int) -> Optional[int]:
+    return (period + 2) // 3 if is_valid_period(period) else None

--- a/usaspending_api/common/helpers/orm_helpers.py
+++ b/usaspending_api/common/helpers/orm_helpers.py
@@ -1,7 +1,9 @@
 from datetime import date
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models import Aggregate, CharField, Func, IntegerField
-from usaspending_api.common.helpers.sql_helpers import get_connection
+from django.db.models import Aggregate, CharField, Func, IntegerField, Case, When, Value, Subquery, OuterRef
+from django.db.models.functions import Concat, LPad, Cast
+from usaspending_api.references.models import CGAC
+
 from usaspending_api.search.models import (
     ContractAwardSearchMatview,
     DirectPaymentAwardSearchMatview,
@@ -76,6 +78,56 @@ class BoolOr(Aggregate):
     name = "BoolOr"
 
 
+def get_agency_name_annotation(relation_name: str, cgac_column_name: str) -> Subquery:
+    """
+    Accepts the Django foreign key relation name for the outer queryset to TreasuryAppropriationAccount
+    or FederalAccount join and the CGAC column name and returns an annotation ready Subquery object that
+    retrieves the CGAC agency name.
+    """
+    outer_ref = f"{relation_name}__{cgac_column_name}"
+    return Subquery(CGAC.objects.filter(cgac_code=OuterRef(outer_ref)).values("agency_name"))
+
+
+def get_fyp_notation(relation_name=None):
+    """
+    Generates FYyyyyPpp syntax from submission table.  relation_name is the Django ORM
+    relation name from the foreign key table to the submission table.
+    """
+    relation_prefix = f"{relation_name}__" if relation_name else ""
+    return Concat(
+        Value("FY"),
+        Cast(f"{relation_prefix}reporting_fiscal_year", output_field=CharField()),
+        Value("P"),
+        LPad(Cast(f"{relation_prefix}reporting_fiscal_period", output_field=CharField()), 2, Value("0")),
+    )
+
+
+def get_fyq_notation(relation_name=None):
+    """
+    Generates FYyyyyPpp syntax from submission table.  relation_name is the Django ORM
+    relation name from the foreign key table to the submission table.
+    """
+    relation_prefix = f"{relation_name}__" if relation_name else ""
+    return Concat(
+        Value("FY"),
+        Cast(f"{relation_prefix}reporting_fiscal_year", output_field=CharField()),
+        Value("Q"),
+        Cast(f"{relation_prefix}reporting_fiscal_quarter", output_field=CharField()),
+    )
+
+
+def get_fyp_or_q_notation(relation_name=None):
+    """
+    Generates FYyyyyQq or FYyyyyPpp syntax from submission table.  relation_name is the Django ORM
+    relation name from the foreign key table to the submission table.
+    """
+    relation_prefix = f"{relation_name}__" if relation_name else ""
+    return Case(
+        When(**{f"{relation_prefix}quarter_format_flag": True}, then=get_fyq_notation(relation_name)),
+        default=get_fyp_notation(relation_name),
+    )
+
+
 def generate_raw_quoted_query(queryset):
     """Generates the raw sql from a queryset with quotable types quoted.
 
@@ -99,12 +151,6 @@ def generate_raw_quoted_query(queryset):
             str_fix_param = param
         str_fix_params.append(str_fix_param)
     return sql % tuple(str_fix_params)
-
-
-def generate_where_clause(queryset):
-    """Returns the SQL and params from a queryset all ready to be plugged into an extra method."""
-    compiler = queryset.query.get_compiler(get_connection().alias)
-    return queryset.query.where.as_sql(compiler, compiler.connection)
 
 
 def obtain_view_from_award_group(type_list):
@@ -145,7 +191,3 @@ def subaward_types_are_valid_groups(type_list):
     is_procurement = set(type_list).difference(set(procurement_type_mapping.keys()))
     is_assistance = set(type_list).difference(set(assistance_type_mapping.keys()))
     return bool(is_procurement) != bool(is_assistance)  # clever XOR logic
-
-
-def category_to_award_materialized_views():
-    return {category: values["model"] for category, values in CATEGORY_TO_MODEL.items()}

--- a/usaspending_api/common/helpers/s3_helpers.py
+++ b/usaspending_api/common/helpers/s3_helpers.py
@@ -3,7 +3,7 @@ import io
 import logging
 
 from typing import List
-from usaspending_api import settings
+from django.conf import settings
 
 
 logger = logging.getLogger("script")

--- a/usaspending_api/common/retrieve_file_from_uri.py
+++ b/usaspending_api/common/retrieve_file_from_uri.py
@@ -4,7 +4,7 @@ import tempfile
 import urllib
 
 from shutil import copyfile
-from usaspending_api import settings
+from django.conf import settings
 
 
 VALID_SCHEMES = ("http", "https", "s3", "file", "")

--- a/usaspending_api/common/sqs/sqs_handler.py
+++ b/usaspending_api/common/sqs/sqs_handler.py
@@ -10,7 +10,7 @@ import pickle
 from typing import List
 import uuid
 
-from usaspending_api import settings
+from django.conf import settings
 
 LOCAL_FAKE_QUEUE_NAME = "local-fake-queue"
 UNITTEST_FAKE_QUEUE_NAME = "unittest-fake-queue"

--- a/usaspending_api/common/tests/unit/test_fiscal_year_helpers.py
+++ b/usaspending_api/common/tests/unit/test_fiscal_year_helpers.py
@@ -31,11 +31,11 @@ def test_calculate_fiscal_years():
 
 
 def test_generate_fiscal_month():
-    assert fyh.generate_fiscal_period(date(2000, 9, 30)) == 12
-    assert fyh.generate_fiscal_period(date(2001, 10, 1)) == 1
-    assert fyh.generate_fiscal_period(date(2020, 3, 2)) == 6
-    assert fyh.generate_fiscal_period(date(2017, 5, 30)) == 8
-    assert fyh.generate_fiscal_period(date(2019, 10, 30)) == 1
+    assert fyh.generate_fiscal_month(date(2000, 9, 30)) == 12
+    assert fyh.generate_fiscal_month(date(2001, 10, 1)) == 1
+    assert fyh.generate_fiscal_month(date(2020, 3, 2)) == 6
+    assert fyh.generate_fiscal_month(date(2017, 5, 30)) == 8
+    assert fyh.generate_fiscal_month(date(2019, 10, 30)) == 1
 
 
 def test_generate_fiscal_quarter():

--- a/usaspending_api/common/tests/unit/test_fiscal_year_helpers.py
+++ b/usaspending_api/common/tests/unit/test_fiscal_year_helpers.py
@@ -1,7 +1,7 @@
-from fiscalyear import FiscalDate
-from datetime import date
-
 import usaspending_api.common.helpers.fiscal_year_helpers as fyh
+
+from fiscalyear import FiscalDate
+from datetime import date, MINYEAR, MAXYEAR
 
 
 def test_all_fiscal_years():
@@ -31,11 +31,11 @@ def test_calculate_fiscal_years():
 
 
 def test_generate_fiscal_month():
-    assert fyh.generate_fiscal_month(date(2000, 9, 30)) == 12
-    assert fyh.generate_fiscal_month(date(2001, 10, 1)) == 1
-    assert fyh.generate_fiscal_month(date(2020, 3, 2)) == 6
-    assert fyh.generate_fiscal_month(date(2017, 5, 30)) == 8
-    assert fyh.generate_fiscal_month(date(2019, 10, 30)) == 1
+    assert fyh.generate_fiscal_period(date(2000, 9, 30)) == 12
+    assert fyh.generate_fiscal_period(date(2001, 10, 1)) == 1
+    assert fyh.generate_fiscal_period(date(2020, 3, 2)) == 6
+    assert fyh.generate_fiscal_period(date(2017, 5, 30)) == 8
+    assert fyh.generate_fiscal_period(date(2019, 10, 30)) == 1
 
 
 def test_generate_fiscal_quarter():
@@ -106,10 +106,113 @@ def test_calculate_last_completed_fiscal_quarter():
     assert fyh.calculate_last_completed_fiscal_quarter(2000) == 4
 
 
-def test_convert_fiscal_quarter_to_fiscal_period():
-    assert fyh.convert_fiscal_quarter_to_fiscal_period(1) == 3
-    assert fyh.convert_fiscal_quarter_to_fiscal_period(2) == 6
-    assert fyh.convert_fiscal_quarter_to_fiscal_period(3) == 9
-    assert fyh.convert_fiscal_quarter_to_fiscal_period(4) == 12
-    assert fyh.convert_fiscal_quarter_to_fiscal_period(None) is None
-    assert fyh.convert_fiscal_quarter_to_fiscal_period("1") is None
+def test_is_valid_period():
+    assert fyh.is_valid_period(2) is True
+    assert fyh.is_valid_period(3) is True
+    assert fyh.is_valid_period(4) is True
+    assert fyh.is_valid_period(5) is True
+    assert fyh.is_valid_period(6) is True
+    assert fyh.is_valid_period(7) is True
+    assert fyh.is_valid_period(8) is True
+    assert fyh.is_valid_period(9) is True
+    assert fyh.is_valid_period(10) is True
+    assert fyh.is_valid_period(11) is True
+    assert fyh.is_valid_period(12) is True
+
+    assert fyh.is_valid_period(1) is False
+    assert fyh.is_valid_period(13) is False
+    assert fyh.is_valid_period(None) is False
+    assert fyh.is_valid_period("1") is False
+    assert fyh.is_valid_period("a") is False
+    assert fyh.is_valid_period({"hello": "there"}) is False
+
+
+def test_is_valid_quarter():
+    assert fyh.is_valid_quarter(1) is True
+    assert fyh.is_valid_quarter(2) is True
+    assert fyh.is_valid_quarter(3) is True
+    assert fyh.is_valid_quarter(4) is True
+
+    assert fyh.is_valid_quarter(0) is False
+    assert fyh.is_valid_quarter(5) is False
+    assert fyh.is_valid_quarter(None) is False
+    assert fyh.is_valid_quarter("1") is False
+    assert fyh.is_valid_quarter("a") is False
+    assert fyh.is_valid_quarter({"hello": "there"}) is False
+
+
+def test_is_valid_year():
+    assert fyh.is_valid_year(MINYEAR) is True
+    assert fyh.is_valid_year(MINYEAR + 1) is True
+    assert fyh.is_valid_year(MAXYEAR) is True
+    assert fyh.is_valid_year(MAXYEAR - 1) is True
+    assert fyh.is_valid_year(1999) is True
+
+    assert fyh.is_valid_year(MINYEAR - 1) is False
+    assert fyh.is_valid_year(MAXYEAR + 1) is False
+    assert fyh.is_valid_year(None) is False
+    assert fyh.is_valid_year("1") is False
+    assert fyh.is_valid_year("a") is False
+    assert fyh.is_valid_year({"hello": "there"}) is False
+
+
+def test_is_final_period_of_quarter():
+    assert fyh.is_final_period_of_quarter(3, 1) is True
+    assert fyh.is_final_period_of_quarter(6, 2) is True
+    assert fyh.is_final_period_of_quarter(9, 3) is True
+    assert fyh.is_final_period_of_quarter(12, 4) is True
+
+    assert fyh.is_final_period_of_quarter(1, 1) is False
+    assert fyh.is_final_period_of_quarter(2, 1) is False
+    assert fyh.is_final_period_of_quarter(11, 4) is False
+    assert fyh.is_final_period_of_quarter(0, 1) is False
+    assert fyh.is_final_period_of_quarter(3, 0) is False
+    assert fyh.is_final_period_of_quarter(None, 1) is False
+    assert fyh.is_final_period_of_quarter(3, None) is False
+    assert fyh.is_final_period_of_quarter("a", "b") is False
+    assert fyh.is_final_period_of_quarter([1], {2: 3}) is False
+
+
+def test_get_final_period_of_quarter():
+    assert fyh.get_final_period_of_quarter(1) == 3
+    assert fyh.get_final_period_of_quarter(2) == 6
+    assert fyh.get_final_period_of_quarter(3) == 9
+    assert fyh.get_final_period_of_quarter(4) == 12
+
+    assert fyh.get_final_period_of_quarter(None) is None
+    assert fyh.get_final_period_of_quarter("1") is None
+    assert fyh.get_final_period_of_quarter("a") is None
+    assert fyh.get_final_period_of_quarter({"hello": "there"}) is None
+
+
+def test_get_periods_in_quarter():
+    assert fyh.get_periods_in_quarter(1) == (2, 3)
+    assert fyh.get_periods_in_quarter(2) == (4, 5, 6)
+    assert fyh.get_periods_in_quarter(3) == (7, 8, 9)
+    assert fyh.get_periods_in_quarter(4) == (10, 11, 12)
+
+    assert fyh.get_periods_in_quarter(None) is None
+    assert fyh.get_periods_in_quarter("1") is None
+    assert fyh.get_periods_in_quarter("a") is None
+    assert fyh.get_periods_in_quarter({"hello": "there"}) is None
+
+
+def test_get_quarter_from_period():
+    assert fyh.get_quarter_from_period(2) == 1
+    assert fyh.get_quarter_from_period(3) == 1
+    assert fyh.get_quarter_from_period(4) == 2
+    assert fyh.get_quarter_from_period(5) == 2
+    assert fyh.get_quarter_from_period(6) == 2
+    assert fyh.get_quarter_from_period(7) == 3
+    assert fyh.get_quarter_from_period(8) == 3
+    assert fyh.get_quarter_from_period(9) == 3
+    assert fyh.get_quarter_from_period(10) == 4
+    assert fyh.get_quarter_from_period(11) == 4
+    assert fyh.get_quarter_from_period(12) == 4
+
+    assert fyh.get_quarter_from_period(1) is None
+    assert fyh.get_quarter_from_period(13) is None
+    assert fyh.get_quarter_from_period(None) is None
+    assert fyh.get_quarter_from_period("1") is None
+    assert fyh.get_quarter_from_period("a") is None
+    assert fyh.get_quarter_from_period({"hello": "there"}) is None

--- a/usaspending_api/common/tests/unit/test_helpers.py
+++ b/usaspending_api/common/tests/unit/test_helpers.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from model_mommy import mommy
 
 from usaspending_api.common.helpers.generic_helper import check_valid_toptier_agency
-from usaspending_api.common.helpers.fiscal_year_helpers import generate_fiscal_period, generate_fiscal_year
+from usaspending_api.common.helpers.fiscal_year_helpers import generate_fiscal_month, generate_fiscal_year
 
 
 @pytest.mark.django_db
@@ -22,38 +22,38 @@ def test_check_valid_toptier_agency_invalid():
 def test_generate_fiscal_period_beginning_of_fiscal_year():
     date = datetime.strptime("10/01/2018", "%m/%d/%Y")
     expected = 1
-    actual = generate_fiscal_period(date)
+    actual = generate_fiscal_month(date)
     assert actual == expected
 
 
 def test_generate_fiscal_period_end_of_fiscal_year():
     date = datetime.strptime("09/30/2019", "%m/%d/%Y")
     expected = 12
-    actual = generate_fiscal_period(date)
+    actual = generate_fiscal_month(date)
     assert actual == expected
 
 
 def test_generate_fiscal_period_middle_of_fiscal_year():
     date = datetime.strptime("01/01/2019", "%m/%d/%Y")
     expected = 4
-    actual = generate_fiscal_period(date)
+    actual = generate_fiscal_month(date)
     assert actual == expected
 
 
 def test_generate_fiscal_period_incorrect_data_type_string():
     with pytest.raises(TypeError):
-        generate_fiscal_period("2019")
+        generate_fiscal_month("2019")
 
 
 def test_generate_fiscal_period_incorrect_data_type_int():
     with pytest.raises(TypeError):
-        generate_fiscal_period(2019)
+        generate_fiscal_month(2019)
 
 
 def test_generate_fiscal_period_malformed_date_month_year():
     date = datetime.strptime("10/2018", "%m/%Y").date
     with pytest.raises(Exception):
-        generate_fiscal_period(date)
+        generate_fiscal_month(date)
 
 
 # example of a simple unit test

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1,8 +1,3 @@
-from collections import OrderedDict
-
-from usaspending_api import settings
-from usaspending_api.download.filestreaming import NAMING_CONFLICT_DISCRIMINATOR
-
 """
 Sets up mappings from column names used in downloads to the query paths used to get the data from django.
 
@@ -11,14 +6,15 @@ historical tables TransactionFPDS and TransactionFABS, import download_column_lo
 
 NOTE: To allow for annotations to be used on download a pair of ("<alias>", None) is used so that a placeholder
 for the column is made, but it can be removed to avoid being used as a query path.
-"""
-"""
+
 Code to generate these from spreadsheets:
 
 tail -n +3 'usaspending_api/data/DAIMS_IDD_Resorted+DRW+KB+GGv7/D2-Award (Financial Assistance)-Table 1.csv' >
 d2_columns.csv
-
 """
+from collections import OrderedDict
+from django.conf import settings
+from usaspending_api.download.filestreaming import NAMING_CONFLICT_DISCRIMINATOR
 
 
 query_paths = {
@@ -1468,9 +1464,9 @@ query_paths = {
                 (
                     "last_reported_submission_period",
                     "last_reported_submission_period",
-                ),  # Column is appended to in account_download.py
+                ),  # Column is annotated in account_download.py
                 (
-                    "allocation_transfer_agency_identifer_code",
+                    "allocation_transfer_agency_identifier_code",
                     "treasury_account_identifier__allocation_transfer_agency_id",
                 ),
                 ("agency_identifier_code", "treasury_account_identifier__agency_id"),
@@ -1479,16 +1475,16 @@ query_paths = {
                 ("availability_type_code", "treasury_account_identifier__availability_type_code"),
                 ("main_account_code", "treasury_account_identifier__main_account_code"),
                 ("sub_account_code", "treasury_account_identifier__sub_account_code"),
-                ("treasury_account_symbol", "treasury_account_symbol"),  # Column is appended to in account_download.py
+                ("treasury_account_symbol", "treasury_account_identifier__tas_rendering_label"),
                 ("treasury_account_name", "treasury_account_identifier__account_title"),
-                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is annotated in account_download.py
                 (
-                    "allocation_transfer_agency_identifer_name",
-                    "allocation_transfer_agency_identifer_name",
-                ),  # Column is appended to in account_download.py
+                    "allocation_transfer_agency_identifier_name",
+                    "allocation_transfer_agency_identifier_name",
+                ),  # Column is annotated in account_download.py
                 ("budget_function", "treasury_account_identifier__budget_function_title"),
                 ("budget_subfunction", "treasury_account_identifier__budget_subfunction_title"),
-                ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
+                ("federal_account_symbol", "treasury_account_identifier__federal_account__federal_account_code"),
                 ("federal_account_name", "treasury_account_identifier__federal_account__account_title"),
                 (
                     "budget_authority_unobligated_balance_brought_forward",
@@ -1524,16 +1520,16 @@ query_paths = {
         "federal_account": OrderedDict(
             [
                 ("owning_agency_name", "treasury_account_identifier__federal_account__parent_toptier_agency__name"),
-                ("reporting_agency_name", "reporting_agency_name"),  # Column is appended to in account_download.py
+                ("reporting_agency_name", "reporting_agency_name"),  # Column is annotated in account_download.py
                 (
                     "last_reported_submission_period",
                     "last_reported_submission_period",
-                ),  # Column is appended to in account_download.py
-                ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
+                ),  # Column is annotated in account_download.py
+                ("federal_account_symbol", "treasury_account_identifier__federal_account__federal_account_code"),
                 ("federal_account_name", "treasury_account_identifier__federal_account__account_title"),
-                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
-                ("budget_function", "budget_function"),  # Column is appended to in account_download.py
-                ("budget_subfunction", "budget_subfunction"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is annotated in account_download.py
+                ("budget_function", "budget_function"),  # Column is annotated in account_download.py
+                ("budget_subfunction", "budget_subfunction"),  # Column is annotated in account_download.py
                 (
                     "budget_authority_unobligated_balance_brought_forward",
                     "budget_authority_unobligated_balance_brought_forward",
@@ -1574,24 +1570,24 @@ query_paths = {
                 (
                     "last_reported_submission_period",
                     "last_reported_submission_period",
-                ),  # Column is appended to in account_download.py
-                ("allocation_transfer_agency_identifer_code", "treasury_account__allocation_transfer_agency_id"),
+                ),  # Column is annotated in account_download.py
+                ("allocation_transfer_agency_identifier_code", "treasury_account__allocation_transfer_agency_id"),
                 ("agency_identifier_code", "treasury_account__agency_id"),
                 ("beginning_period_of_availability", "treasury_account__beginning_period_of_availability"),
                 ("ending_period_of_availability", "treasury_account__ending_period_of_availability"),
                 ("availability_type_code", "treasury_account__availability_type_code"),
                 ("main_account_code", "treasury_account__main_account_code"),
                 ("sub_account_code", "treasury_account__sub_account_code"),
-                ("treasury_account_symbol", "treasury_account_symbol"),  # Column is appended to in account_download.py
+                ("treasury_account_symbol", "treasury_account__tas_rendering_label"),
                 ("treasury_account_name", "treasury_account__account_title"),
-                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is annotated in account_download.py
                 (
-                    "allocation_transfer_agency_identifer_name",
-                    "allocation_transfer_agency_identifer_name",
-                ),  # Column is appended to in account_download.py
+                    "allocation_transfer_agency_identifier_name",
+                    "allocation_transfer_agency_identifier_name",
+                ),  # Column is annotated in account_download.py
                 ("budget_function", "treasury_account__budget_function_title"),
                 ("budget_subfunction", "treasury_account__budget_subfunction_title"),
-                ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
+                ("federal_account_symbol", "treasury_account__federal_account__federal_account_code"),
                 ("federal_account_name", "treasury_account__federal_account__account_title"),
                 ("program_activity_code", "program_activity__program_activity_code"),
                 ("program_activity_name", "program_activity__program_activity_name"),
@@ -1615,16 +1611,16 @@ query_paths = {
         "federal_account": OrderedDict(
             [
                 ("owning_agency_name", "treasury_account__federal_account__parent_toptier_agency__name"),
-                ("reporting_agency_name", "reporting_agency_name"),  # Column is appended to in account_download.py
+                ("reporting_agency_name", "reporting_agency_name"),  # Column is annotated in account_download.py
                 (
                     "last_reported_submission_period",
                     "last_reported_submission_period",
-                ),  # Column is appended to in account_download.py
-                ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
+                ),  # Column is annotated in account_download.py
+                ("federal_account_symbol", "treasury_account__federal_account__federal_account_code"),
                 ("federal_account_name", "treasury_account__federal_account__account_title"),
-                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
-                ("budget_function", "budget_function"),  # Column is appended to in account_download.py
-                ("budget_subfunction", "budget_subfunction"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is annotated in account_download.py
+                ("budget_function", "budget_function"),  # Column is annotated in account_download.py
+                ("budget_subfunction", "budget_subfunction"),  # Column is annotated in account_download.py
                 ("program_activity_code", "program_activity__program_activity_code"),
                 ("program_activity_name", "program_activity__program_activity_name"),
                 ("object_class_code", "object_class__object_class"),
@@ -1651,24 +1647,24 @@ query_paths = {
             [
                 ("owning_agency_name", "treasury_account__funding_toptier_agency__name"),
                 ("reporting_agency_name", "submission__reporting_agency_name"),
-                ("submission_period", "submission_period"),  # Column is appended to in account_download.py
-                ("allocation_transfer_agency_identifer_code", "treasury_account__allocation_transfer_agency_id"),
+                ("submission_period", "submission_period"),  # Column is annotated in account_download.py
+                ("allocation_transfer_agency_identifier_code", "treasury_account__allocation_transfer_agency_id"),
                 ("agency_identifier_code", "treasury_account__agency_id"),
                 ("beginning_period_of_availability", "treasury_account__beginning_period_of_availability"),
                 ("ending_period_of_availability", "treasury_account__ending_period_of_availability"),
                 ("availability_type_code", "treasury_account__availability_type_code"),
                 ("main_account_code", "treasury_account__main_account_code"),
                 ("sub_account_code", "treasury_account__sub_account_code"),
-                ("treasury_account_symbol", "treasury_account_symbol"),  # Column is appended to in account_download.py
+                ("treasury_account_symbol", "treasury_account__tas_rendering_label"),
                 ("treasury_account_name", "treasury_account__account_title"),
-                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is annotated in account_download.py
                 (
-                    "allocation_transfer_agency_identifer_name",
-                    "allocation_transfer_agency_identifer_name",
-                ),  # Column is appended to in account_download.py
+                    "allocation_transfer_agency_identifier_name",
+                    "allocation_transfer_agency_identifier_name",
+                ),  # Column is annotated in account_download.py
                 ("budget_function", "treasury_account__budget_function_title"),
                 ("budget_subfunction", "treasury_account__budget_subfunction_title"),
-                ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
+                ("federal_account_symbol", "treasury_account__federal_account__federal_account_code"),
                 ("federal_account_name", "treasury_account__federal_account__account_title"),
                 ("program_activity_code", "program_activity__program_activity_code"),
                 ("program_activity_name", "program_activity__program_activity_name"),
@@ -1692,8 +1688,8 @@ query_paths = {
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
                 ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_by_award_cpe"),
                 ("award_unique_key", "award__generated_unique_award_id"),
-                ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
-                ("award_type", "award_type"),  # Column is appended to in account_download.py
+                ("award_type_code", "award_type_code"),  # Column is annotated in account_download.py
+                ("award_type", "award_type"),  # Column is annotated in account_download.py
                 ("idv_type_code", "award__latest_transaction__contract_data__idv_type"),
                 ("idv_type", "award__latest_transaction__contract_data__idv_type_description"),
                 ("award_description", "award__description"),
@@ -1761,13 +1757,13 @@ query_paths = {
         "federal_account": OrderedDict(
             [
                 ("owning_agency_name", "treasury_account__federal_account__parent_toptier_agency__name"),
-                ("reporting_agency_name", "reporting_agency_name"),  # Column is appended to in account_download.py
-                ("submission_period", "submission_period"),  # Column is appended to in account_download.py
-                ("federal_account_symbol", "federal_account_symbol"),  # Column is appended to in account_download.py
+                ("reporting_agency_name", "reporting_agency_name"),  # Column is annotated in account_download.py
+                ("submission_period", "submission_period"),  # Column is annotated in account_download.py
+                ("federal_account_symbol", "treasury_account__federal_account__federal_account_code"),
                 ("federal_account_name", "treasury_account__federal_account__account_title"),
-                ("agency_identifier_name", "agency_identifier_name"),  # Column is appended to in account_download.py
-                ("budget_function", "budget_function"),  # Column is appended to in account_download.py
-                ("budget_subfunction", "budget_subfunction"),  # Column is appended to in account_download.py
+                ("agency_identifier_name", "agency_identifier_name"),  # Column is annotated in account_download.py
+                ("budget_function", "budget_function"),  # Column is annotated in account_download.py
+                ("budget_subfunction", "budget_subfunction"),  # Column is annotated in account_download.py
                 ("program_activity_code", "program_activity__program_activity_code"),
                 ("program_activity_name", "program_activity__program_activity_name"),
                 ("object_class_code", "object_class__object_class"),
@@ -1783,15 +1779,15 @@ query_paths = {
                 (
                     "award_base_action_date_fiscal_year",
                     "award_base_action_date_fiscal_year",
-                ),  # Column is appended to in account_download.py
+                ),  # Column is annotated in account_download.py
                 ("period_of_performance_start_date", "award__period_of_performance_start_date"),
                 ("period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("ordering_period_end_date", "award__latest_transaction__contract_data__ordering_period_end_date"),
                 ("transaction_obligated_amount", "transaction_obligated_amount"),
                 ("gross_outlay_amount_fyb_to_period_end", "gross_outlay_amount_by_award_cpe"),
                 ("award_unique_key", "award__generated_unique_award_id"),
-                ("award_type_code", "award_type_code"),  # Column is appended to in account_download.py
-                ("award_type", "award_type"),  # Column is appended to in account_download.py
+                ("award_type_code", "award_type_code"),  # Column is annotated in account_download.py
+                ("award_type", "award_type"),  # Column is annotated in account_download.py
                 ("idv_type_code", "award__latest_transaction__contract_data__idv_type"),
                 ("idv_type", "award__latest_transaction__contract_data__idv_type_description"),
                 ("award_description", "award__description"),

--- a/usaspending_api/etl/management/commands/es_configure.py
+++ b/usaspending_api/etl/management/commands/es_configure.py
@@ -3,7 +3,7 @@ import subprocess
 
 from django.core.management.base import BaseCommand
 
-from usaspending_api import settings
+from django.conf import settings
 from usaspending_api.etl.es_etl_helpers import VIEW_COLUMNS, AWARD_VIEW_COLUMNS
 
 CURL_STATEMENT = 'curl -XPUT "{url}" -H "Content-Type: application/json" -d \'{data}\''

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from pathlib import Path
 from time import perf_counter
 
-from usaspending_api import settings
+from django.conf import settings
 from usaspending_api.broker.helpers.last_load_date import get_last_load_date
 from usaspending_api.common.elasticsearch.client import instantiate_elasticsearch_client
 from usaspending_api.common.elasticsearch.elasticsearch_sql_helpers import ensure_view_exists

--- a/usaspending_api/etl/rapidloader.py
+++ b/usaspending_api/etl/rapidloader.py
@@ -2,7 +2,7 @@ from multiprocessing import Process, Queue
 from pathlib import Path
 from time import sleep
 
-from usaspending_api import settings
+from django.conf import settings
 from usaspending_api.broker.helpers.last_load_date import update_last_load_date
 from usaspending_api.etl.es_etl_helpers import (
     DataJob,

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -21,7 +21,7 @@ from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     bolster_missing_time_periods,
     generate_fiscal_date_range,
-    generate_fiscal_period,
+    generate_fiscal_month,
     generate_fiscal_year,
 )
 from usaspending_api.common.helpers.generic_helper import (
@@ -190,7 +190,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         if self.group == "fiscal_year":
             end_date = "{}-09-30".format(current_fy)
         else:
-            current_fiscal_month = generate_fiscal_period(datetime.now(timezone.utc))
+            current_fiscal_month = generate_fiscal_month(datetime.now(timezone.utc))
             days_in_month = monthrange(current_fy, current_fiscal_month)[1]
             end_date = f"{current_fy}-{current_fiscal_month}-{days_in_month}"
 

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -21,7 +21,7 @@ from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     bolster_missing_time_periods,
     generate_fiscal_date_range,
-    generate_fiscal_month,
+    generate_fiscal_period,
     generate_fiscal_year,
 )
 from usaspending_api.common.helpers.generic_helper import (
@@ -190,7 +190,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         if self.group == "fiscal_year":
             end_date = "{}-09-30".format(current_fy)
         else:
-            current_fiscal_month = generate_fiscal_month(datetime.now(timezone.utc))
+            current_fiscal_month = generate_fiscal_period(datetime.now(timezone.utc))
             days_in_month = monthrange(current_fy, current_fiscal_month)[1]
             end_date = f"{current_fy}-{current_fiscal_month}-{days_in_month}"
 

--- a/usaspending_api/transactions/transaction_delete_journal_helpers.py
+++ b/usaspending_api/transactions/transaction_delete_journal_helpers.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from datetime import datetime
 from typing import Optional, List
-from usaspending_api import settings
+from django.conf import settings
 from usaspending_api.common.helpers.date_helper import datetime_is_ge, datetime_is_lt
 from usaspending_api.common.helpers.s3_helpers import access_s3_object, retrieve_s3_bucket_object_list
 from usaspending_api.common.helpers.timing_helpers import ScriptTimer as Timer


### PR DESCRIPTION
**Description:**

Before we were returning the final TAS rows for a fiscal year regardless of the quarter in which it falls.

Now, for Files A and B, we only return TAS rows in the quarter or period requested.  For File C we only return rows in the quarter or period requested OR previous periods if the `transaction_obligated_amount` is non-zero.

Also "fixed" a few typos and bad imports.

And updated the account download endpoint to accepts quarter OR periods.  Is backward compatible so front end should be unaffected until they are ready to support periods.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Materialized views unaffected
5. [x] Frontend unaffected (new contract stuff, but backward compatible)
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-4443](https://federal-spending-transparency.atlassian.net/browse/DEV-4443):
    - [x] Link to this Pull-Request