### PR TITLE
[DEV-6587] Sync datetimes to remove potential for missed records

### DIFF
--- a/usaspending_api/broker/helpers/upsert_fabs_transactions.py
+++ b/usaspending_api/broker/helpers/upsert_fabs_transactions.py
@@ -18,7 +18,7 @@ from usaspending_api.etl.management.load_base import load_data_into_model, forma
 from usaspending_api.references.models import Agency
 
 
-logger = logging.getLogger("console")
+logger = logging.getLogger("script")
 
 BATCH_FETCH_SIZE = 25000
 
@@ -37,11 +37,12 @@ def fetch_fabs_data_generator(dap_uid_list):
         max_index = i + BATCH_FETCH_SIZE if i + BATCH_FETCH_SIZE < total_uid_count else total_uid_count
         fabs_ids_batch = dap_uid_list[i:max_index]
 
-        logger.info(f"Fetching {i + 1}-{max_index} out of {total_uid_count} records from source table")
+        logger.info(f"Fetching {i + 1:,}-{max_index:,} out of {total_uid_count:,} records from source table")
         db_cursor.execute(db_query, [tuple(fabs_ids_batch)])
-        logger.info("Fetching records took {:.2f}s".format(time.perf_counter() - start_time))
+        logger.info(f"Fetching records consumed {time.perf_counter() - start_time:.2f}s")
 
         yield dictfetchall(db_cursor)
+        logger.info(f"Processed approximately {max_index * 100.0/total_uid_count:.2f}% of records")
 
 
 @transaction.atomic

--- a/usaspending_api/broker/management/commands/fabs_nightly_loader.py
+++ b/usaspending_api/broker/management/commands/fabs_nightly_loader.py
@@ -11,8 +11,7 @@ from usaspending_api.broker.helpers.delete_fabs_transactions import (
     delete_fabs_transactions,
     get_delete_pks_for_afa_keys,
 )
-from usaspending_api.broker.helpers.last_load_date import get_last_load_date
-from usaspending_api.broker.helpers.last_load_date import update_last_load_date
+from usaspending_api.broker.helpers.last_load_date import get_last_load_date, update_last_load_date
 from usaspending_api.broker.helpers.upsert_fabs_transactions import upsert_fabs_transactions
 from usaspending_api.broker.models import ExternalDataLoadDate
 from usaspending_api.common.helpers.date_helper import cast_datetime_to_naive, datetime_command_line_argument_type
@@ -30,8 +29,8 @@ UPDATED_AT_MODIFIER_MS = 1
 
 def get_incremental_load_start_datetime():
     """
-    This function is designed to help prevent two issues we've discovered with the FABS nightly
-    pipline:
+    This function is designed to help prevent two issues we've discovered with
+    the FABS nightly pipeline:
 
      #1 LAST_LOAD_LOOKBACK_MINUTES are subtracted from last load datetime to counter a very rare
         race condition where database commits are saved ever so slightly out of order when compared
@@ -48,7 +47,7 @@ def get_incremental_load_start_datetime():
         to prevent FABS transactions submitted between when the source records are copied from
         Broker and when FABS transactions are processed from being skipped.
 
-    An unfortunate side effect of the lookback is that some submissions may be processed more than
+    An unfortunate side effect of the look back is that some submissions may be processed more than
     once.  This SHOULDN'T cause any problems since the FABS loader is designed to be able to reload
     transactions, but it could add to the run time.  To minimize reprocessing, keep the
     LAST_LOAD_LOOKBACK_MINUTES value as small as possible while still preventing skips.  To be
@@ -62,15 +61,19 @@ def get_incremental_load_start_datetime():
             f"for external_data_type_id={lookups.EXTERNAL_DATA_TYPE_DICT['fabs']}.  If this is expected and "
             f"the goal is to reload all submissions, supply the --reload-all switch on the command line."
         )
+    else:
+        logger.info(f"Found value for last USAspending FABS ETL: {last_load_date}")
+
     max_updated_at = TransactionFABS.objects.aggregate(Max("updated_at"))["updated_at__max"]
     if max_updated_at is None:
         return last_load_date
 
     # We add a little tiny bit of time to the max_updated_at to prevent us from always reprocessing
     # records since the SQL that grabs new records is using updated_at >=.  I realize this is a hack
-    # but the pipeline is already running for too long so anything we can do to prevent enlongating
+    # but the pipeline is already running for too long so anything we can do to prevent elongating
     # it should be welcome.
     max_updated_at += timedelta(milliseconds=UPDATED_AT_MODIFIER_MS)
+    logger.info(f"Most recent transaction update datetime: {max_updated_at} (includes {UPDATED_AT_MODIFIER_MS}ms")
 
     return min((last_load_date, max_updated_at))
 
@@ -203,7 +206,7 @@ class Command(BaseCommand):
 
         if is_incremental_load:
             start_datetime = get_incremental_load_start_datetime()
-            logger.info("Processing data for FABS starting from %s" % start_datetime)
+            logger.info(f"Processing data for FABS starting from {start_datetime}")
 
             # We only perform deletes with incremental loads.
             with timer("obtaining delete records", logger.info):
@@ -212,13 +215,14 @@ class Command(BaseCommand):
                 ids_to_delete = get_delete_pks_for_afa_keys(ids_to_delete)
             logger.info(f"{len(ids_to_delete):,} delete ids found in total")
 
-        with timer("retrieving/diff-ing FABS Data", logger.info):
+        with timer("retrieving IDs of FABS to process", logger.info):
             ids_to_upsert = get_fabs_transaction_ids(ids, afa_ids, start_datetime, end_datetime)
 
         update_award_ids = delete_fabs_transactions(ids_to_delete) if is_incremental_load else []
         upsert_fabs_transactions(ids_to_upsert, update_award_ids)
 
         if is_incremental_load:
+            logger.info(f"Storing {processing_start_datetime} for the next incremental run")
             update_last_load_date("fabs", processing_start_datetime)
 
         logger.info("FABS UPDATE FINISHED!")

--- a/usaspending_api/transactions/management/commands/transfer_assistance_records.py
+++ b/usaspending_api/transactions/management/commands/transfer_assistance_records.py
@@ -11,6 +11,7 @@ class Command(AgnosticTransactionLoader, BaseCommand):
     destination_table_name = SourceAssistanceTransaction().table_name
     extra_predicate = [{"field": "is_active", "op": "EQUAL", "value": "true"}]
     last_load_record = "source_assistance_transaction"
+    last_load_record_downstream = "fabs"
     lookback_minutes = 15
     shared_pk = "afa_generated_unique"
     working_file_prefix = "assistance_load_ids"

--- a/usaspending_api/transactions/management/commands/transfer_procurement_records.py
+++ b/usaspending_api/transactions/management/commands/transfer_procurement_records.py
@@ -11,6 +11,7 @@ class Command(AgnosticTransactionLoader, BaseCommand):
     destination_table_name = SourceProcurementTransaction().table_name
     extra_predicate = []
     last_load_record = "source_procurement_transaction"
+    last_load_record_downstream = "fpds"
     lookback_minutes = 0
     shared_pk = "detached_award_proc_unique"
     working_file_prefix = "procurement_load_ids"


### PR DESCRIPTION
**Description:**
There is a gap of time between when the "transfer ETL" script starts and when the next ETL script starts. That gap of time allows transferred records to be missed by the next downstream ETL script run

Example for FABS transactions (applies to FPDS as well):
            Three transaction's update_at datetimes in Broker:
                `txn_a` | 2020/09/01 12:00:00
                `txn_b` | 2020/09/01 12:10:00
                `txn_c` | 2020/09/01 12:20:00
1. transfer_assistance_records.py run on 2020/09/01 12:05:00
    1. copies `txn_a`
    1. records 2020/09/01 12:05:00 as the next datetime to start
1. fabs_nightly_loader starts at 2020/09/01 12:15:00 (example lag)
    1. copies `txn_a`
    1. records 2020/09/01 12:15:00 as the next datetime to start

-- Following run --
1. transfer_assistance_records.py run on 2020/09/01 12:25:00
    1. copies `txn_b` & `txn_c` (since the stored datetime was 2020/09/01 12:05:00)
    1. records 2020/09/01 12:25:00 as the next datetime to start
1. fabs_nightly_loader starts at 2020/09/01 12:30:00 (example lag)
    1. copies `txn_c`
    1. records 2020/09/01 12:30:00 as the next datetime to start

**Problem**
`txn_b` was transferred to USAspending's `source_assistance_transaction`
                BUT IS ABSENT in `transaction_fabs` (and awards and Elasticsearch indexes)

**Technical details:**

- Extra step to sync downstream ETL start times to the leading scripts' start datetime
- Improved logging with more details and correct format

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-6587](https://federal-spending-transparency.atlassian.net/browse/DEV-6587):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected Script
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to API behavior or impact to materialized views
```
