### PR TITLE
[DEV-6179] Fix 'all' agency case breaking downloads

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/bulk_download/awards.md
@@ -54,7 +54,6 @@ This route sends a request to the backend to begin generating a zipfile of award
                 "file_name": "534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
                 "file_url": "/csv_downloads/534_PrimeTransactionsAndSubawards_2020-01-13_H21M04S54995657.zip",
                 "download_request": {
-                    "agency": 50,
                     "columns": [],
                     "download_types": [
                         "prime_awards",
@@ -164,3 +163,5 @@ Agency internal database id. If you wish to include all agencies, use 'all' inst
     + Members
         + `funding`
         + `awarding`
++ `toptier_name` (optional, string)
+    Provided when the `name` belongs to a subtier agency

--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -161,6 +161,8 @@ This route sends a request to the backend to begin generating a zipfile of award
     + Members
         + `funding`
         + `awarding`
++ `toptier_name` (optional, string)
+    Provided when the `name` belongs to a subtier agency
 
 ### TimePeriod (object)
 + `start_date` (required, string)

--- a/usaspending_api/api_contracts/contracts/v2/download/transactions.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/transactions.md
@@ -161,6 +161,8 @@ This route sends a request to the backend to begin generating a zipfile of trans
     + Members
         + `funding`
         + `awarding`
++ `toptier_name` (optional, string)
+    Provided when the `name` belongs to a subtier agency
 
 ### TimePeriod (object)
 + `start_date` (required, string)

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -44,7 +44,6 @@ def validate_award_request(request_data: dict):
     json_request = {"download_types": award_levels, "filters": {}}
 
     # Set defaults of non-required parameters
-    json_request["agency"] = request_data["filters"]["agency"] if request_data["filters"].get("agency") else "all"
     json_request["columns"] = request_data.get("columns", [])
     json_request["file_format"] = str(request_data.get("file_format", "csv")).lower()
 


### PR DESCRIPTION
**Description:**
When selecting "all" agencies in Custom Award Downloads it is causing downloads to return an empty CSV. This is because it is searching for an agency with the name of "all".

**Technical details:**
Small re-write to convert legacy "agency" filter to "agencies" and then handle the "all" agency case.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6179](https://federal-spending-transparency.atlassian.net/browse/DEV-6179):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
