### PR TITLE
[DEV-5602] Change query filter to be 'AND' instead of 'OR'

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -395,6 +395,18 @@ class _DisasterEmergencyFundCodes(_Filter):
         return ES_Q("bool", should=def_codes_query, minimum_should_match=1)
 
 
+class _QueryText(_Filter):
+    """Query text with a specific field to search on (i.e. {'text': <query_text>, 'fields': [<field_to_search_on>]})"""
+
+    underscore_name = "query"
+
+    @classmethod
+    def generate_elasticsearch_query(cls, filter_values: dict, query_type: _QueryType) -> ES_Q:
+        query_text = f"{es_sanitize(filter_values['text'])}*"
+        query_fields = filter_values["fields"]
+        return ES_Q("simple_query_string", query=query_text, default_operator="AND", fields=query_fields)
+
+
 class QueryWithFilters:
 
     filter_lookup = {
@@ -419,6 +431,7 @@ class QueryWithFilters:
         _SetAsideTypeCodes.underscore_name: _SetAsideTypeCodes,
         _ExtentCompetedTypeCodes.underscore_name: _ExtentCompetedTypeCodes,
         _DisasterEmergencyFundCodes.underscore_name: _DisasterEmergencyFundCodes,
+        _QueryText.underscore_name: _QueryText,
     }
 
     unsupported_filters = ["legal_entities"]


### PR DESCRIPTION
**Description:**
The query filter should be similar in functionality to the recipient page.

**Technical details:**
Changed the default_operator used when Elasticsearch performs the query and did a minor refactor to make it more re-usable.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-5602](https://federal-spending-transparency.atlassian.net/browse/DEV-5602):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
