### PR TITLE
add non-zero filter to award amount endpoint to better match search

### DIFF
--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -22,6 +22,7 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
             self.all_closed_defc_submissions,
             self.has_award_of_provided_type,
             self.is_in_provided_def_codes,
+            self.is_non_zero_award_spending,
         ]
 
         count_field = self.unique_file_c


### PR DESCRIPTION
**Description:**
As a part of my investigation on discrepancies between counts, I noticed that the elasticsearch index filters out FABA with zero spending, so we should do the same with the award/amount endpoint

**Technical details:**


**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created

**Area for explaining above N/A when needed:**
```
```
