### PR TITLE
[DEV-6198] Fixing Advanced Search filter tree ordering

### DIFF
--- a/usaspending_api/references/v2/views/filter_tree/naics.py
+++ b/usaspending_api/references/v2/views/filter_tree/naics.py
@@ -1,5 +1,4 @@
 import logging
-from collections import OrderedDict
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,6 +12,10 @@ from usaspending_api.references.models import NAICS
 from usaspending_api.references.v2.views.filter_tree.filter_tree import DEFAULT_CHILDREN
 
 logger = logging.getLogger("console")
+
+
+def get_six_digit_naics_count(code: str) -> int:
+    return NAICS.objects.annotate(text_len=Length("code")).filter(code__startswith=code, text_len=6).count()
 
 
 class NAICSViewSet(APIView):
@@ -37,37 +40,26 @@ class NAICSViewSet(APIView):
                 "allow_nulls": True,
             },
         ]
-        validated = TinyShield(models).block(data)
-        return validated
+        return TinyShield(models).block(data)
 
-    def _fetch_children(self, naics_code, naics_filter=None) -> list:
+    def _fetch_children(self, naics_code) -> list:
         results = []
-        if naics_filter:
-            naics = NAICS.objects.annotate(text_len=Length("code")).filter(
-                **naics_filter, code__startswith=naics_code, text_len=len(naics_code) + 2
-            )
-        else:
-            naics = NAICS.objects.annotate(text_len=Length("code")).filter(
-                code__startswith=naics_code, text_len=len(naics_code) + 2
-            )
-        for naic in naics:
-            if len(naic.code) < 6:
-                result = OrderedDict()
-                result["naics"] = naic.code
-                result["naics_description"] = naic.description
-                result["count"] = (
-                    NAICS.objects.annotate(text_len=Length("code"))
-                    .filter(code__startswith=naic.code, text_len=6)
-                    .count()
-                )
+
+        naics_list = NAICS.objects.annotate(text_len=Length("code")).filter(
+            code__startswith=naics_code, text_len=len(naics_code) + 2
+        )
+        for naics in naics_list:
+            if len(naics.code) < 6:
+                result = {
+                    "naics": naics.code,
+                    "naics_description": naics.description,
+                    "count": get_six_digit_naics_count(naics.code),
+                }
             else:
-                result = OrderedDict()
-                result["naics"] = naic.code
-                result["naics_description"] = naic.description
-                result["count"] = DEFAULT_CHILDREN
+                result = {"naics": naics.code, "naics_description": naics.description, "count": DEFAULT_CHILDREN}
             results.append(result)
-        results.sort(key=lambda x: x["naics"])
-        return results
+
+        return sorted(results, key=lambda x: x["naics"])
 
     def _filter_search(self, naics_filter: dict) -> dict:
         search_filter = Q(description__icontains=naics_filter["description__icontains"])
@@ -77,18 +69,18 @@ class NAICSViewSet(APIView):
         tier1_codes = set()
         tier2_codes = set()
         tier3_codes = set()
-        naics = list(NAICS.objects.annotate(text_len=Length("code")).filter(search_filter))
-        tier3_naics = [naic for naic in naics if len(naic.code) == 6]
-        tier2_naics = [naic for naic in naics if len(naic.code) == 4]
-        tier1_naics = [naic for naic in naics if len(naic.code) == 2]
-        for naic in tier3_naics:
-            tier3_codes.add(naic.code)
-            tier2_codes.add(naic.code[:4])
-            tier1_codes.add(naic.code[:2])
+        naics_list = list(NAICS.objects.annotate(text_len=Length("code")).filter(search_filter))
+        tier3_naics = [naics for naics in naics_list if len(naics.code) == 6]
+        tier2_naics = [naics for naics in naics_list if len(naics.code) == 4]
+        tier1_naics = [naics for naics in naics_list if len(naics.code) == 2]
+        for naics in tier3_naics:
+            tier3_codes.add(naics.code)
+            tier2_codes.add(naics.code[:4])
+            tier1_codes.add(naics.code[:2])
 
-        for naic in tier2_naics:
-            tier2_codes.add(naic.code)
-            tier1_codes.add(naic.code[:2])
+        for naics in tier2_naics:
+            tier2_codes.add(naics.code)
+            tier1_codes.add(naics.code[:2])
 
         extra_tier2_naics = NAICS.objects.annotate(text_len=Length("code")).filter(code__in=tier2_codes, text_len=4)
         extra_tier1_naics = NAICS.objects.annotate(text_len=Length("code")).filter(code__in=tier1_codes, text_len=2)
@@ -96,57 +88,53 @@ class NAICSViewSet(APIView):
         tier1 = set(list(tier1_naics)) | set(list(extra_tier1_naics))
         tier2_results = {}
 
-        for naic in tier2:
-            result = OrderedDict()
-            result["naics"] = naic.code
-            result["naics_description"] = naic.description
-            result["count"] = (
-                NAICS.objects.annotate(text_len=Length("code")).filter(code__startswith=naic.code, text_len=6).count()
-            )
-            result["children"] = []
-            tier2_results[naic.code] = result
+        for naics in tier2:
+            result = {
+                "naics": naics.code,
+                "naics_description": naics.description,
+                "count": get_six_digit_naics_count(naics.code),
+                "children": [],
+            }
+            tier2_results[naics.code] = result
 
-        for naic in tier3_naics:
-            result = OrderedDict()
-            result["naics"] = naic.code
-            result["naics_description"] = naic.description
-            result["count"] = DEFAULT_CHILDREN
-            tier2_results[naic.code[:4]]["children"].append(result)
-            tier2_results[naic.code[:4]]["children"].sort(key=lambda x: x["naics"])
+        for naics in tier3_naics:
+            result = {
+                "naics": naics.code,
+                "naics_description": naics.description,
+                "count": DEFAULT_CHILDREN,
+            }
+            tier2_results[naics.code[:4]]["children"].append(result)
+            tier2_results[naics.code[:4]]["children"].sort(key=lambda x: x["naics"])
         tier1_results = {}
-        for naic in tier1:
-            result = OrderedDict()
-            result["naics"] = naic.code
-            result["naics_description"] = naic.description
-            result["count"] = (
-                NAICS.objects.annotate(text_len=Length("code")).filter(code__startswith=naic.code, text_len=6).count()
-            )
-            result["children"] = []
-            tier1_results[naic.code] = result
+        for naics in tier1:
+            result = {
+                "naics": naics.code,
+                "naics_description": naics.description,
+                "count": get_six_digit_naics_count(naics.code),
+                "children": [],
+            }
+            tier1_results[naics.code] = result
         for key in tier2_results.keys():
             tier1_results[key[:2]]["children"].append(tier2_results[key])
             tier1_results[key[:2]]["children"].sort(key=lambda x: x["naics"])
         results = []
         for key in tier1_results.keys():
             results.append(tier1_results[key])
-        results.sort(key=lambda x: x["naics"])
-        response_content = OrderedDict({"results": results})
-        return response_content
+
+        return {"results": sorted(results, key=lambda x: x["naics"])}
 
     def _default_view(self) -> dict:
-        naics = NAICS.objects.annotate(text_len=Length("code")).filter(text_len=2)
-        results = []
-        for naic in naics:
-            result = OrderedDict()
-            result["naics"] = naic.code
-            result["naics_description"] = naic.description
-            result["count"] = (
-                NAICS.objects.annotate(text_len=Length("code")).filter(code__startswith=naic.code, text_len=6).count()
-            )
-            results.append(result)
-        results.sort(key=lambda x: x["naics"])
-        response_content = OrderedDict({"results": results})
-        return response_content
+        naics_list = NAICS.objects.annotate(text_len=Length("code")).filter(text_len=2)
+        results = [
+            {
+                "naics": naics.code,
+                "naics_description": naics.description,
+                "count": get_six_digit_naics_count(naics.code),
+            }
+            for naics in naics_list
+        ]
+
+        return {"results": sorted(results, key=lambda x: x["naics"])}
 
     def _business_logic(self, request_data: dict) -> dict:
         naics_filter = {}
@@ -161,27 +149,25 @@ class NAICSViewSet(APIView):
             naics_filter.update({"description__icontains": description})
             return self._filter_search(naics_filter)
 
-        naics = NAICS.objects.filter(**naics_filter)
+        naics_list = NAICS.objects.filter(**naics_filter)
         results = []
-        for naic in naics:
-            result = OrderedDict()
-            if len(naic.code) < 6:
-                result["naics"] = naic.code
-                result["naics_description"] = naic.description
-                result["count"] = (
-                    NAICS.objects.annotate(text_len=Length("code"))
-                    .filter(code__startswith=naic.code, text_len=6)
-                    .count()
-                )
-                result["children"] = self._fetch_children(naic.code)
+        for naics in naics_list:
+            if len(naics.code) < 6:
+                result = {
+                    "naics": naics.code,
+                    "naics_description": naics.description,
+                    "count": get_six_digit_naics_count(naics.code),
+                    "children": self._fetch_children(naics.code),
+                }
             else:
-                result["naics"] = naic.code
-                result["naics_description"] = naic.description
-                result["count"] = DEFAULT_CHILDREN
+                result = {
+                    "naics": naics.code,
+                    "naics_description": naics.description,
+                    "count": DEFAULT_CHILDREN,
+                }
             results.append(result)
 
-        response_content = OrderedDict({"results": results})
-        return response_content
+        return {"results": results}
 
     @cache_response()
     def get(self, request: Request, requested_naics: str = None) -> Response:

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -102,7 +102,7 @@ class PSCFilterTree(FilterTree):
                     "children": None,
                 }
             )
-        return retval
+        return sorted(retval, key=lambda x: x["id"])
 
     def tier_2_search(self, ancestor_array, filter_string, lower_tier_nodes=None) -> list:
         filters = [
@@ -152,7 +152,7 @@ class PSCFilterTree(FilterTree):
                     "children": None,
                 }
             )
-        return retval
+        return sorted(retval, key=lambda x: x["id"])
 
     def tier_1_search(self, ancestor_array, filter_string, lower_tier_nodes=None) -> list:
         filters = [Q(Q(Q(length=1) & Q(code__in=PSC_GROUPS["Service"]["terms"])) | Q(length=2))]
@@ -186,7 +186,7 @@ class PSCFilterTree(FilterTree):
                     "children": None,
                 }
             )
-        return retval
+        return sorted(retval, key=lambda x: x["id"])
 
     def toptier_search(self, filter_string, tier1_nodes=None):
         retval = []
@@ -208,7 +208,7 @@ class PSCFilterTree(FilterTree):
                             "children": None,
                         }
                     )
-        return retval
+        return sorted(retval, key=lambda x: x["id"])
 
     def _combine_nodes(self, upper_tier, lower_tier):
         for upper_node in upper_tier:
@@ -217,9 +217,8 @@ class PSCFilterTree(FilterTree):
             for lower_node in lower_tier:
                 if upper_node["id"] in lower_node["ancestors"] and lower_node["id"] not in node_ids:
                     children.append(lower_node)
-            sorted(children, key=lambda x: x["id"])
             if len(children) > 0:
-                upper_node["children"] = children
+                upper_node["children"] = sorted(children, key=lambda x: x["id"])
         return upper_tier
 
     def _path_is_valid(self, path: list) -> bool:

--- a/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
@@ -36,8 +36,7 @@ class TASFilterTree(FilterTree):
             for lower_node in lower_tier:
                 if upper_node["id"] in lower_node["ancestors"]:
                     children.append(lower_node)
-            sorted(children, key=lambda x: x["id"])
-            upper_node["children"] = children
+            upper_node["children"] = sorted(children, key=lambda x: x["id"])
         return upper_tier
 
     def tier_2_search(self, ancestor_array, filter_string) -> list:
@@ -71,7 +70,7 @@ class TASFilterTree(FilterTree):
                     "children": None,
                 }
             )
-        return retval
+        return sorted(retval, key=lambda x: x["id"])
 
     def tier_1_search(self, ancestor_array, filter_string, tier2_nodes=None) -> list:
         filters = [Q(has_faba=True)]
@@ -98,19 +97,19 @@ class TASFilterTree(FilterTree):
             .values("federal_account__federal_account_code", "federal_account__account_title", "agency")
             .annotate(count=Count("treasury_account_identifier"))
         )
-        retval = []
-        for item in data:
-            ancestor_array = [item["agency"]]
-            retval.append(
-                {
-                    "id": item["federal_account__federal_account_code"],
-                    "ancestors": ancestor_array,
-                    "description": item["federal_account__account_title"],
-                    "count": item["count"],
-                    "children": None,
-                }
-            )
-        return retval
+
+        retval = [
+            {
+                "id": item["federal_account__federal_account_code"],
+                "ancestors": [item["agency"]],
+                "description": item["federal_account__account_title"],
+                "count": item["count"],
+                "children": None,
+            }
+            for item in data
+        ]
+
+        return sorted(retval, key=lambda x: x["id"])
 
     def toptier_search(self, filter_string=None, tier1_nodes=None):
         filters = [Q(has_faba=True)]


### PR DESCRIPTION
**Description:**
Most of the filter trees were not explicitly ordered and instead were implicitly using the order of records obtained from database tables

**Technical details:**

1. One misuse of `sorted()` (should have been `<list>.sort()`)
2. OrderedDict is unnecessary in Python 3.7 and was often used for dictionaries with single keys, so the library was remoed and replaced by dictionaries
3. Simplified / reduced a little code
4. Added `sorted()` to many places in the filter tree logic

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (No changes were desired from refactor)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6198](https://federal-spending-transparency.atlassian.net/browse/DEV-6198):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API (no noticeable differences)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to API schema or database
```
