### PR TITLE
added values to award amounts

### DIFF
--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -61,5 +61,5 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
             ).aggregate(**fields)
         else:
             return self.when_non_zero_award_spending(
-                FinancialAccountsByAwards.objects.filter(*filters).annotate(unique_c=count_field)
+                FinancialAccountsByAwards.objects.filter(*filters).annotate(unique_c=count_field).values("unique_c")
             ).aggregate(**fields)


### PR DESCRIPTION
Description:
Fixes part of discrepancies between results from award/amount and spending endpoints

Technical details:
For our group by needed to filter out awards with net 0 outlays or obligations, we were accidentally including the primary key, rendering the filter useless. This narrows down the values checked.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
