### PR TITLE
adding headers as tags to root span in datadog trace

### DIFF
--- a/usaspending_api/common/datadog.py
+++ b/usaspending_api/common/datadog.py
@@ -1,0 +1,11 @@
+from ddtrace import tracer
+
+def add_headers(get_response):
+    def middleware(request):
+        span = tracer.current_root_span()
+        for header in request.headers: 
+            span.set_tag("http.headers.%s" % header, request.headers[header])
+        response = get_response(request)
+        return response
+
+    return middleware

--- a/usaspending_api/common/datadog.py
+++ b/usaspending_api/common/datadog.py
@@ -1,9 +1,10 @@
 from ddtrace import tracer
 
+
 def add_headers(get_response):
     def middleware(request):
         span = tracer.current_root_span()
-        for header in request.headers: 
+        for header in request.headers:
             span.set_tag("http.headers.%s" % header, request.headers[header])
         response = get_response(request)
         return response

--- a/usaspending_api/common/datadog.py
+++ b/usaspending_api/common/datadog.py
@@ -4,8 +4,9 @@ from ddtrace import tracer
 def add_headers(get_response):
     def middleware(request):
         span = tracer.current_root_span()
-        for header in request.headers:
-            span.set_tag("http.headers.%s" % header, request.headers[header])
+        if span:
+            for header in request.headers:
+                span.set_tag("http.headers.%s" % header, request.headers[header])
         response = get_response(request)
         return response
 

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -190,6 +190,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "usaspending_api.common.logging.LoggingMiddleware",
+    "usaspending_api.common.datadog.add_headers",
 ]
 
 ROOT_URLCONF = "usaspending_api.urls"


### PR DESCRIPTION
**Description:**
adding headers as tags to root span in datadog trace. This will allow us to see the headers as they relate to a traced request, as well as if the request originated from frontend or API consumer.

**Technical details:**
datadog's django auto-instrumentation does not automatically include http headers in traces. So, we need to get them from django.request and add them to the root span's tag set.

**Requirements for PR merge:**

1. [N/A] Unit & integration tests updated
2. [N/A] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [N/A] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [N/A] Domain Expert <OPTIONAL>
4. [N/A] Matview impact assessment completed
5. [N/A] Frontend impact assessment completed
6. [N/A] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [OPS-1043](https://federal-spending-transparency.atlassian.net/browse/OPS-1043):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [N/A] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
