### PR TITLE
[DEV-6035] Use inner join for agency count

### DIFF
--- a/usaspending_api/disaster/v2/views/agency/count.py
+++ b/usaspending_api/disaster/v2/views/agency/count.py
@@ -30,7 +30,11 @@ class AgencyCountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
         if self.award_type_codes:
             count = (
                 CovidFinancialAccountMatview.objects.annotate(cast_def_codes=Cast("def_codes", ArrayField(TextField())))
-                .filter(type__in=self.award_type_codes, cast_def_codes__overlap=self.def_codes)
+                .filter(
+                    type__in=self.award_type_codes,
+                    cast_def_codes__overlap=self.def_codes,
+                    award__funding_agency__toptier_agency__isnull=False,
+                )
                 .values("award__funding_agency__toptier_agency")
                 .distinct()
                 .count()


### PR DESCRIPTION
**Description:**
Agency count is currently off by one in some cases when specifying award type codes.

**Technical details:**
Django ORM code was producing SQL that did a LEFT JOIN to get the agency and it needed to be an INNER JOIN to ensure that NULL is not counted as an agency. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6035](https://federal-spending-transparency.atlassian.net/browse/DEV-6035):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
