### PR TITLE
[DEV-6033] Regex to handle quotes in a json formatted string

### DIFF
--- a/usaspending_api/common/elasticsearch/json_helpers.py
+++ b/usaspending_api/common/elasticsearch/json_helpers.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 
 def json_str_to_dict(string: str) -> dict:
@@ -12,5 +13,12 @@ def json_str_to_dict(string: str) -> dict:
 
     try:
         return json.loads(string.encode("unicode_escape"))
+    except json.decoder.JSONDecodeError:
+        pass  # One more attempt to Decode
+
+    try:
+        regex = r"\"([^\"]*)\"\s?:\s?\"([^\"]*(?:(?:\w|\s)?(?:\"|\')?(?:\w|\s)?)*[^\"]*)(?:(?:\"\,)|(?:\"\}))"
+        matches = re.findall(regex, string)
+        return {key: value for key, value in matches}
     except json.decoder.JSONDecodeError as e:
         raise e

--- a/usaspending_api/common/elasticsearch/json_helpers.py
+++ b/usaspending_api/common/elasticsearch/json_helpers.py
@@ -13,7 +13,7 @@ def json_str_to_dict(string: str) -> dict:
 
     try:
         return json.loads(string.encode("unicode_escape"))
-    except json.decoder.JSONDecodeError as e:
+    except json.decoder.JSONDecodeError:
 
         # Try to parse the string with Regex before throwing error
         key_count_regex = r"\"[^\"]*\"\s?:"
@@ -30,4 +30,4 @@ def json_str_to_dict(string: str) -> dict:
         ):
             return {key: value for key, value in grouping_matches}
         else:
-            return e  # Return the JSONDecodeError since we couldn't salvage with regex
+            raise json.decoder.JSONDecodeError(f"Unable to parse '{string}' even using regex")

--- a/usaspending_api/common/elasticsearch/json_helpers.py
+++ b/usaspending_api/common/elasticsearch/json_helpers.py
@@ -13,12 +13,21 @@ def json_str_to_dict(string: str) -> dict:
 
     try:
         return json.loads(string.encode("unicode_escape"))
-    except json.decoder.JSONDecodeError:
-        pass  # One more attempt to Decode
-
-    try:
-        regex = r"\"([^\"]*)\"\s?:\s?\"([^\"]*(?:(?:\w|\s)?(?:\"|\')?(?:\w|\s)?)*[^\"]*)(?:(?:\"\,)|(?:\"\}))"
-        matches = re.findall(regex, string)
-        return {key: value for key, value in matches}
     except json.decoder.JSONDecodeError as e:
-        raise e
+
+        # Try to parse the string with Regex before throwing error
+        key_count_regex = r"\"[^\"]*\"\s?:"
+        grouping_regex = r"\"([^\"]*)\"\s?:\s?\"([^\"]*(?:(?:\w|\s)?(?:\"|\')?(?:\w|\s)?)*[^\"]*)(?:(?:\"\,)|(?:\"\}))"
+
+        key_count_matches = re.findall(key_count_regex, string)
+        grouping_matches = re.findall(grouping_regex, string)
+
+        # Need to verify the correct number of elements in case grouping regex didn't work
+        if (
+            isinstance(key_count_matches, list)
+            and isinstance(grouping_matches, list)
+            and len(key_count_matches) == len(grouping_matches)
+        ):
+            return {key: value for key, value in grouping_matches}
+        else:
+            return e  # Return the JSONDecodeError since we couldn't salvage with regex


### PR DESCRIPTION
**Description:**
There are Recipient Names that are causing issues when trying to decode a JSON formatted string to a dictionary due to not being properly escaped. As a temporary fix, these cases are handled as edge cases so that the endpoint will return successfully.

**Technical details:**
The regex is a "last chance" for the JSON Decoder to create a dictionary from the JSON formatted string. The particular recipient that caused the issues (or at least the Aggregation Key that caused the issue) is shown here:
```'{"name":""E" SECURITY, LLC","unique_id":"079542464","hash":"8b87be1f-002e-83d3-f6f9-a0d6b05edf41","levels":"{C}"}'```
After this change the Recipient Spending endpoint now returns a result for this recipient as:
```
{
            "id": [
                "8b87be1f-002e-83d3-f6f9-a0d6b05edf41-C"
            ],
            "code": "079542464",
            "description": "\"E\" SECURITY, LLC",
            "award_count": 1,
            "obligation": 156880.0,
            "outlay": 0.0
        },
```


As a stress test, the following string was tested against the regex:
```{"name":"DAWN "'DYLAN" BAIRD-MYLES PROPERTY MANAGEMENT  & REAL ESTATE","unique_id":"079542464","hash":"8b87be1f-002e-83d3-f6f9-a0d6b05edf41","levels":"{C}"}```

The results it produced are shown here:
![Screen Shot 2020-09-01 at 9 36 05 AM](https://user-images.githubusercontent.com/40359517/91882570-0423cc00-ec38-11ea-9086-0c8d8bfd581c.png)


**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6033](https://federal-spending-transparency.atlassian.net/browse/DEV-6033):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
