### PR TITLE
[DEV-5892] Adds componentized files refresh and drops for chunked matview sql generator

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
@@ -153,7 +153,7 @@ def create_componentized_files(sql_json):
     write_sql_file(insert_into_table, filename_base + "__inserts")
 
     create_indexes, rename_old_indexes, rename_new_indexes = make_indexes_sql(
-        sql_json, table_temp_name, UNIQUE_STRING, GLOBAL_ARGS.quiet
+        sql_json, table_temp_name, UNIQUE_STRING, False, GLOBAL_ARGS.quiet
     )
     write_sql_file(create_indexes, filename_base + "__indexes")
 

--- a/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
@@ -180,6 +180,9 @@ def create_chunked_componentized_files(sql_json):
     sql_strings = make_matview_refresh(table_name, "")
     write_sql_file(sql_strings, filename_base + "__refresh")
 
+    sql_strings = make_matview_create(table_name, sql_json["matview_sql"])
+    write_sql_file(sql_strings, filename_base + "__matview")
+
 
 def create_monolith_file(sql_json):
     sql_strings = create_all_sql_strings(sql_json)

--- a/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
@@ -16,6 +16,7 @@ from shared_sql_generator import (
     make_table_drops,
     make_table_inserts,
     make_matview_empty,
+    make_matview_refresh,
     TEMPLATE,
 )
 
@@ -169,6 +170,17 @@ def create_componentized_files(sql_json):
     write_sql_file(sql_strings, filename_base + "__empty")
 
 
+def create_chunked_componentized_files(sql_json):
+    table_name = sql_json["final_name"]
+    filename_base = os.path.join(DEST_FOLDER, COMPONENT_DIR, sql_json["final_name"])
+
+    sql_strings = make_matview_drops(table_name)
+    write_sql_file(sql_strings, filename_base + "__drops")
+
+    sql_strings = make_matview_refresh(table_name, "")
+    write_sql_file(sql_strings, filename_base + "__refresh")
+
+
 def create_monolith_file(sql_json):
     sql_strings = create_all_sql_strings(sql_json)
     print_debug('Preparing to store "{}" in sql file'.format(sql_json["final_name"]))
@@ -210,6 +222,7 @@ def main(source_file):
         chunked_sql_json = add_chunk_strings(sql_json, chunk)
 
         create_monolith_file(chunked_sql_json)
+        create_chunked_componentized_files(chunked_sql_json)
 
     print_debug("Done")
 

--- a/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/matview_sql_generator.py
@@ -117,7 +117,7 @@ def create_all_sql_strings(sql_json):
     matview_temp_name = matview_name + "_temp"
 
     create_indexes, rename_old_indexes, rename_new_indexes = make_indexes_sql(
-        sql_json, matview_temp_name, UNIQUE_STRING, GLOBAL_ARGS.quiet
+        sql_json, matview_temp_name, UNIQUE_STRING, True, GLOBAL_ARGS.quiet
     )
     create_stats, rename_old_stats, rename_new_stats = make_stats_sql(sql_json, matview_temp_name, UNIQUE_STRING)
 
@@ -158,7 +158,7 @@ def create_componentized_files(sql_json):
     matview_temp_name = matview_name + "_temp"
 
     create_indexes, rename_old_indexes, rename_new_indexes = make_indexes_sql(
-        sql_json, matview_temp_name, UNIQUE_STRING, GLOBAL_ARGS.quiet
+        sql_json, matview_temp_name, UNIQUE_STRING, True, GLOBAL_ARGS.quiet
     )
     create_stats, rename_old_stats, rename_new_stats = make_stats_sql(sql_json, matview_temp_name, UNIQUE_STRING)
 

--- a/usaspending_api/database_scripts/matview_generator/shared_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/shared_sql_generator.py
@@ -104,7 +104,7 @@ def make_matview_refresh(matview_name, concurrently="CONCURRENTLY "):
     return statement_list
 
 
-def make_indexes_sql(sql_json, matview_name, unique_string, quiet):
+def make_indexes_sql(sql_json, matview_name, unique_string, progress_sql, quiet):
     unique_name_list = []
     create_indexes = []
     rename_old_indexes = []
@@ -134,7 +134,7 @@ def make_indexes_sql(sql_json, matview_name, unique_string, quiet):
 
     indexes_and_msg = []
     for n, index in enumerate(create_indexes):
-        if n % 10 == 0 and n > 0:
+        if n % 10 == 0 and n > 0 and progress_sql:
             console = TEMPLATE["sql_print_output"].format("{} indexes created, {} remaining".format(n, total - n))
             indexes_and_msg.append(console)
         indexes_and_msg.append(index)


### PR DESCRIPTION
**Description:**
This adds "refresh" and "drops" componentized files for matview chunks in the `chunked_matview_sql_generator.py`. 

**Technical details:**
Previously chunks didn't get their own componentized files, but they are needed for `matview_runner.groovy`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5892](https://federal-spending-transparency.atlassian.net/browse/DEV-5892):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Fixes to an ETL script
```
