### PR TITLE
Populate fiscal_year field when updating award records

### DIFF
--- a/usaspending_api/etl/award_helpers.py
+++ b/usaspending_api/etl/award_helpers.py
@@ -67,6 +67,7 @@ SET
   awarding_agency_id                      = l.awarding_agency_id,
   category                                = l.category,
   certified_date                          = l.action_date,
+  fiscal_year                             = fy(l.action_date),
   funding_agency_id                       = l.funding_agency_id,
   last_modified_date                      = l.last_modified_date,
   period_of_performance_current_end_date  = l.period_of_performance_current_end_date,
@@ -94,6 +95,7 @@ WHERE
     OR a.awarding_agency_id                      IS DISTINCT FROM l.awarding_agency_id
     OR a.category                                IS DISTINCT FROM l.category
     OR a.certified_date                          IS DISTINCT FROM l.action_date
+    OR a.fiscal_year                             IS DISTINCT FROM fy(l.action_date)
     OR a.funding_agency_id                       IS DISTINCT FROM l.funding_agency_id
     OR a.last_modified_date                      IS DISTINCT FROM l.last_modified_date
     OR a.period_of_performance_current_end_date  IS DISTINCT FROM l.period_of_performance_current_end_date


### PR DESCRIPTION
**Description:**
`fiscal_year` is a neglected field in the `awards` table. Unfortunately, this was realized and not only were people running queries using this field, but ETL scripts were based on the values (or lack of values). Simple change so moving forward awards will be correctly updated

**Technical details:**
For a complete fix:
- `usaspending_api/database_scripts/job_archive/recompute_all_awards.py` should be run.
- If the above script is run, the update_date will be set and will be pulled into Elasticsearch indexes

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created (TBD)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
No changes to API or matviews. Data Changes TBD
```
