### PR TITLE
[DEV-5673] DEFC Action date fix

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -393,11 +393,7 @@ class _DisasterEmergencyFundCodes(_Filter):
         for v in filter_values:
             def_codes_query.append(ES_Q("match", disaster_emergency_fund_codes=v))
         if query_type == _QueryType.AWARDS:
-            return ES_Q(
-                "bool",
-                should=def_codes_query,
-                minimum_should_match=1,
-            )
+            return ES_Q("bool", should=def_codes_query, minimum_should_match=1,)
         return ES_Q(
             "bool",
             should=def_codes_query,

--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -392,6 +392,12 @@ class _DisasterEmergencyFundCodes(_Filter):
         def_codes_query = []
         for v in filter_values:
             def_codes_query.append(ES_Q("match", disaster_emergency_fund_codes=v))
+        if query_type == _QueryType.AWARDS:
+            return ES_Q(
+                "bool",
+                should=def_codes_query,
+                minimum_should_match=1,
+            )
         return ES_Q(
             "bool",
             should=def_codes_query,

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -992,7 +992,7 @@ def test_defc_date_filter(client, monkeypatch, elasticsearch_transaction_index):
         "awards.TransactionNormalized",
         id=100,
         action_date="2020-01-01",
-        federal_action_obligation=10,
+        federal_action_obligation=22,
         award_id=99,
         is_fpds=True,
         type="A",

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -969,48 +969,36 @@ def test_defc_date_filter(client, monkeypatch, elasticsearch_transaction_index):
         group_name="covid_19",
     )
     mommy.make(
-        "accounts.FederalAccount",
-        id=99,
+        "accounts.FederalAccount", id=99,
     )
     mommy.make(
-        "accounts.TreasuryAppropriationAccount",
-        federal_account_id=99,
-        treasury_account_identifier=99,
+        "accounts.TreasuryAppropriationAccount", federal_account_id=99, treasury_account_identifier=99,
     )
     mommy.make(
-        "awards.FinancialAccountsByAwards",
-        pk=1,
-        award_id=99,
-        disaster_emergency_fund=defc1,
-        treasury_account_id=99
+        "awards.FinancialAccountsByAwards", pk=1, award_id=99, disaster_emergency_fund=defc1, treasury_account_id=99
     )
     mommy.make("awards.Award", id=99, total_obligation=20, piid="0001")
     mommy.make(
         "awards.TransactionNormalized",
         id=99,
-        action_date='2020-04-02',
+        action_date="2020-04-02",
         federal_action_obligation=10,
         award_id=99,
         is_fpds=True,
         type="A",
     )
-    mommy.make(
-        "awards.TransactionFPDS",
-        transaction_id=99,
-        piid="0001"
-    )
+    mommy.make("awards.TransactionFPDS", transaction_id=99, piid="0001")
     mommy.make(
         "awards.TransactionNormalized",
         id=100,
-        action_date='2020-01-01',
+        action_date="2020-01-01",
         federal_action_obligation=10,
         award_id=99,
         is_fpds=True,
         type="A",
     )
     mommy.make(
-        "awards.TransactionFPDS",
-        transaction_id=100,
+        "awards.TransactionFPDS", transaction_id=100,
     )
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
     resp = client.post(
@@ -1020,6 +1008,4 @@ def test_defc_date_filter(client, monkeypatch, elasticsearch_transaction_index):
     )
     assert resp.status_code == status.HTTP_200_OK
     print(resp.json().get("results"))
-    assert (
-        {"aggregated_amount":10, "time_period":{"fiscal_year":"2020"}} in resp.json().get("results")
-    )
+    assert {"aggregated_amount": 10, "time_period": {"fiscal_year": "2020"}} in resp.json().get("results")

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -957,3 +957,69 @@ def test_failure_with_invalid_group(client, monkeypatch, elasticsearch_transacti
     )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert resp.json().get("detail") == "Missing value: 'group' is a required field", "Expected to fail with no group"
+
+
+@pytest.mark.django_db
+def test_defc_date_filter(client, monkeypatch, elasticsearch_transaction_index):
+    defc1 = mommy.make(
+        "references.DisasterEmergencyFundCode",
+        code="L",
+        public_law="PUBLIC LAW FOR CODE L",
+        title="TITLE FOR CODE L",
+        group_name="covid_19",
+    )
+    mommy.make(
+        "accounts.FederalAccount",
+        id=99,
+    )
+    mommy.make(
+        "accounts.TreasuryAppropriationAccount",
+        federal_account_id=99,
+        treasury_account_identifier=99,
+    )
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        pk=1,
+        award_id=99,
+        disaster_emergency_fund=defc1,
+        treasury_account_id=99
+    )
+    mommy.make("awards.Award", id=99, total_obligation=20, piid="0001")
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=99,
+        action_date='2020-04-02',
+        federal_action_obligation=10,
+        award_id=99,
+        is_fpds=True,
+        type="A",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=99,
+        piid="0001"
+    )
+    mommy.make(
+        "awards.TransactionNormalized",
+        id=100,
+        action_date='2020-01-01',
+        federal_action_obligation=10,
+        award_id=99,
+        is_fpds=True,
+        type="A",
+    )
+    mommy.make(
+        "awards.TransactionFPDS",
+        transaction_id=100,
+    )
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
+    resp = client.post(
+        "/api/v2/search/spending_over_time",
+        content_type="application/json",
+        data=json.dumps({"group": "fiscal_year", "filters": {"def_codes": ["L"]}}),
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    print(resp.json().get("results"))
+    assert (
+        {"aggregated_amount":10, "time_period":{"fiscal_year":"2020"}} in resp.json().get("results")
+    )


### PR DESCRIPTION
**Description:**
Changes the code for DEFC filter to no longer filter awards by action date, only transactions.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5673](https://federal-spending-transparency.atlassian.net/browse/DEV-5673):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to matviews, not ops tickets needed
```
