### PR TITLE
dev-4817 updated documentation to not mention old functionality

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -24,6 +24,13 @@ This route sends a request to the backend to begin generating a zipfile of award
 
             {
                 "filters": {
+                    "agencies": [
+                        {
+                            "type": "awarding",
+                            "tier": "subtier",
+                            "name": "Department of Agriculture"
+                        }
+                    ],
                     "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
                     "sub_award_types": ["procurement"],
                     "date_range": {
@@ -53,6 +60,13 @@ This route sends a request to the backend to begin generating a zipfile of award
                 "file_name": "534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
                 "file_url": "/csv_downloads/534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
                 "download_request": {
+                    "agencies": [
+                        {
+                            "type": "awarding",
+                            "tier": "subtier",
+                            "name": "Department of Agriculture"
+                        }
+                    ],
                     "columns": [],
                     "download_types": [
                         "prime_awards",

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -24,21 +24,48 @@ This route sends a request to the backend to begin generating a zipfile of award
 
             {
                 "filters": {
+                    "prime_award_types": [
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "IDV_A",
+                        "IDV_B",
+                        "IDV_B_A",
+                        "IDV_B_B",
+                        "IDV_B_C",
+                        "IDV_C",
+                        "IDV_D",
+                        "IDV_E",
+                        "02",
+                        "03",
+                        "04",
+                        "05",
+                        "10",
+                        "06",
+                        "07",
+                        "08",
+                        "09",
+                        "11"
+                    ],
+                    "sub_award_types": [],
+                    "sub_agency": "Animal and Plant Health Inspection Service",
+                    "date_type": "action_date",
+                    "date_range": {
+                        "start_date": "2019-10-01",
+                        "end_date": "2020-09-30"
+                    },
                     "agencies": [
                         {
-                            "type": "awarding",
+                            "type": "funding",
                             "tier": "subtier",
-                            "name": "Department of Agriculture"
+                            "name": "Animal and Plant Health Inspection Service",
+                            "toptier_name": "Department of Agriculture"
                         }
-                    ],
-                    "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
-                    "sub_award_types": ["procurement"],
-                    "date_range": {
-                        "start_date": "2019-01-01",
-                        "end_date": "2019-12-31"
-                    },
-                    "date_type": "action_date"
-                }
+                    ]
+                },
+                "columns": [],
+                "file_format": "csv"
             }
 
 
@@ -56,40 +83,57 @@ This route sends a request to the backend to begin generating a zipfile of award
     + Body
             
             {
-                "status_url": "http://localhost:8000/api/v2/download/status?file_name=534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
-                "file_name": "534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
-                "file_url": "/csv_downloads/534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
+                "status_url": "https://api.usaspending.gov/api/v2/download/status?file_name=All_PrimeTransactions_2020-09-16_H15M20S52934397.zip",
+                "file_name": "All_PrimeTransactions_2020-09-16_H15M20S52934397.zip",
+                "file_url": "https://files.usaspending.gov/generated_downloads/dev/All_PrimeTransactions_2020-09-16_H15M20S52934397.zip",
                 "download_request": {
-                    "agencies": [
-                        {
-                            "type": "awarding",
-                            "tier": "subtier",
-                            "name": "Department of Agriculture"
-                        }
-                    ],
+                    "agency": "all",
                     "columns": [],
                     "download_types": [
-                        "prime_awards",
-                        "sub_awards"
+                        "prime_awards"
                     ],
                     "file_format": "csv",
                     "filters": {
                         "agencies": [
                             {
-                                "name": "Office of the Federal Coordinator for Alaska Natural Gas Transportation Projects",
-                                "tier": "toptier",
-                                "type": "awarding"
+                                "name": "Animal and Plant Health Inspection Service",
+                                "tier": "subtier",
+                                "toptier_name": "Department of Agriculture",
+                                "type": "funding"
                             }
                         ],
                         "prime_and_sub_award_types": {
-                            "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
-                            "sub_award_types": ["procurement"]
+                            "prime_awards": [
+                                "02",
+                                "03",
+                                "04",
+                                "05",
+                                "06",
+                                "07",
+                                "08",
+                                "09",
+                                "10",
+                                "11",
+                                "A",
+                                "B",
+                                "C",
+                                "D",
+                                "IDV_A",
+                                "IDV_B",
+                                "IDV_B_A",
+                                "IDV_B_B",
+                                "IDV_B_C",
+                                "IDV_C",
+                                "IDV_D",
+                                "IDV_E"
+                            ],
+                            "sub_awards": []
                         },
                         "time_period": [
                             {
                                 "date_type": "action_date",
-                                "end_date": "2019-12-31",
-                                "start_date": "2019-01-01"
+                                "end_date": "2020-09-30",
+                                "start_date": "2019-10-01"
                             }
                         ]
                     },

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -49,7 +49,6 @@ This route sends a request to the backend to begin generating a zipfile of award
                         "11"
                     ],
                     "sub_award_types": [],
-                    "sub_agency": "Animal and Plant Health Inspection Service",
                     "date_type": "action_date",
                     "date_range": {
                         "start_date": "2019-10-01",
@@ -188,8 +187,6 @@ This route sends a request to the backend to begin generating a zipfile of award
     + Members
         + `domestic`
         + `foreign`
-+ `sub_agency` (optional, string)
-    Sub-agency name to include (based on the agency filter)
 + `sub_award_types` (optional, array[enum[string]])
     + Members
         + `grant`

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -162,3 +162,4 @@ This route sends a request to the backend to begin generating a zipfile of award
         + `funding`
         + `awarding`
 + `toptier_name` (optional, string)
+    Required if and only if `tier`=`subtier`

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -90,10 +90,7 @@ This route sends a request to the backend to begin generating a zipfile of award
 ## Filter Objects
 
 ### Filters (object)
-+ `agencies` (optional, array[Agency], fixed-type)
-All requests must either include the `agencies` or `agency` parameter.
-+ `agency` (optional, string)
-Agency internal database id. If you wish to include all agencies, use 'all' instead of a specific number. The three-digit agency AID/CGAC should not be used;   instead, make a request to the [/api/v2/bulk_download/list_agencies/](https://github.com/fedspendingtransparency/usaspending-api/blob/master/usaspending_api/api_contracts/contracts/v2/bulk_download/list_agencies.md) endpoint and find the toptier_agency_id (the internal database id) of the agency of interest.
++ `agencies` (required, array[Agency], fixed-type)
 + `prime_award_types` (optional, array[enum[string]])
     + Members
         + `IDV_A`
@@ -164,3 +161,4 @@ Agency internal database id. If you wish to include all agencies, use 'all' inst
     + Members
         + `funding`
         + `awarding`
++ `toptier_name` (optional, string)

--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -24,7 +24,6 @@ This route sends a request to the backend to begin generating a zipfile of award
 
             {
                 "filters": {
-                    "agency": 50,
                     "prime_award_types": ["02", "03", "04", "05", "A", "B", "C", "D"],
                     "sub_award_types": ["procurement"],
                     "date_range": {
@@ -54,7 +53,6 @@ This route sends a request to the backend to begin generating a zipfile of award
                 "file_name": "534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
                 "file_url": "/csv_downloads/534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
                 "download_request": {
-                    "agency": 50,
                     "columns": [],
                     "download_types": [
                         "prime_awards",

--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -35,7 +35,7 @@ This route sends a request to the backend to begin generating a zipfile of award
                     "agencies": [
                         {
                             "type": "awarding",
-                            "tier": "subtier",
+                            "tier": "toptier",
                             "name": "Department of Agriculture"
                         }
                     ],
@@ -83,7 +83,7 @@ This route sends a request to the backend to begin generating a zipfile of award
                         "agencies": [
                             {
                                 "type": "awarding",
-                                "tier": "subtier",
+                                "tier": "toptier",
                                 "name": "Department of Agriculture"
                             }
                         ],

--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -161,6 +161,7 @@ This route sends a request to the backend to begin generating a zipfile of award
     + Members
         + `funding`
         + `awarding`
++ `toptier_name` (optional, string)
 
 ### TimePeriod (object)
 + `start_date` (required, string)

--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -60,7 +60,6 @@ This route sends a request to the backend to begin generating a zipfile of award
                 "file_name": "PrimeAwardSummariesAndSubawards_2020-01-13_H21M05S48397603.zip",
                 "file_url": "/csv_downloads/PrimeAwardSummariesAndSubawards_2020-01-13_H21M05S48397603.zip",
                 "download_request": {
-                    "agency": "all",
                     "columns": [
                         "assistance_award_unique_key",
                         "award_id_fain",

--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -32,6 +32,13 @@ This route sends a request to the backend to begin generating a zipfile of award
 
             {
                 "filters": {
+                    "agencies": [
+                        {
+                            "type": "awarding",
+                            "tier": "subtier",
+                            "name": "Department of Agriculture"
+                        }
+                    ],
                     "keywords": ["Defense"]
                 },
                 "columns": [
@@ -73,6 +80,13 @@ This route sends a request to the backend to begin generating a zipfile of award
                     ],
                     "file_format": "csv",
                     "filters": {
+                        "agencies": [
+                            {
+                                "type": "awarding",
+                                "tier": "subtier",
+                                "name": "Department of Agriculture"
+                            }
+                        ],
                         "award_type_codes": [
                             "02",
                             "03",

--- a/usaspending_api/api_contracts/contracts/v2/download/transactions.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/transactions.md
@@ -161,6 +161,7 @@ This route sends a request to the backend to begin generating a zipfile of trans
     + Members
         + `funding`
         + `awarding`
++ `toptier_name` (optional, string)
 
 ### TimePeriod (object)
 + `start_date` (required, string)


### PR DESCRIPTION
**Description:**
Updates documentation:

* Don't mention the old `agency` param, as that's now legacy
* Do add toptier_name to instances of the agency object