### PR TITLE
Fix/dev 6594 agency overview not sorting by count

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ POSTGRES_PASSWORD=usaspender
 
 ## Change to host.docker.internal if you are running a local Postgres. Otherwise leave as-is, so
 ## Docker will use the Postgres created by Compose.
-POSTGRES_HOST=usaspending-db
+POSTGRES_HOST=host.docker.internal
 POSTGRES_PORT=5432
 
 # MATVIEW_SQL_DIR has to be inside of the project (check the docker-compose file)

--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ POSTGRES_PASSWORD=usaspender
 
 ## Change to host.docker.internal if you are running a local Postgres. Otherwise leave as-is, so
 ## Docker will use the Postgres created by Compose.
-POSTGRES_HOST=host.docker.internal
+POSTGRES_HOST=usaspending-db
 POSTGRES_PORT=5432
 
 # MATVIEW_SQL_DIR has to be inside of the project (check the docker-compose file)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -29,13 +29,14 @@ This endpoint returns an overview of government agency submission data.
         + Default: `current_total_budget_authority_amount`
         + Members
             + `current_total_budget_authority_amount`
-            + `percent_of_total_budgetary_resources`
             + `fiscal_period`
             + `fiscal_year`
             + `missing_tas_accounts_count`
+            + `missing_tas_accounts_total`
             + `obligation_difference`
-            + `recent_publication_date_certified`
+            + `percent_of_total_budgetary_resources`
             + `recent_publication_date`
+            + `recent_publication_date_certified`
             + `tas_obligation_not_in_gtas_total`
             + `unlinked_contract_award_count`
             + `unlinked_assistance_award_count`

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -15,16 +15,17 @@ class AgencyOverview(AgencyBase, PaginationMixin):
 
     def get(self, request, toptier_code):
         self.sortable_columns = [
-            "fiscal_year",
             "current_total_budget_authority_amount",
+            "fiscal_year",
+            "missing_tas_accounts_count",
             "missing_tas_accounts_total",
             "obligation_difference",
+            "percent_of_total_budgetary_resources",
             "recent_publication_date",
             "recent_publication_date_certified",
             "tas_obligation_not_in_gtas_total",
             "unlinked_contract_award_count",
             "unlinked_assistance_award_count",
-            "percent_of_total_budgetary_resources",
         ]
         self.default_sort_column = "current_total_budget_authority_amount"
         results = self.get_agency_overview()
@@ -133,6 +134,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
             key=lambda x: x["tas_account_discrepancies_totals"][self.pagination.sort_key]
             if (
                 self.pagination.sort_key == "missing_tas_accounts_count"
+                or self.pagination.sort_key == "missing_tas_accounts_total"
                 or self.pagination.sort_key == "tas_obligation_not_in_gtas_total"
             )
             else (x[self.pagination.sort_key], x[self.pagination.secondary_sort_key])


### PR DESCRIPTION
**Description:**
When implemented, missing_tas_accounts_total was listed as a sorting option instead of missing_tas_accounts_count. This just adds missing_tas_accounts_count to the sorting options.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated -NA
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations -NA
    - [x] Domain Expert -NA
4. [x] Matview impact assessment completed -NA
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created -NA
8. [x] Jira Ticket (https://federal-spending-transparency.atlassian.net/browse/DEV-6594):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download) -NA
    - [x] Before / After data comparison -NA

**Area for explaining above N/A when needed:**
simply adding a sort option to otherwise-finished endpoint
