### PR TITLE
[DEV-5839] TAS/PSC filter speedup

### DIFF
--- a/usaspending_api/references/v2/views/filter_tree/filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/filter_tree.py
@@ -54,10 +54,15 @@ class FilterTree(metaclass=ABCMeta):
         raw_children = self.raw_search(ancestor_array + [retval.id])
         temp_children = [
             self._linked_node_from_data(ancestor_array + [retval.id], elem, filter_string, child_layers - 1)
-            for elem in raw_children if self.matches_filter(Node(**elem, count=0, children=None, ancestors=None), filter_string)
+            for elem in raw_children
         ]
+
         if child_layers:
-            children = temp_children
+            if filter_string:
+                temp_children = [elem for elem in temp_children if self.matches_filter(elem, filter_string)]
+                children = temp_children
+            else:
+                children = temp_children
         else:
             children = None
 
@@ -91,7 +96,6 @@ class FilterTree(metaclass=ABCMeta):
         pass
 
     def matches_filter(self, node: Node, filter_string) -> bool:
-
         if (filter_string.lower() in node.id.lower()) or (filter_string.lower() in node.description.lower()):
             return True
         if node.children:

--- a/usaspending_api/references/v2/views/filter_tree/filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/filter_tree.py
@@ -54,7 +54,7 @@ class FilterTree(metaclass=ABCMeta):
         raw_children = self.raw_search(ancestor_array + [retval.id])
         temp_children = [
             self._linked_node_from_data(ancestor_array + [retval.id], elem, filter_string, child_layers - 1)
-            for elem in raw_children
+            for elem in raw_children if self.matches_filter(Node(**elem, count=0, children=None, ancestors=None), filter_string)
         ]
         if child_layers:
             children = temp_children
@@ -91,6 +91,7 @@ class FilterTree(metaclass=ABCMeta):
         pass
 
     def matches_filter(self, node: Node, filter_string) -> bool:
+
         if (filter_string.lower() in node.id.lower()) or (filter_string.lower() in node.description.lower()):
             return True
         if node.children:

--- a/usaspending_api/references/v2/views/filter_tree/filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/filter_tree.py
@@ -43,7 +43,7 @@ class FilterTree(metaclass=ABCMeta):
 
         retval = [
             self._linked_node_from_data(ancestor_array, elem, filter_string, child_layers)
-            for elem in self.raw_search(ancestor_array)
+            for elem in self.raw_search(ancestor_array, filter_string)
         ]
         if filter_string:
             retval = [elem for elem in retval if self.matches_filter(elem, filter_string)]
@@ -51,18 +51,14 @@ class FilterTree(metaclass=ABCMeta):
 
     def _linked_node_from_data(self, ancestor_array, data, filter_string, child_layers):
         retval = self.unlinked_node_from_data(ancestor_array, data)
-        raw_children = self.raw_search(ancestor_array + [retval.id])
+        raw_children = self.raw_search(ancestor_array + [retval.id], filter_string)
         temp_children = [
             self._linked_node_from_data(ancestor_array + [retval.id], elem, filter_string, child_layers - 1)
             for elem in raw_children
         ]
 
         if child_layers:
-            if filter_string:
-                temp_children = [elem for elem in temp_children if self.matches_filter(elem, filter_string)]
-                children = temp_children
-            else:
-                children = temp_children
+            children = temp_children
         else:
             children = None
 

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -24,7 +24,7 @@ class PSCFilterTree(FilterTree):
         if len(tiered_keys) == 0:
             return self._toptier_search()
         elif len(tiered_keys) == 1:
-            return self._psc_from_group(tiered_keys[0], filter_string)
+            return self._psc_from_group(tiered_keys[0])
         else:
             return self._psc_from_parent(tiered_keys[-1], filter_string)
 
@@ -40,7 +40,7 @@ class PSCFilterTree(FilterTree):
     def _toptier_search(self):
         return PSC_GROUPS.keys()
 
-    def _psc_from_group(self, group, filter_string: str):
+    def _psc_from_group(self, group):
         # The default regex value will match nothing
         filters = [Q(code__iregex=PSC_GROUPS.get(group, {}).get("pattern") or "(?!)")]
         return [{"id": object.code, "description": object.description} for object in PSC.objects.filter(*filters)]

--- a/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
@@ -2,17 +2,17 @@ from usaspending_api.common.helpers.business_logic_helpers import cfo_presentati
 from usaspending_api.accounts.models import TreasuryAppropriationAccount, FederalAccount
 from usaspending_api.references.v2.views.filter_tree.filter_tree import UnlinkedNode, FilterTree
 from usaspending_api.references.models import ToptierAgency
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 
 
 class TASFilterTree(FilterTree):
-    def raw_search(self, tiered_keys):
+    def raw_search(self, tiered_keys, filter_search):
         if len(tiered_keys) == 0:
             return self._toptier_search()
         if len(tiered_keys) == 1:
-            return self._fa_given_agency(tiered_keys[0])
+            return self._fa_given_agency(tiered_keys[0], filter_search)
         if len(tiered_keys) == 2:
-            return self._tas_given_fa(tiered_keys[0], tiered_keys[1])
+            return self._tas_given_fa(tiered_keys[0], tiered_keys[1], filter_search)
         return []
 
     def _toptier_search(self):
@@ -35,19 +35,29 @@ class TASFilterTree(FilterTree):
     def _dictionary_from_agency(self, agency):
         return {"toptier_code": agency["toptier_code"], "name": agency["name"], "abbreviation": agency["abbreviation"]}
 
-    def _fa_given_agency(self, agency):
+    def _fa_given_agency(self, agency, filter_string):
+        filters = [
+            Q(has_faba=True),
+            Q(parent_toptier_agency__toptier_code=agency)
+        ]
+        if filter_string:
+            filters.append(Q(Q(federal_account_code__icontains=filter_string) | Q(account_title__icontains=filter_string)))
         return FederalAccount.objects.annotate(
             has_faba=Exists(faba_with_file_D_data().filter(treasury_account__federal_account=OuterRef("pk")))
-        ).filter(has_faba=True, parent_toptier_agency__toptier_code=agency)
+        ).filter(*filters)
 
-    def _tas_given_fa(self, agency, fed_account):
+    def _tas_given_fa(self, agency, fed_account, filter_string):
+        filters = [
+            Q(has_faba=True),
+            Q(federal_account__federal_account_code=fed_account),
+            Q(federal_account__parent_toptier_agency__toptier_code=agency)
+        ]
+        # if filter_string:
+        #     filters.append(
+        #         Q(Q(tas_rendering_label__icontains=filter_string) | Q(federal_account__account_title__icontains=filter_string)))
         return TreasuryAppropriationAccount.objects.annotate(
             has_faba=Exists(faba_with_file_D_data().filter(treasury_account=OuterRef("pk")))
-        ).filter(
-            has_faba=True,
-            federal_account__federal_account_code=fed_account,
-            federal_account__parent_toptier_agency__toptier_code=agency,
-        )
+        ).filter(*filters)
 
     def unlinked_node_from_data(self, ancestors: list, data) -> UnlinkedNode:
         if len(ancestors) == 0:  # A tier zero search is returning an agency dictionary

--- a/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
@@ -6,13 +6,13 @@ from django.db.models import Exists, OuterRef, Q
 
 
 class TASFilterTree(FilterTree):
-    def raw_search(self, tiered_keys, filter_search):
+    def raw_search(self, tiered_keys, filter_search: str):
         if len(tiered_keys) == 0:
             return self._toptier_search()
         if len(tiered_keys) == 1:
             return self._fa_given_agency(tiered_keys[0], filter_search)
         if len(tiered_keys) == 2:
-            return self._tas_given_fa(tiered_keys[0], tiered_keys[1], filter_search)
+            return self._tas_given_fa(tiered_keys[0], tiered_keys[1])
         return []
 
     def _toptier_search(self):
@@ -35,26 +35,22 @@ class TASFilterTree(FilterTree):
     def _dictionary_from_agency(self, agency):
         return {"toptier_code": agency["toptier_code"], "name": agency["name"], "abbreviation": agency["abbreviation"]}
 
-    def _fa_given_agency(self, agency, filter_string):
-        filters = [
-            Q(has_faba=True),
-            Q(parent_toptier_agency__toptier_code=agency)
-        ]
+    def _fa_given_agency(self, agency, filter_string: str):
+        filters = [Q(has_faba=True), Q(parent_toptier_agency__toptier_code=agency)]
         if filter_string:
-            filters.append(Q(Q(federal_account_code__icontains=filter_string) | Q(account_title__icontains=filter_string)))
+            filters.append(
+                Q(Q(federal_account_code__icontains=filter_string) | Q(account_title__icontains=filter_string))
+            )
         return FederalAccount.objects.annotate(
             has_faba=Exists(faba_with_file_D_data().filter(treasury_account__federal_account=OuterRef("pk")))
         ).filter(*filters)
 
-    def _tas_given_fa(self, agency, fed_account, filter_string):
+    def _tas_given_fa(self, agency, fed_account):
         filters = [
             Q(has_faba=True),
             Q(federal_account__federal_account_code=fed_account),
-            Q(federal_account__parent_toptier_agency__toptier_code=agency)
+            Q(federal_account__parent_toptier_agency__toptier_code=agency),
         ]
-        # if filter_string:
-        #     filters.append(
-        #         Q(Q(tas_rendering_label__icontains=filter_string) | Q(federal_account__account_title__icontains=filter_string)))
         return TreasuryAppropriationAccount.objects.annotate(
             has_faba=Exists(faba_with_file_D_data().filter(treasury_account=OuterRef("pk")))
         ).filter(*filters)


### PR DESCRIPTION
**Description:**
Modifies the behavior of the PSC reference endpoint, as well as performance improvements to both the TAS and PSC reference endpoints on the Advanced search page.

**Technical details:**
The main performance improvement is that instead of returning all the "children" of a given node from the DB and then filtering those children by the filter string, we add the filter string to the database call, which seems to have a pretty decent 
improvement to performance.
Performance Testing:

  | {{api_url}}/api/v2/references/filter_tree/tas/?depth=2&filter=073-1154 | {{api_url}}/api/v2/references/filter_tree/tas/?depth=2&filter=salaries | {{api_url}}/api/v2/references/filter_tree/tas/ | {{api_url}}/api/v2/references/filter_tree/tas/091/ | {{api_url}}/api/v2/references/filter_tree/tas/?depth=2&filter=stabilization | {{api_url}}/api/v2/references/filter_tree/tas/?depth=2&filter=institute
-- | -- | -- | -- | -- | -- | --
old   (sandbox) | 9.97 s | 6.37 s | 6.19 s | 1387 ms | 6.06 s | 7.07 s
new   (sandbox) | 818 ms | 1125 ms | 522 ms | 537 ms | 488 ms | 6.20 s


  | {{api_url}}/api/v2/references/filter_tree/psc/?depth=-1&filter=research | {{api_url}}/api/v2/references/filter_tree/psc/?depth=-1&filter=education | {{api_url}}/api/v2/references/filter_tree/psc/?depth=-1&filter=salaries | {{api_url}}/api/v2/references/filter_tree/psc/?depth=-1&filter=EQPT | {{api_url}}/api/v2/references/filter_tree/psc/ | {{api_url}}/api/v2/references/filter_tree/psc/?depth=-1&filter=engineer | {{api_url}}/api/v2/references/filter_tree/psc/?depth=-1&filter=agriculture
-- | -- | -- | -- | -- | -- | -- | --
new  (sandbox) | 801 ms | 494 ms | 877 ms | 1025 ms | 548 ms | 1307 ms | 1063 ms
old   (sandbox) | 7.40 s | 4.55 s | 4.76 s | 4.64 s | 4.50 s | 4.59 s | 4.50 s



**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-5839](https://federal-spending-transparency.atlassian.net/browse/DEV-5839):
    - [X] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to frontend, no changes to matviews, no ops tickets needed.
```
