### PR TITLE
Mod/dev 6438 create agency discrepancies endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/discrepancies.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/discrepancies.md
@@ -13,7 +13,7 @@ This endpoint returns an overview of government agency TAS discrepancies data.
     + `agency_code`: `020` (required, string)
         The specific agency code.
     + `fiscal_year`: 2020 (required, number)
-        The fiscal year.
+        The fiscal year (2017 or later).
     + `fiscal_period`: 10 (required, number)
         The fiscal period. Valid values: 2-12 (2 = November ... 12 = September)
         For retrieving quarterly data, provide the period which equals 'quarter * 3' (e.g. Q2 = P6)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/discrepancies.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/discrepancies.md
@@ -16,7 +16,7 @@ This endpoint returns an overview of government agency TAS discrepancies data.
         The fiscal year.
     + `fiscal_period`: 10 (required, number)
         The fiscal period. Valid values: 2-12 (2 = November ... 12 = September)
-        For retriving quarterly data, provide the period which equals 'quarter * 3' (e.g. Q2 = P6)
+        For retrieving quarterly data, provide the period which equals 'quarter * 3' (e.g. Q2 = P6)
     + `page` (optional, number)
         The page of results to return based on the limit.
         + Default: 1

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -121,6 +121,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/recipient/state/](/api/v2/recipient/state/)|GET| Returns basic information about the specified state |
 |[/api/v2/recipient/state/awards/<FIPS\>/](/api/v2/recipient/state/awards/51/)|GET| Returns award breakdown based on FIPS |
 |[/api/v2/reporting/agencies/<TOPTIER_CODE\>/differences/](/api/v2/reporting/agencies/097/differences/)|GET| Returns About the Data information about differences in account balance and spending obligations for a specific agency/year/period |
+|[/api/v2/reporting/agencies/<TOPTIER_CODE\>/discrepancies/](/api/v2/reporting/agencies/097/discrepancies/)|GET| Returns TAS discrepancies of the specified agency's submission data for a specific FY/FP |
 |[/api/v2/references/agency/<AGENCY_ID\>/](/api/v2/references/agency/479/)|GET| Returns basic information about a federal agency |
 |[/api/v2/references/award_types/](/api/v2/references/award_types/)|GET| Returns a map of award types by award grouping. |
 |[/api/v2/references/cfda/totals/<CFDA/>/](/api/v2/references/cfda/totals/10.555/)|GET| Provides total values for provided CFDA |

--- a/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
@@ -72,9 +72,9 @@ def test_sort(setup_test_data, client):
     expected_results = [{"tas": "TAS 2", "amount": 1.0}, {"tas": "TAS 1", "amount": 10.0}]
     assert response["results"] == expected_results
 
-    resp = client.get(url + "&order=desc&limit=1&page=2")
+    resp = client.get(url + "&order=asc&limit=1&page=2")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 1
-    expected_results = [{"tas": "TAS 2", "amount": 1.0}]
+    expected_results = [{"tas": "TAS 1", "amount": 10.0}]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
@@ -1,0 +1,215 @@
+import pytest
+from model_mommy import mommy
+from rest_framework import status
+
+
+url = "/api/v2/reporting/agencies/123/discrepancies/?fiscal_year=2020&fiscal_period=2"
+
+
+@pytest.fixture
+def setup_test_data(db):
+    """ Insert test data into DB """
+    mommy.make(
+        "reporting.ReportingAgencyMissingTas",
+        toptier_code=123,
+        fiscal_year=2020,
+        fiscal_period=2,
+        tas_rendering_label="TAS 1",
+        obligated_amount=10.0,
+    )
+    mommy.make(
+        "reporting.ReportingAgencyMissingTas",
+        toptier_code=123,
+        fiscal_year=2020,
+        fiscal_period=2,
+        tas_rendering_label="TAS 2",
+        obligated_amount=1.0,
+    )
+    mommy.make(
+        "reporting.ReportingAgencyMissingTas",
+        toptier_code=321,
+        fiscal_year=2020,
+        fiscal_period=2,
+        tas_rendering_label="TAS 2",
+        obligated_amount=12.0,
+    )
+
+
+def test_basic_success(setup_test_data, client):
+    resp = client.get("/api/v2/reporting/agencies/123/discrepancies/?fiscal_year=2020&fiscal_period=3")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 0
+
+    resp = client.get(url)
+    print(resp.json())
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 2
+    expected_results = [
+        {"tas": "TAS 1", "amount": 10.0,},
+        {"tas": "TAS 2", "amount": 1.0,},
+    ]
+    assert response["results"] == expected_results
+
+
+# def test_pagination(setup_test_data, client):
+#     resp = client.get(url + "?sort=current_total_budget_authority_amount&order=asc")
+#     assert resp.status_code == status.HTTP_200_OK
+#     response = resp.json()
+#     assert len(response["results"]) == 3
+#     expected_results = [
+#         {
+#             "fiscal_year": 2020,
+#             "fiscal_period": 12,
+#             "current_total_budget_authority_amount": 100.0,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 18.6,
+#                 "tas_accounts_total": 100.00,
+#                 "tas_obligation_not_in_gtas_total": 12.0,
+#                 "missing_tas_accounts_count": 1,
+#             },
+#             "obligation_difference": 0.0,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         },
+#         {
+#             "fiscal_year": 2019,
+#             "fiscal_period": 6,
+#             "current_total_budget_authority_amount": 22478810.97,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 1788370.03,
+#                 "tas_accounts_total": 200.00,
+#                 "tas_obligation_not_in_gtas_total": 11.0,
+#                 "missing_tas_accounts_count": 2,
+#             },
+#             "obligation_difference": 84931.95,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         },
+#         {
+#             "fiscal_year": 2019,
+#             "fiscal_period": 9,
+#             "current_total_budget_authority_amount": 22478810.98,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 1788370.04,
+#                 "tas_accounts_total": None,
+#                 "tas_obligation_not_in_gtas_total": 0.0,
+#                 "missing_tas_accounts_count": 0,
+#             },
+#             "obligation_difference": 84931.96,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         },
+#     ]
+#     assert response["results"] == expected_results
+
+#     resp = client.get(url + "?limit=1")
+#     response = resp.json()
+#     assert len(response["results"]) == 1
+#     expected_results = [
+#         {
+#             "fiscal_year": 2019,
+#             "fiscal_period": 9,
+#             "current_total_budget_authority_amount": 22478810.98,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 1788370.04,
+#                 "tas_accounts_total": None,
+#                 "tas_obligation_not_in_gtas_total": 0.0,
+#                 "missing_tas_accounts_count": 0,
+#             },
+#             "obligation_difference": 84931.96,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         }
+#     ]
+#     assert response["results"] == expected_results
+
+#     resp = client.get(url + "?limit=1&page=2")
+#     response = resp.json()
+#     assert len(response["results"]) == 1
+#     expected_results = [
+#         {
+#             "fiscal_year": 2019,
+#             "fiscal_period": 6,
+#             "current_total_budget_authority_amount": 22478810.97,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 1788370.03,
+#                 "tas_accounts_total": 200.00,
+#                 "tas_obligation_not_in_gtas_total": 11.0,
+#                 "missing_tas_accounts_count": 2,
+#             },
+#             "obligation_difference": 84931.95,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         }
+#     ]
+#     assert response["results"] == expected_results
+
+
+# def test_secondary_sort(setup_test_data, client):
+#     resp = client.get(url + "?sort=fiscal_year&order=asc")
+#     assert resp.status_code == status.HTTP_200_OK
+#     response = resp.json()
+#     assert len(response["results"]) == 3
+#     expected_results = [
+#         {
+#             "fiscal_year": 2019,
+#             "fiscal_period": 6,
+#             "current_total_budget_authority_amount": 22478810.97,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 1788370.03,
+#                 "tas_accounts_total": 200.00,
+#                 "tas_obligation_not_in_gtas_total": 11.0,
+#                 "missing_tas_accounts_count": 2,
+#             },
+#             "obligation_difference": 84931.95,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         },
+#         {
+#             "fiscal_year": 2019,
+#             "fiscal_period": 9,
+#             "current_total_budget_authority_amount": 22478810.98,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 1788370.04,
+#                 "tas_accounts_total": None,
+#                 "tas_obligation_not_in_gtas_total": 0.0,
+#                 "missing_tas_accounts_count": 0,
+#             },
+#             "obligation_difference": 84931.96,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         },
+#         {
+#             "fiscal_year": 2020,
+#             "fiscal_period": 12,
+#             "current_total_budget_authority_amount": 100.0,
+#             "recent_publication_date": None,
+#             "recent_publication_date_certified": False,
+#             "tas_account_discrepancies_totals": {
+#                 "gtas_obligation_total": 18.6,
+#                 "tas_accounts_total": 100.00,
+#                 "tas_obligation_not_in_gtas_total": 12.0,
+#                 "missing_tas_accounts_count": 1,
+#             },
+#             "obligation_difference": 0.0,
+#             "unlinked_contract_award_count": 0,
+#             "unlinked_assistance_award_count": 0,
+#         },
+#     ]
+#     assert response["results"] == expected_results

--- a/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
@@ -3,7 +3,7 @@ from model_mommy import mommy
 from rest_framework import status
 
 
-url = "/api/v2/reporting/agencies/123/discrepancies/?fiscal_year=2020&fiscal_period=2"
+url = "/api/v2/reporting/agencies/123/discrepancies/"
 
 
 @pytest.fixture
@@ -36,11 +36,11 @@ def setup_test_data(db):
 
 
 def test_basic_success(setup_test_data, client):
-    resp = client.get("/api/v2/reporting/agencies/123/discrepancies/?fiscal_year=2020&fiscal_period=3")
+    resp = client.get(url + "?fiscal_year=2020&fiscal_period=3")
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json()["results"]) == 0
 
-    resp = client.get(url)
+    resp = client.get(url + "?fiscal_year=2020&fiscal_period=2")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 2
@@ -49,14 +49,14 @@ def test_basic_success(setup_test_data, client):
 
 
 def test_pagination(setup_test_data, client):
-    resp = client.get(url + "&limit=1")
+    resp = client.get(url + "?fiscal_year=2020&fiscal_period=2&limit=1")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 1
     expected_results = [{"tas": "TAS 1", "amount": 10.0}]
     assert response["results"] == expected_results
 
-    resp = client.get(url + "&limit=1&page=2")
+    resp = client.get(url + "?fiscal_year=2020&fiscal_period=2&limit=1&page=2")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 1
@@ -65,14 +65,14 @@ def test_pagination(setup_test_data, client):
 
 
 def test_sort(setup_test_data, client):
-    resp = client.get(url + "&sort=tas")
+    resp = client.get(url + "?fiscal_year=2020&fiscal_period=2&sort=tas")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 2
     expected_results = [{"tas": "TAS 2", "amount": 1.0}, {"tas": "TAS 1", "amount": 10.0}]
     assert response["results"] == expected_results
 
-    resp = client.get(url + "&order=asc&limit=1&page=2")
+    resp = client.get(url + "?fiscal_year=2020&fiscal_period=2&order=asc&limit=1&page=2")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 1

--- a/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
@@ -38,11 +38,9 @@ def setup_test_data(db):
 def test_basic_success(setup_test_data, client):
     resp = client.get("/api/v2/reporting/agencies/123/discrepancies/?fiscal_year=2020&fiscal_period=3")
     assert resp.status_code == status.HTTP_200_OK
-    response = resp.json()
-    assert len(response["results"]) == 0
+    assert len(resp.json()["results"]) == 0
 
     resp = client.get(url)
-    print(resp.json())
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 2

--- a/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
@@ -44,170 +44,37 @@ def test_basic_success(setup_test_data, client):
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 2
-    expected_results = [
-        {"tas": "TAS 1", "amount": 10.0,},
-        {"tas": "TAS 2", "amount": 1.0,},
-    ]
+    expected_results = [{"tas": "TAS 1", "amount": 10.0}, {"tas": "TAS 2", "amount": 1.0}]
     assert response["results"] == expected_results
 
 
-# def test_pagination(setup_test_data, client):
-#     resp = client.get(url + "?sort=current_total_budget_authority_amount&order=asc")
-#     assert resp.status_code == status.HTTP_200_OK
-#     response = resp.json()
-#     assert len(response["results"]) == 3
-#     expected_results = [
-#         {
-#             "fiscal_year": 2020,
-#             "fiscal_period": 12,
-#             "current_total_budget_authority_amount": 100.0,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 18.6,
-#                 "tas_accounts_total": 100.00,
-#                 "tas_obligation_not_in_gtas_total": 12.0,
-#                 "missing_tas_accounts_count": 1,
-#             },
-#             "obligation_difference": 0.0,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         },
-#         {
-#             "fiscal_year": 2019,
-#             "fiscal_period": 6,
-#             "current_total_budget_authority_amount": 22478810.97,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 1788370.03,
-#                 "tas_accounts_total": 200.00,
-#                 "tas_obligation_not_in_gtas_total": 11.0,
-#                 "missing_tas_accounts_count": 2,
-#             },
-#             "obligation_difference": 84931.95,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         },
-#         {
-#             "fiscal_year": 2019,
-#             "fiscal_period": 9,
-#             "current_total_budget_authority_amount": 22478810.98,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 1788370.04,
-#                 "tas_accounts_total": None,
-#                 "tas_obligation_not_in_gtas_total": 0.0,
-#                 "missing_tas_accounts_count": 0,
-#             },
-#             "obligation_difference": 84931.96,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         },
-#     ]
-#     assert response["results"] == expected_results
+def test_pagination(setup_test_data, client):
+    resp = client.get(url + "&limit=1")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
+    expected_results = [{"tas": "TAS 1", "amount": 10.0}]
+    assert response["results"] == expected_results
 
-#     resp = client.get(url + "?limit=1")
-#     response = resp.json()
-#     assert len(response["results"]) == 1
-#     expected_results = [
-#         {
-#             "fiscal_year": 2019,
-#             "fiscal_period": 9,
-#             "current_total_budget_authority_amount": 22478810.98,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 1788370.04,
-#                 "tas_accounts_total": None,
-#                 "tas_obligation_not_in_gtas_total": 0.0,
-#                 "missing_tas_accounts_count": 0,
-#             },
-#             "obligation_difference": 84931.96,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         }
-#     ]
-#     assert response["results"] == expected_results
-
-#     resp = client.get(url + "?limit=1&page=2")
-#     response = resp.json()
-#     assert len(response["results"]) == 1
-#     expected_results = [
-#         {
-#             "fiscal_year": 2019,
-#             "fiscal_period": 6,
-#             "current_total_budget_authority_amount": 22478810.97,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 1788370.03,
-#                 "tas_accounts_total": 200.00,
-#                 "tas_obligation_not_in_gtas_total": 11.0,
-#                 "missing_tas_accounts_count": 2,
-#             },
-#             "obligation_difference": 84931.95,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         }
-#     ]
-#     assert response["results"] == expected_results
+    resp = client.get(url + "&limit=1&page=2")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
+    expected_results = [{"tas": "TAS 2", "amount": 1.0}]
+    assert response["results"] == expected_results
 
 
-# def test_secondary_sort(setup_test_data, client):
-#     resp = client.get(url + "?sort=fiscal_year&order=asc")
-#     assert resp.status_code == status.HTTP_200_OK
-#     response = resp.json()
-#     assert len(response["results"]) == 3
-#     expected_results = [
-#         {
-#             "fiscal_year": 2019,
-#             "fiscal_period": 6,
-#             "current_total_budget_authority_amount": 22478810.97,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 1788370.03,
-#                 "tas_accounts_total": 200.00,
-#                 "tas_obligation_not_in_gtas_total": 11.0,
-#                 "missing_tas_accounts_count": 2,
-#             },
-#             "obligation_difference": 84931.95,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         },
-#         {
-#             "fiscal_year": 2019,
-#             "fiscal_period": 9,
-#             "current_total_budget_authority_amount": 22478810.98,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 1788370.04,
-#                 "tas_accounts_total": None,
-#                 "tas_obligation_not_in_gtas_total": 0.0,
-#                 "missing_tas_accounts_count": 0,
-#             },
-#             "obligation_difference": 84931.96,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         },
-#         {
-#             "fiscal_year": 2020,
-#             "fiscal_period": 12,
-#             "current_total_budget_authority_amount": 100.0,
-#             "recent_publication_date": None,
-#             "recent_publication_date_certified": False,
-#             "tas_account_discrepancies_totals": {
-#                 "gtas_obligation_total": 18.6,
-#                 "tas_accounts_total": 100.00,
-#                 "tas_obligation_not_in_gtas_total": 12.0,
-#                 "missing_tas_accounts_count": 1,
-#             },
-#             "obligation_difference": 0.0,
-#             "unlinked_contract_award_count": 0,
-#             "unlinked_assistance_award_count": 0,
-#         },
-#     ]
-#     assert response["results"] == expected_results
+def test_sort(setup_test_data, client):
+    resp = client.get(url + "&sort=tas")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 2
+    expected_results = [{"tas": "TAS 2", "amount": 1.0}, {"tas": "TAS 1", "amount": 10.0}]
+    assert response["results"] == expected_results
+
+    resp = client.get(url + "&order=desc&limit=1&page=2")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
+    expected_results = [{"tas": "TAS 2", "amount": 1.0}]
+    assert response["results"] == expected_results

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -6,7 +6,6 @@ from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 
-
 from usaspending_api.reporting.models import ReportingAgencyMissingTas
 from usaspending_api.submissions.models import SubmissionAttributes
 
@@ -54,16 +53,11 @@ class AgencyDiscrepancies(AgencyBase, PaginationMixin):
         )
 
     def get_agency_discrepancies(self):
+        print(ReportingAgencyMissingTas.objects.values("tas_rendering_label", "obligated_amount"))
         result_list = ReportingAgencyMissingTas.objects.filter(
             toptier_code=self.toptier_code, fiscal_year=self.fiscal_year, fiscal_period=self.fiscal_period
         ).values("tas_rendering_label", "obligated_amount")
-        return self.format_results(result_list)
-
-    def format_results(self, result_list):
         results = [
-            {"tas": result["tas_rendering_label"], "amount": result["obligated_amount"],} for result in result_list
+            {"tas": result["tas_rendering_label"], "amount": result["obligated_amount"]} for result in result_list
         ]
-        results = sorted(
-            results, key=lambda x: x[self.pagination.sort_key], reverse=self.pagination.sort_order == "desc",
-        )
-        return results
+        return sorted(results, key=lambda x: x[self.pagination.sort_key], reverse=self.pagination.sort_order == "desc")

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -43,7 +43,9 @@ class AgencyDiscrepancies(AgencyBase, PaginationMixin):
             "tas",
         ]
         self.default_sort_column = "amount"
-        results = self.get_agency_discrepancies()
+        results = self.get_agency_discrepancies(
+            fiscal_year=request.query_params.get("fiscal_year"), fiscal_period=request.query_params.get("fiscal_period")
+        )
         return Response(
             {
                 "page_metadata": get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page),
@@ -52,10 +54,9 @@ class AgencyDiscrepancies(AgencyBase, PaginationMixin):
             }
         )
 
-    def get_agency_discrepancies(self):
-        print(ReportingAgencyMissingTas.objects.values("tas_rendering_label", "obligated_amount"))
+    def get_agency_discrepancies(self, fiscal_year, fiscal_period):
         result_list = ReportingAgencyMissingTas.objects.filter(
-            toptier_code=self.toptier_code, fiscal_year=self.fiscal_year, fiscal_period=self.fiscal_period
+            toptier_code=self.toptier_code, fiscal_year=fiscal_year, fiscal_period=fiscal_period
         ).values("tas_rendering_label", "obligated_amount")
         results = [
             {"tas": result["tas_rendering_label"], "amount": result["obligated_amount"]} for result in result_list

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -1,0 +1,69 @@
+from django.db.models import Subquery, OuterRef, DecimalField, Func, F, Q, IntegerField
+from rest_framework.response import Response
+from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.common.validator.tinyshield import TinyShield
+
+from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
+from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
+
+
+from usaspending_api.reporting.models import ReportingAgencyMissingTas
+from usaspending_api.submissions.models import SubmissionAttributes
+
+
+class AgencyDiscrepancies(AgencyBase, PaginationMixin):
+    """Returns TAS discrepancies of the specified agency's submission data for a specific FY/FP"""
+
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/discrepancies.md"
+
+    def get(self, request, toptier_code):
+        model = [
+            {
+                "key": "fiscal_year",
+                "name": "fiscal_year",
+                "type": "integer",
+                "min": 2017,
+                "optional": False,
+                "default": None,
+                "allow_nulls": False,
+            },
+            {
+                "key": "fiscal_period",
+                "name": "fiscal_period",
+                "type": "integer",
+                "min": 2,
+                "max": 12,
+                "optional": False,
+                "default": None,
+                "allow_nulls": False,
+            },
+        ]
+        TinyShield(model).block(request.query_params)
+        self.sortable_columns = [
+            "amount",
+            "tas",
+        ]
+        self.default_sort_column = "amount"
+        results = self.get_agency_discrepancies()
+        return Response(
+            {
+                "page_metadata": get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page),
+                "results": results[self.pagination.lower_limit : self.pagination.upper_limit],
+                "messages": self.standard_response_messages,
+            }
+        )
+
+    def get_agency_discrepancies(self):
+        result_list = ReportingAgencyMissingTas.objects.filter(
+            toptier_code=self.toptier_code, fiscal_year=self.fiscal_year, fiscal_period=self.fiscal_period
+        ).values("tas_rendering_label", "obligated_amount")
+        return self.format_results(result_list)
+
+    def format_results(self, result_list):
+        results = [
+            {"tas": result["tas_rendering_label"], "amount": result["obligated_amount"],} for result in result_list
+        ]
+        results = sorted(
+            results, key=lambda x: x[self.pagination.sort_key], reverse=self.pagination.sort_order == "desc",
+        )
+        return results

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -56,7 +56,6 @@ class AgencyDiscrepancies(AgencyBase, PaginationMixin):
                 toptier_code=self.toptier_code, fiscal_year=fiscal_year, fiscal_period=fiscal_period
             )
             .exclude(obligated_amount=0)
-            .values("tas_rendering_label", "obligated_amount")
             .annotate(tas=F("tas_rendering_label"), amount=F("obligated_amount"))
             .values("tas", "amount")
         )

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -58,10 +58,10 @@ class AgencyDiscrepancies(AgencyBase, PaginationMixin):
             .exclude(obligated_amount=0)
             .values("tas_rendering_label", "obligated_amount")
             .annotate(tas=F("tas_rendering_label"), amount=F("obligated_amount"))
+            .values("tas", "amount")
         )
-        results = [{"tas": result["tas"], "amount": result["amount"]} for result in result_list]
         return sorted(
-            results,
+            result_list,
             key=lambda x: (x["amount"], x["tas"]) if self.pagination.sort_key == "amount" else x["tas"],
             reverse=self.pagination.sort_order == "desc",
         )

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -50,9 +50,13 @@ class AgencyDiscrepancies(AgencyBase, PaginationMixin):
         )
 
     def get_agency_discrepancies(self, fiscal_year, fiscal_period):
-        result_list = ReportingAgencyMissingTas.objects.filter(
-            toptier_code=self.toptier_code, fiscal_year=fiscal_year, fiscal_period=fiscal_period
-        ).values("tas_rendering_label", "obligated_amount")
+        result_list = (
+            ReportingAgencyMissingTas.objects.filter(
+                toptier_code=self.toptier_code, fiscal_year=fiscal_year, fiscal_period=fiscal_period
+            )
+            .exclude(obligated_amount=0)
+            .values("tas_rendering_label", "obligated_amount")
+        )
         results = [
             {"tas": result["tas_rendering_label"], "amount": result["obligated_amount"]} for result in result_list
         ]

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/discrepancies.py
@@ -1,13 +1,8 @@
-from django.db.models import Subquery, OuterRef, DecimalField, Func, F, Q, IntegerField
 from rest_framework.response import Response
-from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.validator.tinyshield import TinyShield
-
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
-
 from usaspending_api.reporting.models import ReportingAgencyMissingTas
-from usaspending_api.submissions.models import SubmissionAttributes
 
 
 class AgencyDiscrepancies(AgencyBase, PaginationMixin):

--- a/usaspending_api/reporting/v2/views/agencies/urls.py
+++ b/usaspending_api/reporting/v2/views/agencies/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from usaspending_api.reporting.v2.views.agencies.agency_code.discrepancies import AgencyDiscrepancies
 from usaspending_api.reporting.v2.views.agencies.agency_code.overview import AgencyOverview
 from usaspending_api.reporting.v2.views.agencies.overview import AgenciesOverview
 from usaspending_api.reporting.v2.views.differences import Differences
@@ -8,6 +9,7 @@ from usaspending_api.reporting.v2.views.submission_history import SubmissionHist
 urlpatterns = [
     url(r"^overview/$", AgenciesOverview.as_view()),
     url(r"^(?P<toptier_code>[0-9]{3,4})/differences/$", Differences.as_view()),
+    url(r"^(?P<toptier_code>[0-9]{3,4})/discrepancies/$", AgencyDiscrepancies.as_view()),
     url(r"^(?P<toptier_code>[0-9]{3,4})/overview/$", AgencyOverview.as_view()),
     url(
         r"^(?P<toptier_code>[0-9]{3,4})/(?P<fiscal_year>[0-9]{4})/(?P<fiscal_period>[0-9]{1,2})/submission_history/$",


### PR DESCRIPTION
**Description:**
create About the Data endpoint /api/v2/reporting/agencies/{agency_code}/discrepancies/ to access data in reporting_agency_missing_tas table

**Technical details:**
standard api with sort/paginng, just that table

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [x] Operations na new endpoint
    - [x] Domain Expert na
4. [x] Matview impact assessment completed na
5. [x] Frontend impact assessment completed na
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created na
8. [x] Jira Ticket [DEV-6438](https://federal-spending-transparency.atlassian.net/browse/DEV-6438):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison na new data point

**Area for explaining above N/A when needed:**
```
```
