### PR TITLE
[DEV-5666] Add 'award_count' to disaster/spending_by_geography

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/disaster/spending_by_geography.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/spending_by_geography.md
@@ -67,21 +67,24 @@ This endpoint provides geographical spending information from emergency/disaster
                         "amount": 4771026.93,
                         "display_name": "North Dakota",
                         "population": 762062,
-                        "per_capita": 6.26
+                        "per_capita": 6.26,
+                        "award_count": 185
                     },
                     {
                         "shape_code": "NV",
                         "amount": 26928552.59,
                         "display_name": "Nevada",
                         "population": 3080156,
-                        "per_capita": 8.74
+                        "per_capita": 8.74,
+                        "award_count": 124
                     },
                     {
                         "shape_code": "OH",
                         "amount": 187505278.16,
                         "display_name": "Ohio",
                         "population": 11689100,
-                        "per_capita": 16.04
+                        "per_capita": 16.04,
+                        "award_count": 134
                     }
                 ]
             }
@@ -100,6 +103,7 @@ This endpoint provides geographical spending information from emergency/disaster
 + `shape_code` (required, string)
 + `population` (required, number, nullable)
 + `per_capita` (required, number, nullable)
++ `award_count` (required, number)
 
 
 ## DEFC (enum[string])

--- a/usaspending_api/disaster/tests/fixtures/recipient_location_data.py
+++ b/usaspending_api/disaster/tests/fixtures/recipient_location_data.py
@@ -41,9 +41,9 @@ def awards_and_transactions():
     sub1 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2022,
-        reporting_fiscal_period=7,
+        reporting_fiscal_period=8,
         quarter_format_flag=False,
-        reporting_period_start="2022-04-01",
+        reporting_period_start="2022-05-01",
     )
     sub2 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -55,9 +55,9 @@ def awards_and_transactions():
     sub3 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2022,
-        reporting_fiscal_period=7,
+        reporting_fiscal_period=8,
         quarter_format_flag=False,
-        reporting_period_start="2022-04-01",
+        reporting_period_start="2022-05-01",
     )
 
     # Financial Accounts by Awards

--- a/usaspending_api/disaster/tests/integration/test_recipient_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_recipient_loans.py
@@ -44,7 +44,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
             "face_value_of_loan": 30.0,
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
-            "outlay": 0.0,
+            "outlay": 10.0,
         },
         {
             "code": "DUNS Number not provided",
@@ -53,7 +53,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
             "face_value_of_loan": 3.0,
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
-            "outlay": 0.0,
+            "outlay": 1.0,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -84,7 +84,7 @@ def test_correct_response_multiple_defc(
             "face_value_of_loan": 30.0,
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
-            "outlay": 0.0,
+            "outlay": 10.0,
         },
         {
             "code": "DUNS Number not provided",
@@ -93,7 +93,7 @@ def test_correct_response_multiple_defc(
             "face_value_of_loan": 3.0,
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
-            "outlay": 0.0,
+            "outlay": 1.0,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -166,7 +166,7 @@ def test_pagination_page_and_limit(client, monkeypatch, helpers, elasticsearch_a
                 "face_value_of_loan": 30.0,
                 "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
                 "obligation": 20.0,
-                "outlay": 0.0,
+                "outlay": 10.0,
             }
         ],
         "page_metadata": {
@@ -209,7 +209,7 @@ def test_correct_response_with_award_type_codes(
                 "face_value_of_loan": 30.0,
                 "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
                 "obligation": 20.0,
-                "outlay": 0.0,
+                "outlay": 10.0,
             },
             {
                 "code": "DUNS Number not provided",
@@ -218,7 +218,7 @@ def test_correct_response_with_award_type_codes(
                 "face_value_of_loan": 3.0,
                 "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
                 "obligation": 2.0,
-                "outlay": 0.0,
+                "outlay": 1.0,
             },
         ],
         "page_metadata": {

--- a/usaspending_api/disaster/tests/integration/test_recipient_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_recipient_spending.py
@@ -38,7 +38,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
             "description": "RECIPIENT 2",
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
-            "outlay": 0.0,
+            "outlay": 10.0,
         },
         {
             "code": "DUNS Number not provided",
@@ -46,7 +46,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
             "description": "RECIPIENT 1",
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
-            "outlay": 0.0,
+            "outlay": 1.0,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -67,7 +67,7 @@ def test_correct_response_multiple_defc(
             "description": "RECIPIENT 3",
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
             "obligation": 202200.0,
-            "outlay": 1100.0,
+            "outlay": 101100.0,
         },
         {
             "code": "456789123",
@@ -75,7 +75,7 @@ def test_correct_response_multiple_defc(
             "description": "RECIPIENT 2",
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
-            "outlay": 0.0,
+            "outlay": 10.0,
         },
         {
             "code": "DUNS Number not provided",
@@ -83,7 +83,7 @@ def test_correct_response_multiple_defc(
             "description": "RECIPIENT 1",
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
-            "outlay": 0.0,
+            "outlay": 1.0,
         },
         {
             "code": "096354360",
@@ -91,7 +91,7 @@ def test_correct_response_multiple_defc(
             "description": "MULTIPLE RECIPIENTS",
             "id": None,
             "obligation": 20000.0,
-            "outlay": 0.0,
+            "outlay": 10000.0,
         },
         {
             "code": "DUNS Number not provided",
@@ -99,7 +99,7 @@ def test_correct_response_multiple_defc(
             "description": "MULTIPLE RECIPIENTS",
             "id": None,
             "obligation": 2000000.0,
-            "outlay": 0.0,
+            "outlay": 1000000.0,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -123,7 +123,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
             "description": "RECIPIENT 3",
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
             "obligation": 202200.0,
-            "outlay": 1100.0,
+            "outlay": 101100.0,
         }
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -157,7 +157,7 @@ def test_correct_response_with_award_type_codes(
             "description": "RECIPIENT 2",
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
-            "outlay": 0.0,
+            "outlay": 10.0,
         },
         {
             "code": "DUNS Number not provided",
@@ -165,7 +165,7 @@ def test_correct_response_with_award_type_codes(
             "description": "RECIPIENT 1",
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
-            "outlay": 0.0,
+            "outlay": 1.0,
         },
         {
             "code": "096354360",
@@ -173,7 +173,7 @@ def test_correct_response_with_award_type_codes(
             "description": "MULTIPLE RECIPIENTS",
             "id": None,
             "obligation": 20000.0,
-            "outlay": 0.0,
+            "outlay": 10000.0,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -220,7 +220,7 @@ def test_pagination_page_and_limit(client, monkeypatch, helpers, elasticsearch_a
                 "description": "RECIPIENT 2",
                 "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
                 "obligation": 20.0,
-                "outlay": 0.0,
+                "outlay": 10.0,
             }
         ],
         "page_metadata": {

--- a/usaspending_api/disaster/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/disaster/tests/integration/test_spending_by_geography.py
@@ -128,6 +128,7 @@ def _test_correct_response_for_county(client):
                 "per_capita": 2000220.0,
                 "population": 1,
                 "shape_code": "45001",
+                "award_count": 3,
             },
             {
                 "amount": 200000.0,
@@ -135,6 +136,7 @@ def _test_correct_response_for_county(client):
                 "per_capita": 20000.0,
                 "population": 10,
                 "shape_code": "45005",
+                "award_count": 1,
             },
         ],
         "messages": [get_time_period_message()],
@@ -164,6 +166,7 @@ def _test_correct_response_for_district(client):
                 "per_capita": None,
                 "population": None,
                 "shape_code": "4510",
+                "award_count": 1,
             },
             {
                 "amount": 200200.0,
@@ -171,8 +174,16 @@ def _test_correct_response_for_district(client):
                 "per_capita": 2002.0,
                 "population": 100,
                 "shape_code": "4550",
+                "award_count": 2,
             },
-            {"amount": 22000.0, "display_name": "WA-50", "per_capita": 22.0, "population": 1000, "shape_code": "5350"},
+            {
+                "amount": 22000.0,
+                "display_name": "WA-50",
+                "per_capita": 22.0,
+                "population": 1000,
+                "shape_code": "5350",
+                "award_count": 2,
+            },
         ],
         "messages": [get_time_period_message()],
     }
@@ -195,6 +206,7 @@ def _test_correct_response_for_state(client):
                 "per_capita": 2.2,
                 "population": 10000,
                 "shape_code": "WA",
+                "award_count": 2,
             },
         ],
         "messages": [get_time_period_message()],
@@ -236,6 +248,7 @@ def _test_correct_response_for_obligation(client):
                 "per_capita": 2200.22,
                 "population": 1000,
                 "shape_code": "SC",
+                "award_count": 4,
             },
             {
                 "amount": 22000.0,
@@ -243,6 +256,7 @@ def _test_correct_response_for_obligation(client):
                 "per_capita": 2.2,
                 "population": 10000,
                 "shape_code": "WA",
+                "award_count": 2,
             },
         ],
         "messages": [get_time_period_message()],
@@ -263,18 +277,20 @@ def _test_correct_response_for_outlay(client):
         "spending_type": "outlay",
         "results": [
             {
-                "amount": 100.0,
+                "amount": 1100110.0,
                 "display_name": "South Carolina",
-                "per_capita": 0.1,
+                "per_capita": 1100.11,
                 "population": 1000,
                 "shape_code": "SC",
+                "award_count": 4,
             },
             {
-                "amount": 1000.0,
+                "amount": 11000.0,
                 "display_name": "Washington",
-                "per_capita": 0.1,
+                "per_capita": 1.1,
                 "population": 10000,
                 "shape_code": "WA",
+                "award_count": 2,
             },
         ],
         "messages": [get_time_period_message()],
@@ -304,8 +320,16 @@ def _test_correct_response_for_face_value_of_loan(client):
                 "per_capita": 0.33,
                 "population": 1000,
                 "shape_code": "SC",
+                "award_count": 4,
             },
-            {"amount": 0.0, "display_name": "Washington", "per_capita": 0.0, "population": 10000, "shape_code": "WA"},
+            {
+                "amount": 0.0,
+                "display_name": "Washington",
+                "per_capita": 0.0,
+                "population": 10000,
+                "shape_code": "WA",
+                "award_count": 2,
+            },
         ],
         "messages": [get_time_period_message()],
     }
@@ -342,7 +366,14 @@ def _test_correct_response_of_loans(client):
         "geo_layer": "county",
         "spending_type": "obligation",
         "results": [
-            {"amount": 220.0, "display_name": "Charleston", "per_capita": 220.0, "population": 1, "shape_code": "45001"}
+            {
+                "amount": 220.0,
+                "display_name": "Charleston",
+                "per_capita": 220.0,
+                "population": 1,
+                "shape_code": "45001",
+                "award_count": 2,
+            }
         ],
         "messages": [get_time_period_message()],
     }
@@ -372,6 +403,7 @@ def _test_correct_response_of_contracts(client):
                 "per_capita": None,
                 "population": None,
                 "shape_code": "4510",
+                "award_count": 1,
             },
             {
                 "amount": 200000.0,
@@ -379,8 +411,16 @@ def _test_correct_response_of_contracts(client):
                 "per_capita": 2000.0,
                 "population": 100,
                 "shape_code": "4550",
+                "award_count": 1,
             },
-            {"amount": 22000.0, "display_name": "WA-50", "per_capita": 22.0, "population": 1000, "shape_code": "5350"},
+            {
+                "amount": 22000.0,
+                "display_name": "WA-50",
+                "per_capita": 22.0,
+                "population": 1000,
+                "shape_code": "5350",
+                "award_count": 2,
+            },
         ],
         "messages": [get_time_period_message()],
     }

--- a/usaspending_api/disaster/v2/views/spending_by_geography.py
+++ b/usaspending_api/disaster/v2/views/spending_by_geography.py
@@ -163,6 +163,7 @@ class SpendingByGeographyViewSet(DisasterBase):
                 "shape_code": shape_code or None,
                 "population": population,
                 "per_capita": per_capita,
+                "award_count": int(bucket.get("doc_count", 0)),
             }
 
         return results


### PR DESCRIPTION
**Description:**
Add `award_count` to the /v2/disaster/spending_by_geography endpoint.

**Technical details:**
Populate the `award_count` on the response using the `doc_count` attribute of each bucket. This value represents the number of documents that go into each aggregation bucket, which in this case is the number of awards since it uses the Awards Index with each document being a different Award.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [X] Matview impact assessment completed (N/A)
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created (N/A)
8. [X] Jira Ticket [DEV-5666](https://federal-spending-transparency.atlassian.net/browse/DEV-5666):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
