### PR TITLE
[DEV-6162] fix subaward date field

### DIFF
--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -571,7 +571,7 @@ def subaward_annotations():
         ),
         "prime_award_disaster_emergency_fund_codes": Case(
             When(
-                broker_subaward__action_date__gte=datetime.date(2020, 4, 1),
+                broker_subaward__sub_action_date__gte=datetime.date(2020, 4, 1),
                 then=Subquery(
                     FinancialAccountsByAwards.objects.filter(
                         filter_limit_to_closed_periods(), award_id=OuterRef("award_id")
@@ -602,7 +602,7 @@ def subaward_annotations():
         ),
         "prime_award_outlayed_amount_funded_by_COVID-19_supplementals": Case(
             When(
-                broker_subaward__action_date__gte=datetime.date(2020, 4, 1),
+                broker_subaward__sub_action_date__gte=datetime.date(2020, 4, 1),
                 then=Subquery(
                     FinancialAccountsByAwards.objects.filter(
                         filter_by_latest_closed_periods(),
@@ -619,7 +619,7 @@ def subaward_annotations():
         ),
         "prime_award_obligated_amount_funded_by_COVID-19_supplementals": Case(
             When(
-                broker_subaward__action_date__gte=datetime.date(2020, 4, 1),
+                broker_subaward__sub_action_date__gte=datetime.date(2020, 4, 1),
                 then=Subquery(
                     FinancialAccountsByAwards.objects.filter(
                         filter_limit_to_closed_periods(),


### PR DESCRIPTION
**Description:**
Switches date field being checked for allowing DEFC data in the subaward download files.

**Technical details:**
Change to use `broker_subaward__sub_action_date` rather than `broker_subaward__action_date`

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-6162](https://federal-spending-transparency.atlassian.net/browse/DEV-6162):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
