### PR TITLE
[DEV-5602] Minor fix to the query text filter for ES (QAT)

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -409,9 +409,9 @@ class _QueryText(_Filter):
 
     @classmethod
     def generate_elasticsearch_query(cls, filter_values: dict, query_type: _QueryType) -> ES_Q:
-        query_text = f"{es_sanitize(filter_values['text'])}*"
+        query_text = es_sanitize(filter_values["text"])
         query_fields = filter_values["fields"]
-        return ES_Q("simple_query_string", query=query_text, default_operator="AND", fields=query_fields)
+        return ES_Q("multi_match", query=query_text, type="phrase_prefix", fields=query_fields)
 
 
 class QueryWithFilters:


### PR DESCRIPTION
**Description:**
Previous functionality would surface recipients such as `YORK STREET PROJECT A NEW JERSEY NONPROFIT CORPORATION` when searching for `NEW YORK`. New functionality should not surface that recipient and will follow similar to the functionality below taken from ES documentation:

When searching for `quick brown f` this is how the query would handle matches. This search would match a message value of `quick brown fox` or `two quick brown ferrets` but not `the fox is quick and brown`.


**Technical details:**
Changed the query type to be `multi_match` due to multiple fields and using the `match_phrase_prefix` query type.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (n/a)
2. [x] API documentation updated (n/a)
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (n/a)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (n/a)
8. [x] Jira Ticket [DEV-5602](https://federal-spending-transparency.atlassian.net/browse/DEV-5602):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
