### PR TITLE
[DEV-4785] Spending Explorer file C unreported

### DIFF
--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -892,8 +892,8 @@ def test_unreported_file_c(client):
     response2 = resp2.json()
     expected_results = {
         "total": -15,
-        "agencies": ["random_recipient_name_2", "random_recipient_name_1", "Unreported Data"],
-        "amounts": [-3, -9, -3],
+        "agencies": ["random_recipient_name_2","Unreported Data", "random_recipient_name_1"],
+        "amounts": [-3, -3, -9],
     }
 
     actual_results = {

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -892,7 +892,7 @@ def test_unreported_file_c(client):
     response2 = resp2.json()
     expected_results = {
         "total": -15,
-        "agencies": ["random_recipient_name_2", "Unreported Data", "random_recipient_name_1"],
+        "agencies": ["random_recipient_name_2", "Non-Award Spending", "random_recipient_name_1"],
         "amounts": [-3, -3, -9],
     }
 

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -883,17 +883,9 @@ def test_unreported_file_c(client):
         mommy.make(entry.pop("model"), **entry)
 
     json_request = {"type": "recipient", "filters": {"agency": "-1", "fy": "1600", "quarter": "1"}}
-    resp = client.post(
-        "/api/v2/spending/",
-        content_type="application/json",
-        data=json_request
-    )
+    resp = client.post("/api/v2/spending/", content_type="application/json", data=json_request)
     json_request2 = {"type": "object_class", "filters": {"agency": "-1", "fy": "1600", "quarter": "1"}}
-    resp2 = client.post(
-        "/api/v2/spending/",
-        content_type="application/json",
-        data=json_request2
-    )
+    resp2 = client.post("/api/v2/spending/", content_type="application/json", data=json_request2)
     assert resp.status_code == status.HTTP_200_OK
     assert resp2.status_code == status.HTTP_200_OK
     response = resp.json()
@@ -901,7 +893,7 @@ def test_unreported_file_c(client):
     expected_results = {
         "total": -15,
         "agencies": ["random_recipient_name_2", "random_recipient_name_1", "Unreported Data"],
-        "amounts": [-3, -9, -2],
+        "amounts": [-3, -9, -3],
     }
 
     actual_results = {

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -892,7 +892,7 @@ def test_unreported_file_c(client):
     response2 = resp2.json()
     expected_results = {
         "total": -15,
-        "agencies": ["random_recipient_name_2","Unreported Data", "random_recipient_name_1"],
+        "agencies": ["random_recipient_name_2", "Unreported Data", "random_recipient_name_1"],
         "amounts": [-3, -3, -9],
     }
 

--- a/usaspending_api/spending_explorer/v2/filters/explorer.py
+++ b/usaspending_api/spending_explorer/v2/filters/explorer.py
@@ -98,10 +98,6 @@ class Explorer(object):
         # Recipients Queryset
         alt_set = (
             self.alt_set.filter(~Q(transaction_obligated_amount=Decimal("NaN")))
-            .filter(
-                Q(award__latest_transaction__contract_data__awardee_or_recipient_legal__isnull=False)
-                | Q(award__latest_transaction__assistance_data__awardee_or_recipient_legal__isnull=False)
-            )
             .annotate(
                 id=Coalesce(
                     "award__latest_transaction__contract_data__awardee_or_recipient_legal",

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -45,7 +45,6 @@ def get_unreported_data_obj(
         for key in result_keys:
             condensed_entry[key] = entry[key] if key != "id" else str(entry[key])
         result_set.append(condensed_entry)
-
     gtas = (
         GTASSF133Balances.objects.filter(fiscal_year=fiscal_year, fiscal_period=fiscal_period)
         .values("fiscal_year", "fiscal_period")
@@ -55,7 +54,6 @@ def get_unreported_data_obj(
     expected_total = gtas[0]["obligations_incurred_total_cpe__sum"] if gtas else None
     if spending_type in VALID_UNREPORTED_DATA_TYPES and set(filters.keys()).issubset(set(VALID_UNREPORTED_FILTERS)):
         unreported_obj = {"id": None, "code": None, "type": spending_type, "name": UNREPORTED_DATA_NAME, "amount": None}
-
         # if both values are actually available, then calculate the amount, otherwise leave it as the default of None
         if not (actual_total is None or expected_total is None):
             unreported_obj["amount"] = expected_total - actual_total
@@ -164,7 +162,6 @@ def type_filter(_type, filters, limit=None):
             alt_set = exp.award()
         if _type == "award_category":
             alt_set = exp.award_category()
-
         # Total value of filtered results
         actual_total = 0
 
@@ -183,9 +180,21 @@ def type_filter(_type, filters, limit=None):
                     award["name"] = code
             actual_total += award["total"]
 
-        alt_set = alt_set[:limit] if _type == "award" else alt_set
+        result_set = list(alt_set)
 
-        results = {"total": actual_total, "end_date": fiscal_date, "results": list(alt_set)}
+        # we need to get the File B data for the same set of filters, so we re-run the spending_filter but without setting the _type to any of the alt keys.
+        alt_set2, queryset2 = spending_filter(alt_set, queryset, filters, "")
+        expected_total = queryset2.aggregate(total=Sum("amount"))["total"]
+        unreported_obj = {"id": None, "code": None, "type": _type, "name": UNREPORTED_DATA_NAME, "amount": None}
+        if not (actual_total is None or expected_total is None):
+            unreported_obj["amount"] = expected_total - actual_total
+            result_set.append(unreported_obj)
+            actual_total = expected_total
+            result_set = sorted(result_set, key=lambda k: k["amount"], reverse=True)
+
+        result_set = result_set[:limit] if _type == "award" else result_set
+
+        results = {"total": actual_total, "end_date": fiscal_date, "results": result_set}
 
     else:
         # Annotate and get explorer _type filtered results
@@ -203,10 +212,8 @@ def type_filter(_type, filters, limit=None):
             queryset = exp.object_class()
         if _type == "agency":
             queryset = exp.agency()
-
         # Actual total value of filtered results
         actual_total = queryset.aggregate(total=Sum("amount"))["total"]
-
         result_set, expected_total = get_unreported_data_obj(
             queryset=queryset,
             filters=filters,

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -213,7 +213,7 @@ def type_filter(_type, filters, limit=None):
         if _type == "agency":
             queryset = exp.agency()
         # Actual total value of filtered results
-        actual_total = queryset.aggregate(total=Sum("amount"))["total"]
+        actual_total = queryset.aggregate(total=Sum("amount"))["total"] or 0
         result_set, expected_total = get_unreported_data_obj(
             queryset=queryset,
             filters=filters,

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -10,6 +10,7 @@ from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
 
 UNREPORTED_DATA_NAME = "Unreported Data"
+UNREPORTED_FILE_C_NAME = "Non-Award Spending"
 VALID_UNREPORTED_DATA_TYPES = ["agency", "budget_function", "object_class"]
 VALID_UNREPORTED_FILTERS = ["fy", "quarter", "period"]
 
@@ -185,12 +186,12 @@ def type_filter(_type, filters, limit=None):
         # we need to get the File B data for the same set of filters, so we re-run the spending_filter but without setting the _type to any of the alt keys.
         alt_set2, queryset2 = spending_filter(alt_set, queryset, filters, "")
         expected_total = queryset2.aggregate(total=Sum("amount"))["total"]
-        unreported_obj = {"id": None, "code": None, "type": _type, "name": UNREPORTED_DATA_NAME, "amount": None}
+        unreported_obj = {"id": None, "code": None, "type": _type, "name": UNREPORTED_FILE_C_NAME, "amount": None}
         if not (actual_total is None or expected_total is None):
             unreported_obj["amount"] = expected_total - actual_total
             result_set.append(unreported_obj)
             actual_total = expected_total
-            result_set = sorted(result_set, key=lambda k: k["amount"], reverse=True)
+            result_set.sort(key=lambda k: k["amount"], reverse=True)
 
         result_set = result_set[:limit] if _type == "award" else result_set
 

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -179,7 +179,11 @@ def type_filter(_type, filters, limit=None):
                 award["code"] = code
                 if _type == "award":
                     award["name"] = code
-            actual_total += award["total"]
+            if award["amount"] is None:
+                award["amount"] = 0
+            if award["name"] is None:
+                award["name"] = "Blank {}".format(_type.capitalize().replace("_", " "))
+            actual_total += award["total"] or 0
 
         result_set = list(alt_set)
 


### PR DESCRIPTION
**Description:**
Fixes an issue in the spending explorer where it would appear that large amounts of spending would "vanish" when switching from a File B layer to a File C layer (recipients, awards)

**Technical details:**
The reason that money seemed to be disappearing was that there are large amounts of money in File B that's non-award spending, and when switching to any of the award level/ File C spending, we did not include the non-award spending. This PR essentially queries File B data with the same filters we are using for File C, then adds the difference to the results from the File C request as "Unreported Data". 

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-4785](https://federal-spending-transparency.atlassian.net/browse/DEV-4785):
    - [X] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
