### PR TITLE
[DEV-5557] Handle nonzero case for downloads (QAT)

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -414,6 +414,20 @@ class _QueryText(_Filter):
         return ES_Q("multi_match", query=query_text, type="phrase_prefix", fields=query_fields)
 
 
+class _NonzeroFields(_Filter):
+    """List of fields where at least one should have a nonzero value for each document"""
+
+    underscore_name = "nonzero_fields"
+
+    @classmethod
+    def generate_elasticsearch_query(cls, filter_values: List[str], query_type: _QueryType) -> ES_Q:
+        non_zero_queries = []
+        for field in filter_values:
+            non_zero_queries.append(ES_Q("range", **{field: {"gt": 0}}))
+            non_zero_queries.append(ES_Q("range", **{field: {"lt": 0}}))
+        return ES_Q("bool", should=non_zero_queries, minimum_should_match=1)
+
+
 class QueryWithFilters:
 
     filter_lookup = {
@@ -439,6 +453,7 @@ class QueryWithFilters:
         _ExtentCompetedTypeCodes.underscore_name: _ExtentCompetedTypeCodes,
         _DisasterEmergencyFundCodes.underscore_name: _DisasterEmergencyFundCodes,
         _QueryText.underscore_name: _QueryText,
+        _NonzeroFields.underscore_name: _NonzeroFields,
     }
 
     unsupported_filters = ["legal_entities"]

--- a/usaspending_api/disaster/v2/views/elasticsearch_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_base.py
@@ -78,6 +78,7 @@ class ElasticsearchDisasterBase(DisasterBase):
         self.filter_query = QueryWithFilters.generate_awards_elasticsearch_query(self.filters)
 
         # Ensure that only non-zero values are taken into consideration
+        # TODO: Refactor to use new NonzeroFields filter in QueryWithFilters
         non_zero_queries = []
         for field in self.sum_column_mapping.values():
             non_zero_queries.append(ES_Q("range", **{field: {"gt": 0}}))

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -261,6 +261,9 @@ def validate_disaster_recipient_request(request_data):
     elif award_type_codes <= set(other_type_mapping.keys()):
         award_category = "Other-Financial-Assistance"
 
+    # Filter so that at least one of these has a nonzero value
+    filters["nonzero_fields"] = ["total_covid_obligation", "total_covid_outlay", "total_loan_value"]
+
     # Need to specify the field to use "query" filter on if present
     query_text = filters.pop("query", None)
     if query_text:


### PR DESCRIPTION
**Description:**
Forgot to handle the nonzero case for downloads and so the number of recipients were off between download and recipient table.

**Technical details:**
Created a new filter to handle adding nonzero fields. This could be used by elasticsearch_base.py, but to minimize code changes at this point I have left a todo and only added to downloads.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (n/a)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (n/a)
5. [x] Frontend impact assessment completed (n/a)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (n/a)
8. [x] Jira Ticket [DEV-5557](https://federal-spending-transparency.atlassian.net/browse/DEV-5557):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
