### PR TITLE
When in DEBUG mode, set logging level to debug and include all SQL

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -365,6 +365,9 @@ if DEBUG:
         if "console" not in LOGGING["loggers"][logger]["handlers"]:
             LOGGING["loggers"][logger]["handlers"] += ["console"]
 
+    LOGGING["handlers"]["console"]["level"] = "DEBUG"
+    LOGGING["loggers"]["django.db.backends"] = {"handlers": ["console"], "level": "DEBUG"}
+
 
 # If caches added or renamed, edit clear_caches in usaspending_api/etl/helpers.py
 CACHES = {


### PR DESCRIPTION
**Description:**
When running the Django app in debug mode: log more

**Technical details:**
All SQL Django is executing will be logged in debug mode too

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Changing DEBUG logging
```
