### PR TITLE
[DEV-5635] Fix Agency ID response values

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
@@ -91,8 +91,10 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
         + `asc`
 + `sort` (optional, enum[string])
     Optional parameter indicating what value results should be sorted by
-    + Default: `description`
+    + Default: `id`
     + Members
+        + `id`
+        + `code`
         + `description`
         + `count`
         + `face_value_of_loan`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md
@@ -90,8 +90,10 @@ Returns spending details of CFDA receiving supplemental funding budgetary resour
         + `asc`
 + `sort` (optional, enum[string])
     Optional parameter indicating what value results should be sorted by
-    + Default: `description`
+    + Default: `id`
     + Members
+        + `id`
+        + `code`
         + `description`
         + `count`
         + `obligation`

--- a/usaspending_api/database_scripts/etl/award_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/award_delta_view.sql
@@ -71,7 +71,7 @@ SELECT
       THEN CONCAT(
         '{"name":"', vw_award_search.funding_toptier_agency_name,
         '","code":"', vw_award_search.funding_toptier_agency_code,
-        '","id":"', FA.toptier_agency_id, '"}'
+        '","id":"', FA.id, '"}'
       )
     ELSE NULL
   END AS funding_toptier_agency_agg_key,
@@ -80,7 +80,7 @@ SELECT
       THEN CONCAT(
         '{"name":"', vw_award_search.funding_subtier_agency_name,
         '","code":"', vw_award_search.funding_subtier_agency_code,
-        '","id":"', FA.subtier_agency_id, '"}'
+        '","id":"', FA.id, '"}'
       )
     ELSE NULL
   END AS funding_subtier_agency_agg_key,

--- a/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
@@ -13,10 +13,12 @@ def disaster_account_data():
     sa1 = mommy.make("references.SubtierAgency", subtier_agency_id=1007, subtier_code="1007", name="Subtier 1007")
     sa2 = mommy.make("references.SubtierAgency", subtier_agency_id=1008, subtier_code="1008", name="Subtier 1008")
     sa3 = mommy.make("references.SubtierAgency", subtier_agency_id=2008, subtier_code="2008", name="Subtier 2008")
+    sa4 = mommy.make("references.SubtierAgency", subtier_agency_id=3008, subtier_code="3008", name="Subtier 3008")
 
     ag1 = mommy.make("references.Agency", id=1, toptier_agency=ta1, subtier_agency=sa1)
     ag2 = mommy.make("references.Agency", id=2, toptier_agency=ta2, subtier_agency=sa2)
     ag3 = mommy.make("references.Agency", id=3, toptier_agency=ta2, subtier_agency=sa3)
+    mommy.make("references.Agency", id=4, toptier_agency=ta3, subtier_agency=sa4)
 
     sub1 = mommy.make(
         "submissions.SubmissionAttributes",

--- a/usaspending_api/disaster/tests/integration/test_cfda_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_loans.py
@@ -169,6 +169,11 @@ def test_pagination_page_and_limit(
             "previous": 1,
             "total": 2,
         },
+        "message": (
+            "Notice! API Request to sort on 'id' field isn't fully "
+            "implemented. Results were actually sorted using 'description' "
+            "field."
+        ),
     }
 
     assert resp.status_code == status.HTTP_200_OK
@@ -192,7 +197,9 @@ def test_correct_response_with_award_type_codes(
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
-    resp = helpers.post_for_spending_endpoint(client, url, award_type_codes=["07"], def_codes=["L", "M"])
+    resp = helpers.post_for_spending_endpoint(
+        client, url, award_type_codes=["07"], def_codes=["L", "M"], sort="description"
+    )
     expected_results = {
         "results": [
             {
@@ -230,7 +237,9 @@ def test_correct_response_with_award_type_codes(
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_results
 
-    resp = helpers.post_for_spending_endpoint(client, url, award_type_codes=["08"], def_codes=["L", "M"])
+    resp = helpers.post_for_spending_endpoint(
+        client, url, award_type_codes=["08"], def_codes=["L", "M"], sort="description"
+    )
     expected_results = {
         "results": [
             {

--- a/usaspending_api/disaster/tests/integration/test_cfda_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_spending.py
@@ -209,7 +209,7 @@ def test_pagination_page_and_limit(
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
-    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], page=2, limit=1)
+    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], page=2, limit=1, sort="description")
     expected_results = {
         "results": [
             {

--- a/usaspending_api/disaster/tests/integration/test_disaster_agency_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_agency_loans.py
@@ -14,7 +14,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_award_index,
     resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M", "N", "O", "P"])
     expected_results = [
         {
-            "id": 8,
+            "id": 3,
             "code": "008",
             "description": "Agency 008",
             "children": [],
@@ -22,7 +22,17 @@ def test_basic_success(client, disaster_account_data, elasticsearch_award_index,
             "obligation": 2000.0,
             "outlay": 20000.0,
             "face_value_of_loan": 333.0,
-        }
+        },
+        {
+            "id": 2,
+            "code": "008",
+            "description": "Agency 008",
+            "children": [],
+            "count": 0,
+            "obligation": 2000.0,
+            "outlay": 20000.0,
+            "face_value_of_loan": 333.0,
+        },
     ]
 
     assert resp.status_code == status.HTTP_200_OK
@@ -45,7 +55,7 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
     )
     expected_results = [
         {
-            "id": 7,
+            "id": 1,
             "code": "007",
             "description": "Agency 007",
             "count": 1,
@@ -54,7 +64,7 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
             "face_value_of_loan": 333.0,
             "children": [
                 {
-                    "id": 1007,
+                    "id": 1,
                     "code": "1007",
                     "description": "Subtier 1007",
                     "count": 1,

--- a/usaspending_api/disaster/tests/integration/test_disaster_agency_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_agency_spending.py
@@ -11,7 +11,9 @@ url = "/api/v2/disaster/agency/spending/"
 def test_basic_success(client, disaster_account_data, elasticsearch_award_index, monkeypatch, helpers):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
-    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M", "N", "O", "P"], spending_type="total")
+    resp = helpers.post_for_spending_endpoint(
+        client, url, def_codes=["L", "M", "N", "O", "P"], spending_type="total", sort="description"
+    )
     expected_results = [
         {
             "id": 9,
@@ -68,7 +70,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_award_index,
     resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M", "N", "O", "P"], spending_type="award")
     expected_results = [
         {
-            "id": 9,
+            "id": 4,
             "code": "009",
             "description": "Agency 009",
             "children": [],
@@ -78,7 +80,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_award_index,
             "total_budgetary_resources": None,
         },
         {
-            "id": 8,
+            "id": 3,
             "code": "008",
             "description": "Agency 008",
             "children": [],
@@ -88,7 +90,17 @@ def test_basic_success(client, disaster_account_data, elasticsearch_award_index,
             "total_budgetary_resources": None,
         },
         {
-            "id": 7,
+            "id": 2,
+            "code": "008",
+            "description": "Agency 008",
+            "children": [],
+            "count": 0,
+            "obligation": 22000.0,
+            "outlay": 20000.0,
+            "total_budgetary_resources": None,
+        },
+        {
+            "id": 1,
             "code": "007",
             "description": "Agency 007",
             "children": [],
@@ -113,33 +125,43 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
     )
     expected_results = [
         {
-            "id": 8,
+            "id": 3,
             "code": "008",
             "description": "Agency 008",
-            "count": 3,
-            "obligation": 22220218.0,
+            "count": 2,
+            "obligation": 20220218.0,
             "outlay": 0.0,
             "children": [
                 {
-                    "id": 2008,
+                    "id": 3,
                     "code": "2008",
                     "description": "Subtier 2008",
                     "count": 2,
                     "obligation": 20220218.0,
                     "outlay": 0.0,
-                },
+                }
+            ],
+        },
+        {
+            "id": 2,
+            "code": "008",
+            "description": "Agency 008",
+            "count": 1,
+            "obligation": 2000000.0,
+            "outlay": 0.0,
+            "children": [
                 {
-                    "id": 1008,
+                    "id": 2,
                     "code": "1008",
                     "description": "Subtier 1008",
                     "count": 1,
                     "obligation": 2000000.0,
                     "outlay": 0.0,
-                },
+                }
             ],
         },
         {
-            "id": 7,
+            "id": 1,
             "code": "007",
             "description": "Agency 007",
             "count": 1,
@@ -147,7 +169,7 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
             "outlay": 0.0,
             "children": [
                 {
-                    "id": 1007,
+                    "id": 1,
                     "code": "1007",
                     "description": "Subtier 1007",
                     "count": 1,
@@ -166,7 +188,7 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
     )
     expected_results = [
         {
-            "id": 8,
+            "id": 3,
             "code": "008",
             "description": "Agency 008",
             "count": 1,
@@ -174,7 +196,7 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
             "outlay": 0.0,
             "children": [
                 {
-                    "id": 2008,
+                    "id": 3,
                     "code": "2008",
                     "description": "Subtier 2008",
                     "count": 1,
@@ -193,31 +215,34 @@ def test_award_type_codes(client, disaster_account_data, elasticsearch_award_ind
     )
     expected_results = [
         {
-            "id": 8,
+            "id": 3,
             "code": "008",
             "description": "Agency 008",
-            "count": 2,
-            "obligation": 1999998.0,
+            "count": 1,
+            "obligation": -2.0,
+            "outlay": 0.0,
+            "children": [
+                {"id": 3, "code": "2008", "description": "Subtier 2008", "count": 1, "obligation": -2.0, "outlay": 0.0}
+            ],
+        },
+        {
+            "id": 2,
+            "code": "008",
+            "description": "Agency 008",
+            "count": 1,
+            "obligation": 2000000.0,
             "outlay": 0.0,
             "children": [
                 {
-                    "id": 2008,
-                    "code": "2008",
-                    "description": "Subtier 2008",
-                    "count": 1,
-                    "obligation": -2.0,
-                    "outlay": 0.0,
-                },
-                {
-                    "id": 1008,
+                    "id": 2,
                     "code": "1008",
                     "description": "Subtier 1008",
                     "count": 1,
                     "obligation": 2000000.0,
                     "outlay": 0.0,
-                },
+                }
             ],
-        }
+        },
     ]
 
     assert resp.status_code == status.HTTP_200_OK

--- a/usaspending_api/disaster/tests/integration/test_recipient_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_recipient_loans.py
@@ -156,7 +156,7 @@ def test_missing_defc(client, monkeypatch, helpers, elasticsearch_award_index, a
 def test_pagination_page_and_limit(client, monkeypatch, helpers, elasticsearch_award_index, awards_and_transactions):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
-    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], page=2, limit=1)
+    resp = helpers.post_for_spending_endpoint(client, url, def_codes=["L", "M"], page=2, limit=1, sort="description")
     expected_results = {
         "results": [
             {
@@ -199,7 +199,9 @@ def test_correct_response_with_award_type_codes(
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
-    resp = helpers.post_for_spending_endpoint(client, url, award_type_codes=["07"], def_codes=["L", "M"])
+    resp = helpers.post_for_spending_endpoint(
+        client, url, award_type_codes=["07"], def_codes=["L", "M"], sort="description"
+    )
     expected_results = {
         "results": [
             {
@@ -235,7 +237,9 @@ def test_correct_response_with_award_type_codes(
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_results
 
-    resp = helpers.post_for_spending_endpoint(client, url, award_type_codes=["08"], def_codes=["L", "M"])
+    resp = helpers.post_for_spending_endpoint(
+        client, url, award_type_codes=["08"], def_codes=["L", "M"], sort="description"
+    )
     expected_results = {
         "results": [
             {

--- a/usaspending_api/disaster/tests/integration/test_recipient_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_recipient_spending.py
@@ -232,6 +232,9 @@ def test_pagination_page_and_limit(client, monkeypatch, helpers, elasticsearch_a
             "hasNext": True,
             "hasPrevious": True,
         },
+        "message": "Notice! API Request to sort on 'id' field isn't fully "
+        "implemented. Results were actually sorted using 'description' "
+        "field.",
     }
 
     assert resp.status_code == status.HTTP_200_OK

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -74,7 +74,7 @@ class LoansByAgencyViewSet(LoansPaginationMixin, LoansMixin, DisasterBase):
         ]
 
         annotations = {
-            "id": F("treasury_account__funding_toptier_agency"),
+            "id": F("treasury_account__funding_toptier_agency__agency"),
             "code": F("treasury_account__funding_toptier_agency__toptier_code"),
             "description": F("treasury_account__funding_toptier_agency__name"),
             # Currently, this endpoint can never have children.
@@ -96,7 +96,7 @@ class LoansByAgencyViewSet(LoansPaginationMixin, LoansMixin, DisasterBase):
         return (
             FinancialAccountsByAwards.objects.filter(*filters)
             .values(
-                "treasury_account__funding_toptier_agency",
+                "treasury_account__funding_toptier_agency__agency",
                 "treasury_account__funding_toptier_agency__toptier_code",
                 "treasury_account__funding_toptier_agency__name",
             )

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -146,7 +146,7 @@ class SpendingByAgencyViewSet(PaginationMixin, SpendingMixin, DisasterBase):
         ]
 
         annotations = {
-            "id": F("treasury_account__funding_toptier_agency"),
+            "id": F("treasury_account__funding_toptier_agency__agency"),
             "code": F("treasury_account__funding_toptier_agency__toptier_code"),
             "description": F("treasury_account__funding_toptier_agency__name"),
             # Currently, this endpoint can never have children.
@@ -168,7 +168,7 @@ class SpendingByAgencyViewSet(PaginationMixin, SpendingMixin, DisasterBase):
         return (
             FinancialAccountsByAwards.objects.filter(*filters)
             .values(
-                "treasury_account__funding_toptier_agency",
+                "treasury_account__funding_toptier_agency__agency",
                 "treasury_account__funding_toptier_agency__toptier_code",
                 "treasury_account__funding_toptier_agency__name",
             )

--- a/usaspending_api/disaster/v2/views/elasticsearch_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_base.py
@@ -24,9 +24,9 @@ class ElasticsearchSpendingPaginationMixin(_BasePaginationMixin):
     sum_column_mapping = {"obligation": "total_covid_obligation", "outlay": "total_covid_outlay"}
     sort_column_mapping = {
         "count": "_count",
-        "description": "_key",  # True sort field
-        "code": "_key",  # Fake sort, really sorting on description
-        "id": "_key",  # Fake sort, really sorting on description
+        "description": "_key",  # _key will ultimately sort on description value
+        "code": "_key",  # Façade sort behavior, really sorting on description
+        "id": "_key",  # Façade sort, really sorting on description
         **sum_column_mapping,
     }
 
@@ -43,9 +43,9 @@ class ElasticsearchLoansPaginationMixin(_BasePaginationMixin):
     }
     sort_column_mapping = {
         "count": "_count",
-        "description": "_key",  # True sort field
-        "code": "_key",  # Fake sort, really sorting on description
-        "id": "_key",  # Fake sort, really sorting on description
+        "description": "_key",  # _key will ultimately sort on description value
+        "code": "_key",  # Façade sort behavior, really sorting on description
+        "id": "_key",  # Façade sort, really sorting on description
         **sum_column_mapping,
     }
 
@@ -97,8 +97,8 @@ class ElasticsearchDisasterBase(DisasterBase):
 
         if self.pagination.sort_key in ("id", "code"):
             response["message"] = (
-                f"Notice! API Requests to sort on '{self.pagination.sort_key}' field isn't fully implemented."
-                " Results were actually sorted by 'description'"
+                f"Notice! API Request to sort on '{self.pagination.sort_key}' field isn't fully implemented."
+                " Results were actually sorted using 'description' field."
             )
 
         return Response(response)


### PR DESCRIPTION
**Description:**
Original implementation returned the values from `id` in `toptier_agency` instead of `agency`

**Technical details:**
Required ES re-index of awards index

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5635](https://federal-spending-transparency.atlassian.net/browse/DEV-5635):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to matviews
```
