### PR TITLE
[DEV-5943] Leveraging proper concat usage in postgres requires non-django function

### DIFF
--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -31,7 +31,12 @@ from django.db.models import Case, CharField, DateField, DecimalField, F, Func, 
 from django.db.models.functions import Cast, Coalesce, Concat
 from usaspending_api.accounts.models import FederalAccount
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.common.helpers.orm_helpers import FiscalYear, get_agency_name_annotation, get_fyp_or_q_notation
+from usaspending_api.common.helpers.orm_helpers import (
+    ConcatAll,
+    FiscalYear,
+    get_agency_name_annotation,
+    get_fyp_or_q_notation,
+)
 from usaspending_api.download.filestreaming import NAMING_CONFLICT_DISCRIMINATOR
 from usaspending_api.download.v2.download_column_historical_lookups import query_paths
 from usaspending_api.references.models import ToptierAgency
@@ -355,7 +360,7 @@ def award_financial_derivations(derived_fields):
         When(
             **{
                 "award__generated_unique_award_id__isnull": False,
-                "then": Concat(
+                "then": ConcatAll(
                     Value(AWARD_URL), Func(F("award__generated_unique_award_id"), function="urlencode"), Value("/")
                 ),
             }

--- a/usaspending_api/disaster/v2/views/object_class/loans.py
+++ b/usaspending_api/disaster/v2/views/object_class/loans.py
@@ -1,7 +1,8 @@
 from django.db.models import F, Value, TextField, Min
-from django.db.models.functions import Cast, Concat
+from django.db.models.functions import Cast
 from rest_framework.response import Response
 from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.common.helpers.orm_helpers import ConcatAll
 from usaspending_api.disaster.v2.views.disaster_base import (
     DisasterBase,
     LoansPaginationMixin,
@@ -38,8 +39,8 @@ class ObjectClassLoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin,
     @property
     def queryset(self):
         query = self.construct_loan_queryset(
-            Concat("object_class__major_object_class", Value(":"), "object_class__object_class"),
-            ObjectClass.objects.annotate(join_key=Concat("major_object_class", Value(":"), "object_class")),
+            ConcatAll("object_class__major_object_class", Value(":"), "object_class__object_class"),
+            ObjectClass.objects.annotate(join_key=ConcatAll("major_object_class", Value(":"), "object_class")),
             "join_key",
         )
 

--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models.functions import Cast, Concat
+from django.db.models.functions import Cast
 from django.db.models import (
     Case,
     DateField,
@@ -17,8 +17,7 @@ from django.db.models import (
     Value,
     When,
 )
-
-from usaspending_api.common.helpers.orm_helpers import FiscalYear
+from usaspending_api.common.helpers.orm_helpers import FiscalYear, ConcatAll
 from usaspending_api.awards.models import Award, FinancialAccountsByAwards
 from usaspending_api.disaster.v2.views.disaster_base import (
     filter_by_latest_closed_periods,
@@ -63,7 +62,7 @@ def universal_transaction_matview_annotations():
             .values("value"),
             output_field=TextField(),
         ),
-        "usaspending_permalink": Concat(
+        "usaspending_permalink": ConcatAll(
             Value(AWARD_URL), Func(F("transaction__award__generated_unique_award_id"), function="urlencode"), Value("/")
         ),
         "disaster_emergency_fund_codes_for_overall_award": Case(
@@ -78,7 +77,7 @@ def universal_transaction_matview_annotations():
                             Case(
                                 When(
                                     disaster_emergency_fund__code__isnull=False,
-                                    then=Concat(
+                                    then=ConcatAll(
                                         F("disaster_emergency_fund__code"),
                                         Value(": "),
                                         F("disaster_emergency_fund__public_law"),
@@ -137,7 +136,7 @@ def universal_transaction_matview_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
+                    ConcatAll(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
                     output_field=TextField(),
                 )
             )
@@ -152,7 +151,7 @@ def universal_transaction_matview_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(
+                    ConcatAll(
                         F("program_activity__program_activity_code"),
                         Value(": "),
                         F("program_activity__program_activity_name"),
@@ -188,7 +187,7 @@ def universal_award_matview_annotations():
             .values("value"),
             output_field=TextField(),
         ),
-        "usaspending_permalink": Concat(
+        "usaspending_permalink": ConcatAll(
             Value(AWARD_URL), Func(F("award__generated_unique_award_id"), function="urlencode"), Value("/")
         ),
         "disaster_emergency_fund_codes": Subquery(
@@ -198,7 +197,7 @@ def universal_award_matview_annotations():
                     Case(
                         When(
                             disaster_emergency_fund__code__isnull=False,
-                            then=Concat(
+                            then=ConcatAll(
                                 F("disaster_emergency_fund__code"),
                                 Value(": "),
                                 F("disaster_emergency_fund__public_law"),
@@ -245,7 +244,7 @@ def universal_award_matview_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
+                    ConcatAll(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
                     output_field=TextField(),
                 )
             )
@@ -260,7 +259,7 @@ def universal_award_matview_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(
+                    ConcatAll(
                         F("program_activity__program_activity_code"),
                         Value(": "),
                         F("program_activity__program_activity_name"),
@@ -297,7 +296,7 @@ def idv_order_annotations():
             .values("value"),
             output_field=TextField(),
         ),
-        "usaspending_permalink": Concat(
+        "usaspending_permalink": ConcatAll(
             Value(AWARD_URL), Func(F("generated_unique_award_id"), function="urlencode"), Value("/")
         ),
         "disaster_emergency_fund_codes": Subquery(
@@ -307,7 +306,7 @@ def idv_order_annotations():
                     Case(
                         When(
                             disaster_emergency_fund__code__isnull=False,
-                            then=Concat(
+                            then=ConcatAll(
                                 F("disaster_emergency_fund__code"),
                                 Value(": "),
                                 F("disaster_emergency_fund__public_law"),
@@ -353,7 +352,7 @@ def idv_order_annotations():
             FinancialAccountsByAwards.objects.filter(filter_limit_to_closed_periods(), award_id=OuterRef("id"))
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
+                    ConcatAll(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
                     output_field=TextField(),
                 )
             )
@@ -368,7 +367,7 @@ def idv_order_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(
+                    ConcatAll(
                         F("program_activity__program_activity_code"),
                         Value(": "),
                         F("program_activity__program_activity_name"),
@@ -404,7 +403,7 @@ def idv_transaction_annotations():
             .values("value"),
             output_field=TextField(),
         ),
-        "usaspending_permalink": Concat(
+        "usaspending_permalink": ConcatAll(
             Value(AWARD_URL), Func(F("award__generated_unique_award_id"), function="urlencode"), Value("/")
         ),
         "disaster_emergency_fund_codes_for_overall_award": Case(
@@ -419,7 +418,7 @@ def idv_transaction_annotations():
                             Case(
                                 When(
                                     disaster_emergency_fund__code__isnull=False,
-                                    then=Concat(
+                                    then=ConcatAll(
                                         F("disaster_emergency_fund__code"),
                                         Value(": "),
                                         F("disaster_emergency_fund__public_law"),
@@ -478,7 +477,7 @@ def idv_transaction_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
+                    ConcatAll(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
                     output_field=TextField(),
                 )
             )
@@ -493,7 +492,7 @@ def idv_transaction_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(
+                    ConcatAll(
                         F("program_activity__program_activity_code"),
                         Value(": "),
                         F("program_activity__program_activity_name"),
@@ -533,7 +532,7 @@ def subaward_annotations():
             .values("value"),
             output_field=TextField(),
         ),
-        "usaspending_permalink": Concat(
+        "usaspending_permalink": ConcatAll(
             Value(AWARD_URL), Func(F("award__generated_unique_award_id"), function="urlencode"), Value("/")
         ),
         "prime_award_object_classes_funding_this_award": Subquery(
@@ -542,7 +541,7 @@ def subaward_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
+                    ConcatAll(F("object_class__object_class"), Value(": "), F("object_class__object_class_name")),
                     output_field=TextField(),
                 )
             )
@@ -557,7 +556,7 @@ def subaward_annotations():
             )
             .annotate(
                 value=ExpressionWrapper(
-                    Concat(
+                    ConcatAll(
                         F("program_activity__program_activity_code"),
                         Value(": "),
                         F("program_activity__program_activity_name"),
@@ -582,7 +581,7 @@ def subaward_annotations():
                             Case(
                                 When(
                                     disaster_emergency_fund__code__isnull=False,
-                                    then=Concat(
+                                    then=ConcatAll(
                                         F("disaster_emergency_fund__code"),
                                         Value(": "),
                                         F("disaster_emergency_fund__public_law"),


### PR DESCRIPTION
**Description:**
When working on DEV-5943 I realized the inefficient Django `concat` function was used in some places when concatenating more than two fields/strings. This minor warmfix PR should help with performance for some downloads and `/object_class/loans/`

**Technical details:**
Django's concat function oddly creates nested concatenations when there are more than 2 fields/text. Replacing with a simple function helps with performance when operating on large numbers of rows.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-5943](https://federal-spending-transparency.atlassian.net/browse/DEV-5943):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Minor changes for better ORM
```
