### PR TITLE
[DEV-5812] COVID-19 Download Publish Date filtering

### DIFF
--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_d1_awards.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_d1_awards.sql
@@ -1,3 +1,13 @@
+WITH recent_submission AS (
+    SELECT
+        "dabs_submission_window_schedule"."submission_reveal_date",
+        "dabs_submission_window_schedule"."submission_fiscal_year",
+        "dabs_submission_window_schedule"."is_quarter",
+        "dabs_submission_window_schedule"."submission_fiscal_month"
+    FROM "dabs_submission_window_schedule"
+    WHERE
+        "dabs_submission_window_schedule"."submission_reveal_date" <= now()
+)
 SELECT
     "awards"."generated_unique_award_id" AS "contract_award_unique_key",
     "awards"."piid" AS "award_id_piid",
@@ -289,6 +299,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
+    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_d1_awards.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_d1_awards.sql
@@ -1,4 +1,4 @@
-WITH recent_submission AS (
+WITH closed_submissions AS (
     SELECT
         "dabs_submission_window_schedule"."submission_reveal_date",
         "dabs_submission_window_schedule"."submission_fiscal_year",
@@ -299,9 +299,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
-    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
-        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
+    INNER JOIN closed_submissions ON (sa."reporting_fiscal_period" = "closed_submissions"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "closed_submissions"."is_quarter"
+        AND sa."reporting_fiscal_year" = "closed_submissions"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_d1_awards.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_d1_awards.sql
@@ -301,7 +301,7 @@ INNER JOIN (
         AND sa.reporting_period_start >= '2020-04-01'
     INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
         AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_d2_awards.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_d2_awards.sql
@@ -115,7 +115,7 @@ INNER JOIN (
         AND sa.reporting_period_start >= '2020-04-01'
     INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
         AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_d2_awards.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_d2_awards.sql
@@ -1,3 +1,13 @@
+WITH recent_submission AS (
+    SELECT
+        "dabs_submission_window_schedule"."submission_reveal_date",
+        "dabs_submission_window_schedule"."submission_fiscal_year",
+        "dabs_submission_window_schedule"."is_quarter",
+        "dabs_submission_window_schedule"."submission_fiscal_month"
+    FROM "dabs_submission_window_schedule"
+    WHERE
+        "dabs_submission_window_schedule"."submission_reveal_date" <= now()
+)
 SELECT
     "awards"."generated_unique_award_id" AS "assistance_award_unique_key",
     "awards"."fain" AS "award_id_fain",
@@ -103,6 +113,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
+    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_d2_awards.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_d2_awards.sql
@@ -1,4 +1,4 @@
-WITH recent_submission AS (
+WITH closed_submissions AS (
     SELECT
         "dabs_submission_window_schedule"."submission_reveal_date",
         "dabs_submission_window_schedule"."submission_fiscal_year",
@@ -113,9 +113,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
-    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
-        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
+    INNER JOIN closed_submissions ON (sa."reporting_fiscal_period" = "closed_submissions"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "closed_submissions"."is_quarter"
+        AND sa."reporting_fiscal_year" = "closed_submissions"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
@@ -1,3 +1,13 @@
+WITH recent_submission AS (
+    SELECT
+        "dabs_submission_window_schedule"."submission_reveal_date",
+        "dabs_submission_window_schedule"."submission_fiscal_year",
+        "dabs_submission_window_schedule"."is_quarter",
+        "dabs_submission_window_schedule"."submission_fiscal_month"
+    FROM "dabs_submission_window_schedule"
+    WHERE
+        "dabs_submission_window_schedule"."submission_reveal_date" <= now()
+)
 SELECT
     "broker_subaward"."unique_award_key" AS "prime_award_unique_key",
     "broker_subaward"."award_id" AS "prime_award_piid",
@@ -120,6 +130,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
+    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
@@ -1,4 +1,4 @@
-WITH recent_submission AS (
+WITH closed_submissions AS (
     SELECT
         "dabs_submission_window_schedule"."submission_reveal_date",
         "dabs_submission_window_schedule"."submission_fiscal_year",
@@ -130,9 +130,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
-    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
-        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
+    INNER JOIN closed_submissions ON (sa."reporting_fiscal_period" = "closed_submissions"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "closed_submissions"."is_quarter"
+        AND sa."reporting_fiscal_year" = "closed_submissions"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
@@ -132,7 +132,7 @@ INNER JOIN (
         AND sa.reporting_period_start >= '2020-04-01'
     INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
         AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
@@ -128,7 +128,7 @@ INNER JOIN (
         AND sa.reporting_period_start >= '2020-04-01'
     INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
         AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
@@ -1,3 +1,13 @@
+WITH recent_submission AS (
+    SELECT
+        "dabs_submission_window_schedule"."submission_reveal_date",
+        "dabs_submission_window_schedule"."submission_fiscal_year",
+        "dabs_submission_window_schedule"."is_quarter",
+        "dabs_submission_window_schedule"."submission_fiscal_month"
+    FROM "dabs_submission_window_schedule"
+    WHERE
+        "dabs_submission_window_schedule"."submission_reveal_date" <= now()
+)
 SELECT
     "broker_subaward"."unique_award_key" AS "prime_award_unique_key",
     "broker_subaward"."award_id" AS "prime_award_fain",
@@ -116,6 +126,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
+    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
+        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year" AND sa.published_date >= recent_submission.submission_reveal_date)
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
@@ -1,4 +1,4 @@
-WITH recent_submission AS (
+WITH closed_submissions AS (
     SELECT
         "dabs_submission_window_schedule"."submission_reveal_date",
         "dabs_submission_window_schedule"."submission_fiscal_year",
@@ -126,9 +126,9 @@ INNER JOIN (
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
         AND sa.reporting_period_start >= '2020-04-01'
-    INNER JOIN recent_submission ON (sa."reporting_fiscal_period" = "recent_submission"."submission_fiscal_month"
-        AND sa."quarter_format_flag" = "recent_submission"."is_quarter"
-        AND sa."reporting_fiscal_year" = "recent_submission"."submission_fiscal_year")
+    INNER JOIN closed_submissions ON (sa."reporting_fiscal_period" = "closed_submissions"."submission_fiscal_month"
+        AND sa."quarter_format_flag" = "closed_submissions"."is_quarter"
+        AND sa."reporting_fiscal_year" = "closed_submissions"."submission_fiscal_year")
     LEFT JOIN (
         SELECT   submission_fiscal_year, is_quarter, max(submission_fiscal_month) AS submission_fiscal_month
         FROM     dabs_submission_window_schedule


### PR DESCRIPTION
**Description:**
Restricts the records being downloaded to records that have their submission published date >= the reveal date for the submission window they were submitted in.


**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [N/A] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-5812](https://federal-spending-transparency.atlassian.net/browse/DEV-5812):
    - [X] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No frontend changes, no matview changes
```
