### PR TITLE
[DEV-5855] Remove the timestamp truncation from ES ETL

### DIFF
--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -291,7 +291,7 @@ def configure_sql_strings(config, filename, deleted_ids):
     """
     Populates the formatted strings defined globally in this file to create the desired SQL
     """
-    update_date_str = UPDATE_DATE_SQL.format(config["starting_date"].strftime("%Y-%m-%d"))
+    update_date_str = UPDATE_DATE_SQL.format(config["starting_date"])
     if config["load_type"] == "awards":
         view_name = settings.ES_AWARDS_ETL_VIEW_NAME
         view_type = "award"

--- a/usaspending_api/etl/management/commands/es_rapidloader.py
+++ b/usaspending_api/etl/management/commands/es_rapidloader.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--load_type",
+            "--load-type",
             type=str,
             help="Select which type of load to perform, current options are transactions or awards.",
             choices=["transactions", "awards"],

--- a/usaspending_api/etl/tests/test_es_rapidloader.py
+++ b/usaspending_api/etl/tests/test_es_rapidloader.py
@@ -148,13 +148,13 @@ def test_configure_sql_strings():
     copy_sql = """"COPY (
     SELECT *
     FROM award_delta_view
-    WHERE fiscal_year=2019 AND update_date >= '2007-10-01'
+    WHERE fiscal_year=2019 AND update_date >= '2007-10-01 00:00:00+00:00'
 ) TO STDOUT DELIMITER ',' CSV HEADER" > 'filename'
 """
     count_sql = """
 SELECT COUNT(*) AS count
 FROM award_delta_view
-WHERE fiscal_year=2019 AND update_date >= '2007-10-01'
+WHERE fiscal_year=2019 AND update_date >= '2007-10-01 00:00:00+00:00'
 """
     assert copy == copy_sql
     assert count == count_sql


### PR DESCRIPTION
**Description:**
There are no benefits and plenty of disadvantages when truncating the timestamp from the start time of the Elasticsearch ETL script. It is common for a large volume of records to be re-processed the following day even if the data have not changed. Since the timestamp is already being stored in the database and automatically added from the CLI this is a minor lift.

**Technical details:**
Additionally fixing CLI param to be consistent with others

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-5855](https://federal-spending-transparency.atlassian.net/browse/DEV-5855):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Script
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to data or frontend
```
