### PR TITLE
DEV-6305: unlinked award counts endpoint placeholder

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -36,6 +36,8 @@ This endpoint returns an overview of government agency submission data.
             + `recent_publication_date_certified`
             + `recent_publication_date`
             + `tas_obligation_not_in_gtas_total`
+            + `unlinked_contract_award_count`
+            + `unlinked_assistance_award_count`
 
 + Response 200 (application/json)
 
@@ -71,7 +73,9 @@ This endpoint returns an overview of government agency submission data.
                             "tas_obligation_not_in_gtas_total": 343345,
                             "missing_tas_accounts_count": 10
                         },
-                        "obligation_difference": 436376232652.87
+                        "obligation_difference": 436376232652.87,
+                        "unlinked_contract_award_count": 0,
+                        "unlinked_assistance_award_count": 0
                     },
                     {
                         "fiscal_year": 2020,
@@ -85,7 +89,9 @@ This endpoint returns an overview of government agency submission data.
                             "tas_obligation_not_in_gtas_total": 11543,
                             "missing_tas_accounts_count": 10
                         },
-                        "obligation_difference": 436376232652.87
+                        "obligation_difference": 436376232652.87,
+                        "unlinked_contract_award_count": 0,
+                        "unlinked_assistance_award_count": 0
                     }
                 ]
             }
@@ -117,3 +123,5 @@ This endpoint returns an overview of government agency submission data.
 + `tas_account_discrepancies_totals` (required, array[TASTotals], fixed-type)
 + `obligation_difference` (required, number)
     The difference in file A and file B obligations.
++ `unlinked_contract_award_count` (required, number)
++ `unlinked_assistance_award_count` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
@@ -42,6 +42,8 @@ This endpoint returns an overview list of government agencies submission data.
             + `recent_publication_date`
             + `recent_publication_date_certified`
             + `tas_obligation_not_in_gtas_total`
+            + `unlinked_contract_award_count`
+            + `unlinked_assistance_award_count`
 
 + Response 200 (application/json)
 
@@ -78,7 +80,9 @@ This endpoint returns an overview list of government agencies submission data.
                             "tas_obligation_not_in_gtas_total": 11543,
                             "missing_tas_accounts_count": 20
                         },
-                        "obligation_difference": 436376232652.87
+                        "obligation_difference": 436376232652.87,
+                        "unlinked_contract_award_count": 0,
+                        "unlinked_assistance_award_count": 0
                     },
                     {
                         "agency_name": "Department of Treasury",
@@ -94,7 +98,9 @@ This endpoint returns an overview list of government agencies submission data.
                             "tas_obligation_not_in_gtas_total": 11543,
                             "missing_tas_accounts_count": 10
                         },
-                        "obligation_difference": 436376232652.87
+                        "obligation_difference": 436376232652.87,
+                        "unlinked_contract_award_count": 0,
+                        "unlinked_assistance_award_count": 0
                     }
                 ]
             }
@@ -127,3 +133,5 @@ This endpoint returns an overview list of government agencies submission data.
 + `tas_account_discrepancies_totals` (required, array[TASTotals], fixed-type)
 + `obligation_difference` (required, number)
     The difference in File A and File B obligations.
++ `unlinked_contract_award_count` (required, number)
++ `unlinked_assistance_award_count` (required, number)

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -193,6 +193,8 @@ def test_basic_success(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
         {
             "agency_name": "Test Agency 3",
@@ -209,6 +211,8 @@ def test_basic_success(setup_test_data, client):
                 "missing_tas_accounts_count": 0,
             },
             "obligation_difference": 10.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
     ]
     assert response["results"] == expected_results
@@ -235,6 +239,8 @@ def test_filter(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         }
     ]
     assert response["results"] == expected_results
@@ -261,6 +267,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         }
     ]
     assert response["results"] == expected_results
@@ -285,6 +293,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 0,
             },
             "obligation_difference": 10.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         }
     ]
     assert response["results"] == expected_results
@@ -309,6 +319,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 0,
             },
             "obligation_difference": 10.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
         {
             "agency_name": "Test Agency 2",
@@ -325,6 +337,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
     ]
     assert response["results"] == expected_results
@@ -352,6 +366,8 @@ def test_fiscal_year_period_selection(setup_test_data, client):
                 "missing_tas_accounts_count": 2,
             },
             "obligation_difference": 84931.95,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         }
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -150,6 +150,8 @@ def test_basic_success(setup_test_data, client):
                 "missing_tas_accounts_count": 2,
             },
             "obligation_difference": 84931.95,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
         {
             "fiscal_year": 2020,
@@ -164,6 +166,8 @@ def test_basic_success(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
     ]
     assert response["results"] == expected_results
@@ -188,6 +192,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
         {
             "fiscal_year": 2019,
@@ -202,6 +208,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 2,
             },
             "obligation_difference": 84931.95,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         },
     ]
     assert response["results"] == expected_results
@@ -223,6 +231,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 2,
             },
             "obligation_difference": 84931.95,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         }
     ]
     assert response["results"] == expected_results
@@ -244,6 +254,8 @@ def test_pagination(setup_test_data, client):
                 "missing_tas_accounts_count": 1,
             },
             "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
         }
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -99,6 +99,8 @@ class AgencyOverview(AgencyBase):
                     "missing_tas_accounts_count": result["missing_tas_accounts"],
                 },
                 "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
+                "unlinked_contract_award_count": 0,
+                "unlinked_assistance_award_count": 0,
             }
             for result in result_list
         ]
@@ -124,6 +126,8 @@ class AgencyOverview(AgencyBase):
             "recent_publication_date",
             "recent_publication_date_certified",
             "tas_obligation_not_in_gtas_total",
+            "unlinked_contract_award_count",
+            "unlinked_assistance_award_count",
         ]
         default_sort_column = "current_total_budget_authority_amount"
         model = customize_pagination_with_sort_columns(sortable_columns, default_sort_column)

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -120,6 +120,8 @@ class AgenciesOverview(AgencyBase):
                     "missing_tas_accounts_count": result["missing_tas_accounts"],
                 },
                 "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
+                "unlinked_contract_award_count": 0,
+                "unlinked_assistance_award_count": 0,
             }
             for result in result_list
         ]
@@ -146,6 +148,8 @@ class AgenciesOverview(AgencyBase):
             "recent_publication_date",
             "recent_publication_date_certified",
             "tas_obligation_not_in_gtas_total",
+            "unlinked_contract_award_count",
+            "unlinked_assistance_award_count",
         ]
         default_sort_column = "current_total_budget_authority_amount"
         model = customize_pagination_with_sort_columns(sortable_columns, default_sort_column)


### PR DESCRIPTION
**Description:**
Updating the contract and putting placeholder values for unlinked awards in the two overview endpoints so frontend can begin coding to them.

**Technical details:**
`/api/v2/reporting/agencies/overview` and `/api/v2/reporting/agencies/<agency_code>/overview` have two new keys to account for unlinked awards. Currently hardcoded to 0

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend
4. Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. Data validation completed (N/A)
7. Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6305](https://federal-spending-transparency.atlassian.net/browse/DEV-6305):
    - [x] Link to this Pull-Request
    - Performance evaluation of affected (API | Script | Download) (N/A)
    - Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
```
