### PR TITLE
[DEV-5413] Minor tweak to one of the agency endpoints to prevent running query twice

### DIFF
--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -68,14 +68,12 @@ class SpendingByAgencyViewSet(PaginationMixin, SpendingMixin, FabaOutlayMixin, D
         else:
             results = self.total_queryset
 
+        results = list(results.order_by(*self.pagination.robust_order_by_fields))
+
         return Response(
             {
-                "results": list(
-                    results.order_by(*self.pagination.robust_order_by_fields)[
-                        self.pagination.lower_limit : self.pagination.upper_limit
-                    ]
-                ),
-                "page_metadata": get_pagination_metadata(results.count(), self.pagination.limit, self.pagination.page),
+                "results": results[self.pagination.lower_limit : self.pagination.upper_limit],
+                "page_metadata": get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page),
             }
         )
 


### PR DESCRIPTION
**Description:**

Oversight on my part.  Query was running twice, once to return results and a second time to perform count.  Bad @kbard.  This a very slow endpoint so this should help a little with performance issues.  More invasive changes incoming.

**Requirements for PR merge:**

1. [x] Unit & integration tests unaffected
2. [x] API documentation unaffected
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matviews unaffected
5. [x] Frontend unaffected
6. [x] Data validation completed
7. [x] No Operations ticket required
8. [x] Jira Ticket [DEV-5413](https://federal-spending-transparency.atlassian.net/browse/DEV-5413):
    - [x] Link to this Pull-Request