### PR TITLE
[DEV-5322] change documentation in QAT, not just DEV 

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -91,7 +91,7 @@ This route sends a request to the backend to begin generating a zipfile of award
 
 ### Filters (object)
 + `agency` (required, string)
-    Agency database id to include, 'all' is also an option to include all agencies
+Agency internal database id. If you wish to include all agencies, use 'all' instead of a specific number. The three-digit agency AID/CGAC should not be used;   instead, make a request to the [/api/v2/bulk_download/list_agencies/](https://github.com/fedspendingtransparency/usaspending-api/blob/master/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md) endpoint and find the toptier_agency_id (the internal database id) of the agency of interest.
 + `prime_award_types` (optional, array[enum[string]])
     + Members
         + `IDV_A`


### PR DESCRIPTION
**Description:**
These changes went into DEV but not QAT due to a miscommunication it was not merged on time for code freeze. This PR is to correct that, and the original PR is https://github.com/fedspendingtransparency/usaspending-api/pull/2740

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5322](https://federal-spending-transparency.atlassian.net/browse/DEV-5322):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
