### PR TITLE
Mod/dev 6564 add total and percent to overview

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -67,7 +67,7 @@ This endpoint returns an overview of government agency submission data.
                         "fiscal_period": 7,
                         "current_total_budget_authority_amount": 192340342676.75,
                         "total_budgetary_resources": 13105812389531.01,
-                        "percent_of_total_budgetary_resources": 1.4675957274529006,
+                        "percent_of_total_budgetary_resources": 1.47,
                         "recent_publication_date": "2020-08-13T13:40:21.181994Z",
                         "recent_publication_date_certified": true,
                         "tas_account_discrepancies_totals": {
@@ -85,7 +85,7 @@ This endpoint returns an overview of government agency submission data.
                         "fiscal_period": 6,
                         "current_total_budget_authority_amount": 192243648186.87,
                         "total_budgetary_resources": 10127796351165.57,
-                        "percent_of_total_budgetary_resources": 1.8981784538424826,
+                        "percent_of_total_budgetary_resources": 1.90,
                         "recent_publication_date": "2020-05-14T13:08:23.624634Z",
                         "recent_publication_date_certified": true,
                         "tas_account_discrepancies_totals": {

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -29,6 +29,7 @@ This endpoint returns an overview of government agency submission data.
         + Default: `current_total_budget_authority_amount`
         + Members
             + `current_total_budget_authority_amount`
+            + `percent_of_total_budgetary_resources`
             + `fiscal_period`
             + `fiscal_year`
             + `missing_tas_accounts_count`
@@ -65,6 +66,8 @@ This endpoint returns an overview of government agency submission data.
                         "fiscal_year": 2020,
                         "fiscal_period": 12,
                         "current_total_budget_authority_amount": 8361447130497.72,
+                        "total_budgetary_resources": ,
+                        "percent_of_total_budgetary_resources": ,
                         "recent_publication_date": "2020-01-10T11:59:21Z",
                         "recent_publication_date_certified": false,
                         "tas_account_discrepancies_totals": {
@@ -81,7 +84,9 @@ This endpoint returns an overview of government agency submission data.
                         "fiscal_year": 2020,
                         "fiscal_period": 9,
                         "current_total_budget_authority_amount": 8361447130497.72,
-                        "recent_publication_date": null,
+                        "total_budgetary_resources": ,
+                        "percent_of_total_budgetary_resources": ,
+.                        "recent_publication_date": null,
                         "recent_publication_date_certified": true,
                         "tas_account_discrepancies_totals": {
                             "gtas_obligation_total": 66432,
@@ -117,6 +122,8 @@ This endpoint returns an overview of government agency submission data.
 + `fiscal_year` (required, number)
 + `fiscal_period` (required, number)
 + `current_total_budget_authority_amount` (required, number)
++ `total_budgetary_resources` (required, number)
++ `percent_of_total_budgetary_resources` (required, number)
 + `recent_publication_date` (required, string, nullable)
 + `recent_publication_date_certified` (required, boolean)
 + `recent_publication_date_certified` (required, boolean)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -10,7 +10,7 @@ This endpoint is used to power USAspending.gov's About the Data \| Agencies agen
 This endpoint returns an overview of government agency submission data.
 
 + Parameters
-    + `agency_code`: `020` (required, string)
+    + `agency_code` (required, string)
         The specific agency.
     + `page` (optional, number)
         The page of results to return based on the limit.
@@ -64,37 +64,37 @@ This endpoint returns an overview of government agency submission data.
                 "results": [
                     {
                         "fiscal_year": 2020,
-                        "fiscal_period": 12,
-                        "current_total_budget_authority_amount": 8361447130497.72,
-                        "total_budgetary_resources": ,
-                        "percent_of_total_budgetary_resources": ,
-                        "recent_publication_date": "2020-01-10T11:59:21Z",
-                        "recent_publication_date_certified": false,
+                        "fiscal_period": 7,
+                        "current_total_budget_authority_amount": 192340342676.75,
+                        "total_budgetary_resources": 13105812389531.01,
+                        "percent_of_total_budgetary_resources": 1.4675957274529006,
+                        "recent_publication_date": "2020-08-13T13:40:21.181994Z",
+                        "recent_publication_date_certified": true,
                         "tas_account_discrepancies_totals": {
-                            "gtas_obligation_total": 66432,
-                            "tas_accounts_total": 2342,
-                            "tas_obligation_not_in_gtas_total": 343345,
-                            "missing_tas_accounts_count": 10
+                            "gtas_obligation_total": 62668762422.57,
+                            "tas_accounts_total": 62659366681.07,
+                            "tas_obligation_not_in_gtas_total": 9395741.5,
+                            "missing_tas_accounts_count": 9
                         },
-                        "obligation_difference": 436376232652.87,
+                        "obligation_difference": 12581114.45,
                         "unlinked_contract_award_count": 0,
                         "unlinked_assistance_award_count": 0
                     },
                     {
                         "fiscal_year": 2020,
-                        "fiscal_period": 9,
-                        "current_total_budget_authority_amount": 8361447130497.72,
-                        "total_budgetary_resources": ,
-                        "percent_of_total_budgetary_resources": ,
-                        "recent_publication_date": null,
+                        "fiscal_period": 6,
+                        "current_total_budget_authority_amount": 192243648186.87,
+                        "total_budgetary_resources": 10127796351165.57,
+                        "percent_of_total_budgetary_resources": 1.8981784538424826,
+                        "recent_publication_date": "2020-05-14T13:08:23.624634Z",
                         "recent_publication_date_certified": true,
                         "tas_account_discrepancies_totals": {
-                            "gtas_obligation_total": 66432,
-                            "tas_accounts_total": 23903,
-                            "tas_obligation_not_in_gtas_total": 11543,
-                            "missing_tas_accounts_count": 10
+                            "gtas_obligation_total": 42417596510.72,
+                            "tas_accounts_total": 42417271495.34,
+                            "tas_obligation_not_in_gtas_total": 325015.38,
+                            "missing_tas_accounts_count": 2
                         },
-                        "obligation_difference": 436376232652.87,
+                        "obligation_difference": 14702670.23,
                         "unlinked_contract_award_count": 0,
                         "unlinked_assistance_award_count": 0
                     }

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -10,7 +10,7 @@ This endpoint is used to power USAspending.gov's About the Data \| Agencies agen
 This endpoint returns an overview of government agency submission data.
 
 + Parameters
-    + `agency_code` (required, string)
+    + `agency_code`: `020` (required, string)
         The specific agency.
     + `page` (optional, number)
         The page of results to return based on the limit.

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -86,7 +86,7 @@ This endpoint returns an overview of government agency submission data.
                         "current_total_budget_authority_amount": 8361447130497.72,
                         "total_budgetary_resources": ,
                         "percent_of_total_budgetary_resources": ,
-.                        "recent_publication_date": null,
+                        "recent_publication_date": null,
                         "recent_publication_date_certified": true,
                         "tas_account_discrepancies_totals": {
                             "gtas_obligation_total": 66432,

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -170,6 +170,8 @@ def setup_test_data(db):
         tas_rendering_label="TAS 2",
         obligated_amount=12.0,
     )
+    mommy.make("references.GTASSF133Balances", id=1, fiscal_year=current_fiscal_year(), fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())), total_budgetary_resources_cpe=200)
+    mommy.make("references.GTASSF133Balances", id=2, fiscal_year=2019, fiscal_period=6, total_budgetary_resources_cpe=22478810.97)
 
 
 def test_basic_success(setup_test_data, client):
@@ -184,6 +186,8 @@ def test_basic_success(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -202,6 +206,8 @@ def test_basic_success(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -230,6 +236,8 @@ def test_filter(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -258,6 +266,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -284,6 +294,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -310,6 +322,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -328,6 +342,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -357,6 +373,8 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "agency_code": "123",
             "agency_id": 1,
             "current_total_budget_authority_amount": 22478810.97,
+            "total_budgetary_resources": ,
+            "percent_of_total_budgetary_resources": ,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -9,9 +9,6 @@ from usaspending_api.common.helpers.fiscal_year_helpers import (
 )
 
 url = "/api/v2/reporting/agencies/overview/"
-prev_fiscal_year = current_fiscal_year() - 1
-prev_fiscal_qtr = get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(prev_fiscal_year))
-print(prev_fiscal_year, prev_fiscal_qtr)
 
 
 @pytest.fixture
@@ -23,8 +20,10 @@ def setup_test_data(db):
     sub2 = mommy.make(
         "submissions.SubmissionAttributes",
         submission_id=2,
-        reporting_fiscal_year=prev_fiscal_year,
-        reporting_fiscal_period=prev_fiscal_qtr,
+        reporting_fiscal_year=current_fiscal_year(),
+        reporting_fiscal_period=get_final_period_of_quarter(
+            calculate_last_completed_fiscal_quarter(current_fiscal_year())
+        ),
     )
     mommy.make("references.Agency", id=1, toptier_agency_id=1, toptier_flag=True)
     mommy.make("references.Agency", id=2, toptier_agency_id=2, toptier_flag=True)
@@ -131,8 +130,8 @@ def setup_test_data(db):
         "reporting.ReportingAgencyOverview",
         reporting_agency_overview_id=2,
         toptier_code=987,
-        fiscal_year=prev_fiscal_year,
-        fiscal_period=prev_fiscal_qtr,
+        fiscal_year=current_fiscal_year(),
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())),
         total_dollars_obligated_gtas=18.6,
         total_budgetary_resources=100,
         total_diff_approp_ocpa_obligated_amounts=0,
@@ -141,8 +140,8 @@ def setup_test_data(db):
         "reporting.ReportingAgencyOverview",
         reporting_agency_overview_id=3,
         toptier_code="001",
-        fiscal_year=prev_fiscal_year,
-        fiscal_period=prev_fiscal_qtr,
+        fiscal_year=current_fiscal_year(),
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())),
         total_dollars_obligated_gtas=20.0,
         total_budgetary_resources=10.0,
         total_diff_approp_ocpa_obligated_amounts=10.0,
@@ -177,9 +176,6 @@ def test_basic_success(setup_test_data, client):
     resp = client.get(url)
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
-
-    print(response)
-
     assert len(response["results"]) == 2
     expected_results = [
         {
@@ -188,8 +184,6 @@ def test_basic_success(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -208,8 +202,6 @@ def test_basic_success(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -238,8 +230,6 @@ def test_filter(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -268,8 +258,6 @@ def test_pagination(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -296,8 +284,6 @@ def test_pagination(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -324,8 +310,6 @@ def test_pagination(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -344,8 +328,6 @@ def test_pagination(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -375,8 +357,6 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "agency_code": "123",
             "agency_id": 1,
             "current_total_budget_authority_amount": 22478810.97,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -390,8 +370,4 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "unlinked_assistance_award_count": 0,
         }
     ]
-
-    print(response["results"])
-
     assert response["results"] == expected_results
-

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -9,6 +9,9 @@ from usaspending_api.common.helpers.fiscal_year_helpers import (
 )
 
 url = "/api/v2/reporting/agencies/overview/"
+prev_fiscal_year = current_fiscal_year() - 1
+prev_fiscal_qtr = get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(prev_fiscal_year))
+print(prev_fiscal_year, prev_fiscal_qtr)
 
 
 @pytest.fixture
@@ -20,10 +23,8 @@ def setup_test_data(db):
     sub2 = mommy.make(
         "submissions.SubmissionAttributes",
         submission_id=2,
-        reporting_fiscal_year=current_fiscal_year(),
-        reporting_fiscal_period=get_final_period_of_quarter(
-            calculate_last_completed_fiscal_quarter(current_fiscal_year())
-        ),
+        reporting_fiscal_year=prev_fiscal_year,
+        reporting_fiscal_period=prev_fiscal_qtr,
     )
     mommy.make("references.Agency", id=1, toptier_agency_id=1, toptier_flag=True)
     mommy.make("references.Agency", id=2, toptier_agency_id=2, toptier_flag=True)
@@ -130,8 +131,8 @@ def setup_test_data(db):
         "reporting.ReportingAgencyOverview",
         reporting_agency_overview_id=2,
         toptier_code=987,
-        fiscal_year=current_fiscal_year(),
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())),
+        fiscal_year=prev_fiscal_year,
+        fiscal_period=prev_fiscal_qtr,
         total_dollars_obligated_gtas=18.6,
         total_budgetary_resources=100,
         total_diff_approp_ocpa_obligated_amounts=0,
@@ -140,8 +141,8 @@ def setup_test_data(db):
         "reporting.ReportingAgencyOverview",
         reporting_agency_overview_id=3,
         toptier_code="001",
-        fiscal_year=current_fiscal_year(),
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())),
+        fiscal_year=prev_fiscal_year,
+        fiscal_period=prev_fiscal_qtr,
         total_dollars_obligated_gtas=20.0,
         total_budgetary_resources=10.0,
         total_diff_approp_ocpa_obligated_amounts=10.0,
@@ -170,14 +171,15 @@ def setup_test_data(db):
         tas_rendering_label="TAS 2",
         obligated_amount=12.0,
     )
-    mommy.make("references.GTASSF133Balances", id=1, fiscal_year=current_fiscal_year(), fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())), total_budgetary_resources_cpe=200)
-    mommy.make("references.GTASSF133Balances", id=2, fiscal_year=2019, fiscal_period=6, total_budgetary_resources_cpe=22478810.97)
 
 
 def test_basic_success(setup_test_data, client):
     resp = client.get(url)
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
+
+    print(response)
+
     assert len(response["results"]) == 2
     expected_results = [
         {
@@ -186,8 +188,8 @@ def test_basic_success(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -206,8 +208,8 @@ def test_basic_success(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -236,8 +238,8 @@ def test_filter(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -266,8 +268,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -294,8 +296,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -322,8 +324,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -342,8 +344,8 @@ def test_pagination(setup_test_data, client):
             "agency_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -373,8 +375,8 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "agency_code": "123",
             "agency_id": 1,
             "current_total_budget_authority_amount": 22478810.97,
-            "total_budgetary_resources": ,
-            "percent_of_total_budgetary_resources": ,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -388,4 +390,8 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "unlinked_assistance_award_count": 0,
         }
     ]
+
+    print(response["results"])
+
     assert response["results"] == expected_results
+

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -139,6 +139,12 @@ def setup_test_data(db):
         tas_rendering_label="TAS 2",
         obligated_amount=12.0,
     )
+    mommy.make(
+        "references.GTASSF133Balances", id=2, fiscal_year=2019, fiscal_period=6, total_budgetary_resources_cpe=20000000,
+    )
+    mommy.make(
+        "references.GTASSF133Balances", id=1, fiscal_year=2020, fiscal_period=12, total_budgetary_resources_cpe=1000000,
+    )
 
 
 def test_basic_success(setup_test_data, client):
@@ -151,6 +157,8 @@ def test_basic_success(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -167,6 +175,8 @@ def test_basic_success(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -183,6 +193,8 @@ def test_basic_success(setup_test_data, client):
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -209,6 +221,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -225,6 +239,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -241,6 +257,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -264,6 +282,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -287,6 +307,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -313,6 +335,8 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -329,6 +353,8 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -345,6 +371,8 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": 0,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -141,7 +141,6 @@ def setup_test_data(db):
     mommy.make(
         "references.GTASSF133Balances",
         id=1,
-        # create_date=datetime(2020, 1, 1, 12, 0, 0),
         fiscal_year=2019,
         fiscal_period=6,
         total_budgetary_resources_cpe=200000000,
@@ -149,7 +148,6 @@ def setup_test_data(db):
     mommy.make(
         "references.GTASSF133Balances",
         id=2,
-        # create_date=datetime(2020, 1, 1, 12, 0, 0),
         fiscal_year=2019,
         fiscal_period=9,
         total_budgetary_resources_cpe=150000000,
@@ -157,7 +155,6 @@ def setup_test_data(db):
     mommy.make(
         "references.GTASSF133Balances",
         id=3,
-        # create_date=datetime(2020, 1, 1, 12, 0, 0),
         fiscal_year=2020,
         fiscal_period=12,
         total_budgetary_resources_cpe=100000000,

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -172,7 +172,7 @@ def test_basic_success(setup_test_data, client):
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
             "total_budgetary_resources": 150000000,
-            "percent_of_total_budgetary_resources": 14.985873986666667,
+            "percent_of_total_budgetary_resources": 14.99,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -190,7 +190,7 @@ def test_basic_success(setup_test_data, client):
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
-            "percent_of_total_budgetary_resources": 11.239405485,
+            "percent_of_total_budgetary_resources": 11.24,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -208,7 +208,7 @@ def test_basic_success(setup_test_data, client):
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
-            "percent_of_total_budgetary_resources": 0.0001,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -236,7 +236,7 @@ def test_pagination(setup_test_data, client):
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
-            "percent_of_total_budgetary_resources": 0.0001,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -254,7 +254,7 @@ def test_pagination(setup_test_data, client):
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
-            "percent_of_total_budgetary_resources": 11.239405485,
+            "percent_of_total_budgetary_resources": 11.24,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -272,7 +272,7 @@ def test_pagination(setup_test_data, client):
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
             "total_budgetary_resources": 150000000,
-            "percent_of_total_budgetary_resources": 14.985873986666667,
+            "percent_of_total_budgetary_resources": 14.99,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -297,7 +297,7 @@ def test_pagination(setup_test_data, client):
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
             "total_budgetary_resources": 150000000,
-            "percent_of_total_budgetary_resources": 14.985873986666667,
+            "percent_of_total_budgetary_resources": 14.99,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -322,7 +322,7 @@ def test_pagination(setup_test_data, client):
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
-            "percent_of_total_budgetary_resources": 11.239405485,
+            "percent_of_total_budgetary_resources": 11.24,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -350,7 +350,7 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
-            "percent_of_total_budgetary_resources": 11.239405485,
+            "percent_of_total_budgetary_resources": 11.24,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -368,7 +368,7 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
             "total_budgetary_resources": 150000000,
-            "percent_of_total_budgetary_resources": 14.985873986666667,
+            "percent_of_total_budgetary_resources": 14.99,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -386,7 +386,7 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
-            "percent_of_total_budgetary_resources": 0.0001,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -412,7 +412,7 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
             "total_budgetary_resources": 150000000,
-            "percent_of_total_budgetary_resources": 14.985873986666667,
+            "percent_of_total_budgetary_resources": 14.99,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -430,7 +430,7 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
-            "percent_of_total_budgetary_resources": 11.239405485,
+            "percent_of_total_budgetary_resources": 11.24,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -448,7 +448,7 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
-            "percent_of_total_budgetary_resources": 0.0001,
+            "percent_of_total_budgetary_resources": 0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -1,7 +1,7 @@
 import pytest
 from model_mommy import mommy
 from rest_framework import status
-
+from datetime import datetime
 
 url = "/api/v2/reporting/agencies/123/overview/"
 
@@ -140,10 +140,28 @@ def setup_test_data(db):
         obligated_amount=12.0,
     )
     mommy.make(
-        "references.GTASSF133Balances", id=2, fiscal_year=2019, fiscal_period=6, total_budgetary_resources_cpe=20000000,
+        "references.GTASSF133Balances",
+        id=1,
+        # create_date=datetime(2020, 1, 1, 12, 0, 0),
+        fiscal_year=2019,
+        fiscal_period=6,
+        total_budgetary_resources_cpe=200000000,
     )
     mommy.make(
-        "references.GTASSF133Balances", id=1, fiscal_year=2020, fiscal_period=12, total_budgetary_resources_cpe=1000000,
+        "references.GTASSF133Balances",
+        id=2,
+        # create_date=datetime(2020, 1, 1, 12, 0, 0),
+        fiscal_year=2019,
+        fiscal_period=9,
+        total_budgetary_resources_cpe=150000000,
+    )
+    mommy.make(
+        "references.GTASSF133Balances",
+        id=3,
+        # create_date=datetime(2020, 1, 1, 12, 0, 0),
+        fiscal_year=2020,
+        fiscal_period=12,
+        total_budgetary_resources_cpe=100000000,
     )
 
 
@@ -157,8 +175,8 @@ def test_basic_success(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 150000000,
+            "percent_of_total_budgetary_resources": 14.985873986666667,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -175,8 +193,8 @@ def test_basic_success(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 200000000,
+            "percent_of_total_budgetary_resources": 11.239405485,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -193,8 +211,8 @@ def test_basic_success(setup_test_data, client):
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 100000000,
+            "percent_of_total_budgetary_resources": 0.0001,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -221,8 +239,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 100000000,
+            "percent_of_total_budgetary_resources": 0.0001,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -239,8 +257,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 200000000,
+            "percent_of_total_budgetary_resources": 11.239405485,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -257,8 +275,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 150000000,
+            "percent_of_total_budgetary_resources": 14.985873986666667,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -282,8 +300,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 150000000,
+            "percent_of_total_budgetary_resources": 14.985873986666667,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -307,8 +325,8 @@ def test_pagination(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 200000000,
+            "percent_of_total_budgetary_resources": 11.239405485,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -335,8 +353,8 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 6,
             "current_total_budget_authority_amount": 22478810.97,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 200000000,
+            "percent_of_total_budgetary_resources": 11.239405485,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -353,8 +371,8 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_year": 2019,
             "fiscal_period": 9,
             "current_total_budget_authority_amount": 22478810.98,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 150000000,
+            "percent_of_total_budgetary_resources": 14.985873986666667,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
@@ -371,8 +389,8 @@ def test_secondary_sort(setup_test_data, client):
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
-            "total_budgetary_resources": 0,
-            "percent_of_total_budgetary_resources": 0,
+            "total_budgetary_resources": 100000000,
+            "percent_of_total_budgetary_resources": 0.0001,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -1,7 +1,6 @@
 import pytest
 from model_mommy import mommy
 from rest_framework import status
-from datetime import datetime
 
 url = "/api/v2/reporting/agencies/123/overview/"
 
@@ -382,6 +381,68 @@ def test_secondary_sort(setup_test_data, client):
                 "missing_tas_accounts_count": 0,
             },
             "obligation_difference": 84931.96,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
+        },
+        {
+            "fiscal_year": 2020,
+            "fiscal_period": 12,
+            "current_total_budget_authority_amount": 100.0,
+            "total_budgetary_resources": 100000000,
+            "percent_of_total_budgetary_resources": 0.0001,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": 18.6,
+                "tas_accounts_total": 100.00,
+                "tas_obligation_not_in_gtas_total": 12.0,
+                "missing_tas_accounts_count": 1,
+            },
+            "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
+        },
+    ]
+    assert response["results"] == expected_results
+
+    resp = client.get(url + "?sort=percent_of_total_budgetary_resources&order=desc")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 3
+    expected_results = [
+        {
+            "fiscal_year": 2019,
+            "fiscal_period": 9,
+            "current_total_budget_authority_amount": 22478810.98,
+            "total_budgetary_resources": 150000000,
+            "percent_of_total_budgetary_resources": 14.985873986666667,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": 1788370.04,
+                "tas_accounts_total": None,
+                "tas_obligation_not_in_gtas_total": 0.0,
+                "missing_tas_accounts_count": 0,
+            },
+            "obligation_difference": 84931.96,
+            "unlinked_contract_award_count": 0,
+            "unlinked_assistance_award_count": 0,
+        },
+        {
+            "fiscal_year": 2019,
+            "fiscal_period": 6,
+            "current_total_budget_authority_amount": 22478810.97,
+            "total_budgetary_resources": 200000000,
+            "percent_of_total_budgetary_resources": 11.239405485,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": 1788370.03,
+                "tas_accounts_total": 200.00,
+                "tas_obligation_not_in_gtas_total": 11.0,
+                "missing_tas_accounts_count": 2,
+            },
+            "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
         },

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -79,7 +79,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                     .values("count"),
                     output_field=IntegerField(),
                 ),
-                gtas_total_budgetary_resources=Subquery(  # question for reviewer: since this is a dividend, are there circumstances that it would be 0 or nonexistent?
+                gtas_total_budgetary_resources=Subquery(
                     GTASSF133Balances.objects.filter(
                         fiscal_year=OuterRef("fiscal_year"), fiscal_period=OuterRef("fiscal_period")
                     )
@@ -111,9 +111,9 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 "fiscal_period": result["fiscal_period"],
                 "current_total_budget_authority_amount": result["total_budgetary_resources"],
                 "total_budgetary_resources": result["gtas_total_budgetary_resources"],
-                "percent_of_total_budgetary_resources": result["total_budgetary_resources"]
-                * 100
-                / result["gtas_total_budgetary_resources"],
+                "percent_of_total_budgetary_resources": round(
+                    result["total_budgetary_resources"] * 100 / result["gtas_total_budgetary_resources"], 2
+                ),
                 "recent_publication_date": result["recent_publication_date"],
                 "recent_publication_date_certified": result["recent_publication_date_certified"] is not None,
                 "tas_account_discrepancies_totals": {

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -24,6 +24,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
             "tas_obligation_not_in_gtas_total",
             "unlinked_contract_award_count",
             "unlinked_assistance_award_count",
+            "percent_of_total_budgetary_resources",
         ]
         self.default_sort_column = "current_total_budget_authority_amount"
         results = self.get_agency_overview()
@@ -104,9 +105,6 @@ class AgencyOverview(AgencyBase, PaginationMixin):
         return self.format_results(result_list)
 
     def format_results(self, result_list):
-
-        print(result_list)
-
         results = [
             {
                 "fiscal_year": result["fiscal_year"],

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -78,7 +78,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                     .values("count"),
                     output_field=IntegerField(),
                 ),
-                gtas_total_budgetary_resources=Subquery(
+                gtas_total_budgetary_resources=Subquery(  # question for reviewer: since this is a dividend, are there circumstances that it would be 0 or nonexistent?
                     GTASSF133Balances.objects.filter(
                         fiscal_year=OuterRef("fiscal_year"), fiscal_period=OuterRef("fiscal_period")
                     )
@@ -104,13 +104,18 @@ class AgencyOverview(AgencyBase, PaginationMixin):
         return self.format_results(result_list)
 
     def format_results(self, result_list):
+
+        print(result_list)
+
         results = [
             {
                 "fiscal_year": result["fiscal_year"],
                 "fiscal_period": result["fiscal_period"],
                 "current_total_budget_authority_amount": result["total_budgetary_resources"],
                 "total_budgetary_resources": result["gtas_total_budgetary_resources"],
-                "percent_of_total_budgetary_resources": result["total_budgetary_resources"] * 100 / result["gtas_total_budgetary_resources"],
+                "percent_of_total_budgetary_resources": result["total_budgetary_resources"]
+                * 100
+                / result["gtas_total_budgetary_resources"],
                 "recent_publication_date": result["recent_publication_date"],
                 "recent_publication_date_certified": result["recent_publication_date_certified"] is not None,
                 "tas_account_discrepancies_totals": {

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -4,6 +4,7 @@ from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMi
 
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.reporting.models import ReportingAgencyOverview, ReportingAgencyTas, ReportingAgencyMissingTas
+from usaspending_api.references.models import GTASSF133Balances
 from usaspending_api.submissions.models import SubmissionAttributes
 
 
@@ -77,12 +78,21 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                     .values("count"),
                     output_field=IntegerField(),
                 ),
+                gtas_total_budgetary_resources=Subquery(
+                    GTASSF133Balances.objects.filter(
+                        fiscal_year=OuterRef("fiscal_year"), fiscal_period=OuterRef("fiscal_period")
+                    )
+                    .annotate(the_sum=Func(F("total_budgetary_resources_cpe"), function="SUM"))
+                    .values("the_sum"),
+                    output_field=DecimalField(max_digits=23, decimal_places=2),
+                ),
             )
             .values(
                 "fiscal_year",
                 "fiscal_period",
                 "total_dollars_obligated_gtas",
                 "total_budgetary_resources",
+                "gtas_total_budgetary_resources",
                 "total_diff_approp_ocpa_obligated_amounts",
                 "recent_publication_date",
                 "recent_publication_date_certified",
@@ -99,6 +109,8 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 "fiscal_year": result["fiscal_year"],
                 "fiscal_period": result["fiscal_period"],
                 "current_total_budget_authority_amount": result["total_budgetary_resources"],
+                "total_budgetary_resources": result["gtas_total_budgetary_resources"],
+                "percent_of_total_budgetary_resources": result["total_budgetary_resources"] * 100 / result["gtas_total_budgetary_resources"],
                 "recent_publication_date": result["recent_publication_date"],
                 "recent_publication_date_certified": result["recent_publication_date_certified"] is not None,
                 "tas_account_discrepancies_totals": {


### PR DESCRIPTION
**Description:**
add GTAS total_budgetary_resources for each results' fiscal period (and percent of that value) to the return payload

**Technical details:**
get sum of total_budgetary_resources_cpe for each fiscal period & calc percentage

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations NA-only adding data to existing endpoint
    - [x] Domain Expert NA
4. [x] Matview impact assessment completed NA
5. [x] Frontend impact assessment completed NA
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created NA
8. [x] Jira Ticket [https://federal-spending-transparency.atlassian.net/browse/DEV-6564]:
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
