### PR TITLE
DEV-6480: Secondary sort fy

### DIFF
--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -111,6 +111,8 @@ class AgencyOverview(AgencyBase):
                 self.pagination.sort_key == "missing_tas_accounts_count"
                 or self.pagination.sort_key == "tas_obligation_not_in_gtas_total"
             )
+            else (x[self.pagination.sort_key], x[self.pagination.secondary_sort_key])
+            if self.pagination.secondary_sort_key is not None
             else x[self.pagination.sort_key],
             reverse=self.pagination.sort_order == "desc",
         )
@@ -132,11 +134,14 @@ class AgencyOverview(AgencyBase):
         default_sort_column = "current_total_budget_authority_amount"
         model = customize_pagination_with_sort_columns(sortable_columns, default_sort_column)
         request_data = TinyShield(model).block(self.request.query_params)
+        sort_key = request_data.get("sort", default_sort_column)
+        secondary_sort = "fiscal_period" if sort_key == "fiscal_year" else None
         return Pagination(
             page=request_data["page"],
             limit=request_data["limit"],
             lower_limit=(request_data["page"] - 1) * request_data["limit"],
             upper_limit=(request_data["page"] * request_data["limit"]),
-            sort_key=request_data.get("sort", default_sort_column),
+            sort_key=sort_key,
             sort_order=request_data["order"],
+            secondary_sort_key=secondary_sort,
         )


### PR DESCRIPTION
**Description:**
Adding a secondary sort to the single agency overview by fiscal period when sorting by fiscal year

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6480](https://federal-spending-transparency.atlassian.net/browse/DEV-6480):
    - Link to this Pull-Request (N/A)
    - Performance evaluation of affected (API | Script | Download) (N/A)
    - Before / After data comparison (N/A)

**Area for explaining above N/A when needed:**
```
```
