### PR TITLE
[DEV-6468] Update boto3 endpoint format for SQS

### DIFF
--- a/usaspending_api/common/sqs/sqs_handler.py
+++ b/usaspending_api/common/sqs/sqs_handler.py
@@ -245,6 +245,6 @@ def get_sqs_queue(region_name=settings.USASPENDING_AWS_REGION, queue_name=settin
         return _FakeFileBackedSQSQueue.instance()
     else:
         # stuff that's in get_queue
-        sqs = boto3.resource("sqs", region_name)
+        sqs = boto3.resource("sqs", endpoint_url=f"https://sqs.{region_name}.amazonaws.com", region_name=region_name)
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         return queue

--- a/usaspending_api/common/tests/unit/test_sqs_work_dispatcher.py
+++ b/usaspending_api/common/tests/unit/test_sqs_work_dispatcher.py
@@ -502,9 +502,10 @@ class SQSWorkDispatcherTests(TestCase):
     def test_faulty_queue_connection_raises_correct_exception(self):
         """When a queue cannot be connected to, it raises the appropriate exception"""
         try:
+            region_name = "us-gov-west-1"
             # note: connection max retries config not in botocore v1.5.x
-            client_config = Config(region_name="us-gov-west-1", connect_timeout=1, read_timeout=1)
-            sqs = boto3.resource("sqs", config=client_config)
+            client_config = Config(region_name=region_name, connect_timeout=1, read_timeout=1)
+            sqs = boto3.resource("sqs", config=client_config, endpoint_url=f"https://sqs.{region_name}.amazonaws.com")
             queue = sqs.Queue("75f4f422-3866-4e4f-9dc9-5364e3de3eaf")
             dispatcher = SQSWorkDispatcher(
                 queue, worker_process_name="Test Worker Process", long_poll_seconds=1, monitor_sleep_time=1


### PR DESCRIPTION
**Description:**
Need to update endpoint URL to support migration to DTI.

**Technical details:**
In order to support Python2 boto3 will use a legacy format for the URL when the endpoint_url is not specified or certain regions are detected. DTI requires that that a different endpoint format is used for SQS. 

Old format: `https://<REGION>.queue.amazonaws.com/`
New format: `https://sqs.<REGION>.amazonaws.com/`

This was tested by pushing updates to both DTI and DAOI Sandbox and testing that downloads were still functional since that is the primary use of SQS for USAspending.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6468](https://federal-spending-transparency.atlassian.net/browse/DEV-6468):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
