### PR TITLE
HOTFIX: [DEV-6181] Delete ES docs before incrementally UPSERTing to avoid dupes

### DIFF
--- a/usaspending_api/etl/es_etl_helpers.py
+++ b/usaspending_api/etl/es_etl_helpers.py
@@ -8,7 +8,8 @@ from collections import defaultdict
 from datetime import datetime
 from django.conf import settings
 from django.core.management import call_command
-from elasticsearch import helpers, TransportError
+from elasticsearch import helpers, TransportError, Elasticsearch
+from elasticsearch_dsl import Search, Q as ES_Q
 from time import perf_counter, sleep
 from typing import Optional
 
@@ -478,9 +479,38 @@ def es_data_loader(client, fetch_jobs, done_jobs, config):
     return
 
 
-def streaming_post_to_es(client, chunk, index_name: str, type: str, job_id=None):
+def streaming_post_to_es(
+    client, chunk, index_name: str, type: str, job_id=None, delete_before_index=True, delete_key="_id"
+):
+    """
+    Called this repeatedly with successive chunks of data to pump into an Elasticsearch index.
+
+    Args:
+        client: Elasticsearch client
+        chunk (List[dict]): list of dictionary objects holding field_name:value data
+        index_name (str): name of targetted index
+        type (str): indexed data type (e.g. awards or transactions)
+        job_id (str): name of ES ETL job being run, used in logging
+        delete_before_index (bool): When true, attempts to delete given documents by a unique key before indexing them.
+            NOTE: For incremental loads, we must "delete-before-index" due to the fact that on many of our indices,
+                we have different values for _id and routing key.
+                Not doing this exposed a bug in our approach to expedite incremental UPSERTS aimed at allowing ES to
+                overwrite documents when it encountered one already existing by a given _id. The problem is that the
+                index operation uses the routing key to target only 1 shard for its index/overwrite. If the routing key
+                value changes between two incremental loads of the same doc with the same _id, it may get routed to a
+                different shard and won't overwrite the original doc, leaving duplicates across all shards in the index.
+        delete_key (str): The column (field) name used for value lookup in the given chunk to derive documents to be
+            deleted, if delete_before_index is True. Currently defaulting to "_id", taking advantage of the fact
+            that we are explicitly setting "_id" in the documents to-be-indexed, which is a unique key for each doc
+            (e.g. the PK of the DB row)
+
+    Returns: (succeeded, failed) tuple, which counts successful index doc writes vs. failed doc writes
+    """
     success, failed = 0, 0
     try:
+        if delete_before_index:
+            value_list = [doc[delete_key] for doc in chunk]
+            delete_docs_by_unique_key(client, delete_key, value_list, job_id, index_name)
         for ok, item in helpers.parallel_bulk(client, chunk, index=index_name):
             success = [success, success + 1][ok]
             failed = [failed + 1, failed][ok]
@@ -536,8 +566,30 @@ def set_final_index_config(client, index):
     client.indices.put_settings(final_index_settings, index)
     client.indices.refresh(index)
     for setting, value in final_index_settings.items():
-        message = f'Changing "{setting}" from {current_settings.get(setting)} to {value}'
+        message = f'Changed "{setting}" from {current_settings.get(setting)} to {value}'
         printf({"msg": message, "job": None, "f": "ES Settings"})
+
+
+def toggle_refresh_off(client, index):
+    client.indices.put_settings({"refresh_interval": "-1"}, index)
+    message = (
+        f'Set "refresh_interval": "-1" to turn auto refresh off during incremental load. Manual refreshes will '
+        f"occur for each batch completion."
+    )
+    printf({"msg": message, "job": None, "f": "ES Settings"})
+
+
+def toggle_refresh_on(client, index):
+    response = client.indices.get(index)
+    aliased_index_name = list(response.keys())[0]
+    current_refresh_interval = response[aliased_index_name]["settings"]["index"]["refresh_interval"]
+    es_settingsfile = str(settings.APP_DIR / "etl" / "es_config_objects.json")
+    with open(es_settingsfile) as f:
+        settings_dict = json.load(f)
+    final_refresh_interval = settings_dict["final_index_settings"]["refresh_interval"]
+    client.indices.put_settings({"refresh_interval": final_refresh_interval}, index)
+    message = f'Changed "refresh_interval" from {current_refresh_interval} to {final_refresh_interval}'
+    printf({"msg": message, "job": None, "f": "ES Settings"})
 
 
 def swap_aliases(client, index, load_type):
@@ -587,10 +639,19 @@ def post_to_elasticsearch(client, job, config, chunksize=250000):
             printf({"msg": f"No documents to add/delete for chunk #{count}", "f": "ES Index", "job": job.name})
             continue
 
+        # Only delete before adding/inserting/indexing new docs on incremental loads, not full reindexes
+        is_incremental = config["is_incremental_load"] and str(config["is_incremental_load"]).lower() == "true"
+
         iteration = perf_counter()
         current_rows = f"({count * chunksize + 1:,}-{count * chunksize + len(chunk):,})"
         printf({"msg": f"ES Stream #{count} rows [{current_rows}/{job.count:,}]", "job": job.name, "f": "ES Index"})
-        streaming_post_to_es(client, chunk, job.index, config["load_type"], job.name)
+        streaming_post_to_es(
+            client, chunk, job.index, config["load_type"], job.name, delete_before_index=is_incremental
+        )
+        if is_incremental:
+            # refresh_interval is off during incremental loads.
+            # Manually refresh after delete + insert complete for search consistency
+            client.indices.refresh(job.index)
         printf(
             {
                 "msg": f"Iteration group #{count} took {perf_counter() - iteration:.2f}s",
@@ -756,11 +817,61 @@ def delete_from_es(client, id_list, job_id, config, index=None):
                 )
             except Exception as e:
                 printf({"msg": f"[ERROR][ERROR][ERROR]\n{str(e)}", "f": "ES Delete", "job": job_id})
+                raise SystemExit(1)
     end_ = client.count(index=index)["count"]
 
     msg = f"ES Deletes took {perf_counter() - start:.2f}s. Deleted {start_ - end_:,} records"
     printf({"msg": msg, "f": "ES Delete", "job": job_id})
     return
+
+
+def delete_docs_by_unique_key(client: Elasticsearch, key: str, value_list: list, job_id: str, index) -> int:
+    """
+    Bulk delete a batch of documents whose field identified by ``key`` matches any value provided in the
+    ``values_list``.
+
+    Args:
+        client (Elasticsearch): elasticsearch-dsl client for making calls to an ES cluster
+        key (str): name of filed in targeted elasticearch index that shoudld have a unique value for
+            every doc in the index. Ideally the field or sub-field provided is of ``keyword`` type.
+        value_list (list): if key field has these values, the document will be deleted
+        job_id (str): name of ES ETL job being run, used in logging
+        index (str): name of index (or alias) to target for the ``_delete_by_query`` ES operation.
+
+            NOTE: This delete routine looks at just the index name given. If there are duplicate records across
+            multiple indexes, an alias or wildcard should be provided for ``index`` param that covers multiple
+            indices, or this will need to be run once per index.
+
+    Returns: Number of ES documents deleted
+    """
+    start = perf_counter()
+
+    printf({"msg": f"Deleting up to {len(value_list):,} document(s)", "f": "ES Delete", "job": job_id})
+    assert index, "index name must be provided"
+
+    deleted = 0
+    is_error = False
+    try:
+        # 65,536 is max number of terms that can be added to an ES terms filter query
+        values_generator = chunks(value_list, 50000)
+        for chunk_of_values in values_generator:
+            # Creates an Elasticsearch query criteria for the _delete_by_query call
+            q = ES_Q("terms", **{key: chunk_of_values})
+            # Invoking _delete_by_query as per the elasticsearch-dsl docs:
+            #   https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#delete-by-query
+            response = Search(using=client, index=index).filter(q).delete()
+            chunk_deletes = response["deleted"]
+            deleted += chunk_deletes
+    except Exception as e:
+        is_error = True
+        printf({"msg": f"[ERROR][ERROR][ERROR]\n{str(e)}", "f": "ES Delete", "job": job_id})
+        raise SystemExit(1)
+    finally:
+        error_text = " before encountering an error" if is_error else ""
+        msg = f"ES Deletes took {perf_counter() - start:.2f}s. Deleted {deleted:,} records{error_text}"
+        printf({"msg": msg, "f": "ES Delete", "job": job_id})
+
+    return deleted
 
 
 def get_deleted_award_ids(client, id_list, config, index=None):

--- a/usaspending_api/etl/rapidloader.py
+++ b/usaspending_api/etl/rapidloader.py
@@ -17,6 +17,7 @@ from usaspending_api.etl.es_etl_helpers import (
     swap_aliases,
     take_snapshot,
     get_updated_record_count,
+    toggle_refresh_on,
 )
 
 
@@ -107,5 +108,6 @@ class Rapidloader:
             take_snapshot(self.elasticsearch_client, self.config["index_name"], settings.ES_REPOSITORY)
 
         if self.config["is_incremental_load"]:
+            toggle_refresh_on(self.elasticsearch_client, self.config["index_name"])
             printf({"msg": f"Storing datetime {self.config['processing_start_datetime']} for next incremental load"})
             update_last_load_date(f"es_{self.config['load_type']}", self.config["processing_start_datetime"])


### PR DESCRIPTION
**Description:**
For incremental loads, we must "delete-before-index" due to the fact that on many of our indices, we have different values for `_id` and `routing` key.
Not doing this exposed a bug in our approach to expedite incremental UPSERTS aimed at allowing ES to overwrite documents when it encountered one already existing by a given _id. The problem is that the index operation uses the routing key to target only 1 shard for its index/overwrite. If the routing key value changes between two incremental loads of the same doc with the same _id, it may get routed to a different shard and won't overwrite the original doc, leaving duplicates across all shards in the index. 

fwiw - _NOT_ using a routing key would default it to the same values as the `_id` and this would not have been a problem. But we need routing keys to guarantee that we can get accurate sorts-by-aggregated-amounts (like Total Obligation) when aggregating/rolling-up on a Recipient in elasticsearch -- since it's a high-cardinality term, and we're limited to 10k buckets.

**Technical details:**
1. Using ES's `_delete_by_query` to remove all docs in each batch before attempting to add/overwrite them. This ensures a clean slate for the indexing and no duplicates
1. Using ES filter context and `terms` query to match an array of `_id` values that may exist in ES against the incremental updates from RDS ... to get the docs to delete
1. Also turned off the `refresh_interval` and manually refreshing after each batch so there is not a period of missing data between the delete and index of a batch of docs.

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6181](https://federal-spending-transparency.atlassian.net/browse/DEV-6181):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
