### PR TITLE
[DEV-5299] Only allow assistance filters and minor cleanup on API contract

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md
@@ -67,14 +67,17 @@ Returns loan spending details of Agencies receiving supplemental funding budgeta
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[enum[string]], fixed-type)
-    + Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
-    + If ANY award type codes are provided, loan amounts will be summed for the distinct set of toptier agencies,
++ `award_type_codes` (optional, array[enum[string]], fixed-type)  
+    Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans.
+
+    If ANY award type codes are provided, loan amounts will be summed for the distinct set of toptier agencies,
     whose subtier agencies funded loan awards linked to `FinancialAccountsByAwards` records (which are derived from DABS File C).
-    + If this parameter is not provided, loan amounts will be summed for a different set of agencies: 
+
+    If this parameter is not provided, loan amounts will be summed for a different set of agencies: 
     the distinct set of toptier agencies "owning" appropriations accounts used in funding _any_ award spending
     for this disaster (i.e. from agencies "owning" Treasury Account Symbol (TAS) accounts on `FinancialAccountsByAwards`
     records, which are derived from DABS File C).
+
     + Members
         + `07`
         + `08`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md
@@ -67,7 +67,7 @@ Returns loan spending details of Agencies receiving supplemental funding budgeta
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[string], fixed-type)
++ `award_type_codes` (optional, array[enum[string]], fixed-type)
     + Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
     + If ANY award type codes are provided, loan amounts will be summed for the distinct set of toptier agencies,
     whose subtier agencies funded loan awards linked to `FinancialAccountsByAwards` records (which are derived from DABS File C).

--- a/usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md
@@ -72,14 +72,16 @@ Returns spending details of Agencies receiving supplemental funding budgetary re
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[AwardTypeCodes], fixed-type)
-    + Only to be used when `"spending_type": "award"`
-    + If ANY award type codes are provided, obligation and outlay spending amounts will be summed for the distinct set of toptier
-      agencies, whose subtier agencies funded awards -- awards of the type given by `award_type_codes` -- linked to
-      `FinancialAccountsByAwards` records (which are derived from DABS File C).
-    + If this parameter is not provided, obligation and outlay spending amounts will be summed for a different set of agencies:
-      the distinct set of toptier agencies "owning" appropriations accounts used in funding _any_ award spending for this disaster
-      (i.e. from agencies "owning" Treasury Account Symbol (TAS) accounts on `FinancialAccountsByAwards` records, which are derived from DABS File C).
++ `award_type_codes` (optional, array[AwardTypeCodes], fixed-type)  
+    Only to be used when `"spending_type": "award"`.
+
+    If ANY award type codes are provided, obligation and outlay spending amounts will be summed for the distinct set of toptier
+    agencies, whose subtier agencies funded awards -- awards of the type given by `award_type_codes` -- linked to
+    `FinancialAccountsByAwards` records (which are derived from DABS File C).
+
+    If this parameter is not provided, obligation and outlay spending amounts will be summed for a different set of agencies:
+    the distinct set of toptier agencies "owning" appropriations accounts used in funding _any_ award spending for this disaster
+    (i.e. from agencies "owning" Treasury Account Symbol (TAS) accounts on `FinancialAccountsByAwards` records, which are derived from DABS File C).
 + `query` (optional, string)
     A "keyword" or "search term" to filter down results based on this text snippet
 

--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
@@ -67,7 +67,7 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[string], fixed-type)
++ `award_type_codes` (optional, array[enum[string]], fixed-type)
     + Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
     + Default: `["07", "08"]`
     + Members

--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
@@ -68,7 +68,7 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
 + `award_type_codes` (optional, array[enum[string]], fixed-type)
-    + Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
+    Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
     + Default: `["07", "08"]`
     + Members
         + `07`
@@ -91,10 +91,8 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
         + `asc`
 + `sort` (optional, enum[string])
     Optional parameter indicating what value results should be sorted by
-    + Default: `id`
+    + Default: `description`
     + Members
-        + `id`
-        + `code`
         + `description`
         + `count`
         + `face_value_of_loan`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md
@@ -90,10 +90,8 @@ Returns spending details of CFDA receiving supplemental funding budgetary resour
         + `asc`
 + `sort` (optional, enum[string])
     Optional parameter indicating what value results should be sorted by
-    + Default: `id`
+    + Default: `description`
     + Members
-        + `id`
-        + `code`
         + `description`
         + `count`
         + `obligation`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/recipient/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/recipient/loans.md
@@ -66,7 +66,7 @@ Returns loan spending details of recipients receiving supplemental funding budge
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
 + `award_type_codes` (optional, array[enum[string]], fixed-type)
-    + Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
+    Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
     + Default: `["07", "08"]`
     + Members
         + `07`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/recipient/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/recipient/loans.md
@@ -65,7 +65,7 @@ Returns loan spending details of recipients receiving supplemental funding budge
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[string], fixed-type)
++ `award_type_codes` (optional, array[enum[string]], fixed-type)
     + Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans
     + Default: `["07", "08"]`
     + Members

--- a/usaspending_api/disaster/tests/integration/test_cfda_count.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_count.py
@@ -40,6 +40,21 @@ def test_correct_response_multiple_defc(
 
 
 @pytest.mark.django_db
+def test_correct_response_with_award_type_codes(
+    client, monkeypatch, helpers, elasticsearch_award_index, cfda_awards_and_transactions
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+
+    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], award_type_codes=["11"])
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["count"] == 0
+
+    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], award_type_codes=["07", "09", "11"])
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["count"] == 2
+
+
+@pytest.mark.django_db
 def test_invalid_defc(client, monkeypatch, helpers, elasticsearch_award_index, cfda_awards_and_transactions):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
@@ -64,3 +79,17 @@ def test_missing_defc(client, monkeypatch, helpers, elasticsearch_award_index, c
     resp = helpers.post_for_count_endpoint(client, url)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"
+
+
+@pytest.mark.django_db
+def test_invalid_award_type_codes(
+    client, monkeypatch, helpers, elasticsearch_award_index, cfda_awards_and_transactions
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+
+    resp = helpers.post_for_spending_endpoint(client, url, award_type_codes=["ZZ", "08"], def_codes=["L", "M"])
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        resp.data["detail"]
+        == "Field 'filter|award_type_codes' is outside valid values ['02', '03', '04', '05', '06', '07', '08', '09', '10', '11']"
+    )

--- a/usaspending_api/disaster/tests/integration/test_cfda_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_spending.py
@@ -132,12 +132,12 @@ def test_correct_response_with_award_type_codes(
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
-    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], award_type_codes=["IDV_A"])
+    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], award_type_codes=["11"])
     expected_results = []
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["results"] == expected_results
 
-    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], award_type_codes=["07", "A", "B"])
+    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], award_type_codes=["07", "09", "11"])
     expected_results = [
         {
             "code": "20.200",
@@ -187,6 +187,20 @@ def test_missing_defc(client, monkeypatch, helpers, elasticsearch_award_index, c
     resp = helpers.post_for_spending_endpoint(client, url)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.data["detail"] == "Missing value: 'filter|def_codes' is a required field"
+
+
+@pytest.mark.django_db
+def test_invalid_award_type_codes(
+    client, monkeypatch, helpers, elasticsearch_award_index, cfda_awards_and_transactions
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+
+    resp = helpers.post_for_spending_endpoint(client, url, award_type_codes=["ZZ", "08"], def_codes=["L", "M"])
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        resp.data["detail"]
+        == "Field 'filter|award_type_codes' is outside valid values ['02', '03', '04', '05', '06', '07', '08', '09', '10', '11']"
+    )
 
 
 @pytest.mark.django_db

--- a/usaspending_api/disaster/v2/views/cfda/count.py
+++ b/usaspending_api/disaster/v2/views/cfda/count.py
@@ -16,7 +16,7 @@ class CfdaCountViewSet(DisasterBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/cfda/count.md"
 
-    required_filters = ["def_codes", "award_type_codes"]
+    required_filters = ["def_codes", "_assistance_award_type_codes"]
 
     @cache_response()
     def post(self, request: Request) -> Response:

--- a/usaspending_api/disaster/v2/views/cfda/spending.py
+++ b/usaspending_api/disaster/v2/views/cfda/spending.py
@@ -15,7 +15,7 @@ class CfdaSpendingViewSet(ElasticsearchSpendingPaginationMixin, ElasticsearchDis
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md"
 
-    required_filters = ["def_codes", "award_type_codes", "query"]
+    required_filters = ["def_codes", "_assistance_award_type_codes", "query"]
     query_fields = ["cfda_title", "cfda_number"]
     agg_key = "cfda_agg_key"
 

--- a/usaspending_api/disaster/v2/views/disaster_base.py
+++ b/usaspending_api/disaster/v2/views/disaster_base.py
@@ -8,7 +8,7 @@ from rest_framework.views import APIView
 from typing import List
 
 from usaspending_api.awards.models.financial_accounts_by_awards import FinancialAccountsByAwards
-from usaspending_api.awards.v2.lookups.lookups import award_type_mapping, loan_type_mapping
+from usaspending_api.awards.v2.lookups.lookups import award_type_mapping, loan_type_mapping, assistance_type_mapping
 from usaspending_api.common.data_classes import Pagination
 from usaspending_api.common.helpers.fiscal_year_helpers import generate_fiscal_year_and_month
 from usaspending_api.common.validator import customize_pagination_with_sort_columns, TinyShield
@@ -103,7 +103,7 @@ class DisasterBase(APIView):
                 "name": "award_type_codes",
                 "type": "array",
                 "array_type": "enum",
-                "enum_values": list(award_type_mapping.keys()),
+                "enum_values": sorted(list(award_type_mapping.keys())),
                 "allow_nulls": True,
                 "optional": True,
             },
@@ -112,10 +112,20 @@ class DisasterBase(APIView):
                 "name": "award_type_codes",
                 "type": "array",
                 "array_type": "enum",
-                "enum_values": list(loan_type_mapping.keys()),
+                "enum_values": sorted(list(loan_type_mapping.keys())),
                 "allow_nulls": True,
                 "optional": True,
                 "default": list(loan_type_mapping.keys()),
+            },
+            "_assistance_award_type_codes": {
+                "key": "filter|award_type_codes",
+                "name": "award_type_codes",
+                "type": "array",
+                "array_type": "enum",
+                "enum_values": sorted(list(assistance_type_mapping.keys())),
+                "allow_nulls": True,
+                "optional": True,
+                "default": list(assistance_type_mapping.keys()),
             },
         }
         model = [object_keys_lookup[key] for key in self.required_filters]

--- a/usaspending_api/disaster/v2/views/disaster_base.py
+++ b/usaspending_api/disaster/v2/views/disaster_base.py
@@ -79,7 +79,7 @@ class DisasterBase(APIView):
 
     @cached_property
     def filters(self):
-        all_def_codes = sorted(list(DisasterEmergencyFundCode.objects.values_list("code", flat=True)))
+        all_def_codes = sorted(DisasterEmergencyFundCode.objects.values_list("code", flat=True))
         object_keys_lookup = {
             "def_codes": {
                 "key": "filter|def_codes",
@@ -103,7 +103,7 @@ class DisasterBase(APIView):
                 "name": "award_type_codes",
                 "type": "array",
                 "array_type": "enum",
-                "enum_values": sorted(list(award_type_mapping.keys())),
+                "enum_values": sorted(award_type_mapping.keys()),
                 "allow_nulls": True,
                 "optional": True,
             },
@@ -112,7 +112,7 @@ class DisasterBase(APIView):
                 "name": "award_type_codes",
                 "type": "array",
                 "array_type": "enum",
-                "enum_values": sorted(list(loan_type_mapping.keys())),
+                "enum_values": sorted(loan_type_mapping.keys()),
                 "allow_nulls": True,
                 "optional": True,
                 "default": list(loan_type_mapping.keys()),
@@ -122,7 +122,7 @@ class DisasterBase(APIView):
                 "name": "award_type_codes",
                 "type": "array",
                 "array_type": "enum",
-                "enum_values": sorted(list(assistance_type_mapping.keys())),
+                "enum_values": sorted(assistance_type_mapping.keys()),
                 "allow_nulls": True,
                 "optional": True,
                 "default": list(assistance_type_mapping.keys()),


### PR DESCRIPTION
**Description:**
Realized during demos that the CFDA endpoints should only allow the Assistance Award Type Codes. Additionally, needed to cleanup API Contracts where the `award_type_codes` was added for loans endpoints.

**Technical details:**
The `enum_values` for the TinyShield model are now sorted to prevent random order being returned when non-valid award_type_codes are passed back. This helps to make sure that tests don't break because of values not being sorted the same way as expected.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-5299](https://federal-spending-transparency.atlassian.net/browse/DEV-5299):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
