### PR TITLE
[DEV-4930] ENABLE_CARES_ACT_FEATURES = True

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -32,7 +32,7 @@ API_SEARCH_MIN_DATE = "2007-10-01"  # Beginning of FY2008
 # This flag is used to control dark release features for the CARES Act initiative.  Set this to True
 # for testing and once the CARES Act features go live.  Remove all references to this global once
 # we have finished fully rolling out all CARES Act features.
-ENABLE_CARES_ACT_FEATURES = False
+ENABLE_CARES_ACT_FEATURES = True
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/


### PR DESCRIPTION
**Description:**
Undark the CARES Act features in backend code for Sprint 110 release heading to production on Monday 7/13.

**Technical details:**
This would allow the usaspending submission loader in prod to be compliant with the broker CARES act changes. And also allow real prod loads of monthly submissions as early as the 17th of July.

BUT - are there things in backend guarded by that flag that we would not want getting into prod on Jul 13th.

One example is starting to put a DEFC column in the downloads I don't think it would be populated with any data, because the P7/8/9 in prod would not have closed yet.

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [x] Appropriate Operations ticket(s) created
    - Related to: https://github.com/fedspendingtransparency/usaspending-config/pull/725, which was being done to open up these features for nightly pipeline runs in nonprod envs
8. [NA] Jira Ticket
    - [NA] Link to this Pull-Request
    - [NA] Performance evaluation of affected (API | Script | Download)
    - [NA] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
