### PR TITLE
[Hotfix][DEV-6413] Account for COVID FY with total budgetary resources

### DIFF
--- a/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
@@ -51,6 +51,16 @@ def disaster_account_data():
         submission_fiscal_month=8,
         submission_reveal_date="2020-5-15",
     )
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        id=2021120,
+        is_quarter=False,
+        submission_fiscal_year=2021,
+        submission_fiscal_quarter=4,
+        submission_fiscal_month=12,
+        submission_reveal_date="2021-11-17",
+        period_start_date="2021-09-01",
+    )
     # Unclosed submisssion window
     dsws4 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
@@ -570,8 +580,9 @@ def disaster_account_data():
         treasury_account_identifier=tas3,
         budget_authority_appropriation_amount_cpe=2398472389.78,
         total_budgetary_resources_cpe=23984723890.78,
-        fiscal_period=8,
-        fiscal_year=2022,
+        budget_authority_unobligated_balance_brought_forward_cpe=1000,
+        fiscal_period=12,
+        fiscal_year=2021,
     )
     mommy.make(
         "references.GTASSF133Balances",
@@ -580,6 +591,7 @@ def disaster_account_data():
         treasury_account_identifier=tas2,
         budget_authority_appropriation_amount_cpe=892743123.12,
         total_budgetary_resources_cpe=8927431230.12,
+        budget_authority_unobligated_balance_brought_forward_cpe=2000,
         fiscal_period=8,
         fiscal_year=2022,
     )

--- a/usaspending_api/disaster/tests/fixtures/federal_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/federal_account_data.py
@@ -11,6 +11,26 @@ def generic_account_data():
         "submissions.DABSSubmissionWindowSchedule",
         id=11,
         is_quarter=False,
+        submission_fiscal_year=2020,
+        submission_fiscal_quarter=4,
+        submission_fiscal_month=12,
+        submission_reveal_date="2020-11-17",
+        period_start_date="2020-09-01",
+    )
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        id=22,
+        is_quarter=False,
+        submission_fiscal_year=2021,
+        submission_fiscal_quarter=4,
+        submission_fiscal_month=12,
+        submission_reveal_date="2021-11-17",
+        period_start_date="2021-09-01",
+    )
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        id=33,
+        is_quarter=False,
         submission_fiscal_year=2022,
         submission_fiscal_quarter=3,
         submission_fiscal_month=7,
@@ -19,7 +39,7 @@ def generic_account_data():
     )
     mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
-        id=22,
+        id=44,
         is_quarter=True,
         submission_fiscal_year=2022,
         submission_fiscal_quarter=3,
@@ -180,8 +200,9 @@ def generic_account_data():
     mommy.make(
         "references.GTASSF133Balances",
         budget_authority_appropriation_amount_cpe=4358.0,
-        fiscal_year=2022,
-        fiscal_period=7,
+        budget_authority_unobligated_balance_brought_forward_cpe=1000,
+        fiscal_year=2020,
+        fiscal_period=12,
         disaster_emergency_fund_code="M",
         treasury_account_identifier=tre_acct1,
         total_budgetary_resources_cpe=43580.0,
@@ -189,8 +210,9 @@ def generic_account_data():
     mommy.make(
         "references.GTASSF133Balances",
         budget_authority_appropriation_amount_cpe=109237.0,
-        fiscal_year=2022,
-        fiscal_period=7,
+        budget_authority_unobligated_balance_brought_forward_cpe=2000,
+        fiscal_year=2021,
+        fiscal_period=12,
         disaster_emergency_fund_code="M",
         treasury_account_identifier=tre_acct2,
         total_budgetary_resources_cpe=1092370.0,
@@ -198,6 +220,7 @@ def generic_account_data():
     mommy.make(
         "references.GTASSF133Balances",
         budget_authority_appropriation_amount_cpe=39248.0,
+        budget_authority_unobligated_balance_brought_forward_cpe=3000,
         fiscal_year=2022,
         fiscal_period=7,
         disaster_emergency_fund_code="M",

--- a/usaspending_api/disaster/tests/integration/test_disaster_agency_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_agency_spending.py
@@ -29,7 +29,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_account_inde
             "award_count": None,
             "obligation": 11000000.0,
             "outlay": 11.0,
-            "total_budgetary_resources": 23984723890.78,
+            "total_budgetary_resources": 23984722890.78,
         },
         {
             "id": 2,
@@ -39,7 +39,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_account_inde
             "award_count": None,
             "obligation": 1000.0,
             "outlay": 10000.0,
-            "total_budgetary_resources": 8927431230.12,
+            "total_budgetary_resources": 8927429230.12,
         },
         {
             "id": 1,
@@ -56,7 +56,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_account_inde
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["results"] == expected_results
 
-    expected_totals = {"obligation": 11001000.0, "outlay": 10011.0, "total_budgetary_resources": 32912155120.9}
+    expected_totals = {"obligation": 11001000.0, "outlay": 10011.0, "total_budgetary_resources": 32912152120.9}
     assert resp.json()["totals"] == expected_totals
 
     resp = helpers.post_for_spending_endpoint(client, url, def_codes=["M", "L"], spending_type="total")

--- a/usaspending_api/disaster/tests/integration/test_federal_account_total.py
+++ b/usaspending_api/disaster/tests/integration/test_federal_account_total.py
@@ -21,7 +21,7 @@ def test_federal_account_success(client, generic_account_data, monkeypatch, help
                     "id": 22,
                     "obligation": 100.0,
                     "outlay": 111.0,
-                    "total_budgetary_resources": 43580.0,
+                    "total_budgetary_resources": 42580.0,
                 }
             ],
             "code": "000-0000",
@@ -30,7 +30,7 @@ def test_federal_account_success(client, generic_account_data, monkeypatch, help
             "id": 21,
             "obligation": 100.0,
             "outlay": 111.0,
-            "total_budgetary_resources": 43580.0,
+            "total_budgetary_resources": 42580.0,
         }
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -47,7 +47,7 @@ def test_federal_account_success(client, generic_account_data, monkeypatch, help
                     "id": 24,
                     "obligation": 3.0,
                     "outlay": 333.0,
-                    "total_budgetary_resources": 392480.0,
+                    "total_budgetary_resources": 389480.0,
                 },
                 {
                     "code": "2020/98",
@@ -56,7 +56,7 @@ def test_federal_account_success(client, generic_account_data, monkeypatch, help
                     "id": 23,
                     "obligation": 201.0,
                     "outlay": 223.0,
-                    "total_budgetary_resources": 1092370.0,
+                    "total_budgetary_resources": 1090370.0,
                 },
                 {
                     "code": "2020/99",
@@ -65,7 +65,7 @@ def test_federal_account_success(client, generic_account_data, monkeypatch, help
                     "id": 22,
                     "obligation": 100.0,
                     "outlay": 111.0,
-                    "total_budgetary_resources": 43580.0,
+                    "total_budgetary_resources": 42580.0,
                 },
             ],
             "code": "000-0000",
@@ -74,13 +74,13 @@ def test_federal_account_success(client, generic_account_data, monkeypatch, help
             "id": 21,
             "obligation": 304.0,
             "outlay": 667.0,
-            "total_budgetary_resources": 1528430.0,
+            "total_budgetary_resources": 1522430.0,
         }
     ]
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["results"] == expected_results
 
-    expected_totals = {"obligation": 304.0, "outlay": 667.0, "total_budgetary_resources": 1528430.0}
+    expected_totals = {"obligation": 304.0, "outlay": 667.0, "total_budgetary_resources": 1522430.0}
     assert resp.json()["totals"] == expected_totals
 
 

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -14,9 +14,10 @@ from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.disaster.v2.views.disaster_base import (
     DisasterBase,
+    FabaOutlayMixin,
+    latest_gtas_of_each_year_queryset,
     PaginationMixin,
     SpendingMixin,
-    FabaOutlayMixin,
 )
 from usaspending_api.disaster.v2.views.elasticsearch_base import (
     ElasticsearchDisasterBase,
@@ -24,7 +25,7 @@ from usaspending_api.disaster.v2.views.elasticsearch_base import (
 )
 from usaspending_api.disaster.v2.views.elasticsearch_account_base import ElasticsearchAccountDisasterBase
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
-from usaspending_api.references.models import GTASSF133Balances, Agency, ToptierAgency
+from usaspending_api.references.models import Agency, ToptierAgency
 from usaspending_api.submissions.models import SubmissionAttributes
 from usaspending_api.search.v2.elasticsearch_helper import get_summed_value_as_float
 
@@ -178,14 +179,19 @@ class SpendingByAgencyViewSet(
             "outlay": cte.col.outlay,
             "total_budgetary_resources": Coalesce(
                 Subquery(
-                    GTASSF133Balances.objects.filter(
+                    latest_gtas_of_each_year_queryset()
+                    .filter(
                         disaster_emergency_fund_code__in=self.def_codes,
-                        fiscal_period=self.latest_reporting_period["submission_fiscal_month"],
-                        fiscal_year=self.latest_reporting_period["submission_fiscal_year"],
                         treasury_account_identifier__funding_toptier_agency_id=OuterRef("toptier_agency_id"),
                     )
-                    .annotate(amount=Func("total_budgetary_resources_cpe", function="Sum"))
-                    .values("amount"),
+                    .annotate(
+                        amount=Func("total_budgetary_resources_cpe", function="Sum"),
+                        unobligated_balance=Func(
+                            "budget_authority_unobligated_balance_brought_forward_cpe", function="Sum"
+                        ),
+                    )
+                    .annotate(total_budget_authority=F("amount") - F("unobligated_balance"))
+                    .values("total_budget_authority"),
                     output_field=DecimalField(),
                 ),
                 0,

--- a/usaspending_api/disaster/v2/views/federal_account/spending.py
+++ b/usaspending_api/disaster/v2/views/federal_account/spending.py
@@ -10,12 +10,12 @@ from usaspending_api.common.data_classes import Pagination
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.disaster.v2.views.federal_account.federal_account_result import FedAcctResults, FedAccount, TAS
 from usaspending_api.disaster.v2.views.disaster_base import (
+    FabaOutlayMixin,
+    latest_gtas_of_each_year_queryset,
     PaginationMixin,
     SpendingMixin,
-    FabaOutlayMixin,
 )
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
-from usaspending_api.references.models.gtas_sf133_balances import GTASSF133Balances
 from usaspending_api.disaster.v2.views.elasticsearch_account_base import ElasticsearchAccountDisasterBase
 
 
@@ -175,14 +175,19 @@ class SpendingViewSet(
             ),
             "total_budgetary_resources": Coalesce(
                 Subquery(
-                    GTASSF133Balances.objects.filter(
+                    latest_gtas_of_each_year_queryset()
+                    .filter(
                         disaster_emergency_fund_code__in=self.def_codes,
-                        fiscal_period=self.latest_reporting_period["submission_fiscal_month"],
-                        fiscal_year=self.latest_reporting_period["submission_fiscal_year"],
                         treasury_account_identifier=OuterRef("treasury_account"),
                     )
-                    .annotate(amount=Func("total_budgetary_resources_cpe", function="Sum"))
-                    .values("amount"),
+                    .annotate(
+                        amount=Func("total_budgetary_resources_cpe", function="Sum"),
+                        unobligated_balance=Func(
+                            "budget_authority_unobligated_balance_brought_forward_cpe", function="Sum"
+                        ),
+                    )
+                    .annotate(total_budget_authority=F("amount") - F("unobligated_balance"))
+                    .values("total_budget_authority"),
                     output_field=DecimalField(),
                 ),
                 0,


### PR DESCRIPTION
**Description:**
Currently the total budgetary resources on the COVID Page for Federal Account and Agency tables are not accounting for all COVID FY. This change takes into account all current and future FY that include COVID data.

After searching around it appears that at least other places using Postgres are currently taking into account multiple FY.

**Technical details:**
Make use of the pre-existing `latest_gtas_of_each_year_queryset()` method to capture all necessary GTAS and use the same calculation logic as currently used by the `/api/v2/disaster/overview` endpoint. 

Additionally, adjusted test cases to have examples of GTAS spread across multiple different FY.

Few screenshots to showcase the change with data from QAT. The `Total Budgetary Resources` is greater than the `Total Obligations` in every row and as a whole the `Unlinked Data -> Total Budgetary Resources` row for both tables has gone down significantly now that it takes into account both FY 2020/21. 

Federal Account -- Total Spending -- OLD:
![federal_account__old](https://user-images.githubusercontent.com/40359517/105085095-233ac300-5a4c-11eb-9d4d-a734246f2898.png)

Federal Account -- Total Spending -- NEW:
![federal_account__new](https://user-images.githubusercontent.com/40359517/105085102-26ce4a00-5a4c-11eb-8c11-5ff7e9717abc.png)


Agency -- Total Spending -- OLD:
![agency__old](https://user-images.githubusercontent.com/40359517/105085099-259d1d00-5a4c-11eb-8566-65d61a8fed10.png)

Agency -- Total Spending -- NEW:
![agency__new](https://user-images.githubusercontent.com/40359517/105085105-2766e080-5a4c-11eb-8b3b-93877311ab16.png)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6413](https://federal-spending-transparency.atlassian.net/browse/DEV-6413):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
Hate the SQL that it generates, but it is not much different from the original.
```
