### PR TITLE
Ftr/dev 5892 chunk utm refresh - Index Concurrency 

### DIFF
--- a/usaspending_api/common/management/commands/matview_runner.py
+++ b/usaspending_api/common/management/commands/matview_runner.py
@@ -40,7 +40,6 @@ class Command(BaseCommand):
         self.remove_matviews = not args["leave_old"]
         self.run_dependencies = args["dependencies"]
         self.chunk_count = args["chunk_count"]
-        self.index_concurrency = args["index_concurrency"]
 
     def add_arguments(self, parser):
         parser.add_argument("--only", choices=list(MATERIALIZED_VIEWS.keys()))
@@ -71,12 +70,6 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--chunk-count", default=10, help="Number of chunks to split chunked matviews into", type=int
-        )
-        parser.add_argument(
-            "--index-concurrency",
-            default=5,
-            help="Concurrency limit for index creation on the Universal Transaction Table",
-            type=int,
         )
 
     def handle(self, *args, **options):
@@ -140,9 +133,7 @@ class Command(BaseCommand):
         if "universal_transaction_matview" in self.chunked_matviews:
             logger.info("Inserting data from universal_transaction_matview chunks into single table.")
             call_command(
-                "combine_universal_transaction_matview_chunks",
-                chunk_count=self.chunk_count,
-                index_concurrency=self.index_concurrency,
+                "combine_universal_transaction_matview_chunks", chunk_count=self.chunk_count, index_concurrency=20,
             )
 
         for view in OVERLAY_VIEWS:

--- a/usaspending_api/etl/management/commands/combine_universal_transaction_matview_chunks.py
+++ b/usaspending_api/etl/management/commands/combine_universal_transaction_matview_chunks.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--chunk-count", default=10, help="Number of chunked matviews to read from", type=int)
+        parser.add_argument("--index-concurrency", default=5, help="Concurrency limit for index creation", type=int)
         parser.add_argument(
             "--matview-dir",
             type=Path,
@@ -42,6 +43,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         chunk_count = options["chunk_count"]
+        index_concurrency = options["index_concurrency"]
         self.matview_dir = options["matview_dir"]
 
         logger.info(f"Chunk Count: {chunk_count}")
@@ -53,7 +55,7 @@ class Command(BaseCommand):
             self.insert_matview_data(chunk_count)
 
         with Timer("Creating table indexes"):
-            self.create_indexes()
+            self.create_indexes(index_concurrency)
 
         with Timer("Swapping Tables/Indexes"):
             self.swap_matviews()
@@ -91,8 +93,8 @@ class Command(BaseCommand):
         tasks = []
 
         insert_table_sql = (
-            self.matview_dir / "componentized" / "universal_transaction_matview__inserts.sql"
-        ).read_text()
+            (self.matview_dir / "componentized" / "universal_transaction_matview__inserts.sql").read_text().strip()
+        )
 
         for i, sql in enumerate(sqlparse.split(insert_table_sql)):
             tasks.append(
@@ -102,20 +104,27 @@ class Command(BaseCommand):
         loop.run_until_complete(asyncio.gather(*tasks))
         loop.close()
 
-    def create_indexes(self):
-        loop = asyncio.new_event_loop()
+    async def index_with_concurrency(self, index_concurrency):
+        semaphore = asyncio.Semaphore(index_concurrency)
         tasks = []
 
+        async def create_with_sem(sql, index):
+            async with semaphore:
+                return await async_run_creates(sql, wrapper=Timer(f"Creating Index {index}"),)
+
         index_table_sql = (
-            self.matview_dir / "componentized" / "universal_transaction_matview__indexes.sql"
-        ).read_text()
+            (self.matview_dir / "componentized" / "universal_transaction_matview__indexes.sql").read_text().strip()
+        )
 
         for i, sql in enumerate(sqlparse.split(index_table_sql)):
-            tasks.append(
-                asyncio.ensure_future(async_run_creates(sql, wrapper=Timer(f"Creating Index {i}"),), loop=loop,)
-            )
+            logger.info(f"Creating future for index: {i} - SQL: {sql}")
+            tasks.append(create_with_sem(sql, i))
 
-        loop.run_until_complete(asyncio.gather(*tasks))
+        return await asyncio.gather(*tasks)
+
+    def create_indexes(self, index_concurrency):
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self.index_with_concurrency(index_concurrency))
         loop.close()
 
     @transaction.atomic

--- a/usaspending_api/etl/management/commands/combine_universal_transaction_matview_chunks.py
+++ b/usaspending_api/etl/management/commands/combine_universal_transaction_matview_chunks.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--chunk-count", default=10, help="Number of chunked matviews to read from", type=int)
-        parser.add_argument("--index-concurrency", default=5, help="Concurrency limit for index creation", type=int)
+        parser.add_argument("--index-concurrency", default=20, help="Concurrency limit for index creation", type=int)
         parser.add_argument(
             "--matview-dir",
             type=Path,


### PR DESCRIPTION
**Description:**
This PR adds an --index-concurrency parameter to the `matview_runner` and `combine_universal_transaction_matview` commands. This parameter specifies the max concurrency to use when creating the indexes on the `universal_transaction_matview` table.

**Technical details:**
Uses asyncio Semaphore to control concurrency limit 

**Requirements for PR merge:**

1. N/A - Unit & integration tests updated
2. N/A - API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-5892](https://federal-spending-transparency.atlassian.net/browse/DEV-5892):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [] Before / After data comparison
