### PR TITLE
[DEV-5557] Point to the right download for COVID Page Download (QAT)

### DIFF
--- a/usaspending_api/download/download_utils.py
+++ b/usaspending_api/download/download_utils.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+from django.conf import settings
+
 from usaspending_api.common.helpers.text_helpers import slugify_text_for_file_names
 from usaspending_api.common.logging import get_remote_addr
 from usaspending_api.download.helpers import write_to_download_log
@@ -18,7 +20,7 @@ def create_unique_filename(json_request, origination=None):
         slug_text = slugify_text_for_file_names(json_request.get("assistance_id"), "UNKNOWN", 50)
         download_name = f"ASST_{slug_text}_{timestamp}.zip"
     elif json_request["request_type"] == "disaster_recipient":
-        download_name = f"COVID-19_Profile_{timestamp}.zip"
+        download_name = f"{settings.COVID19_DOWNLOAD_FILENAME_PREFIX}_{timestamp}.zip"
     elif json_request["request_type"] == "account":
         file_name_template = obtain_zip_filename_format(json_request["download_types"])
         agency = obtain_filename_prefix_from_agency_id(request_agency)

--- a/usaspending_api/download/download_utils.py
+++ b/usaspending_api/download/download_utils.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from django.conf import settings
 
 from usaspending_api.common.helpers.text_helpers import slugify_text_for_file_names
 from usaspending_api.common.logging import get_remote_addr
@@ -20,7 +19,7 @@ def create_unique_filename(json_request, origination=None):
         slug_text = slugify_text_for_file_names(json_request.get("assistance_id"), "UNKNOWN", 50)
         download_name = f"ASST_{slug_text}_{timestamp}.zip"
     elif json_request["request_type"] == "disaster_recipient":
-        download_name = f"{settings.COVID19_DOWNLOAD_FILENAME_PREFIX}_{timestamp}.zip"
+        download_name = f"COVID-19_Recipients_{json_request['award_category']}_{timestamp}.zip"
     elif json_request["request_type"] == "account":
         file_name_template = obtain_zip_filename_format(json_request["download_types"])
         agency = obtain_filename_prefix_from_agency_id(request_agency)

--- a/usaspending_api/download/lookups.py
+++ b/usaspending_api/download/lookups.py
@@ -236,7 +236,7 @@ VALUE_MAPPINGS = {
         "source_type": "disaster",
         "table": AwardSearchView,
         "table_name": "recipient",
-        "download_name": "COVID-19-Recipients_{award_category}_{timestamp}",
+        "download_name": "COVID-19_Recipients_{award_category}_{timestamp}",
         "filter_function": AwardsElasticsearchDownload.query,
         "annotations_function": disaster_recipient_annotations,
         "base_fields": ["recipient_name", "recipient_unique_id"],

--- a/usaspending_api/download/tests/integration/test_download_disaster_recipient.py
+++ b/usaspending_api/download/tests/integration/test_download_disaster_recipient.py
@@ -393,7 +393,7 @@ def test_download_success(client, monkeypatch, awards_and_transactions, elastics
 
     resp_json = resp.json()
     assert resp.status_code == status.HTTP_200_OK
-    assert re.match(r".*COVID-19_Profile_.*\.zip", resp_json["file_url"])
+    assert re.match(r".*COVID-19_Recipients_.*\.zip", resp_json["file_url"])
     assert resp_json["download_request"]["columns"] == [
         "recipient",
         "award_obligations",
@@ -409,7 +409,7 @@ def test_tsv_download_success(client, monkeypatch, awards_and_transactions, elas
 
     resp_json = resp.json()
     assert resp.status_code == status.HTTP_200_OK
-    assert re.match(r".*COVID-19_Profile_.*\.zip", resp_json["file_url"])
+    assert re.match(r".*COVID-19_Recipients_.*\.zip", resp_json["file_url"])
     assert resp_json["download_request"]["columns"] == [
         "recipient",
         "award_obligations",
@@ -425,7 +425,7 @@ def test_pstxt_download_success(client, monkeypatch, awards_and_transactions, el
 
     resp_json = resp.json()
     assert resp.status_code == status.HTTP_200_OK
-    assert re.match(r".*COVID-19_Profile_.*\.zip", resp_json["file_url"])
+    assert re.match(r".*COVID-19_Recipients_.*\.zip", resp_json["file_url"])
     assert resp_json["download_request"]["columns"] == [
         "recipient",
         "award_obligations",

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -47,11 +47,15 @@ class BaseDownloadViewSet(APIView):
         request_type: DownloadRequestType = DownloadRequestType.AWARD,
         origination: Optional[str] = None,
     ):
+        # This download is pre-generated and does not have the "request_type" property since it did not
+        # go through our normal download generation process (it is added below). A check for this
+        # in the json_request is used to determine uniqueness from other Disaster downloads.
         if request_type == DownloadRequestType.DISASTER:
             filename = (
                 DownloadJob.objects.filter(
                     file_name__startswith=settings.COVID19_DOWNLOAD_FILENAME_PREFIX, error_message__isnull=True
                 )
+                .exclude(json_request__contains="request_type")
                 .order_by("-update_date")
                 .values_list("file_name", flat=True)
                 .first()

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -47,15 +47,11 @@ class BaseDownloadViewSet(APIView):
         request_type: DownloadRequestType = DownloadRequestType.AWARD,
         origination: Optional[str] = None,
     ):
-        # This download is pre-generated and does not have the "request_type" property since it did not
-        # go through our normal download generation process (it is added below). A check for this
-        # in the json_request is used to determine uniqueness from other Disaster downloads.
         if request_type == DownloadRequestType.DISASTER:
             filename = (
                 DownloadJob.objects.filter(
                     file_name__startswith=settings.COVID19_DOWNLOAD_FILENAME_PREFIX, error_message__isnull=True
                 )
-                .exclude(json_request__contains="request_type")
                 .order_by("-update_date")
                 .values_list("file_name", flat=True)
                 .first()


### PR DESCRIPTION
**Description:**
COVID Page download is grabbing the wrong download file since both COVID Page and Disaster Recipient both name the file `COVID-19_Profile...`. Now the COVID Page download only looks at the generated COVID Page downloads.

**Technical details:**
Add a check for a property that is only added to our downloads if they go through our download generation process, which the COVID page download does not since it is pre-generated. This will need to be changed if we move away from pre-generated download.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (n/a)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (n/a)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (n/a)
8. [x] Jira Ticket [DEV-5557](https://federal-spending-transparency.atlassian.net/browse/DEV-5557):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
