### PR TITLE
Fix Disaster Endpoints to Accommodate Data

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_disaster_agency_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_agency_count.py
@@ -27,21 +27,24 @@ def test_agency_count_success(client, monkeypatch, disaster_account_data, helper
 
 
 @pytest.mark.django_db
-def test_agency_count_invalid_defc(client, disaster_account_data, helpers):
+def test_agency_count_invalid_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, ["ZZ"])
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Field 'filter|def_codes' is outside valid values ['9', 'L', 'M', 'N', 'O', 'P']"
 
 
 @pytest.mark.django_db
-def test_agency_count_invalid_defc_type(client, disaster_account_data, helpers):
+def test_agency_count_invalid_defc_type(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, "100")
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Invalid value in 'filter|def_codes'. '100' is not a valid type (array)"
 
 
 @pytest.mark.django_db
-def test_agency_count_missing_defc(client, disaster_account_data, helpers):
+def test_agency_count_missing_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"

--- a/usaspending_api/disaster/tests/integration/test_disaster_def_code_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_def_code_count.py
@@ -27,21 +27,24 @@ def test_def_code_count_success(client, monkeypatch, disaster_account_data, help
 
 
 @pytest.mark.django_db
-def test_def_code_count_invalid_defc(client, disaster_account_data, helpers):
+def test_def_code_count_invalid_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, ["ZZ"])
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Field 'filter|def_codes' is outside valid values ['9', 'L', 'M', 'N', 'O', 'P']"
 
 
 @pytest.mark.django_db
-def test_def_code_count_invalid_defc_type(client, disaster_account_data, helpers):
+def test_def_code_count_invalid_defc_type(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, "100")
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Invalid value in 'filter|def_codes'. '100' is not a valid type (array)"
 
 
 @pytest.mark.django_db
-def test_def_code_count_missing_defc(client, disaster_account_data, helpers):
+def test_def_code_count_missing_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"

--- a/usaspending_api/disaster/tests/integration/test_disaster_federal_account_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_federal_account_count.py
@@ -27,21 +27,24 @@ def test_federal_account_count_success(client, monkeypatch, disaster_account_dat
 
 
 @pytest.mark.django_db
-def test_federal_account_count_invalid_defc(client, disaster_account_data, helpers):
+def test_federal_account_count_invalid_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, ["ZZ"])
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Field 'filter|def_codes' is outside valid values ['9', 'L', 'M', 'N', 'O', 'P']"
 
 
 @pytest.mark.django_db
-def test_federal_account_count_invalid_defc_type(client, disaster_account_data, helpers):
+def test_federal_account_count_invalid_defc_type(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, "100")
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Invalid value in 'filter|def_codes'. '100' is not a valid type (array)"
 
 
 @pytest.mark.django_db
-def test_federal_account_count_missing_defc(client, disaster_account_data, helpers):
+def test_federal_account_count_missing_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"

--- a/usaspending_api/disaster/tests/integration/test_disaster_object_class_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_object_class_count.py
@@ -27,21 +27,24 @@ def test_object_class_count_success(client, monkeypatch, disaster_account_data, 
 
 
 @pytest.mark.django_db
-def test_object_class_count_invalid_defc(client, disaster_account_data, helpers):
+def test_object_class_count_invalid_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, ["ZZ"])
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Field 'filter|def_codes' is outside valid values ['9', 'L', 'M', 'N', 'O', 'P']"
 
 
 @pytest.mark.django_db
-def test_object_class_count_invalid_defc_type(client, disaster_account_data, helpers):
+def test_object_class_count_invalid_defc_type(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, "100")
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.data["detail"] == "Invalid value in 'filter|def_codes'. '100' is not a valid type (array)"
 
 
 @pytest.mark.django_db
-def test_object_class_count_missing_defc(client, disaster_account_data, helpers):
+def test_object_class_count_missing_defc(client, monkeypatch, disaster_account_data, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"

--- a/usaspending_api/disaster/v2/views/agency/count.py
+++ b/usaspending_api/disaster/v2/views/agency/count.py
@@ -17,21 +17,10 @@ class AgencyCountViewSet(DisasterBase):
 
     @cache_response()
     def post(self, request: Request) -> Response:
-        filters = [
-            Q(treasury_account__funding_toptier_agency=OuterRef("pk")),
-            Q(disaster_emergency_fund__code__in=self.def_codes),
-            Q(submission__reporting_period_start__gte=self.reporting_period_min),
-            Q(
+        sub_queries = []
+        if self.last_closed_monthly_submission_dates:
+            sub_queries.append(
                 Q(
-                    submission__quarter_format_flag=True,
-                    submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_year"
-                    ),
-                    submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_quarter"
-                    ),
-                )
-                | Q(
                     submission__quarter_format_flag=False,
                     submission__reporting_fiscal_year__lte=self.last_closed_monthly_submission_dates.get(
                         "submission_fiscal_year"
@@ -40,7 +29,29 @@ class AgencyCountViewSet(DisasterBase):
                         "submission_fiscal_month"
                     ),
                 )
-            ),
+            )
+
+        sub_queries.append(
+            Q(
+                submission__quarter_format_flag=True,
+                submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_year"
+                ),
+                submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_quarter"
+                ),
+            )
+        )
+
+        sub_queryset = sub_queries.pop()
+        for query in sub_queries:
+            sub_queryset |= query
+
+        filters = [
+            Q(treasury_account__funding_toptier_agency=OuterRef("pk")),
+            Q(disaster_emergency_fund__code__in=self.def_codes),
+            Q(submission__reporting_period_start__gte=self.reporting_period_min),
+            sub_queryset,
             Q(
                 Q(obligations_incurred_by_program_object_class_cpe__gt=0)
                 | Q(obligations_incurred_by_program_object_class_cpe__lt=0)

--- a/usaspending_api/disaster/v2/views/def_code/count.py
+++ b/usaspending_api/disaster/v2/views/def_code/count.py
@@ -17,21 +17,10 @@ class DefCodeCountViewSet(DisasterBase):
 
     @cache_response()
     def post(self, request: Request) -> Response:
-        filters = [
-            Q(disaster_emergency_fund_id=OuterRef("pk")),
-            Q(disaster_emergency_fund__code__in=self.def_codes),
-            Q(submission__reporting_period_start__gte=self.reporting_period_min),
-            Q(
+        sub_queries = []
+        if self.last_closed_monthly_submission_dates:
+            sub_queries.append(
                 Q(
-                    submission__quarter_format_flag=True,
-                    submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_year"
-                    ),
-                    submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_quarter"
-                    ),
-                )
-                | Q(
                     submission__quarter_format_flag=False,
                     submission__reporting_fiscal_year__lte=self.last_closed_monthly_submission_dates.get(
                         "submission_fiscal_year"
@@ -40,7 +29,29 @@ class DefCodeCountViewSet(DisasterBase):
                         "submission_fiscal_month"
                     ),
                 )
-            ),
+            )
+
+        sub_queries.append(
+            Q(
+                submission__quarter_format_flag=True,
+                submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_year"
+                ),
+                submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_quarter"
+                ),
+            )
+        )
+
+        sub_queryset = sub_queries.pop()
+        for query in sub_queries:
+            sub_queryset |= query
+
+        filters = [
+            Q(disaster_emergency_fund_id=OuterRef("pk")),
+            Q(disaster_emergency_fund__code__in=self.def_codes),
+            Q(submission__reporting_period_start__gte=self.reporting_period_min),
+            sub_queryset,
             Q(
                 Q(obligations_incurred_by_program_object_class_cpe__gt=0)
                 | Q(obligations_incurred_by_program_object_class_cpe__lt=0)

--- a/usaspending_api/disaster/v2/views/federal_account/count.py
+++ b/usaspending_api/disaster/v2/views/federal_account/count.py
@@ -17,21 +17,10 @@ class FederalAccountCountViewSet(DisasterBase):
 
     @cache_response()
     def post(self, request: Request) -> Response:
-        filters = [
-            Q(treasury_account__federal_account_id=OuterRef("pk")),
-            Q(disaster_emergency_fund__code__in=self.def_codes),
-            Q(submission__reporting_period_start__gte=self.reporting_period_min),
-            Q(
+        sub_queries = []
+        if self.last_closed_monthly_submission_dates:
+            sub_queries.append(
                 Q(
-                    submission__quarter_format_flag=True,
-                    submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_year"
-                    ),
-                    submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_quarter"
-                    ),
-                )
-                | Q(
                     submission__quarter_format_flag=False,
                     submission__reporting_fiscal_year__lte=self.last_closed_monthly_submission_dates.get(
                         "submission_fiscal_year"
@@ -40,7 +29,29 @@ class FederalAccountCountViewSet(DisasterBase):
                         "submission_fiscal_month"
                     ),
                 )
-            ),
+            )
+
+        sub_queries.append(
+            Q(
+                submission__quarter_format_flag=True,
+                submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_year"
+                ),
+                submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_quarter"
+                ),
+            )
+        )
+
+        sub_queryset = sub_queries.pop()
+        for query in sub_queries:
+            sub_queryset |= query
+
+        filters = [
+            Q(treasury_account__federal_account_id=OuterRef("pk")),
+            Q(disaster_emergency_fund__code__in=self.def_codes),
+            Q(submission__reporting_period_start__gte=self.reporting_period_min),
+            sub_queryset,
             Q(
                 Q(obligations_incurred_by_program_object_class_cpe__gt=0)
                 | Q(obligations_incurred_by_program_object_class_cpe__lt=0)

--- a/usaspending_api/disaster/v2/views/object_class/count.py
+++ b/usaspending_api/disaster/v2/views/object_class/count.py
@@ -17,21 +17,10 @@ class ObjectClassCountViewSet(DisasterBase):
 
     @cache_response()
     def post(self, request: Request) -> Response:
-        filters = [
-            Q(object_class_id=OuterRef("pk")),
-            Q(disaster_emergency_fund__code__in=self.def_codes),
-            Q(submission__reporting_period_start__gte=self.reporting_period_min),
-            Q(
+        sub_queries = []
+        if self.last_closed_monthly_submission_dates:
+            sub_queries.append(
                 Q(
-                    submission__quarter_format_flag=True,
-                    submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_year"
-                    ),
-                    submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
-                        "submission_fiscal_quarter"
-                    ),
-                )
-                | Q(
                     submission__quarter_format_flag=False,
                     submission__reporting_fiscal_year__lte=self.last_closed_monthly_submission_dates.get(
                         "submission_fiscal_year"
@@ -40,7 +29,29 @@ class ObjectClassCountViewSet(DisasterBase):
                         "submission_fiscal_month"
                     ),
                 )
-            ),
+            )
+
+        sub_queries.append(
+            Q(
+                submission__quarter_format_flag=True,
+                submission__reporting_fiscal_year__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_year"
+                ),
+                submission__reporting_fiscal_quarter__lte=self.last_closed_quarterly_submission_dates.get(
+                    "submission_fiscal_quarter"
+                ),
+            )
+        )
+
+        sub_queryset = sub_queries.pop()
+        for query in sub_queries:
+            sub_queryset |= query
+
+        filters = [
+            Q(object_class_id=OuterRef("pk")),
+            Q(disaster_emergency_fund__code__in=self.def_codes),
+            Q(submission__reporting_period_start__gte=self.reporting_period_min),
+            sub_queryset,
             Q(
                 Q(obligations_incurred_by_program_object_class_cpe__gt=0)
                 | Q(obligations_incurred_by_program_object_class_cpe__lt=0)


### PR DESCRIPTION
**Description:**
We need to support the possibility of not having the latest closed submission for monthly.

**Technical details:**
Since there are currently no monthly submissions that have closed we need to add at least temporary support. Any use of a monthly submission closed date checks to make sure that it exists before being used. We know that quarterly submissions exist so the same check is not necessary.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. N/A Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. N/A Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - N/A Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
