### PR TITLE
[DEV-6457] Fix ES covid endpoint discrepancies

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_federal_account_award.py
+++ b/usaspending_api/disaster/tests/integration/test_federal_account_award.py
@@ -77,7 +77,6 @@ def test_federal_account_award_success(client, generic_account_data, monkeypatch
                     "outlay": 111.0,
                     "total_budgetary_resources": None,
                 },
-
             ],
         }
     ]

--- a/usaspending_api/disaster/tests/integration/test_federal_account_award.py
+++ b/usaspending_api/disaster/tests/integration/test_federal_account_award.py
@@ -51,6 +51,15 @@ def test_federal_account_award_success(client, generic_account_data, monkeypatch
             "total_budgetary_resources": None,
             "children": [
                 {
+                    "code": "2020/52",
+                    "award_count": 1,
+                    "description": "ferns",
+                    "id": 24,
+                    "obligation": 3.0,
+                    "outlay": 333.0,
+                    "total_budgetary_resources": None,
+                },
+                {
                     "code": "2020/98",
                     "award_count": 2,
                     "description": "evergreens",
@@ -68,15 +77,7 @@ def test_federal_account_award_success(client, generic_account_data, monkeypatch
                     "outlay": 111.0,
                     "total_budgetary_resources": None,
                 },
-                {
-                    "code": "2020/52",
-                    "award_count": 1,
-                    "description": "ferns",
-                    "id": 24,
-                    "obligation": 3.0,
-                    "outlay": 333.0,
-                    "total_budgetary_resources": None,
-                },
+
             ],
         }
     ]

--- a/usaspending_api/disaster/tests/integration/test_federal_account_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_federal_account_loans.py
@@ -20,15 +20,6 @@ def test_federal_account_loans_success(client, generic_account_data, elasticsear
         {
             "children": [
                 {
-                    "code": "2020/98",
-                    "award_count": 1,
-                    "description": "evergreens",
-                    "face_value_of_loan": 3333.0,
-                    "id": 23,
-                    "outlay": 1.0,
-                    "obligation": 1.0,
-                },
-                {
                     "code": "2020/52",
                     "award_count": 1,
                     "description": "ferns",
@@ -36,6 +27,15 @@ def test_federal_account_loans_success(client, generic_account_data, elasticsear
                     "id": 24,
                     "outlay": 333.0,
                     "obligation": 3.0,
+                },
+                {
+                    "code": "2020/98",
+                    "award_count": 1,
+                    "description": "evergreens",
+                    "face_value_of_loan": 3333.0,
+                    "id": 23,
+                    "outlay": 1.0,
+                    "obligation": 1.0,
                 },
             ],
             "code": "000-0000",

--- a/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
+++ b/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
@@ -26,7 +26,7 @@ def test_basic_object_class_award_success(
             "outlay": 0.0,
             "children": [
                 {
-                    "id": 1,
+                    "id": "1",
                     "code": "0001",
                     "description": "0001 name",
                     "award_count": 1,

--- a/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
+++ b/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
@@ -117,7 +117,7 @@ def test_object_class_query(client, elasticsearch_account_index, basic_faba_with
             "outlay": 0.0,
             "children": [
                 {
-                    "id": 1,
+                    "id": "1",
                     "code": "0001",
                     "description": "0001 name",
                     "award_count": 1,

--- a/usaspending_api/disaster/tests/integration/test_object_class_spending_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_object_class_spending_loans.py
@@ -68,7 +68,6 @@ def test_object_class_adds_value_across_awards(
     setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_spending_endpoint(client, url, def_codes=["M"])
-    print(resp.json())
     assert resp.json()["results"][0]["face_value_of_loan"] == 10
 
 

--- a/usaspending_api/disaster/tests/integration/test_object_class_spending_loans.py
+++ b/usaspending_api/disaster/tests/integration/test_object_class_spending_loans.py
@@ -68,6 +68,7 @@ def test_object_class_adds_value_across_awards(
     setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_spending_endpoint(client, url, def_codes=["M"])
+    print(resp.json())
     assert resp.json()["results"][0]["face_value_of_loan"] == 10
 
 

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -53,7 +53,7 @@ class LoansByAgencyViewSet(LoansPaginationMixin, ElasticsearchAccountDisasterBas
     required_filters = ["def_codes", "query"]
     query_fields = ["funding_toptier_agency_name.contains"]
     agg_key = "financial_accounts_by_award.funding_toptier_agency_id"  # primary (tier-1) aggregation key
-    nested_nonzero_fields = {"outlay": "gross_outlay_amount_by_award_cpe", "obligation": "transaction_obligated_amount"}
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     top_hits_fields = [
         "financial_accounts_by_award.funding_toptier_agency_code",
@@ -83,7 +83,6 @@ class LoansByAgencyViewSet(LoansPaginationMixin, ElasticsearchAccountDisasterBas
                 for key, val in self.nested_nonzero_fields.items()
             },
             "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],
-            "children": [],
         }
 
     @property

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -80,7 +80,7 @@ class LoansByAgencyViewSet(LoansPaginationMixin, ElasticsearchAccountDisasterBas
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
                 for key, val in self.nested_nonzero_fields.items()
             },
             "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -76,6 +76,7 @@ class LoansByAgencyViewSet(LoansPaginationMixin, ElasticsearchAccountDisasterBas
             "id": int(bucket["key"]),
             "code": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["funding_toptier_agency_code"],
             "description": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["funding_toptier_agency_name"],
+            "children": [],
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -63,7 +63,7 @@ class SpendingByAgencyViewSet(
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md"
     required_filters = ["def_codes", "award_type_codes", "query"]
-    nested_nonzero_fields = {"outlay": "gross_outlay_amount_by_award_cpe", "obligation": "transaction_obligated_amount"}
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "funding_toptier_agency_name",

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -112,7 +112,7 @@ class SpendingByAgencyViewSet(
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
                 for key, val in self.nested_nonzero_fields.items()
             },
             "total_budgetary_resources": None,

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -1,4 +1,5 @@
 import logging
+from decimal import Decimal
 
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import Case, DecimalField, F, IntegerField, Q, Sum, Value, When, Subquery, OuterRef, Func, Exists
@@ -64,7 +65,6 @@ class SpendingByAgencyViewSet(
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md"
     required_filters = ["def_codes", "award_type_codes", "query"]
     nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
-    nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "funding_toptier_agency_name",
         "funding_toptier_agency_name.contains",
@@ -112,7 +112,7 @@ class SpendingByAgencyViewSet(
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: round(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
                 for key, val in self.nested_nonzero_fields.items()
             },
             "total_budgetary_resources": None,

--- a/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
@@ -44,7 +44,6 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
 
         # Ensure that only non-zero values are taken into consideration
         filters["nested_nonzero_fields"] = list(self.nested_nonzero_fields.values())
-        # filters["nonzero_fields"] = list(self.nonzero_fields.values())
         self.filter_query = QueryWithFilters.generate_accounts_elasticsearch_query(filters)
         # using a set value here as doing an extra ES query is detrimental to performance
         # And the dimensions on which group-by aggregations are performed so far

--- a/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
@@ -44,7 +44,7 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
 
         # Ensure that only non-zero values are taken into consideration
         filters["nested_nonzero_fields"] = list(self.nested_nonzero_fields.values())
-        filters["nonzero_fields"] = list(self.nonzero_fields.values())
+        # filters["nonzero_fields"] = list(self.nonzero_fields.values())
         self.filter_query = QueryWithFilters.generate_accounts_elasticsearch_query(filters)
         # using a set value here as doing an extra ES query is detrimental to performance
         # And the dimensions on which group-by aggregations are performed so far

--- a/usaspending_api/disaster/v2/views/federal_account/loans.py
+++ b/usaspending_api/disaster/v2/views/federal_account/loans.py
@@ -60,9 +60,9 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
                     # the count of distinct awards contributing to the totals
                     "obligation": temp_results[result["id"]]["obligation"] + result["obligation"],
                     "outlay": temp_results[result["id"]]["outlay"] + result["outlay"],
+                    "children": temp_results[result["id"]]["children"] + result["children"],
                     "face_value_of_loan": temp_results[result["id"]]["face_value_of_loan"]
                     + result["face_value_of_loan"],
-                    "children": temp_results[result["id"]]["children"] + result["children"],
                 }
             else:
                 temp_results[result["id"]] = result
@@ -78,8 +78,8 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
             # the count of distinct awards contributing to the totals
             "obligation": child["obligation"],
             "outlay": child["outlay"],
-            "face_value_of_loan": child["face_value_of_loan"],
             "children": [child],
+            "face_value_of_loan": child["face_value_of_loan"],
         }
 
     def _build_child_json_result(self, bucket: dict):

--- a/usaspending_api/disaster/v2/views/federal_account/loans.py
+++ b/usaspending_api/disaster/v2/views/federal_account/loans.py
@@ -39,6 +39,7 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
     @cache_response()
     def post(self, request):
         self.filters.update({"award_type_codes": ["07", "08"]})
+        self.has_children = True
         return self.perform_elasticsearch_search(loans=True)
 
     def build_elasticsearch_result(self, info_buckets: List[dict]) -> List[dict]:

--- a/usaspending_api/disaster/v2/views/federal_account/loans.py
+++ b/usaspending_api/disaster/v2/views/federal_account/loans.py
@@ -1,4 +1,5 @@
 from typing import List
+from decimal import Decimal
 
 from django.db.models import F
 from usaspending_api.accounts.models import TreasuryAppropriationAccount
@@ -17,7 +18,6 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/federal_account/loans.md"
     agg_key = "financial_accounts_by_award.treasury_account_id"  # primary (tier-1) aggregation key
     nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
-    nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "federal_account_symbol",
         "federal_account_symbol.contains",
@@ -90,7 +90,7 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: round(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]))
                 for key, val in self.nested_nonzero_fields.items()
             },
             "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],

--- a/usaspending_api/disaster/v2/views/federal_account/loans.py
+++ b/usaspending_api/disaster/v2/views/federal_account/loans.py
@@ -16,7 +16,7 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/federal_account/loans.md"
     agg_key = "financial_accounts_by_award.treasury_account_id"  # primary (tier-1) aggregation key
-    nested_nonzero_fields = {"outlay": "gross_outlay_amount_by_award_cpe", "obligation": "transaction_obligated_amount"}
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "federal_account_symbol",

--- a/usaspending_api/disaster/v2/views/federal_account/loans.py
+++ b/usaspending_api/disaster/v2/views/federal_account/loans.py
@@ -90,7 +90,7 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]))
+                key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
                 for key, val in self.nested_nonzero_fields.items()
             },
             "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],

--- a/usaspending_api/disaster/v2/views/federal_account/spending.py
+++ b/usaspending_api/disaster/v2/views/federal_account/spending.py
@@ -62,6 +62,7 @@ class SpendingViewSet(
     @cache_response()
     def post(self, request):
         if self.spending_type == "award":
+            self.has_children = True
             return self.perform_elasticsearch_search()
         else:
             results = list(self.total_queryset)

--- a/usaspending_api/disaster/v2/views/federal_account/spending.py
+++ b/usaspending_api/disaster/v2/views/federal_account/spending.py
@@ -39,7 +39,7 @@ class SpendingViewSet(
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/federal_account/spending.md"
     agg_key = "financial_accounts_by_award.treasury_account_id"  # primary (tier-1) aggregation key
-    nested_nonzero_fields = {"outlay": "gross_outlay_amount_by_award_cpe", "obligation": "transaction_obligated_amount"}
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "federal_account_symbol",

--- a/usaspending_api/disaster/v2/views/federal_account/spending.py
+++ b/usaspending_api/disaster/v2/views/federal_account/spending.py
@@ -120,7 +120,7 @@ class SpendingViewSet(
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]))
+                key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
                 for key, val in self.nested_nonzero_fields.items()
             },
             "total_budgetary_resources": None,

--- a/usaspending_api/disaster/v2/views/federal_account/spending.py
+++ b/usaspending_api/disaster/v2/views/federal_account/spending.py
@@ -1,4 +1,5 @@
 from typing import List
+from decimal import Decimal
 
 from django.db.models import Q, Sum, F, Value, DecimalField, Case, When, OuterRef, Subquery, Func, IntegerField
 from django.db.models.functions import Coalesce
@@ -40,7 +41,6 @@ class SpendingViewSet(
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/federal_account/spending.md"
     agg_key = "financial_accounts_by_award.treasury_account_id"  # primary (tier-1) aggregation key
     nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
-    nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "federal_account_symbol",
         "federal_account_symbol.contains",
@@ -120,7 +120,7 @@ class SpendingViewSet(
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: round(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]))
                 for key, val in self.nested_nonzero_fields.items()
             },
             "total_budgetary_resources": None,

--- a/usaspending_api/disaster/v2/views/object_class/loans.py
+++ b/usaspending_api/disaster/v2/views/object_class/loans.py
@@ -18,7 +18,7 @@ class ObjectClassLoansViewSet(LoansMixin, FabaOutlayMixin, LoansPaginationMixin,
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/object_class/loans.md"
     agg_key = "financial_accounts_by_award.object_class"  # primary (tier-1) aggregation key
-    nested_nonzero_fields = {"outlay": "gross_outlay_amount_by_award_cpe", "obligation": "transaction_obligated_amount"}
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "major_object_class_name",

--- a/usaspending_api/disaster/v2/views/object_class/loans.py
+++ b/usaspending_api/disaster/v2/views/object_class/loans.py
@@ -37,6 +37,7 @@ class ObjectClassLoansViewSet(LoansMixin, FabaOutlayMixin, LoansPaginationMixin,
     @cache_response()
     def post(self, request):
         self.filters.update({"award_type_codes": ["07", "08"]})
+        self.has_children = True
         return self.perform_elasticsearch_search(loans=True)
 
     @property

--- a/usaspending_api/disaster/v2/views/object_class/loans.py
+++ b/usaspending_api/disaster/v2/views/object_class/loans.py
@@ -109,7 +109,7 @@ class ObjectClassLoansViewSet(LoansMixin, FabaOutlayMixin, LoansPaginationMixin,
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
                 for key, val in self.nested_nonzero_fields.items()
             },
             "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],

--- a/usaspending_api/disaster/v2/views/object_class/loans.py
+++ b/usaspending_api/disaster/v2/views/object_class/loans.py
@@ -1,4 +1,5 @@
 from typing import List
+from decimal import Decimal
 
 from django.db.models import F, Value, TextField, Min
 from django.db.models.functions import Cast
@@ -19,7 +20,6 @@ class ObjectClassLoansViewSet(LoansMixin, FabaOutlayMixin, LoansPaginationMixin,
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/object_class/loans.md"
     agg_key = "financial_accounts_by_award.object_class"  # primary (tier-1) aggregation key
     nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
-    nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "major_object_class_name",
         "major_object_class_name.contains",
@@ -109,7 +109,7 @@ class ObjectClassLoansViewSet(LoansMixin, FabaOutlayMixin, LoansPaginationMixin,
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: round(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
                 for key, val in self.nested_nonzero_fields.items()
             },
             "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],

--- a/usaspending_api/disaster/v2/views/object_class/spending.py
+++ b/usaspending_api/disaster/v2/views/object_class/spending.py
@@ -61,7 +61,7 @@ class ObjectClassSpendingViewSet(SpendingMixin, FabaOutlayMixin, PaginationMixin
     @cache_response()
     def post(self, request):
         if self.spending_type == "award":
-            self.has_children=True
+            self.has_children = True
             return self.perform_elasticsearch_search()
         else:
             results = list(self.total_queryset)

--- a/usaspending_api/disaster/v2/views/object_class/spending.py
+++ b/usaspending_api/disaster/v2/views/object_class/spending.py
@@ -1,4 +1,5 @@
 from typing import List
+from decimal import Decimal
 
 from django.db.models import Q, Sum, F, Value, Case, When, Min, TextField, IntegerField
 from django.db.models.functions import Coalesce, Cast
@@ -44,7 +45,6 @@ class ObjectClassSpendingViewSet(SpendingMixin, FabaOutlayMixin, PaginationMixin
     # Defined for the Elasticsearch implementation of Spending by Award
     agg_key = "financial_accounts_by_award.object_class"  # primary (tier-1) aggregation key
     nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
-    nonzero_fields = {"outlay": "outlay_sum", "obligation": "obligated_sum"}
     query_fields = [
         "major_object_class_name",
         "major_object_class_name.contains",
@@ -142,8 +142,8 @@ class ObjectClassSpendingViewSet(SpendingMixin, FabaOutlayMixin, PaginationMixin
                     "description": result["description"],
                     "award_count": temp_results[result["code"]]["award_count"] + result["award_count"],
                     # the count of distinct awards contributing to the totals
-                    "obligation": round(temp_results[result["code"]]["obligation"] + result["obligation"], 2),
-                    "outlay": round(temp_results[result["code"]]["outlay"] + result["outlay"], 2),
+                    "obligation": temp_results[result["code"]]["obligation"] + result["obligation"],
+                    "outlay": temp_results[result["code"]]["outlay"] + result["outlay"],
                     "children": temp_results[result["code"]]["children"] + result["children"],
                 }
             else:
@@ -171,7 +171,7 @@ class ObjectClassSpendingViewSet(SpendingMixin, FabaOutlayMixin, PaginationMixin
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: round(float(bucket.get(f"sum_{val}", {"value": 0})["value"]), 2)
+                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]))
                 for key, val in self.nested_nonzero_fields.items()
             },
             "parent_data": [

--- a/usaspending_api/disaster/v2/views/object_class/spending.py
+++ b/usaspending_api/disaster/v2/views/object_class/spending.py
@@ -171,7 +171,7 @@ class ObjectClassSpendingViewSet(SpendingMixin, FabaOutlayMixin, PaginationMixin
             # the count of distinct awards contributing to the totals
             "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
-                key: Decimal(float(bucket.get(f"sum_{val}", {"value": 0})["value"]))
+                key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
                 for key, val in self.nested_nonzero_fields.items()
             },
             "parent_data": [

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_psc.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_psc.py
@@ -41,7 +41,6 @@ def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, 
         ],
         "messages": [get_time_period_message()],
     }
-    print(resp.json())
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
 
     assert resp.json() == expected_response

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -1007,5 +1007,4 @@ def test_defc_date_filter(client, monkeypatch, elasticsearch_transaction_index):
         data=json.dumps({"group": "fiscal_year", "filters": {"def_codes": ["L"]}}),
     )
     assert resp.status_code == status.HTTP_200_OK
-    print(resp.json().get("results"))
     assert {"aggregated_amount": 10, "time_period": {"fiscal_year": "2020"}} in resp.json().get("results")


### PR DESCRIPTION
**Description:**
Minor tweaks to new COVID-19 page endpoints that use the ES accounts index. Fixes minor bug that prevent the child arrays from being sorted. Also removes the top level filtering on `outlay_sum` and `obligated_sum`, which was causing errors in the sums. 

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [X] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-6457](https://federal-spending-transparency.atlassian.net/browse/DEV-6457):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
