### PR TITLE
[DEV-6490] Assurance Statement url

### DIFF
--- a/usaspending_api/agency/v2/views/agency_base.py
+++ b/usaspending_api/agency/v2/views/agency_base.py
@@ -78,6 +78,19 @@ class AgencyBase(APIView):
         if fiscal_period < 2 or fiscal_period > 12:
             raise UnprocessableEntityException(f"fiscal_period must be in the range 2-12")
 
+    @staticmethod
+    def create_assurance_statement_url(result):
+        agency_name_split = result["agency_name"].split(" ")
+        abbreviation_wrapped = f'({result["abbreviation"]})'
+        toptier_code = result["toptier_code"]
+        fiscal_year = result["fiscal_year"]
+        fiscal_period = str(result["fiscal_period"]).zfill(2)
+
+        host = "files.usaspending.gov"
+        agency_directory = "%20".join([toptier_code, "-", *agency_name_split, abbreviation_wrapped])
+        file_name = f"{fiscal_year}-P{fiscal_period}-{toptier_code}_" + "%20".join([*agency_name_split, abbreviation_wrapped]) + "-Assurance_Statement.txt"
+        return f"""https://{host}/agency_submissions/Raw%20DATA%20Act%20Files/{fiscal_year}/P{fiscal_period}/{agency_directory}/{file_name}"""
+
 
 class PaginationMixin:
     @cached_property

--- a/usaspending_api/agency/v2/views/agency_base.py
+++ b/usaspending_api/agency/v2/views/agency_base.py
@@ -80,16 +80,24 @@ class AgencyBase(APIView):
 
     @staticmethod
     def create_assurance_statement_url(result):
+        """
+        Results requires the following five keys to generate the assurance statement url:
+        agency_name, abbreviation, toptier_code, fiscal_year, fiscal_period
+        """
         agency_name_split = result["agency_name"].split(" ")
-        abbreviation_wrapped = f'({result["abbreviation"]})'
+        abbreviation_wrapped = f"({result['abbreviation']})"
         toptier_code = result["toptier_code"]
         fiscal_year = result["fiscal_year"]
-        fiscal_period = str(result["fiscal_period"]).zfill(2)
 
-        host = "files.usaspending.gov"
+        if result["submission_is_quarter"]:
+            fiscal_period = f"Q{int(result['fiscal_period'] / 3)}"
+        else:
+            fiscal_period = f"P{str(result['fiscal_period']).zfill(2)}"
+
+        host = settings.FILES_SERVER_BASE_URL
         agency_directory = "%20".join([toptier_code, "-", *agency_name_split, abbreviation_wrapped])
-        file_name = f"{fiscal_year}-P{fiscal_period}-{toptier_code}_" + "%20".join([*agency_name_split, abbreviation_wrapped]) + "-Assurance_Statement.txt"
-        return f"""https://{host}/agency_submissions/Raw%20DATA%20Act%20Files/{fiscal_year}/P{fiscal_period}/{agency_directory}/{file_name}"""
+        file_name = f"{fiscal_year}-{fiscal_period}-{toptier_code}_" + "%20".join([*agency_name_split, abbreviation_wrapped]) + "-Assurance_Statement.txt"
+        return f"{host}/agency_submissions/Raw%20DATA%20Act%20Files/{fiscal_year}/{fiscal_period}/{agency_directory}/{file_name}"
 
 
 class PaginationMixin:

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -78,7 +78,8 @@ This endpoint returns an overview of government agency submission data.
                         },
                         "obligation_difference": 12581114.45,
                         "unlinked_contract_award_count": 0,
-                        "unlinked_assistance_award_count": 0
+                        "unlinked_assistance_award_count": 0,
+                        "assurance_statement_url": "https://files.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/P07/020%20-%20Department%20of%20the%20Treasury%20(TREAS)/2020-P07-020_Department%20of%20the%20Treasury%20(TREAS)-Assurance_Statement.txt"
                     },
                     {
                         "fiscal_year": 2020,
@@ -96,7 +97,8 @@ This endpoint returns an overview of government agency submission data.
                         },
                         "obligation_difference": 14702670.23,
                         "unlinked_contract_award_count": 0,
-                        "unlinked_assistance_award_count": 0
+                        "unlinked_assistance_award_count": 0,
+                        "assurance_statement_url": "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/Q2/020%20-%20Department%20of%20the%20Treasury%20(TREAS)/2020-Q2-020_Department%20of%20the%20Treasury%20(TREAS)-Assurance_Statement.txt"
                     }
                 ]
             }
@@ -132,3 +134,4 @@ This endpoint returns an overview of government agency submission data.
     The difference in file A and file B obligations.
 + `unlinked_contract_award_count` (required, number)
 + `unlinked_assistance_award_count` (required, number)
++ `assurance_statement_url` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/agency_code/overview.md
@@ -135,4 +135,4 @@ This endpoint returns an overview of government agency submission data.
     The difference in file A and file B obligations.
 + `unlinked_contract_award_count` (required, number)
 + `unlinked_assistance_award_count` (required, number)
-+ `assurance_statement_url` (required, number)
++ `assurance_statement_url` (required, string, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
@@ -82,7 +82,8 @@ This endpoint returns an overview list of government agencies submission data.
                         },
                         "obligation_difference": 436376232652.87,
                         "unlinked_contract_award_count": 0,
-                        "unlinked_assistance_award_count": 0
+                        "unlinked_assistance_award_count": 0,
+                        "assurance_statement_url": "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/P09/075%20-%20Department%20of%20Health%20and%20Human%20Services%20(HHS)/2020-P09-075_Department%20of%20Health%20and%20Human%20Services%20(HHS)-Assurance_Statement.txt"
                     },
                     {
                         "agency_name": "Department of Treasury",
@@ -100,7 +101,8 @@ This endpoint returns an overview list of government agencies submission data.
                         },
                         "obligation_difference": 436376232652.87,
                         "unlinked_contract_award_count": 0,
-                        "unlinked_assistance_award_count": 0
+                        "unlinked_assistance_award_count": 0,
+                        "assurance_statement_url": "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/P09/020%20-%20Department%20of%20the%20Treasury%20(TREAS)/2020-P09-020_Department%20of%20the%20Treasury%20(TREAS)-Assurance_Statement.txt"
                     }
                 ]
             }
@@ -135,3 +137,4 @@ This endpoint returns an overview list of government agencies submission data.
     The difference in File A and File B obligations.
 + `unlinked_contract_award_count` (required, number)
 + `unlinked_assistance_award_count` (required, number)
++ `assurance_statement_url` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
@@ -137,4 +137,4 @@ This endpoint returns an overview list of government agencies submission data.
     The difference in File A and File B obligations.
 + `unlinked_contract_award_count` (required, number)
 + `unlinked_assistance_award_count` (required, number)
-+ `assurance_statement_url` (required, number)
++ `assurance_statement_url` (required, string, nullable)

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -173,6 +173,11 @@ def setup_test_data(db):
     )
 
 
+assurance_statement_1 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2019/P06/123%20-%20Test%20Agency%20(ABC)/2019-P06-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
+assurance_statement_2 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2021/P03/987%20-%20Test%20Agency%202%20(XYZ)/2021-P03-987_Test%20Agency%202%20(XYZ)-Assurance_Statement.txt"
+assurance_statement_3 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2021/P03/001%20-%20Test%20Agency%203%20(AAA)/2021-P03-001_Test%20Agency%203%20(AAA)-Assurance_Statement.txt"
+
+
 def test_basic_success(setup_test_data, client):
     resp = client.get(url)
     assert resp.status_code == status.HTTP_200_OK
@@ -196,6 +201,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2,
         },
         {
             "agency_name": "Test Agency 3",
@@ -214,6 +220,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": 10.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_3,
         },
     ]
     assert response["results"] == expected_results
@@ -242,6 +249,7 @@ def test_filter(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2,
         }
     ]
     assert response["results"] == expected_results
@@ -270,6 +278,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2,
         }
     ]
     assert response["results"] == expected_results
@@ -296,6 +305,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 10.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_3,
         }
     ]
     assert response["results"] == expected_results
@@ -322,6 +332,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 10.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_3,
         },
         {
             "agency_name": "Test Agency 2",
@@ -340,6 +351,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2,
         },
     ]
     assert response["results"] == expected_results
@@ -369,6 +381,7 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_1,
         }
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -161,6 +161,11 @@ def setup_test_data(db):
     )
 
 
+assurance_statement_2019_9 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2019/P09/123%20-%20Test%20Agency%20(ABC)/2019-P09-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
+assurance_statement_2019_6 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2019/P06/123%20-%20Test%20Agency%20(ABC)/2019-P06-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
+assurance_statement_2020_12 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/P12/123%20-%20Test%20Agency%20(ABC)/2020-P12-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
+
+
 def test_basic_success(setup_test_data, client):
     resp = client.get(url)
     assert resp.status_code == status.HTTP_200_OK
@@ -184,6 +189,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_9,
         },
         {
             "fiscal_year": 2019,
@@ -202,6 +208,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_6,
         },
         {
             "fiscal_year": 2020,
@@ -220,6 +227,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2020_12,
         },
     ]
     assert response["results"] == expected_results
@@ -248,6 +256,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2020_12,
         },
         {
             "fiscal_year": 2019,
@@ -266,6 +275,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_6,
         },
         {
             "fiscal_year": 2019,
@@ -284,6 +294,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_9,
         },
     ]
     assert response["results"] == expected_results
@@ -309,6 +320,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_9,
         }
     ]
     assert response["results"] == expected_results
@@ -334,6 +346,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_6,
         }
     ]
     assert response["results"] == expected_results
@@ -362,6 +375,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_6,
         },
         {
             "fiscal_year": 2019,
@@ -380,6 +394,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_9,
         },
         {
             "fiscal_year": 2020,
@@ -398,6 +413,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2020_12,
         },
     ]
     assert response["results"] == expected_results
@@ -424,6 +440,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_9,
         },
         {
             "fiscal_year": 2019,
@@ -442,6 +459,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 84931.95,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2019_6,
         },
         {
             "fiscal_year": 2020,
@@ -460,6 +478,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 0,
             "unlinked_assistance_award_count": 0,
+            "assurance_statement_url": assurance_statement_2020_12,
         },
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -2,6 +2,8 @@ import pytest
 from model_mommy import mommy
 from rest_framework import status
 
+from usaspending_api.agency.v2.views.agency_base import AgencyBase
+
 url = "/api/v2/reporting/agencies/123/overview/"
 
 
@@ -164,6 +166,8 @@ def setup_test_data(db):
 assurance_statement_2019_9 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2019/P09/123%20-%20Test%20Agency%20(ABC)/2019-P09-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
 assurance_statement_2019_6 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2019/P06/123%20-%20Test%20Agency%20(ABC)/2019-P06-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
 assurance_statement_2020_12 = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/P12/123%20-%20Test%20Agency%20(ABC)/2020-P12-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
+
+assurance_statement_quarter = "https://files-nonprod.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2019/Q3/123%20-%20Quarterly%20Agency%20(QA)/2019-Q3-123_Quarterly%20Agency%20(QA)-Assurance_Statement.txt"
 
 
 def test_basic_success(setup_test_data, client):
@@ -482,3 +486,18 @@ def test_secondary_sort(setup_test_data, client):
         },
     ]
     assert response["results"] == expected_results
+
+
+def test_quarterly_assurance_statements():
+    results = {
+        "agency_name": "Quarterly Agency",
+        "abbreviation": "QA",
+        "toptier_code": "123",
+        "fiscal_year": 2019,
+        "fiscal_period": 9,
+        "submission_is_quarter": True,
+    }
+
+    assurance_statement = AgencyBase.create_assurance_statement_url(results)
+
+    assert assurance_statement == assurance_statement_quarter

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
-from usaspending_api.references.models import ToptierAgency, Agency
+from usaspending_api.references.models import ToptierAgency
 from usaspending_api.reporting.models import ReportingAgencyOverview, ReportingAgencyTas, ReportingAgencyMissingTas
 from usaspending_api.references.models import GTASSF133Balances
 from usaspending_api.submissions.models import SubmissionAttributes

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
+from usaspending_api.references.models import ToptierAgency, Agency
 from usaspending_api.reporting.models import ReportingAgencyOverview, ReportingAgencyTas, ReportingAgencyMissingTas
 from usaspending_api.references.models import GTASSF133Balances
 from usaspending_api.submissions.models import SubmissionAttributes
@@ -35,6 +36,8 @@ class AgencyOverview(AgencyBase, PaginationMixin):
         )
 
     def get_agency_overview(self):
+
+        toptier_code_filter = Q(toptier_code=OuterRef("toptier_code"))
         agency_filters = [
             Q(reporting_fiscal_year=OuterRef("fiscal_year")),
             Q(reporting_fiscal_period=OuterRef("fiscal_period")),
@@ -43,6 +46,8 @@ class AgencyOverview(AgencyBase, PaginationMixin):
         result_list = (
             ReportingAgencyOverview.objects.filter(toptier_code=self.toptier_code)
             .annotate(
+                agency_name=Subquery(ToptierAgency.objects.filter(toptier_code_filter).values("name")),
+                abbreviation=Subquery(ToptierAgency.objects.filter(toptier_code_filter).values("abbreviation")),
                 recent_publication_date=Subquery(
                     SubmissionAttributes.objects.filter(*agency_filters).values("published_date")
                 ),
@@ -89,6 +94,9 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 ),
             )
             .values(
+                "agency_name",
+                "abbreviation",
+                "toptier_code",
                 "fiscal_year",
                 "fiscal_period",
                 "total_dollars_obligated_gtas",
@@ -125,6 +133,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
                 "unlinked_contract_award_count": 0,
                 "unlinked_assistance_award_count": 0,
+                "assurance_statement_url": self.create_assurance_statement_url(result),
             }
             for result in result_list
         ]

--- a/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/agency_code/overview.py
@@ -54,6 +54,9 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 recent_publication_date_certified=Subquery(
                     SubmissionAttributes.objects.filter(*agency_filters).values("certified_date")
                 ),
+                submission_is_quarter=Subquery(
+                    SubmissionAttributes.objects.filter(*agency_filters).values("quarter_format_flag")
+                ),
                 tas_obligations=Subquery(
                     ReportingAgencyTas.objects.filter(
                         fiscal_year=OuterRef("fiscal_year"),
@@ -99,6 +102,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 "toptier_code",
                 "fiscal_year",
                 "fiscal_period",
+                "submission_is_quarter",
                 "total_dollars_obligated_gtas",
                 "total_budgetary_resources",
                 "gtas_total_budgetary_resources",

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -62,6 +62,13 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
                         toptier_code=OuterRef("toptier_code"),
                     ).values("certified_date")
                 ),
+                submission_is_quarter=Subquery(
+                    SubmissionAttributes.objects.filter(
+                        reporting_fiscal_year=OuterRef("fiscal_year"),
+                        reporting_fiscal_period=OuterRef("fiscal_period"),
+                        toptier_code=OuterRef("toptier_code"),
+                    ).values("quarter_format_flag")
+                ),
                 tas_obligations=Subquery(
                     ReportingAgencyTas.objects.filter(
                         fiscal_year=OuterRef("fiscal_year"),
@@ -108,6 +115,7 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
                 "missing_tas_accounts",
                 "fiscal_year",
                 "fiscal_period",
+                "submission_is_quarter",
             )
         )
         return self.format_results(result_list)

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -106,6 +106,8 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
                 "tas_obligations",
                 "tas_obligation_not_in_gtas_total",
                 "missing_tas_accounts",
+                "fiscal_year",
+                "fiscal_period",
             )
         )
         return self.format_results(result_list)
@@ -133,6 +135,7 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
                 "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
                 "unlinked_contract_award_count": 0,
                 "unlinked_assistance_award_count": 0,
+                "assurance_statement_url": self.create_assurance_statement_url(result),
             }
             for result in result_list
         ]


### PR DESCRIPTION
**Description:**
This PR adds an `assurance_statement_url` reporting agency overview endpoints.

Example url: https://files.usaspending.gov/agency_submissions/Raw%20DATA%20Act%20Files/2020/P10/073%20-%20Small%20Business%20Administration%20(SBA)/2020-P10-073_Small%20Business%20Administration%20(SBA)-Assurance_Statement.txt

**Technical details:**
URL is built using the following fields:  
- agency_name
- abbreviation
- toptier_code
- fiscal_year
- fiscal_period
- submission_is_quarter

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6490](https://federal-spending-transparency.atlassian.net/browse/DEV-6490):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
