### PR TITLE
Fix tests using hardcoded values instead of current_fiscal_year

### DIFF
--- a/usaspending_api/agency/tests/integration/test_agency_budget_function.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budget_function.py
@@ -12,7 +12,7 @@ url = "/api/v2/agency/{code}/budget_function/{query_params}"
 def test_budget_function_list_success(client, agency_account_data):
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -131,10 +131,10 @@ def test_budget_function_list_bad_order(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_budget_function_list_sort_by_name(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -171,10 +171,10 @@ def test_budget_function_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -214,10 +214,10 @@ def test_budget_function_list_sort_by_name(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_budget_function_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -254,10 +254,10 @@ def test_budget_function_list_sort_by_obligated_amount(client, agency_account_da
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -297,10 +297,10 @@ def test_budget_function_list_sort_by_obligated_amount(client, agency_account_da
 
 @pytest.mark.django_db
 def test_budget_function_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -337,10 +337,10 @@ def test_budget_function_list_sort_by_gross_outlay_amount(client, agency_account
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -380,10 +380,10 @@ def test_budget_function_list_sort_by_gross_outlay_amount(client, agency_account
 
 @pytest.mark.django_db
 def test_budget_function_list_search(client, agency_account_data):
-    query_params = "?fiscal_year=2020&filter=NAME 6"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=NAME 6"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -408,10 +408,10 @@ def test_budget_function_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&filter=AME 5"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=AME 5"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -439,10 +439,10 @@ def test_budget_function_list_search(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_budget_function_list_pagination(client, agency_account_data):
-    query_params = "?fiscal_year=2020&limit=2&page=1"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -473,10 +473,10 @@ def test_budget_function_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&limit=2&page=2"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_agency_federal_account_list.py
+++ b/usaspending_api/agency/tests/integration/test_agency_federal_account_list.py
@@ -12,7 +12,7 @@ url = "/api/v2/agency/{code}/federal_account/{query_params}"
 def test_federal_account_list_success(client, agency_account_data):
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -163,10 +163,10 @@ def test_federal_account_list_bad_order(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_federal_account_list_sort_by_name(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -227,10 +227,10 @@ def test_federal_account_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -294,10 +294,10 @@ def test_federal_account_list_sort_by_name(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_federal_account_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -358,10 +358,10 @@ def test_federal_account_list_sort_by_obligated_amount(client, agency_account_da
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -425,10 +425,10 @@ def test_federal_account_list_sort_by_obligated_amount(client, agency_account_da
 
 @pytest.mark.django_db
 def test_federal_account_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -489,10 +489,10 @@ def test_federal_account_list_sort_by_gross_outlay_amount(client, agency_account
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -556,10 +556,10 @@ def test_federal_account_list_sort_by_gross_outlay_amount(client, agency_account
 
 @pytest.mark.django_db
 def test_federal_account_list_search(client, agency_account_data):
-    query_params = "?fiscal_year=2020&filter=FA 3"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=FA 3"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -592,10 +592,10 @@ def test_federal_account_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&filter=TA 5"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=TA 5"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -631,10 +631,10 @@ def test_federal_account_list_search(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_federal_account_list_pagination(client, agency_account_data):
-    query_params = "?fiscal_year=2020&limit=2&page=1"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -681,10 +681,10 @@ def test_federal_account_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&limit=2&page=2"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_agency_object_class_list.py
+++ b/usaspending_api/agency/tests/integration/test_agency_object_class_list.py
@@ -12,7 +12,7 @@ url = "/api/v2/agency/{code}/object_class/{query_params}"
 def test_object_class_list_success(client, agency_account_data):
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -175,10 +175,10 @@ def test_object_class_list_ignore_duplicates(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_object_class_list_sort_by_name(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -200,10 +200,10 @@ def test_object_class_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -228,10 +228,10 @@ def test_object_class_list_sort_by_name(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_object_class_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -253,10 +253,10 @@ def test_object_class_list_sort_by_obligated_amount(client, agency_account_data)
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -281,10 +281,10 @@ def test_object_class_list_sort_by_obligated_amount(client, agency_account_data)
 
 @pytest.mark.django_db
 def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -306,10 +306,10 @@ def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_da
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -334,10 +334,10 @@ def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_da
 
 @pytest.mark.django_db
 def test_object_class_list_search(client, agency_account_data):
-    query_params = "?fiscal_year=2020&filter=supplies"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=supplies"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -355,10 +355,10 @@ def test_object_class_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&filter=uipm"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=uipm"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -379,10 +379,10 @@ def test_object_class_list_search(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_object_class_list_pagination(client, agency_account_data):
-    query_params = "?fiscal_year=2020&limit=2&page=1"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -403,10 +403,10 @@ def test_object_class_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&limit=2&page=2"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_agency_program_activity_list.py
+++ b/usaspending_api/agency/tests/integration/test_agency_program_activity_list.py
@@ -12,7 +12,7 @@ url = "/api/v2/agency/{code}/program_activity/{query_params}"
 def test_program_activity_list_success(client, agency_account_data):
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -175,10 +175,10 @@ def test_program_activity_list_ignore_duplicates(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_program_activity_list_sort_by_name(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -200,10 +200,10 @@ def test_program_activity_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=name"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -228,10 +228,10 @@ def test_program_activity_list_sort_by_name(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_program_activity_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -253,10 +253,10 @@ def test_program_activity_list_sort_by_obligated_amount(client, agency_account_d
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=obligated_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -281,10 +281,10 @@ def test_program_activity_list_sort_by_obligated_amount(client, agency_account_d
 
 @pytest.mark.django_db
 def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = "?fiscal_year=2020&order=asc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -306,10 +306,10 @@ def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_accoun
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&order=desc&sort=gross_outlay_amount"
+    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -334,10 +334,10 @@ def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_accoun
 
 @pytest.mark.django_db
 def test_program_activity_list_search(client, agency_account_data):
-    query_params = "?fiscal_year=2020&filter=NAME%203"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=NAME%203"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -355,10 +355,10 @@ def test_program_activity_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&filter=AME%202"
+    query_params = f"?fiscal_year={current_fiscal_year()}&filter=AME%202"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -379,10 +379,10 @@ def test_program_activity_list_search(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_program_activity_list_pagination(client, agency_account_data):
-    query_params = "?fiscal_year=2020&limit=2&page=1"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -403,10 +403,10 @@ def test_program_activity_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = "?fiscal_year=2020&limit=2&page=2"
+    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": 2020,
+        "fiscal_year": current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -22,8 +22,9 @@ def setup_test_data(db):
         submission_id=2,
         reporting_fiscal_year=current_fiscal_year(),
         reporting_fiscal_period=get_final_period_of_quarter(
-            calculate_last_completed_fiscal_quarter(current_fiscal_year()) or 3
-        ),
+            calculate_last_completed_fiscal_quarter(current_fiscal_year())
+        )
+        or 3,
     )
     mommy.make("references.Agency", id=1, toptier_agency_id=1, toptier_flag=True)
     mommy.make("references.Agency", id=2, toptier_agency_id=2, toptier_flag=True)

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -22,7 +22,7 @@ def setup_test_data(db):
         submission_id=2,
         reporting_fiscal_year=current_fiscal_year(),
         reporting_fiscal_period=get_final_period_of_quarter(
-            calculate_last_completed_fiscal_quarter(current_fiscal_year())
+            calculate_last_completed_fiscal_quarter(current_fiscal_year()) or 3
         ),
     )
     mommy.make("references.Agency", id=1, toptier_agency_id=1, toptier_flag=True)
@@ -131,7 +131,7 @@ def setup_test_data(db):
         reporting_agency_overview_id=2,
         toptier_code=987,
         fiscal_year=current_fiscal_year(),
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())),
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())) or 3,
         total_dollars_obligated_gtas=18.6,
         total_budgetary_resources=100,
         total_diff_approp_ocpa_obligated_amounts=0,
@@ -141,7 +141,7 @@ def setup_test_data(db):
         reporting_agency_overview_id=3,
         toptier_code="001",
         fiscal_year=current_fiscal_year(),
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())),
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())) or 3,
         total_dollars_obligated_gtas=20.0,
         total_budgetary_resources=10.0,
         total_diff_approp_ocpa_obligated_amounts=10.0,
@@ -165,8 +165,8 @@ def setup_test_data(db):
     mommy.make(
         "reporting.ReportingAgencyMissingTas",
         toptier_code=987,
-        fiscal_year=2020,
-        fiscal_period=12,
+        fiscal_year=current_fiscal_year(),
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())) or 3,
         tas_rendering_label="TAS 2",
         obligated_amount=12.0,
     )


### PR DESCRIPTION
**Description:**
Should fix the tests that are failing due to hardcoded values in the tests. Replaces most instances of `2020` with `current_fiscal_year` for tests using `agency_account_data`. 

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [N/A] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [N/A] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [N/A] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [N/A] Link to this Pull-Request
    - [N/A] Performance evaluation of affected (API | Script | Download)
    - [N/A] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
