### PR TITLE
[DEV-5814] Logs download_count when downloading csv regardless of --skip-counts flag

### DIFF
--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -194,24 +194,24 @@ AWARD_VIEW_COLUMNS = [
     "total_covid_outlay",
 ]
 
-UPDATE_DATE_SQL = "update_date >= '{}'"
+UPDATE_DATE_SQL = "AND update_date >= '{}'"
 
 COUNT_FY_SQL = """
 SELECT COUNT(*) AS count
 FROM {view}
-WHERE {type_fy}fiscal_year={fy} AND {update_date}
+WHERE {type_fy}fiscal_year={fy}{update_date}
 """
 
 COUNT_SQL = """
 SELECT COUNT(*) AS count
 FROM {view}
-WHERE {update_date}
+WHERE update_date >= '{update_date}'
 """
 
 COPY_SQL = """"COPY (
     SELECT *
     FROM {view}
-    WHERE {type_fy}fiscal_year={fy} AND {update_date}
+    WHERE {type_fy}fiscal_year={fy}{update_date}
 ) TO STDOUT DELIMITER ',' CSV HEADER" > '{filename}'
 """
 
@@ -336,14 +336,14 @@ def configure_sql_strings(config, filename, deleted_ids):
 
 
 def get_updated_record_count(config):
-    update_date_str = UPDATE_DATE_SQL.format(config["starting_date"].strftime("%Y-%m-%d"))
+    update_date = config["starting_date"].strftime("%Y-%m-%d")
 
     if config["load_type"] == "awards":
         view_name = settings.ES_AWARDS_ETL_VIEW_NAME
     else:
         view_name = settings.ES_TRANSACTIONS_ETL_VIEW_NAME
 
-    count_sql = COUNT_SQL.format(update_date=update_date_str, view=view_name)
+    count_sql = COUNT_SQL.format(update_date=update_date, view=view_name)
 
     return execute_sql_statement(count_sql, True, config["verbose"])[0]["count"]
 

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -194,12 +194,18 @@ AWARD_VIEW_COLUMNS = [
     "total_covid_outlay",
 ]
 
-UPDATE_DATE_SQL = " AND update_date >= '{}'"
+UPDATE_DATE_SQL = "update_date >= '{}'"
+
+COUNT_FY_SQL = """
+SELECT COUNT(*) AS count
+FROM {view}
+WHERE {type_fy}fiscal_year={fy} AND {update_date}
+"""
 
 COUNT_SQL = """
 SELECT COUNT(*) AS count
 FROM {view}
-WHERE {type_fy}fiscal_year={fy}{update_date}
+WHERE {update_date}
 """
 
 COPY_SQL = """"COPY (
@@ -317,7 +323,7 @@ def configure_sql_strings(config, filename, deleted_ids):
         fy=config["fiscal_year"], update_date=update_date_str, filename=filename, view=view_name, type_fy=type_fy
     )
 
-    count_sql = COUNT_SQL.format(fy=config["fiscal_year"], update_date=update_date_str, view=view_name, type_fy=type_fy)
+    count_sql = COUNT_FY_SQL.format(fy=config["fiscal_year"], update_date=update_date_str, view=view_name, type_fy=type_fy)
     if deleted_ids and config["process_deletes"]:
         id_list = ",".join(["('{}')".format(x) for x in deleted_ids.keys()])
         id_sql = CHECK_IDS_SQL.format(id_list=id_list, fy=config["fiscal_year"], type_fy=type_fy, view_type=view_type)
@@ -325,6 +331,19 @@ def configure_sql_strings(config, filename, deleted_ids):
         id_sql = None
 
     return copy_sql, id_sql, count_sql
+
+
+def get_updated_record_count(config):
+    update_date_str = UPDATE_DATE_SQL.format(config["starting_date"].strftime("%Y-%m-%d"))
+
+    if config["load_type"] == "awards":
+        view_name = settings.ES_AWARDS_ETL_VIEW_NAME
+    else:
+        view_name = settings.ES_TRANSACTIONS_ETL_VIEW_NAME
+
+    count_sql = COUNT_SQL.format(update_date=update_date_str, view=view_name)
+
+    return execute_sql_statement(count_sql, True, config["verbose"])[0]["count"]
 
 
 def execute_sql_statement(cmd, results=False, verbose=False):

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -194,7 +194,7 @@ AWARD_VIEW_COLUMNS = [
     "total_covid_outlay",
 ]
 
-UPDATE_DATE_SQL = "AND update_date >= '{}'"
+UPDATE_DATE_SQL = " AND update_date >= '{}'"
 
 COUNT_FY_SQL = """
 SELECT COUNT(*) AS count

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -211,7 +211,7 @@ WHERE {update_date}
 COPY_SQL = """"COPY (
     SELECT *
     FROM {view}
-    WHERE {type_fy}fiscal_year={fy}{update_date}
+    WHERE {type_fy}fiscal_year={fy} AND {update_date}
 ) TO STDOUT DELIMITER ',' CSV HEADER" > '{filename}'
 """
 

--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -323,7 +323,9 @@ def configure_sql_strings(config, filename, deleted_ids):
         fy=config["fiscal_year"], update_date=update_date_str, filename=filename, view=view_name, type_fy=type_fy
     )
 
-    count_sql = COUNT_FY_SQL.format(fy=config["fiscal_year"], update_date=update_date_str, view=view_name, type_fy=type_fy)
+    count_sql = COUNT_FY_SQL.format(
+        fy=config["fiscal_year"], update_date=update_date_str, view=view_name, type_fy=type_fy
+    )
     if deleted_ids and config["process_deletes"]:
         id_list = ",".join(["('{}')".format(x) for x in deleted_ids.keys()])
         id_sql = CHECK_IDS_SQL.format(id_list=id_list, fy=config["fiscal_year"], type_fy=type_fy, view_type=view_type)

--- a/usaspending_api/etl/rapidloader.py
+++ b/usaspending_api/etl/rapidloader.py
@@ -31,11 +31,7 @@ class Rapidloader:
 
         updated_record_count = get_updated_record_count(self.config)
         printf(
-            {
-                "msg": "Found {} new {} records to update in ElasticSearch".format(
-                    updated_record_count, self.config["load_type"]
-                )
-            }
+            {"msg": f"Found {updated_record_count:,} new {self.config['load_type']} records to add to ElasticSearch"}
         )
 
         job_number = 0

--- a/usaspending_api/etl/rapidloader.py
+++ b/usaspending_api/etl/rapidloader.py
@@ -15,6 +15,7 @@ from usaspending_api.etl.es_etl_helpers import (
     set_final_index_config,
     swap_aliases,
     take_snapshot,
+    get_updated_record_count,
 )
 
 
@@ -27,6 +28,15 @@ class Rapidloader:
     def run_load_steps(self) -> None:
         download_queue = Queue()  # Queue for jobs which need a csv downloaded
         es_ingest_queue = Queue(20)  # Queue for jobs which have a csv and are ready for ES ingest
+
+        updated_record_count = get_updated_record_count(self.config)
+        printf(
+            {
+                "msg": "Found {} new {} records to update in ElasticSearch".format(
+                    updated_record_count, self.config["load_type"]
+                )
+            }
+        )
 
         job_number = 0
         for fiscal_year in self.config["fiscal_years"]:


### PR DESCRIPTION
Description:
The number of rows downloaded into a CSV during the ElasticSearch ETL should be logged whether or not the --skip-counts flag is enabled. This flag is used to determine whether an additional sql script should be run to provide a secondary count to compare against the download count.

Additionally, it logs the total count of records to update before the CSV download phase begins. 

This PR makes the change described above.

Technical details:
The only non-cosmetic change is that the download_db_records method now returns the number of rows in the downloaded csv. It previously returned None if --skip-counts was enabled and the count from the count_sql script if disabled.

Requirements for PR merge:

1. N/A - Unit & integration tests updated
2. N/A - API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. N/A - Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. N/A - Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-5814](https://federal-spending-transparency.atlassian.net/browse/DEV-5814):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison