### PR TITLE
[DEV-5706] Improving Sorting and fixed items from DEV-5621

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md
@@ -67,13 +67,13 @@ Returns loan spending details of Agencies receiving supplemental funding budgeta
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[enum[string]], fixed-type)  
++ `award_type_codes` (optional, array[enum[string]], fixed-type)
     Only accepts loan award type `07` or `08` in the array, since this endpoint is specific to loans.
 
     If ANY award type codes are provided, loan amounts will be summed for the distinct set of toptier agencies,
     whose subtier agencies funded loan awards linked to `FinancialAccountsByAwards` records (which are derived from DABS File C).
 
-    If this parameter is not provided, loan amounts will be summed for a different set of agencies: 
+    If this parameter is not provided, loan amounts will be summed for a different set of agencies:
     the distinct set of toptier agencies "owning" appropriations accounts used in funding _any_ award spending
     for this disaster (i.e. from agencies "owning" Treasury Account Symbol (TAS) accounts on `FinancialAccountsByAwards`
     records, which are derived from DABS File C).
@@ -104,7 +104,7 @@ Returns loan spending details of Agencies receiving supplemental funding budgeta
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `face_value_of_loan`
         + `obligation`
         + `outlay`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md
@@ -72,7 +72,7 @@ Returns spending details of Agencies receiving supplemental funding budgetary re
 
 ## Filter (object)
 + `def_codes` (required, array[DEFC], fixed-type)
-+ `award_type_codes` (optional, array[AwardTypeCodes], fixed-type)  
++ `award_type_codes` (optional, array[AwardTypeCodes], fixed-type)
     Only to be used when `"spending_type": "award"`.
 
     If ANY award type codes are provided, obligation and outlay spending amounts will be summed for the distinct set of toptier
@@ -105,7 +105,7 @@ Returns spending details of Agencies receiving supplemental funding budgetary re
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `total_budgetary_resources`
         + `obligation`
         + `outlay`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/award/amount.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/award/amount.md
@@ -24,13 +24,13 @@ This endpoint provides the Account obligation and outlay aggregations of Awards
     + Attributes (object)
         + `obligation` (required, number)
         + `outlay` (required, number)
-        + `count` (required, number)
+        + `award_count` (required, number)
     + Body
 
             {
                 "obligation": 32984563875,
                 "outlay": 15484564321,
-                "count": 42
+                "award_count": 42
             }
 
 

--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/loans.md
@@ -33,7 +33,7 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
                 "results": [
                     {
                         "code": "20.200",
-                        "count": 2,
+                        "award_count": 2,
                         "description": "CFDA 2",
                         "face_value_of_loan": 330.0,
                         "id": 200,
@@ -43,7 +43,7 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
                     },
                     {
                         "code": "10.100",
-                        "count": 1,
+                        "award_count": 1,
                         "description": "CFDA 1",
                         "face_value_of_loan": 3.0,
                         "id": 100,
@@ -96,7 +96,7 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `face_value_of_loan`
         + `obligation`
         + `outlay`
@@ -105,7 +105,7 @@ Returns loan spending details of CFDA Programs receiving supplemental funding bu
 + `id` (required, string)
 + `code` (required, string)
 + `description` (required, string)
-+ `count` (required, number)
++ `award_count` (required, number)
 + `face_value_of_loan` (required, number, nullable)
 + `obligation` (required, number, nullable)
 + `outlay` (required, number, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/cfda/spending.md
@@ -38,7 +38,7 @@ Returns spending details of CFDA receiving supplemental funding budgetary resour
                 "results": [
                     {
                         "code": "20.200",
-                        "count": 1,
+                        "award_count": 1,
                         "description": "CFDA 2",
                         "id": 200,
                         "obligation": 20.0,
@@ -47,7 +47,7 @@ Returns spending details of CFDA receiving supplemental funding budgetary resour
                     },
                     {
                         "code": "10.100",
-                        "count": 1,
+                        "award_count": 1,
                         "description": "CFDA 1",
                         "id": 100,
                         "obligation": 2.0,
@@ -95,7 +95,7 @@ Returns spending details of CFDA receiving supplemental funding budgetary resour
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `obligation`
         + `outlay`
 
@@ -103,7 +103,7 @@ Returns spending details of CFDA receiving supplemental funding budgetary resour
 + `id` (required, string)
 + `code` (required, string)
 + `description` (required, string)
-+ `count` (required, number)
++ `award_count` (required, number)
 + `obligation` (required, number, nullable)
 + `outlay` (required, number, nullable)
 + `resource_link` (required, string, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/disaster/federal_account/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/federal_account/loans.md
@@ -90,7 +90,7 @@ Returns loan spending details of Federal Accounts receiving supplemental funding
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `face_value_of_loan`
         + `obligation`
         + `outlay`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/federal_account/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/federal_account/spending.md
@@ -128,7 +128,7 @@ Returns spending details of Federal Account and TAS receiving supplemental fundi
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `total_budgetary_resources`
         + `obligation`
         + `outlay`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/object_class/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/object_class/loans.md
@@ -90,7 +90,7 @@ Returns loan spending details of Object Classes receiving supplemental funding b
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `face_value_of_loan`
         + `obligation`
         + `outlay`

--- a/usaspending_api/api_contracts/contracts/v2/disaster/object_class/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/object_class/spending.md
@@ -102,7 +102,7 @@ Returns spending details of Object Classes receiving supplemental funding budget
         + `id`
         + `code`
         + `description`
-        + `count`
+        + `award_count`
         + `obligation`
         + `outlay`
 

--- a/usaspending_api/api_contracts/contracts/v2/disaster/recipient/loans.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/recipient/loans.md
@@ -33,7 +33,7 @@ Returns loan spending details of recipients receiving supplemental funding budge
                 "results": [
                     {
                         "code": "987654321",
-                        "count": 2,
+                        "award_count": 2,
                         "description": "RECIPIENT 3",
                         "face_value_of_loan": 100.0,
                         "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
@@ -42,7 +42,7 @@ Returns loan spending details of recipients receiving supplemental funding budge
                     },
                     {
                         "code": "456789123",
-                        "count": 1,
+                        "award_count": 1,
                         "description": "RECIPIENT 2",
                         "face_value_of_loan": 200.0,
                         "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -92,7 +92,7 @@ Returns loan spending details of recipients receiving supplemental funding budge
     + Default: `description`
     + Members
         + `description`
-        + `count`
+        + `award_count`
         + `face_value_of_loan`
         + `obligation`
         + `outlay`
@@ -102,7 +102,7 @@ Returns loan spending details of recipients receiving supplemental funding budge
 + `code` (required, string)
 + `description` (required, string)
 + `children` (optional, array[Result], fixed-type)
-+ `count` (required, number)
++ `award_count` (required, number)
 + `face_value_of_loan` (required, number, nullable)
 + `obligation` (required, number, nullable)
 + `outlay` (required, number, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/disaster/recipient/spending.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/recipient/spending.md
@@ -33,7 +33,7 @@ Returns spending details of Recipients receiving supplemental funding budgetary 
                 "results": [
                     {
                         "code": "987654321",
-                        "count": 2,
+                        "award_count": 2,
                         "description": "RECIPIENT 3",
                         "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
                         "obligation": 2200.0,
@@ -41,7 +41,7 @@ Returns spending details of Recipients receiving supplemental funding budgetary 
                     },
                     {
                         "code": "456789123",
-                        "count": 1,
+                        "award_count": 1,
                         "description": "RECIPIENT 2",
                         "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
                         "obligation": 20.0,
@@ -86,7 +86,7 @@ Returns spending details of Recipients receiving supplemental funding budgetary 
     + Default: `description`
     + Members
         + `description`
-        + `count`
+        + `award_count`
         + `obligation`
         + `outlay`
 
@@ -94,7 +94,7 @@ Returns spending details of Recipients receiving supplemental funding budgetary 
 + `id` (required, array[string], fixed-type)
 + `code` (required, string)
 + `description` (required, string)
-+ `count` (required, number)
++ `award_count` (required, number)
 + `obligation` (required, number, nullable)
 + `outlay` (required, number, nullable)
 

--- a/usaspending_api/common/data_classes.py
+++ b/usaspending_api/common/data_classes.py
@@ -10,7 +10,18 @@ class Pagination:
     upper_limit: int
     sort_key: Optional[str] = None
     sort_order: Optional[str] = None
+    secondary_sort_key: Optional[str] = None
+
+    @property
+    def _sort_order(self):
+        if self.sort_order == "desc":
+            return "-"
+        return ""
 
     @property
     def order_by(self):
-        return self.sort_key if self.sort_order == "asc" else "-" + self.sort_key
+        return f"{self._sort_order}{self.sort_key}"
+
+    @property
+    def robust_order_by_fields(self):
+        return (self.order_by, f"{self._sort_order}{self.secondary_sort_key}")

--- a/usaspending_api/disaster/tests/integration/test_cfda_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_loans.py
@@ -28,7 +28,7 @@ def test_correct_response_single_defc(
     expected_results = [
         {
             "code": "20.200",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 2",
             "face_value_of_loan": 30.0,
             "id": 200,
@@ -38,7 +38,7 @@ def test_correct_response_single_defc(
         },
         {
             "code": "10.100",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 1",
             "face_value_of_loan": 3.0,
             "id": 100,
@@ -61,7 +61,7 @@ def test_correct_response_multiple_defc(
     expected_results = [
         {
             "code": "20.200",
-            "count": 2,
+            "award_count": 2,
             "description": "CFDA 2",
             "face_value_of_loan": 330.0,
             "id": 200,
@@ -71,7 +71,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "10.100",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 1",
             "face_value_of_loan": 3.0,
             "id": 100,
@@ -100,7 +100,7 @@ def test_correct_response_with_query(
     expected_results = [
         {
             "code": "20.200",
-            "count": 2,
+            "award_count": 2,
             "description": "CFDA 2",
             "face_value_of_loan": 330.0,
             "id": 200,
@@ -151,7 +151,7 @@ def test_pagination_page_and_limit(
         "results": [
             {
                 "code": "10.100",
-                "count": 1,
+                "award_count": 1,
                 "description": "CFDA 1",
                 "face_value_of_loan": 3.0,
                 "id": 100,
@@ -204,7 +204,7 @@ def test_correct_response_with_award_type_codes(
         "results": [
             {
                 "code": "20.200",
-                "count": 1,
+                "award_count": 1,
                 "description": "CFDA 2",
                 "face_value_of_loan": 30.0,
                 "id": 200,
@@ -214,7 +214,7 @@ def test_correct_response_with_award_type_codes(
             },
             {
                 "code": "10.100",
-                "count": 1,
+                "award_count": 1,
                 "description": "CFDA 1",
                 "face_value_of_loan": 3.0,
                 "id": 100,
@@ -244,7 +244,7 @@ def test_correct_response_with_award_type_codes(
         "results": [
             {
                 "code": "20.200",
-                "count": 1,
+                "award_count": 1,
                 "description": "CFDA 2",
                 "face_value_of_loan": 300.0,
                 "id": 200,

--- a/usaspending_api/disaster/tests/integration/test_cfda_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_spending.py
@@ -28,7 +28,7 @@ def test_correct_response_single_defc(
     expected_results = [
         {
             "code": "30.300",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 3",
             "id": 300,
             "obligation": 2000.0,
@@ -37,7 +37,7 @@ def test_correct_response_single_defc(
         },
         {
             "code": "20.200",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 2",
             "id": 200,
             "obligation": 20.0,
@@ -46,7 +46,7 @@ def test_correct_response_single_defc(
         },
         {
             "code": "10.100",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 1",
             "id": 100,
             "obligation": 2.0,
@@ -68,7 +68,7 @@ def test_correct_response_multiple_defc(
     expected_results = [
         {
             "code": "30.300",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 3",
             "id": 300,
             "obligation": 2000.0,
@@ -77,7 +77,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "20.200",
-            "count": 2,
+            "award_count": 2,
             "description": "CFDA 2",
             "id": 200,
             "obligation": 220.0,
@@ -86,7 +86,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "10.100",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 1",
             "id": 100,
             "obligation": 2.0,
@@ -114,7 +114,7 @@ def test_correct_response_with_query(
     expected_results = [
         {
             "code": "30.300",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 3",
             "id": 300,
             "obligation": 2000.0,
@@ -141,7 +141,7 @@ def test_correct_response_with_award_type_codes(
     expected_results = [
         {
             "code": "20.200",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 2",
             "id": 200,
             "obligation": 20.0,
@@ -150,7 +150,7 @@ def test_correct_response_with_award_type_codes(
         },
         {
             "code": "10.100",
-            "count": 1,
+            "award_count": 1,
             "description": "CFDA 1",
             "id": 100,
             "obligation": 2.0,
@@ -214,7 +214,7 @@ def test_pagination_page_and_limit(
         "results": [
             {
                 "code": "20.200",
-                "count": 2,
+                "award_count": 2,
                 "description": "CFDA 2",
                 "id": 200,
                 "obligation": 220.0,

--- a/usaspending_api/disaster/tests/integration/test_disaster_award_amount.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_award_amount.py
@@ -11,19 +11,19 @@ def test_award_amount_success(client, monkeypatch, generic_account_data, unlinke
 
     resp = helpers.post_for_amount_endpoint(client, url, ["L"], ["A", "09", "10"])
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["count"] == 1
+    assert resp.data["award_count"] == 1
     assert resp.data["outlay"] == 222
     assert resp.data["obligation"] == 200
 
     resp = helpers.post_for_amount_endpoint(client, url, ["N", "O"], ["A", "09", "10"])
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["count"] == 2
+    assert resp.data["award_count"] == 2
     assert resp.data["outlay"] == 334
     assert resp.data["obligation"] == 4
 
     resp = helpers.post_for_amount_endpoint(client, url, ["9"], ["B"])
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["count"] == 0
+    assert resp.data["award_count"] == 0
     assert resp.data["outlay"] == 0
     assert resp.data["obligation"] == 0
 
@@ -34,13 +34,13 @@ def test_award_amount_all_success(client, monkeypatch, generic_account_data, unl
 
     resp = helpers.post_for_amount_endpoint(client, url, ["N"], None)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["count"] == 3
+    assert resp.data["award_count"] == 3
     assert resp.data["outlay"] == 10889220.0
     assert resp.data["obligation"] == 1088890.0
 
     resp = helpers.post_for_amount_endpoint(client, url, ["L", "M", "N", "O", "P"], None)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["count"] == 5
+    assert resp.data["award_count"] == 5
     assert resp.data["outlay"] == 10889554.00
     assert resp.data["obligation"] == 1089191.00
 

--- a/usaspending_api/disaster/tests/integration/test_recipient_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_recipient_loans.py
@@ -30,7 +30,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
     expected_results = [
         {
             "code": "987654321",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 3",
             "face_value_of_loan": 300.0,
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
@@ -39,7 +39,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "face_value_of_loan": 30.0,
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -48,7 +48,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "face_value_of_loan": 3.0,
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
@@ -70,7 +70,7 @@ def test_correct_response_multiple_defc(
     expected_results = [
         {
             "code": "987654321",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 3",
             "face_value_of_loan": 300.0,
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
@@ -79,7 +79,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "face_value_of_loan": 30.0,
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -88,7 +88,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "face_value_of_loan": 3.0,
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
@@ -113,7 +113,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
     expected_results = [
         {
             "code": "987654321",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 3",
             "face_value_of_loan": 300.0,
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
@@ -128,7 +128,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
     expected_results = [
         {
             "code": "987654321",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 3",
             "face_value_of_loan": 300.0,
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
@@ -137,7 +137,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "face_value_of_loan": 30.0,
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -146,7 +146,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "face_value_of_loan": 3.0,
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
@@ -161,7 +161,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
     expected_results = [
         {
             "code": "987654321",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 3",
             "face_value_of_loan": 300.0,
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
@@ -170,7 +170,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "face_value_of_loan": 30.0,
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -179,7 +179,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "face_value_of_loan": 3.0,
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
@@ -227,7 +227,7 @@ def test_pagination_page_and_limit(client, monkeypatch, helpers, elasticsearch_a
         "results": [
             {
                 "code": "456789123",
-                "count": 1,
+                "award_count": 1,
                 "description": "RECIPIENT 2",
                 "face_value_of_loan": 30.0,
                 "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -272,7 +272,7 @@ def test_correct_response_with_award_type_codes(
         "results": [
             {
                 "code": "456789123",
-                "count": 1,
+                "award_count": 1,
                 "description": "RECIPIENT 2",
                 "face_value_of_loan": 30.0,
                 "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
@@ -281,7 +281,7 @@ def test_correct_response_with_award_type_codes(
             },
             {
                 "code": "DUNS Number not provided",
-                "count": 1,
+                "award_count": 1,
                 "description": "RECIPIENT 1",
                 "face_value_of_loan": 3.0,
                 "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
@@ -310,7 +310,7 @@ def test_correct_response_with_award_type_codes(
         "results": [
             {
                 "code": "987654321",
-                "count": 1,
+                "award_count": 1,
                 "description": "RECIPIENT 3",
                 "face_value_of_loan": 300.0,
                 "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],

--- a/usaspending_api/disaster/tests/integration/test_recipient_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_recipient_spending.py
@@ -26,7 +26,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
     expected_results = [
         {
             "code": "987654321",
-            "count": 2,
+            "award_count": 2,
             "description": "RECIPIENT 3",
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
             "obligation": 2200.0,
@@ -34,7 +34,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
@@ -42,7 +42,7 @@ def test_correct_response_single_defc(client, monkeypatch, helpers, elasticsearc
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
@@ -63,7 +63,7 @@ def test_correct_response_multiple_defc(
     expected_results = [
         {
             "code": "987654321",
-            "count": 3,
+            "award_count": 3,
             "description": "RECIPIENT 3",
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
             "obligation": 202200.0,
@@ -71,7 +71,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
@@ -79,7 +79,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
@@ -87,7 +87,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "096354360",
-            "count": 1,
+            "award_count": 1,
             "description": "MULTIPLE RECIPIENTS",
             "id": None,
             "obligation": 20000.0,
@@ -95,7 +95,7 @@ def test_correct_response_multiple_defc(
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "MULTIPLE RECIPIENTS",
             "id": None,
             "obligation": 2000000.0,
@@ -119,7 +119,7 @@ def test_correct_response_with_query(client, monkeypatch, helpers, elasticsearch
     expected_results = [
         {
             "code": "987654321",
-            "count": 3,
+            "award_count": 3,
             "description": "RECIPIENT 3",
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
             "obligation": 202200.0,
@@ -145,7 +145,7 @@ def test_correct_response_with_award_type_codes(
     expected_results = [
         {
             "code": "987654321",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 3",
             "id": ["d2894d22-67fc-f9cb-4005-33fa6a29ef86-C", "d2894d22-67fc-f9cb-4005-33fa6a29ef86-R"],
             "obligation": 2000.0,
@@ -153,7 +153,7 @@ def test_correct_response_with_award_type_codes(
         },
         {
             "code": "456789123",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 2",
             "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
             "obligation": 20.0,
@@ -161,7 +161,7 @@ def test_correct_response_with_award_type_codes(
         },
         {
             "code": "DUNS Number not provided",
-            "count": 1,
+            "award_count": 1,
             "description": "RECIPIENT 1",
             "id": ["5f572ec9-8b49-e5eb-22c7-f6ef316f7689-R"],
             "obligation": 2.0,
@@ -169,7 +169,7 @@ def test_correct_response_with_award_type_codes(
         },
         {
             "code": "096354360",
-            "count": 1,
+            "award_count": 1,
             "description": "MULTIPLE RECIPIENTS",
             "id": None,
             "obligation": 20000.0,
@@ -216,7 +216,7 @@ def test_pagination_page_and_limit(client, monkeypatch, helpers, elasticsearch_a
         "results": [
             {
                 "code": "456789123",
-                "count": 1,
+                "award_count": 1,
                 "description": "RECIPIENT 2",
                 "id": ["3c92491a-f2cd-ec7d-294b-7daf91511866-R"],
                 "obligation": 20.0,

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -57,9 +57,10 @@ class LoansByAgencyViewSet(LoansPaginationMixin, LoansMixin, FabaOutlayMixin, Di
     @cache_response()
     def post(self, request):
         results = self.queryset
+
         return Response(
             {
-                "results": results.order_by(self.pagination.order_by)[
+                "results": results.order_by(*self.pagination.robust_order_by_fields)[
                     self.pagination.lower_limit : self.pagination.upper_limit
                 ],
                 "page_metadata": get_pagination_metadata(results.count(), self.pagination.limit, self.pagination.page),

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -70,7 +70,7 @@ class SpendingByAgencyViewSet(PaginationMixin, SpendingMixin, FabaOutlayMixin, D
 
         return Response(
             {
-                "results": results.order_by(self.pagination.order_by)[
+                "results": results.order_by(*self.pagination.robust_order_by_fields)[
                     self.pagination.lower_limit : self.pagination.upper_limit
                 ],
                 "page_metadata": get_pagination_metadata(results.count(), self.pagination.limit, self.pagination.page),
@@ -236,7 +236,7 @@ class SpendingBySubtierAgencyViewSet(ElasticsearchSpendingPaginationMixin, Elast
             "id": int(info["id"]),
             "code": info["code"],
             "description": info["name"],
-            # the count of distinct subtier agencies contributing to the totals
+            # the count of distinct awards contributing to the totals
             "award_count": int(bucket.get("doc_count", 0)),
             **{
                 column: int(bucket.get(self.sum_column_mapping[column], {"value": 0})["value"]) / Decimal("100")

--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -29,7 +29,7 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
             count_field = "award_id"
 
         fields = {
-            "count": Count(count_field, distinct=True),
+            "award_count": Count(count_field, distinct=True),
             "obligation": Coalesce(Sum("transaction_obligated_amount"), 0),
             "outlay": self.outlay_field_annotation,
         }

--- a/usaspending_api/disaster/v2/views/cfda/loans.py
+++ b/usaspending_api/disaster/v2/views/cfda/loans.py
@@ -30,7 +30,7 @@ class CfdaLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisasterB
                     "id": int(info.get("id")) if info.get("id") else None,
                     "code": info.get("code") or None,
                     "description": info.get("description") or None,
-                    "count": int(bucket.get("doc_count", 0)),
+                    "award_count": int(bucket.get("doc_count", 0)),
                     "resource_link": info.get("url") or None,
                     **{
                         column: int(bucket.get(self.sum_column_mapping[column], {"value": 0})["value"]) / Decimal("100")

--- a/usaspending_api/disaster/v2/views/cfda/spending.py
+++ b/usaspending_api/disaster/v2/views/cfda/spending.py
@@ -29,7 +29,7 @@ class CfdaSpendingViewSet(ElasticsearchSpendingPaginationMixin, ElasticsearchDis
                     "id": int(info.get("id")) if info.get("id") else None,
                     "code": info.get("code") or None,
                     "description": info.get("description") or None,
-                    "count": int(bucket.get("doc_count", 0)),
+                    "award_count": int(bucket.get("doc_count", 0)),
                     "resource_link": info.get("url") or None,
                     **{
                         column: int(bucket.get(self.sum_column_mapping[column], {"value": 0})["value"]) / Decimal("100")

--- a/usaspending_api/disaster/v2/views/disaster_base.py
+++ b/usaspending_api/disaster/v2/views/disaster_base.py
@@ -291,18 +291,27 @@ class _BasePaginationMixin:
             upper_limit=(request_data["page"] * request_data["limit"]),
             sort_key=request_data.get("sort", "obligated_amount"),
             sort_order=request_data["order"],
+            secondary_sort_key="id",
         )
 
 
 class PaginationMixin(_BasePaginationMixin):
     @cached_property
     def pagination(self):
-        sortable_columns = ["id", "code", "description", "count", "obligation", "outlay", "total_budgetary_resources"]
+        sortable_columns = [
+            "id",
+            "code",
+            "description",
+            "award_count",
+            "obligation",
+            "outlay",
+            "total_budgetary_resources",
+        ]
         return self.run_models(sortable_columns)
 
 
 class LoansPaginationMixin(_BasePaginationMixin):
     @cached_property
     def pagination(self):
-        sortable_columns = ["id", "code", "description", "count", "obligation", "outlay", "face_value_of_loan"]
+        sortable_columns = ["id", "code", "description", "award_count", "obligation", "outlay", "face_value_of_loan"]
         return self.run_models(sortable_columns)

--- a/usaspending_api/disaster/v2/views/elasticsearch_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_base.py
@@ -24,10 +24,10 @@ from usaspending_api.search.v2.es_sanitization import es_sanitize
 class ElasticsearchSpendingPaginationMixin(_BasePaginationMixin):
     sum_column_mapping = {"obligation": "total_covid_obligation", "outlay": "total_covid_outlay"}
     sort_column_mapping = {
-        "count": "_count",
+        "award_count": "_count",
         "description": "_key",  # _key will ultimately sort on description value
         "code": "_key",  # Façade sort behavior, really sorting on description
-        "id": "_key",  # Façade sort, really sorting on description
+        "id": "_key",  # Façade sort behavior, really sorting on description
         **sum_column_mapping,
     }
 
@@ -43,10 +43,10 @@ class ElasticsearchLoansPaginationMixin(_BasePaginationMixin):
         "face_value_of_loan": "total_loan_value",
     }
     sort_column_mapping = {
-        "count": "_count",
+        "award_count": "_count",
         "description": "_key",  # _key will ultimately sort on description value
         "code": "_key",  # Façade sort behavior, really sorting on description
-        "id": "_key",  # Façade sort, really sorting on description
+        "id": "_key",  # Façade sort behavior, really sorting on description
         **sum_column_mapping,
     }
 
@@ -139,7 +139,10 @@ class ElasticsearchDisasterBase(DisasterBase):
             size = self.pagination.upper_limit
             shard_size = size
             group_by_agg_key_values = {
-                "order": {self.sort_column_mapping[self.pagination.sort_key]: self.pagination.sort_order}
+                "order": {
+                    self.sort_column_mapping[self.pagination.sort_key]: self.pagination.sort_order,
+                    self.sort_column_mapping["id"]: self.pagination.sort_order,
+                }
             }
             bucket_sort_values = {**pagination_values}
         else:
@@ -150,7 +153,10 @@ class ElasticsearchDisasterBase(DisasterBase):
                 shard_size = self.bucket_count + 100
                 group_by_agg_key_values = {}
                 bucket_sort_values = {
-                    "sort": {self.sort_column_mapping[self.pagination.sort_key]: {"order": self.pagination.sort_order}},
+                    "sort": {
+                        self.sort_column_mapping[self.pagination.sort_key]: {"order": self.pagination.sort_order},
+                        self.sort_column_mapping["id"]: {"order": self.pagination.sort_order},
+                    },
                     **pagination_values,
                 }
 
@@ -207,7 +213,10 @@ class ElasticsearchDisasterBase(DisasterBase):
                 "field": self.sub_agg_key,
                 "size": size,
                 "shard_size": shard_size,
-                "order": {self.sort_column_mapping[self.pagination.sort_key]: self.pagination.sort_order},
+                "order": {
+                    self.sort_column_mapping[self.pagination.sort_key]: self.pagination.sort_order,
+                    self.sort_column_mapping["id"]: self.pagination.sort_order,
+                },
             }
         )
         sub_group_by_sub_agg_key = A("terms", **sub_group_by_sub_agg_key_values)

--- a/usaspending_api/disaster/v2/views/federal_account/federal_account_result.py
+++ b/usaspending_api/disaster/v2/views/federal_account/federal_account_result.py
@@ -65,6 +65,8 @@ class FedAcctResults:
             reverse = False
 
         if isinstance(items, list):
-            return sorted(items, key=lambda x: getattr(x, field), reverse=reverse)
+            return sorted(items, key=lambda x: (getattr(x, field), getattr(x, "id")), reverse=reverse)
         else:
-            return {k: items[k] for k in sorted(items, key=lambda x: getattr(x, field), reverse=reverse)}
+            return {
+                k: items[k] for k in sorted(items, key=lambda x: (getattr(x, field), getattr(x, "id")), reverse=reverse)
+            }

--- a/usaspending_api/disaster/v2/views/object_class/object_class_result.py
+++ b/usaspending_api/disaster/v2/views/object_class/object_class_result.py
@@ -69,6 +69,8 @@ class ObjectClassResults:
             reverse = False
 
         if isinstance(items, list):
-            return sorted(items, key=lambda x: getattr(x, field), reverse=reverse)
+            return sorted(items, key=lambda x: (getattr(x, field), getattr(x, "id")), reverse=reverse)
         else:
-            return {k: items[k] for k in sorted(items, key=lambda x: getattr(x, field), reverse=reverse)}
+            return {
+                k: items[k] for k in sorted(items, key=lambda x: (getattr(x, field), getattr(x, "id")), reverse=reverse)
+            }

--- a/usaspending_api/disaster/v2/views/recipient/loans.py
+++ b/usaspending_api/disaster/v2/views/recipient/loans.py
@@ -41,7 +41,7 @@ class RecipientLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisa
                     "id": recipient_hash_list,
                     "code": info["unique_id"] or "DUNS Number not provided",
                     "description": info["name"] or None,
-                    "count": int(bucket.get("doc_count", 0)),
+                    "award_count": int(bucket.get("doc_count", 0)),
                     **{
                         column: int(bucket.get(self.sum_column_mapping[column], {"value": 0})["value"]) / Decimal("100")
                         for column in self.sum_column_mapping

--- a/usaspending_api/disaster/v2/views/recipient/spending.py
+++ b/usaspending_api/disaster/v2/views/recipient/spending.py
@@ -41,7 +41,7 @@ class RecipientSpendingViewSet(ElasticsearchSpendingPaginationMixin, Elasticsear
                     "id": recipient_hash_list,
                     "code": info["unique_id"] or "DUNS Number not provided",
                     "description": info["name"] or None,
-                    "count": int(bucket.get("doc_count", 0)),
+                    "award_count": int(bucket.get("doc_count", 0)),
                     **{
                         column: int(bucket.get(self.sum_column_mapping[column], {"value": 0})["value"]) / Decimal("100")
                         for column in self.sum_column_mapping


### PR DESCRIPTION
**Description:**
1. Added a secondary sort on `id` for all disaster endpoints which support pagination to provide deterministic result order when results are sorted on fields with the same value
1. Changed the sort field from `count` to `award_count` for endpoints modified by #2623
1. Changed Response and sort field for other endpoints from `count` -> `award_count` not addressed in #2623
    - ` /api/v2/disaster/award/amount/` (response only)
    - `/api/v2/disaster/cfda/loans/`
    - `/api/v2/disaster/cfda/spending/`
    - `/api/v2/disaster/recipient/loans/`
    - `/api/v2/disaster/recipient/spending/`
    - `/api/v2/disaster/agency/spending/` (previously inconsistent)
    - `/api/v2/disaster/agency/loans/` (previously inconsistent)

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-5706](https://federal-spending-transparency.atlassian.net/browse/DEV-5706):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to database or ES necessary
```
