### PR TITLE
added guard clause to count base

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_disaster_recipient_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_recipient_count.py
@@ -27,6 +27,13 @@ def test_wrong_award_type(client, monkeypatch, basic_fabs_award, helpers):
 
 
 @pytest.mark.django_db
+def test_no_award_type(client, monkeypatch, basic_fabs_award, helpers):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
+    resp = helpers.post_for_count_endpoint(client, url, ["M"])
+    assert resp.data["count"] == 1
+
+
+@pytest.mark.django_db
 def test_two_transactions_two_awards(client, monkeypatch, basic_fabs_award, basic_fpds_award, helpers):
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = _default_post(client, helpers)

--- a/usaspending_api/disaster/v2/views/count_base.py
+++ b/usaspending_api/disaster/v2/views/count_base.py
@@ -29,4 +29,4 @@ class CountBase(DisasterBase):
         if self.filters.get("award_type_codes"):
             return Q(award__type__in=self.filters.get("award_type_codes"))
         else:
-            return ~Q(pk=None)  # always true
+            return ~Q(pk=None)  # always true; if types are not provided we don't check types

--- a/usaspending_api/disaster/v2/views/count_base.py
+++ b/usaspending_api/disaster/v2/views/count_base.py
@@ -26,4 +26,7 @@ class CountBase(DisasterBase):
         return Q(type__in=self.filters.get("award_type_codes"))
 
     def has_award_of_provided_type(self):
-        return Q(award__type__in=self.filters.get("award_type_codes"))
+        if self.filters.get("award_type_codes"):
+            return Q(award__type__in=self.filters.get("award_type_codes"))
+        else:
+            return ~Q(pk=None)  # always true


### PR DESCRIPTION
**Description:**
Previous functionality would just crash if count endpoints didn't have award types. This checks that, and adds a test to make sure it works.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created

**Area for explaining above N/A when needed:**
```
```
