### PR TITLE
[DEV-5821] Refactor Recipient Count

### DIFF
--- a/usaspending_api/disaster/v2/views/recipient/count.py
+++ b/usaspending_api/disaster/v2/views/recipient/count.py
@@ -1,16 +1,13 @@
-from django.db.models import Count, Case, When, F, TextField, OuterRef, Subquery, Sum, DecimalField, Q, Value
-from django.db.models.functions import Cast, Coalesce
+from django.db.models import Count, Case, When, F, TextField, Q
+from django.db.models.functions import Cast
+from django_cte import With
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.common.helpers.orm_helpers import generate_raw_quoted_query
 from usaspending_api.disaster.v2.views.disaster_base import DisasterBase
 from usaspending_api.awards.models import FinancialAccountsByAwards
-from usaspending_api.disaster.v2.views.disaster_base import (
-    FabaOutlayMixin,
-    AwardTypeMixin,
-)
+from usaspending_api.disaster.v2.views.disaster_base import FabaOutlayMixin, AwardTypeMixin
 from usaspending_api.recipient.v2.lookups import SPECIAL_CASES
 from usaspending_api.search.models import AwardSearchView
 
@@ -27,52 +24,40 @@ class RecipientCountViewSet(DisasterBase, FabaOutlayMixin, AwardTypeMixin):
     @cache_response()
     def post(self, request: Request) -> Response:
 
-        filters = [
-            self.is_in_provided_def_codes,
+        award_filters = [~Q(total_loan_value=0) | ~Q(total_obligation_by_award=0) | ~Q(total_outlay_by_award=0)]
+
+        if self.award_type_codes:
+            award_filters.append(Q(type__in=self.award_type_codes))
+
+        faba_filters = [
             self.all_closed_defc_submissions,
+            self.is_in_provided_def_codes,
         ]
 
-        related_faba = (
-            FinancialAccountsByAwards.objects.filter(*filters)
-            .filter(award_id=OuterRef("award_id"))
-            .order_by()
-            .values("award_id")
+        dollar_annotations = {
+            "inner_obligation": self.obligated_field_annotation,
+            "inner_outlay": self.outlay_field_annotation,
+        }
+
+        cte = With(
+            FinancialAccountsByAwards.objects.filter(*faba_filters).values("award_id").annotate(**dollar_annotations)
         )
-        total_toa = related_faba.annotate(
-            total_toa=Coalesce(Sum("transaction_obligated_amount", output_field=DecimalField()), 0.0)
-        ).values("total_toa")
-        total_outlay = related_faba.annotate(
-            total_outlay=Coalesce(
-                Sum(
-                    Case(
-                        When(self.final_period_submission_query_filters, then=F("gross_outlay_amount_by_award_cpe")),
-                        default=Value(0),
-                    )
-                ),
-                0,
-            )
-        ).values("total_outlay")
 
         recipients = (
-            AwardSearchView.objects.annotate(
-                recipient=Case(
-                    When(recipient_name__in=SPECIAL_CASES, then=F("recipient_name"),),
-                    default=Cast(F("recipient_hash"), output_field=TextField()),
-                    output_field=TextField(),
+            cte.join(AwardSearchView, award_id=cte.col.award_id)
+            .with_cte(cte)
+            .annotate(total_obligation_by_award=cte.col.inner_obligation, total_outlay_by_award=cte.col.inner_outlay)
+            .filter(*award_filters)
+            .values("award_id")
+            .aggregate(
+                count=Count(
+                    Case(
+                        When(recipient_name__in=SPECIAL_CASES, then=F("recipient_name")),
+                        default=Cast(F("recipient_hash"), output_field=TextField()),
+                    ),
+                    distinct=True,
                 )
             )
-            .filter(self.has_award_of_provided_type)
-            .values("recipient")
-            .annotate(total_toa=Subquery(total_toa, output_field=DecimalField()))
-            .annotate(total_outlay=Subquery(total_outlay, output_field=DecimalField()))
-            .filter(~Q(total_toa=0.0) | ~Q(total_outlay=0.0))
-            .extra(
-                where=[
-                    f"Exists({generate_raw_quoted_query(FinancialAccountsByAwards.objects.filter(*filters))}"
-                    f" AND financial_accounts_by_awards.award_id = {AwardSearchView._meta.db_table}.award_id)"
-                ]
-            )
-            .aggregate(count=Count("recipient", distinct=True))
         )
 
         return Response({"count": recipients["count"]})

--- a/usaspending_api/search/models/vw_award_search.py
+++ b/usaspending_api/search/models/vw_award_search.py
@@ -1,7 +1,11 @@
+from django_cte import CTEManager
+
 from usaspending_api.search.models.base_award_search import BaseAwardSearchModel
 
 
 class AwardSearchView(BaseAwardSearchModel):
+    objects = CTEManager()
+
     class Meta:
         managed = False
         db_table = "vw_award_search"


### PR DESCRIPTION
**Description:**
Current implementation of the Disaster Recipient Count endpoint will occasionally timeout on Postgres at more than 5 minutes. This PR gets the timing down to 2 minutes which will still timeout for the API, but will allow the response to be cached for future calls. 

**Technical details:**
Made some minor adjustments and tested code that Kirk provided using a CTE to improve performance. While greater than 2 minutes is not ideal this will allow the endpoint to be cached and further improvements can be attempted later on.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5821](https://federal-spending-transparency.atlassian.net/browse/DEV-5821):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
