### PR TITLE
[DEV-6563] Change ORM implementation to avoid '= True' in SQL exists

### DIFF
--- a/usaspending_api/agency/v2/views/agency_overview.py
+++ b/usaspending_api/agency/v2/views/agency_overview.py
@@ -1,11 +1,11 @@
 from django.conf import settings
-from django.db.models import Exists, OuterRef
 from rest_framework.response import Response
 from usaspending_api.agency.v2.views.agency_base import AgencyBase
 from usaspending_api.awards.models import TransactionNormalized
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.date_helper import fy
-from usaspending_api.references.models import SubtierAgency
+from usaspending_api.common.helpers.orm_helpers import generate_raw_quoted_query
+from usaspending_api.references.models import Agency, SubtierAgency
 
 
 class AgencyOverview(AgencyBase):
@@ -35,17 +35,16 @@ class AgencyOverview(AgencyBase):
         )
 
     def get_subtier_agency_count(self):
+        filters = {"fiscal_year__gte": fy(settings.API_SEARCH_MIN_DATE)}
+        values = ["pk", "awarding_agency__subtier_agency"]
+
         return (
             SubtierAgency.objects.filter(agency__toptier_agency=self.toptier_agency)
-            .annotate(
-                was_an_awarding_agency=Exists(
-                    TransactionNormalized.objects.filter(
-                        fiscal_year__gte=fy(settings.API_SEARCH_MIN_DATE),
-                        awarding_agency__subtier_agency=OuterRef("pk"),
-                    ).values("pk")
-                )
+            .extra(
+                where=[
+                    f"Exists({generate_raw_quoted_query(TransactionNormalized.objects.filter(**filters).values(*values))}"
+                    f" AND {Agency._meta.db_table}.subtier_agency_id = {SubtierAgency._meta.db_table}.subtier_agency_id)"
+                ]
             )
-            .filter(was_an_awarding_agency=True)
-            .values("pk")
             .count()
         )


### PR DESCRIPTION
**Description:**
Changed the ORM code to avoid an `EXISTS () = True` in the WHERE clause. 

**Technical details:**
A similar issue has come up before where the use of `EXISTS` in this current version of Django (2.2.9) create SQL such that `EXISTS () = True`. For some reason that `= True` slows the performance greatly even though the same result is achieved without it. In Django 3.0 and later it is possible to simply have an EXISTS in the .filter() (https://docs.djangoproject.com/en/3.0/ref/models/expressions/#exists-subqueries). However, in versions before 3.0 it is required that the EXISTS is first annotated and then the annotated name can be used.

Should add that this is NOT a perfect solution since the use of `.extra()` is discouraged, however, as mentioned above it is a required work-around until we upgrade to Django 3.0 or above.

Recent runs against DAOI Sandbox has the endpoint completing in under 1 second.

SQL Before:
```
select
	COUNT(*)
from
	(
	select
		"subtier_agency"."subtier_agency_id" as Col1
	from
		"subtier_agency"
	inner join "agency" on
		("subtier_agency"."subtier_agency_id" = "agency"."subtier_agency_id")
	where
		("agency"."toptier_agency_id" = 22
		and exists(
		select
			U0."id"
		from
			"transaction_normalized" U0
		inner join "agency" U1 on
			(U0."awarding_agency_id" = U1."id")
		where
			(U1."subtier_agency_id" = ("subtier_agency"."subtier_agency_id")
			and U0."fiscal_year" >= 2008)) = true)) subquery
```

SQL After:
```
select
	COUNT(*) as "__count"
from
	"subtier_agency"
inner join "agency" as a1 on
	("subtier_agency"."subtier_agency_id" = "a1"."subtier_agency_id")
where
	("a1"."toptier_agency_id" = 22
	and (exists(
	select
		"transaction_normalized"."id", "a2"."subtier_agency_id"
	from
		"transaction_normalized"
	left outer join "agency" as a2 on
		("transaction_normalized"."awarding_agency_id" = "a2"."id")
	where
		"transaction_normalized"."fiscal_year" >= 2008
		and a1.subtier_agency_id = subtier_agency.subtier_agency_id)))
```



**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6563](https://federal-spending-transparency.atlassian.net/browse/DEV-6563):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No change in functionality only the performance. 
```
