### PR TITLE
[DEV-5945] Moves backfill script to correct location and fixes expected cli comment

### DIFF
--- a/usaspending_api/database_scripts/job_archive/backfill_submission_window_id.py
+++ b/usaspending_api/database_scripts/job_archive/backfill_submission_window_id.py
@@ -5,7 +5,7 @@ Jira Ticket Number(s): DEV-5943
 
 Expected CLI:
 
-    $ python3 usaspending_api/database_scripts/job_archive/backfill_faba_distinct_award_key.py
+    $ python3 usaspending_api/database_scripts/job_archive/backfill_submission_window_id.py
 
 Purpose:
 


### PR DESCRIPTION
This is a follow up to PR: https://github.com/fedspendingtransparency/usaspending-api/pull/2793

- Fixes comment for expected CLI to run backfill script
- Moves backfill script to correct directory

**Description:**
This PR adds a foreign key from the `submission_attributes` table to the `dabs_submission_window_schedule` table. Previously these two tables were joined using the following attributes:
- Fiscal Year
- Fiscal Month
- Is Quarter


**Technical details:**
This PR contains two migrations. A SQL script will need to be run between the two migrations to populate the new field:
`python3 usaspending_api/database_scripts/job_archive/backfill_faba_distinct_award_key.py`


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5945](https://federal-spending-transparency.atlassian.net/browse/DEV-5945):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
