### PR TITLE
[DEV-5825] Malformed json strings from Elasticsearch causing HTTP500s

### DIFF
--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -117,7 +117,7 @@ class LoansBySubtierAgencyViewSet(ElasticsearchLoansPaginationMixin, Elasticsear
         return results
 
     def _build_json_result(self, bucket: dict):
-        info = json.loads(bucket.get("key").encode('unicode_escape'))
+        info = json.loads(bucket.get("key").encode("unicode_escape"))
         return {
             "id": int(info["id"]),
             "code": info["code"],

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -117,7 +117,7 @@ class LoansBySubtierAgencyViewSet(ElasticsearchLoansPaginationMixin, Elasticsear
         return results
 
     def _build_json_result(self, bucket: dict):
-        info = json.loads(bucket.get("key"))
+        info = json.loads(bucket.get("key").encode('unicode_escape'))
         return {
             "id": int(info["id"]),
             "code": info["code"],

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -235,7 +235,7 @@ class SpendingBySubtierAgencyViewSet(ElasticsearchSpendingPaginationMixin, Elast
         return results
 
     def _build_json_result(self, bucket: dict):
-        info = json.loads(bucket.get("key"))
+        info = json.loads(bucket.get("key").encode('unicode_escape'))
         return {
             "id": int(info["id"]),
             "code": info["code"],

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -235,7 +235,7 @@ class SpendingBySubtierAgencyViewSet(ElasticsearchSpendingPaginationMixin, Elast
         return results
 
     def _build_json_result(self, bucket: dict):
-        info = json.loads(bucket.get("key").encode('unicode_escape'))
+        info = json.loads(bucket.get("key").encode("unicode_escape"))
         return {
             "id": int(info["id"]),
             "code": info["code"],

--- a/usaspending_api/disaster/v2/views/cfda/loans.py
+++ b/usaspending_api/disaster/v2/views/cfda/loans.py
@@ -24,7 +24,7 @@ class CfdaLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisasterB
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key").encode('unicode_escape'))
+            info = json.loads(bucket.get("key").encode("unicode_escape"))
             results.append(
                 {
                     "id": int(info.get("id")) if info.get("id") else None,

--- a/usaspending_api/disaster/v2/views/cfda/loans.py
+++ b/usaspending_api/disaster/v2/views/cfda/loans.py
@@ -24,7 +24,7 @@ class CfdaLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisasterB
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key"))
+            info = json.loads(bucket.get("key").encode('unicode_escape'))
             results.append(
                 {
                     "id": int(info.get("id")) if info.get("id") else None,

--- a/usaspending_api/disaster/v2/views/cfda/spending.py
+++ b/usaspending_api/disaster/v2/views/cfda/spending.py
@@ -23,7 +23,7 @@ class CfdaSpendingViewSet(ElasticsearchSpendingPaginationMixin, ElasticsearchDis
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key"))
+            info = json.loads(bucket.get("key").encode('unicode_escape'))
             results.append(
                 {
                     "id": int(info.get("id")) if info.get("id") else None,

--- a/usaspending_api/disaster/v2/views/cfda/spending.py
+++ b/usaspending_api/disaster/v2/views/cfda/spending.py
@@ -23,7 +23,7 @@ class CfdaSpendingViewSet(ElasticsearchSpendingPaginationMixin, ElasticsearchDis
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key").encode('unicode_escape'))
+            info = json.loads(bucket.get("key").encode("unicode_escape"))
             results.append(
                 {
                     "id": int(info.get("id")) if info.get("id") else None,

--- a/usaspending_api/disaster/v2/views/recipient/loans.py
+++ b/usaspending_api/disaster/v2/views/recipient/loans.py
@@ -26,7 +26,7 @@ class RecipientLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisa
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key"))
+            info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             # Build a list of hash IDs to handle multiple levels
             recipient_hash = info.get("hash")

--- a/usaspending_api/disaster/v2/views/recipient/loans.py
+++ b/usaspending_api/disaster/v2/views/recipient/loans.py
@@ -26,7 +26,7 @@ class RecipientLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisa
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key").encode('unicode_escape'))
+            info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             # Build a list of hash IDs to handle multiple levels
             recipient_hash = info.get("hash")

--- a/usaspending_api/disaster/v2/views/recipient/spending.py
+++ b/usaspending_api/disaster/v2/views/recipient/spending.py
@@ -26,7 +26,7 @@ class RecipientSpendingViewSet(ElasticsearchSpendingPaginationMixin, Elasticsear
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key").encode('unicode_escape'))
+            info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             # Build a list of hash IDs to handle multiple levels
             recipient_hash = info.get("hash")

--- a/usaspending_api/disaster/v2/views/recipient/spending.py
+++ b/usaspending_api/disaster/v2/views/recipient/spending.py
@@ -26,7 +26,7 @@ class RecipientSpendingViewSet(ElasticsearchSpendingPaginationMixin, Elasticsear
         results = []
         info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in info_buckets:
-            info = json.loads(bucket.get("key"))
+            info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             # Build a list of hash IDs to handle multiple levels
             recipient_hash = info.get("hash")

--- a/usaspending_api/disaster/v2/views/spending_by_geography.py
+++ b/usaspending_api/disaster/v2/views/spending_by_geography.py
@@ -137,7 +137,7 @@ class SpendingByGeographyViewSet(DisasterBase):
         results = {}
         geo_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in geo_info_buckets:
-            geo_info = json.loads(bucket.get("key"))
+            geo_info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             if self.geo_layer == GeoLayer.STATE:
                 display_name = geo_info.get("state_name").title()

--- a/usaspending_api/disaster/v2/views/spending_by_geography.py
+++ b/usaspending_api/disaster/v2/views/spending_by_geography.py
@@ -137,7 +137,7 @@ class SpendingByGeographyViewSet(DisasterBase):
         results = {}
         geo_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in geo_info_buckets:
-            geo_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            geo_info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             if self.geo_layer == GeoLayer.STATE:
                 display_name = geo_info.get("state_name").title()

--- a/usaspending_api/recipient/v2/views/recipients.py
+++ b/usaspending_api/recipient/v2/views/recipients.py
@@ -285,7 +285,7 @@ def obtain_recipient_totals(recipient_id, children=False, year="latest"):
     for bucket in recipient_info_buckets:
         result = {}
         if children:
-            recipient_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            recipient_info = json.loads(bucket.get("key").encode("unicode_escape"))
             hash_with_level = recipient_info.get("hash_with_level") or None
             result = {
                 "recipient_hash": hash_with_level[:-2] if hash_with_level else None,

--- a/usaspending_api/recipient/v2/views/recipients.py
+++ b/usaspending_api/recipient/v2/views/recipients.py
@@ -285,7 +285,7 @@ def obtain_recipient_totals(recipient_id, children=False, year="latest"):
     for bucket in recipient_info_buckets:
         result = {}
         if children:
-            recipient_info = json.loads(bucket.get("key"))
+            recipient_info = json.loads(bucket.get("key").encode('unicode_escape'))
             hash_with_level = recipient_info.get("hash_with_level") or None
             result = {
                 "recipient_hash": hash_with_level[:-2] if hash_with_level else None,

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
@@ -31,7 +31,7 @@ class AbstractAgencyViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMeta
         results = []
         agency_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in agency_info_buckets:
-            agency_info = json.loads(bucket.get("key"))
+            agency_info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
@@ -31,7 +31,7 @@ class AbstractAgencyViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMeta
         results = []
         agency_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in agency_info_buckets:
-            agency_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            agency_info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_federal_account.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_federal_account.py
@@ -27,7 +27,7 @@ class AbstractAccountViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMet
         results = []
         account_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in account_info_buckets:
-            account_info = json.loads(bucket.get("key"))
+            account_info = json.loads(bucket.get("key").encode('unicode_escape'))
             results.append(
                 {
                     "amount": int(bucket.get("sum_field", {"value": 0})["value"]) / Decimal("100"),

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_federal_account.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_federal_account.py
@@ -27,7 +27,7 @@ class AbstractAccountViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMet
         results = []
         account_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in account_info_buckets:
-            account_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            account_info = json.loads(bucket.get("key").encode("unicode_escape"))
             results.append(
                 {
                     "amount": int(bucket.get("sum_field", {"value": 0})["value"]) / Decimal("100"),

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_industry_codes.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_industry_codes.py
@@ -34,7 +34,7 @@ class AbstractIndustryCodeViewSet(AbstractSpendingByCategoryViewSet, metaclass=A
         results = []
         industry_code_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in industry_code_info_buckets:
-            industry_code_info = json.loads(bucket.get("key"))
+            industry_code_info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_industry_codes.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_industry_codes.py
@@ -34,7 +34,7 @@ class AbstractIndustryCodeViewSet(AbstractSpendingByCategoryViewSet, metaclass=A
         results = []
         industry_code_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in industry_code_info_buckets:
-            industry_code_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            industry_code_info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -34,7 +34,7 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
         results = []
         location_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in location_info_buckets:
-            location_info = json.loads(bucket.get("key"))
+            location_info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             if self.location_type == LocationType.CONGRESSIONAL_DISTRICT:
                 if location_info.get("congressional_code") == "90":

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -34,7 +34,7 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
         results = []
         location_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in location_info_buckets:
-            location_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            location_info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             if self.location_type == LocationType.CONGRESSIONAL_DISTRICT:
                 if location_info.get("congressional_code") == "90":

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_recipient_duns.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_recipient_duns.py
@@ -64,7 +64,7 @@ class RecipientDunsViewSet(AbstractSpendingByCategoryViewSet):
         results = []
         location_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in location_info_buckets:
-            recipient_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            recipient_info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_recipient_duns.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_recipient_duns.py
@@ -64,7 +64,7 @@ class RecipientDunsViewSet(AbstractSpendingByCategoryViewSet):
         results = []
         location_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in location_info_buckets:
-            recipient_info = json.loads(bucket.get("key"))
+            recipient_info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -345,7 +345,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         results = {}
         geo_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in geo_info_buckets:
-            geo_info = json.loads(bucket.get("key"))
+            geo_info = json.loads(bucket.get("key").encode('unicode_escape'))
 
             if self.geo_layer == GeoLayer.STATE:
                 display_name = geo_info.get("state_name").title()

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -345,7 +345,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         results = {}
         geo_info_buckets = response.get("group_by_agg_key", {}).get("buckets", [])
         for bucket in geo_info_buckets:
-            geo_info = json.loads(bucket.get("key").encode('unicode_escape'))
+            geo_info = json.loads(bucket.get("key").encode("unicode_escape"))
 
             if self.geo_layer == GeoLayer.STATE:
                 display_name = geo_info.get("state_name").title()


### PR DESCRIPTION
**Description:**
Title says it all. Recipient name contains three leading backslash characters. After the issue appeared in the COVID-19 page I tracked it down in other places across the website.

**Technical details:**
Escaping the slashes with another slash each fixed the issue. API responses will contain `\\\\\\STRIPES/// PARKING LOT SERVICE, INC.` which is correctly parsed by JSON readers, such as the website.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5825](https://federal-spending-transparency.atlassian.net/browse/DEV-5825):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API (No impact)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
