### PR TITLE
[DEV-5977] Add back cfda_website as website_address

### DIFF
--- a/usaspending_api/disaster/tests/fixtures/cfda_data.py
+++ b/usaspending_api/disaster/tests/fixtures/cfda_data.py
@@ -251,6 +251,7 @@ def cfda_awards_and_transactions(db):
         program_number="10.100",
         program_title="CFDA 1",
         url="None;",
+        website_address=None,
     )
     mommy.make(
         "references.Cfda",
@@ -262,6 +263,7 @@ def cfda_awards_and_transactions(db):
         program_number="20.200",
         program_title="CFDA 2",
         url="www.example.com/200",
+        website_address="www.example.com/cfda_website/200",
     )
     mommy.make(
         "references.Cfda",
@@ -273,4 +275,5 @@ def cfda_awards_and_transactions(db):
         program_number="30.300",
         program_title="CFDA 3",
         url="www.example.com/300",
+        website_address="www.example.com/cfda_website/300",
     )

--- a/usaspending_api/disaster/tests/integration/test_cfda_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_loans.py
@@ -39,6 +39,7 @@ def test_correct_response_single_defc(
             "beneficiary_eligibility": "BE2",
             "cfda_federal_agency": "Agency 2",
             "cfda_objectives": "objectives 2",
+            "cfda_website": "www.example.com/cfda_website/200",
         },
         {
             "code": "10.100",
@@ -53,6 +54,7 @@ def test_correct_response_single_defc(
             "beneficiary_eligibility": "BE1",
             "cfda_federal_agency": "Agency 1",
             "cfda_objectives": "objectives 1",
+            "cfda_website": None,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -80,6 +82,7 @@ def test_correct_response_multiple_defc(
             "beneficiary_eligibility": "BE2",
             "cfda_federal_agency": "Agency 2",
             "cfda_objectives": "objectives 2",
+            "cfda_website": "www.example.com/cfda_website/200",
         },
         {
             "code": "10.100",
@@ -94,6 +97,7 @@ def test_correct_response_multiple_defc(
             "beneficiary_eligibility": "BE1",
             "cfda_federal_agency": "Agency 1",
             "cfda_objectives": "objectives 1",
+            "cfda_website": None,
         },
     ]
 
@@ -127,6 +131,7 @@ def test_correct_response_with_query(
             "beneficiary_eligibility": "BE2",
             "cfda_federal_agency": "Agency 2",
             "cfda_objectives": "objectives 2",
+            "cfda_website": "www.example.com/cfda_website/200",
         }
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -183,6 +188,7 @@ def test_pagination_page_and_limit(
                 "beneficiary_eligibility": "BE1",
                 "cfda_federal_agency": "Agency 1",
                 "cfda_objectives": "objectives 1",
+                "cfda_website": None,
             }
         ],
         "page_metadata": {
@@ -241,6 +247,7 @@ def test_correct_response_with_award_type_codes(
                 "beneficiary_eligibility": "BE2",
                 "cfda_federal_agency": "Agency 2",
                 "cfda_objectives": "objectives 2",
+                "cfda_website": "www.example.com/cfda_website/200",
             },
             {
                 "code": "10.100",
@@ -255,6 +262,7 @@ def test_correct_response_with_award_type_codes(
                 "beneficiary_eligibility": "BE1",
                 "cfda_federal_agency": "Agency 1",
                 "cfda_objectives": "objectives 1",
+                "cfda_website": None,
             },
         ],
         "page_metadata": {
@@ -290,6 +298,7 @@ def test_correct_response_with_award_type_codes(
                 "beneficiary_eligibility": "BE2",
                 "cfda_federal_agency": "Agency 2",
                 "cfda_objectives": "objectives 2",
+                "cfda_website": "www.example.com/cfda_website/200",
             }
         ],
         "page_metadata": {

--- a/usaspending_api/disaster/tests/integration/test_cfda_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_cfda_spending.py
@@ -38,6 +38,7 @@ def test_correct_response_single_defc(
             "beneficiary_eligibility": "BE3",
             "cfda_federal_agency": "Agency 3",
             "cfda_objectives": "objectives 3",
+            "cfda_website": "www.example.com/cfda_website/300",
         },
         {
             "code": "20.200",
@@ -51,6 +52,7 @@ def test_correct_response_single_defc(
             "beneficiary_eligibility": "BE2",
             "cfda_federal_agency": "Agency 2",
             "cfda_objectives": "objectives 2",
+            "cfda_website": "www.example.com/cfda_website/200",
         },
         {
             "code": "10.100",
@@ -64,6 +66,7 @@ def test_correct_response_single_defc(
             "beneficiary_eligibility": "BE1",
             "cfda_federal_agency": "Agency 1",
             "cfda_objectives": "objectives 1",
+            "cfda_website": None,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -90,6 +93,7 @@ def test_correct_response_multiple_defc(
             "beneficiary_eligibility": "BE3",
             "cfda_federal_agency": "Agency 3",
             "cfda_objectives": "objectives 3",
+            "cfda_website": "www.example.com/cfda_website/300",
         },
         {
             "code": "20.200",
@@ -103,6 +107,7 @@ def test_correct_response_multiple_defc(
             "beneficiary_eligibility": "BE2",
             "cfda_federal_agency": "Agency 2",
             "cfda_objectives": "objectives 2",
+            "cfda_website": "www.example.com/cfda_website/200",
         },
         {
             "code": "10.100",
@@ -116,6 +121,7 @@ def test_correct_response_multiple_defc(
             "beneficiary_eligibility": "BE1",
             "cfda_federal_agency": "Agency 1",
             "cfda_objectives": "objectives 1",
+            "cfda_website": None,
         },
     ]
 
@@ -148,6 +154,7 @@ def test_correct_response_with_query(
             "beneficiary_eligibility": "BE3",
             "cfda_federal_agency": "Agency 3",
             "cfda_objectives": "objectives 3",
+            "cfda_website": "www.example.com/cfda_website/300",
         }
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -179,6 +186,7 @@ def test_correct_response_with_award_type_codes(
             "beneficiary_eligibility": "BE2",
             "cfda_federal_agency": "Agency 2",
             "cfda_objectives": "objectives 2",
+            "cfda_website": "www.example.com/cfda_website/200",
         },
         {
             "code": "10.100",
@@ -192,6 +200,7 @@ def test_correct_response_with_award_type_codes(
             "beneficiary_eligibility": "BE1",
             "cfda_federal_agency": "Agency 1",
             "cfda_objectives": "objectives 1",
+            "cfda_website": None,
         },
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -261,6 +270,7 @@ def test_pagination_page_and_limit(
                 "beneficiary_eligibility": "BE2",
                 "cfda_federal_agency": "Agency 2",
                 "cfda_objectives": "objectives 2",
+                "cfda_website": "www.example.com/cfda_website/200",
             }
         ],
         "page_metadata": {

--- a/usaspending_api/disaster/v2/views/cfda/loans.py
+++ b/usaspending_api/disaster/v2/views/cfda/loans.py
@@ -47,6 +47,7 @@ class CfdaLoansViewSet(ElasticsearchLoansPaginationMixin, ElasticsearchDisasterB
                     {
                         "cfda_federal_agency": cfda[0].federal_agency,
                         "cfda_objectives": cfda[0].objectives,
+                        "cfda_website": cfda[0].website_address,
                         "applicant_eligibility": cfda[0].applicant_eligibility,
                         "beneficiary_eligibility": cfda[0].beneficiary_eligibility,
                     }

--- a/usaspending_api/disaster/v2/views/cfda/spending.py
+++ b/usaspending_api/disaster/v2/views/cfda/spending.py
@@ -47,6 +47,7 @@ class CfdaSpendingViewSet(ElasticsearchSpendingPaginationMixin, ElasticsearchDis
                     {
                         "cfda_federal_agency": cfda[0].federal_agency,
                         "cfda_objectives": cfda[0].objectives,
+                        "cfda_website": cfda[0].website_address,
                         "applicant_eligibility": cfda[0].applicant_eligibility,
                         "beneficiary_eligibility": cfda[0].beneficiary_eligibility,
                     }


### PR DESCRIPTION
**Description:**
Originally thought `cfda_website` was a duplicate of `resource_link`, but as it turns out the field just needed to reference `website_address` instead of `url`.

**Technical details:**
Put `cfda_website` back and reference `website_address` instead of `url`.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-5977](https://federal-spending-transparency.atlassian.net/browse/DEV-5977):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
