### PR TITLE
[DEV-5039] Increases the pagination limit on the Spending by Category endpoint to 9999

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category.md
@@ -56,7 +56,7 @@ This endpoint returns a list of the top results of specific categories sorted by
     + Attributes (object)
         + `category` (required, string)
         + `results` (required, array[CategoryResult], fixed-type)
-        + `limit` (required, number)
+        + `limit` (required, number) Maximum - 9,999
         + `page_metadata` (PageMetadataObject)
         + `messages` (optional, array[string])
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.

--- a/usaspending_api/search/v2/views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category.py
@@ -70,7 +70,15 @@ class SpendingByCategoryVisualizationViewSet(APIView):
             {"name": "subawards", "key": "subawards", "type": "boolean", "default": False, "optional": True},
         ]
         models.extend(copy.deepcopy(AWARD_FILTER))
-        models.extend(copy.deepcopy(PAGINATION))
+
+        # Set pagination limit to 9,999. Any more would require querything Elasticsearch
+        # with buckets (10,000 and greater)
+        overriden_pagination = copy.deepcopy(PAGINATION)
+        for pagination_option in overriden_pagination:
+            if pagination_option["name"] == "limit":
+                pagination_option["max"] = 9999
+
+        models.extend(overriden_pagination)
 
         # Apply/enforce POST body schema and data validation in request
         original_filters = request.data.get("filters")


### PR DESCRIPTION
**Description:**
This PR increases the max number of results returned from the Spending by Category endpoint from 100 to 9999. This endpoint was recently modified to use Elasticsearch, which allowed for more records to be returned while maintaining good performance. A performance investigation was performed to ensure reasonable execution times. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. N/A - Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [x] Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-5039](https://federal-spending-transparency.atlassian.net/browse/DEV-5039):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
