### PR TITLE
[BRUS2DTI-384] Add ENV for server URL to support DTI migration

### DIFF
--- a/usaspending_api/download/filestreaming/s3_handler.py
+++ b/usaspending_api/download/filestreaming/s3_handler.py
@@ -29,14 +29,10 @@ class S3Handler:
         """
         Gets URL for read
         """
-        subdomain = "files"
-        if self.environment != "production":
-            subdomain = "files-nonprod"
-
-        bucket_url = "https://{}.usaspending.gov/{}/".format(subdomain, self.redirect_dir)
+        bucket_url = f"{settings.FILES_SERVER_BASE_URL}/{self.redirect_dir}/"
         env_dir = ""
         if self.redirect_dir == settings.BULK_DOWNLOAD_S3_REDIRECT_DIR and self.environment != "production":
             # currently only downloads have a bucket per environment
-            env_dir = "{}/".format(self.environment)
-        generated = "{}{}{}".format(bucket_url, env_dir, file_name)
+            env_dir = f"{self.environment}/"
+        generated = f"{bucket_url}{env_dir}{file_name}"
         return generated

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -127,12 +127,11 @@ class BaseDownloadViewSet(APIView):
         if settings.IS_LOCAL:
             protocol = "http"
             host = "localhost:8000"
-        elif settings.DOWNLOAD_ENV == "production":
-            protocol = "https"
-            host = "api.usaspending.gov"
         else:
             protocol = "https"
-            host = f"{settings.DOWNLOAD_ENV}-api.usaspending.gov"
+            host = f"api.{settings.SERVER_BASE_URL}"
+            if settings.DOWNLOAD_ENV != "production":
+                host = f"{settings.DOWNLOAD_ENV}-{host}"
 
         return f"{protocol}://{host}/api/v2/download/status?file_name={file_name}"
 

--- a/usaspending_api/references/management/commands/load_historical_appropriation_account_balances.py
+++ b/usaspending_api/references/management/commands/load_historical_appropriation_account_balances.py
@@ -42,9 +42,7 @@ from usaspending_api.common.retrieve_file_from_uri import RetrieveFileFromUri
 logger = logging.getLogger("script")
 
 
-DEFAULT_CSV_LOCATION = (
-    f'https://files{"-nonprod" if settings.DOWNLOAD_ENV != "production" else ""}.usaspending.gov/reference_data/'
-)
+DEFAULT_CSV_LOCATION = f"{settings.FILES_SERVER_BASE_URL}/reference_data/"
 
 # file_name: temporary_table_name
 FILE_TO_TABLE_MAPPING = {

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -93,17 +93,27 @@ STATE_DATA_BUCKET = ""
 if not STATE_DATA_BUCKET:
     STATE_DATA_BUCKET = os.environ.get("STATE_DATA_BUCKET")
 
-DATA_DICTIONARY_DOWNLOAD_URL = "https://files{}.usaspending.gov/docs/Data_Dictionary_Crosswalk.xlsx".format(
-    "-nonprod" if DOWNLOAD_ENV != "production" else ""
-)
+# Download URLs
+FILES_SERVER_BASE_URL = ""
+SERVER_BASE_URL = ""
+
+if not FILES_SERVER_BASE_URL:
+    FILES_SERVER_BASE_URL = os.environ.get(
+        "FILES_SERVER_BASE_URL",
+        # This default value can be removed after DTI migration is complete
+        f"https://files{'-nonprod' if DOWNLOAD_ENV != 'production' else ''}.usaspending.gov",
+    )
+    SERVER_BASE_URL = FILES_SERVER_BASE_URL[FILES_SERVER_BASE_URL.find(".") + 1 :]
+
+AGENCY_DOWNLOAD_URL = f"{FILES_SERVER_BASE_URL}/reference_data/agency_codes.csv"
+DATA_DICTIONARY_DOWNLOAD_URL = f"{FILES_SERVER_BASE_URL}/docs/Data_Dictionary_Crosswalk.xlsx"
+
+# Local download files
 IDV_DOWNLOAD_README_FILE_PATH = str(APP_DIR / "data" / "idv_download_readme.txt")
 ASSISTANCE_DOWNLOAD_README_FILE_PATH = str(APP_DIR / "data" / "AssistanceSummary_download_readme.txt")
 CONTRACT_DOWNLOAD_README_FILE_PATH = str(APP_DIR / "data" / "ContractSummary_download_readme.txt")
 COVID19_DOWNLOAD_README_FILE_PATH = str(APP_DIR / "data" / "COVID-19_download_readme.txt")
 COVID19_DOWNLOAD_FILENAME_PREFIX = "COVID-19_Profile"
-AGENCY_DOWNLOAD_URL = "https://files{}.usaspending.gov/reference_data/agency_codes.csv".format(
-    "-nonprod" if DOWNLOAD_ENV != "production" else ""
-)
 
 # Elasticsearch
 ES_HOSTNAME = ""


### PR DESCRIPTION
**Description:**
In a few places in the API we currently have hard coded `usaspending.gov`. With the DTI migration there is a need to specify the server URL.

**Technical details:**
Update settings.py so that an ENV can be used to specify the server URL. All hardcoded usages of `usaspending.gov` were also updated to use the new ENV. A default of `usaspending.gov` was left in place to avoid breaking any current functionality. 

Tested in DAOI Sandbox to verify that current functionality is not affected by the change. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations <OPTIONAL>
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [BRUS2DTI-384](https://federal-spending-transparency.atlassian.net/browse/BRUS2DTI-384):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
