### PR TITLE
[DEV-5548] DEFC subaward download

### DIFF
--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -494,7 +494,7 @@ def test_download_awards_with_all_award_types(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 9
-    assert resp.json()["total_columns"] == 558
+    assert resp.json()["total_columns"] == 568
 
 
 def test_download_awards_with_all_prime_awards(client, award_data):
@@ -560,7 +560,7 @@ def test_download_awards_with_all_sub_awards(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 3  # 2 awards, but 1 file with 2 rows and 1 file with 1
-    assert resp.json()["total_columns"] == 186
+    assert resp.json()["total_columns"] == 196
 
 
 def test_download_awards_with_some_sub_awards(client, award_data):
@@ -582,7 +582,7 @@ def test_download_awards_with_some_sub_awards(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 2
-    assert resp.json()["total_columns"] == 91
+    assert resp.json()["total_columns"] == 96
 
 
 def test_download_awards_with_domestic_scope(client, award_data):
@@ -607,7 +607,7 @@ def test_download_awards_with_domestic_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 558
+    assert resp.json()["total_columns"] == 568
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
@@ -630,7 +630,7 @@ def test_download_awards_with_domestic_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 558
+    assert resp.json()["total_columns"] == 568
 
 
 def test_download_awards_with_foreign_scope(client, award_data):
@@ -655,7 +655,7 @@ def test_download_awards_with_foreign_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 558
+    assert resp.json()["total_columns"] == 568
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
@@ -678,7 +678,7 @@ def test_download_awards_with_foreign_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 558
+    assert resp.json()["total_columns"] == 568
 
 
 @pytest.mark.django_db

--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -332,5 +332,60 @@ def subaward_annotations():
         "usaspending_permalink": Concat(
             Value(AWARD_URL), Func(F("award__generated_unique_award_id"), function="urlencode"), Value("/")
         ),
+        "prime_award_disaster_emergency_fund_codes": Case(
+            When(
+                broker_subaward__action_date__gte=datetime.date(2020, 4, 1),
+                then=Subquery(
+                    FinancialAccountsByAwards.objects.filter(
+                        award_id=OuterRef("award_id"), disaster_emergency_fund__isnull=False
+                    )
+                    .annotate(
+                        value=ExpressionWrapper(
+                            Concat(
+                                F("disaster_emergency_fund__code"),
+                                Value(": "),
+                                F("disaster_emergency_fund__public_law"),
+                            ),
+                            output_field=TextField(),
+                        )
+                    )
+                    .values("award_id")
+                    .annotate(total=StringAgg("value", ";", distinct=True))
+                    .values("total"),
+                    output_field=TextField(),
+                ),
+            )
+        ),
+        "prime_award_outlayed_amount_funded_by_COVID-19_supplementals": Case(
+            When(
+                broker_subaward__action_date__gte=datetime.date(2020, 4, 1),
+                then=Subquery(
+                    FinancialAccountsByAwards.objects.filter(
+                        filter_by_latest_closed_periods(),
+                        award_id=OuterRef("award_id"),
+                        # disaster_emergency_fund__group_name="covid_19",
+                    )
+                    .values("award_id")
+                    .annotate(sum=Sum("gross_outlay_amount_by_award_cpe"))
+                    .values("sum"),
+                    output_field=DecimalField(),
+                ),
+            ),
+        ),
+        "prime_award_obligated_amount_funded_by_COVID-19_supplementals": Case(
+            When(
+                broker_subaward__action_date__gte=datetime.date(2020, 4, 1),
+                then=Subquery(
+                    FinancialAccountsByAwards.objects.filter(
+                        award_id=OuterRef("award_id"),  # disaster_emergency_fund__group_name="covid_19"
+                    )
+                    .values("award_id")
+                    .annotate(sum=Sum("transaction_obligated_amount"))
+                    .values("sum"),
+                    output_field=DecimalField(),
+                ),
+            ),
+        ),
+        "prime_award_latest_action_date_fiscal_year": FiscalYear("award__latest_transaction__action_date"),
     }
     return annotation_fields

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -262,6 +262,7 @@ ROW_CONSTRAINT_FILTER_DEFAULTS = {
     "federal_account_ids": [],
     "object_class_ids": [],
     "program_activity_ids": [],
+    "def_codes": [],
 }
 ACCOUNT_FILTER_DEFAULTS = {
     "agency": "all",

--- a/usaspending_api/download/tests/unit/test_file_generation.py
+++ b/usaspending_api/download/tests/unit/test_file_generation.py
@@ -33,7 +33,7 @@ def test_get_transactions_csv_sources(db):
     assert csv_sources[1].source_type == "transactions"
 
 
-def test_get_sub_awards_csv_sources():
+def test_get_sub_awards_csv_sources(db):
     original = VALUE_MAPPINGS["sub_awards"]["filter_function"]
     VALUE_MAPPINGS["sub_awards"]["filter_function"] = MagicMock(returned_value="")
     csv_sources = download_generation.get_download_sources(

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1241,8 +1241,19 @@ query_paths = {
                 ("prime_award_piid", "broker_subaward__award_id"),
                 ("prime_award_parent_piid", "broker_subaward__parent_award_id"),
                 ("prime_award_amount", "broker_subaward__award_amount"),
+                ("prime_award_disaster_emergency_fund_codes", None),  # Annotation is used to create this column
+                (
+                    "prime_award_outlayed_amount_funded_by_COVID-19_supplementals",
+                    None,
+                ),  # Annotation is used to create this column
+                (
+                    "prime_award_obligated_amount_funded_by_COVID-19_supplementals",
+                    None,
+                ),  # Annotation is used to create this column
                 ("prime_award_base_action_date", "broker_subaward__action_date"),
                 ("prime_award_base_action_date_fiscal_year", None),  # Annotation is used to create this column
+                ("prime_award_latest_action_date", "award__latest_transaction__action_date"),
+                ("prime_award_latest_action_date_fiscal_year", None),  # Annotation is used to create this column
                 ("prime_award_period_of_performance_start_date", "award__period_of_performance_start_date"),
                 ("prime_award_period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("period_of_performance_potential_end_date", None),  # Annotation is used to create this column
@@ -1369,8 +1380,19 @@ query_paths = {
                 ("prime_award_unique_key", "broker_subaward__unique_award_key"),
                 ("prime_award_fain", "broker_subaward__award_id"),
                 ("prime_award_amount", "broker_subaward__award_amount"),
+                ("prime_award_disaster_emergency_fund_codes", None),  # Annotation is used to create this column
+                (
+                    "prime_award_outlayed_amount_funded_by_COVID-19_supplementals",
+                    None,
+                ),  # Annotation is used to create this column
+                (
+                    "prime_award_obligated_amount_funded_by_COVID-19_supplementals",
+                    None,
+                ),  # Annotation is used to create this column
                 ("prime_award_base_action_date", "broker_subaward__action_date"),
                 ("prime_award_base_action_date_fiscal_year", None),  # Annotation is used to create this column
+                ("prime_award_latest_action_date", "award__latest_transaction__action_date"),
+                ("prime_award_latest_action_date_fiscal_year", None),  # Annotation is used to create this column
                 ("prime_award_period_of_performance_start_date", "award__period_of_performance_start_date"),
                 ("prime_award_period_of_performance_current_end_date", "award__period_of_performance_current_end_date"),
                 ("prime_award_awarding_agency_code", "broker_subaward__awarding_agency_code"),


### PR DESCRIPTION
**Description:**
Adds disaster emergency fund codes and covid-related obligations and outlays to the subaward download files.

**Technical details:**
DEFC and covid spending are added, summed as usual, and have 
**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [n/a] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5548](https://federal-spending-transparency.atlassian.net/browse/DEV-5548):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
