### PR TITLE
[DEV-5302] Replacing exception with logging

### DIFF
--- a/usaspending_api/disaster/management/commands/generate_covid19_download.py
+++ b/usaspending_api/disaster/management/commands/generate_covid19_download.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             intermediate_data_file_path = final_name.parent / (final_name.name + "_temp")
             data_file, count = self.download_to_csv(sql_file, final_name, str(intermediate_data_file_path))
             if count <= 0:
-                raise Exception(f"Missing Data for {final_name}!!!!")
+                logger.warning(f"Empty data file generated: {final_name}!")
 
             self.filepaths_to_delete.extend(self.working_dir_path.glob(f"{final_name.stem}*"))
 


### PR DESCRIPTION
**Description:**
Early in development of the new download, an exception was mistakenly attributed to an empty CSV file. The check is too stringent for envs which might not contain enough COVID-19 spending data.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-5302](https://federal-spending-transparency.atlassian.net/browse/DEV-5302):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (N/A)
    - [x] Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
Minor change from raising an exception to logging the message
```
