### PR TITLE
Set DEFC reference data array order

### DIFF
--- a/usaspending_api/references/v2/views/def_codes.py
+++ b/usaspending_api/references/v2/views/def_codes.py
@@ -10,8 +10,10 @@ class DEFCodesViewSet(APIView):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/references/def_codes.md"
 
     def get(self, request, format=None):
-        rows = DisasterEmergencyFundCode.objects.annotate(disaster=F("group_name")).values(
-            "code", "public_law", "title", "disaster", "urls"
+        rows = (
+            DisasterEmergencyFundCode.objects.annotate(disaster=F("group_name"))
+            .values("code", "public_law", "title", "disaster", "urls")
+            .order_by("code")
         )
         for row in rows:
             row["urls"] = row["urls"].split("|") if row["urls"] else None


### PR DESCRIPTION
**Description:**
Why you ask? Well, the frontend isn't requesting DEFC values in alphabetical order. While that alone isn't a problem for non-OCD individuals, there _is_ a problem if the order isn't deterministic between deploys or reference data loads. The problem is attempting to create an API cache warmer if the website's requests unexpectedly change over time. This minor change is simply reducing one potential reason for the order observed

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)
**Area for explaining above N/A when needed:**
```
```
