### PR TITLE
[DEV-5881] Gets award ids only missing from latest submission in zero…

### DIFF
--- a/usaspending_api/etl/management/commands/zero_missing_award_outlays.py
+++ b/usaspending_api/etl/management/commands/zero_missing_award_outlays.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("script")
 
 """
 WARNING: This SQL will only correctly identify awards during the first fiscal
-year of Covid submissions. A flaw has been found that will cause some awards in 
+year of Covid submissions. A flaw has been found that will cause some awards in
 FY 21 to be incorrectly identified. This should be replaced before the close of
 the Fiscal Year
 """

--- a/usaspending_api/etl/management/commands/zero_missing_award_outlays.py
+++ b/usaspending_api/etl/management/commands/zero_missing_award_outlays.py
@@ -9,39 +9,44 @@ from usaspending_api.common.elasticsearch.client import instantiate_elasticsearc
 
 logger = logging.getLogger("script")
 
+"""
+WARNING: This SQL will only correctly identify awards during the first fiscal
+year of Covid submissions. A flaw has been found that will cause some awards in 
+FY 21 to be incorrectly identified. This should be replaced before the close of
+the Fiscal Year
+"""
+
 MISSING_COVID_AWARD_SQL = """
-SELECT
-    award_id
-FROM
-    (
-        SELECT
-            DISTINCT ON
-            (faba.award_id) faba.award_id,
-            sa.submission_id,
-            sa.is_final_balances_for_fy,
-            sa.reporting_fiscal_year,
-            sa.reporting_fiscal_period,
-            sa.quarter_format_flag
-        FROM
-            financial_accounts_by_awards faba
-        INNER JOIN disaster_emergency_fund_code defc ON
-            defc.code = faba.disaster_emergency_fund_code
-            AND defc.group_name = 'covid_19'
-        INNER JOIN submission_attributes sa ON
-            faba.submission_id = sa.submission_id
-        WHERE
-            faba.award_id IS NOT NULL
-            AND sa.reporting_period_start >= '2020-04-01'
-        ORDER BY
-            faba.award_id, sa.reporting_period_end DESC
-    ) AS covid_awards
-INNER JOIN dabs_submission_window_schedule dabs ON
-    dabs.submission_fiscal_year = covid_awards.reporting_fiscal_year
-    AND dabs.submission_fiscal_month = covid_awards.reporting_fiscal_period
-    AND dabs.is_quarter = covid_awards.quarter_format_flag
-    AND dabs.submission_reveal_date <= now()
-WHERE
-    covid_awards.is_final_balances_for_fy = FALSE;
+SELECT award_id
+FROM (
+    SELECT
+        DISTINCT ON
+        (faba.award_id) faba.award_id,
+        sa.submission_id,
+        sa.is_final_balances_for_fy,
+        sa.reporting_fiscal_year,
+        sa.reporting_fiscal_period,
+        sa.quarter_format_flag
+    FROM
+        financial_accounts_by_awards faba
+    INNER JOIN disaster_emergency_fund_code defc ON
+        defc.code = faba.disaster_emergency_fund_code
+        AND defc.group_name = 'covid_19'
+    INNER JOIN submission_attributes sa ON
+        sa.reporting_period_start >= '2020-04-01'
+        AND faba.submission_id = sa.submission_id
+    INNER JOIN dabs_submission_window_schedule dabs ON
+        dabs.submission_fiscal_year = sa.reporting_fiscal_year
+        AND dabs.submission_fiscal_month = sa.reporting_fiscal_period
+        AND dabs.is_quarter = sa.quarter_format_flag
+        AND dabs.submission_reveal_date <= now()
+    WHERE
+        faba.award_id IS NOT NULL
+    ORDER BY
+        faba.award_id, submission_reveal_date DESC, is_quarter
+) AS covid_awards
+WHERE covid_awards.is_final_balances_for_fy = FALSE
+;
 """
 
 


### PR DESCRIPTION
…_missing_award_outlays command

**Description:**
This replaces the SQL used in the `zero_missing_award_outlays` command. The previous SQL selected too many award_ids. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. N/A - API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert <OPTIONAL>
4. N/A - Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. [x] Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-5881](https://federal-spending-transparency.atlassian.net/browse/DEV-5881):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
