### PR TITLE
HOTFIX: [DEV-6724] Fixing ES awards delete to lookup delete keys in ES by transaction key

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/__init__.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/__init__.py
@@ -1,9 +1,7 @@
 from usaspending_api.etl.elasticsearch_loader_helpers.delete_data import (
-    check_awards_for_deletes,
     delete_docs_by_unique_key,
     deleted_awards,
     deleted_transactions,
-    get_deleted_award_ids,
 )
 from usaspending_api.etl.elasticsearch_loader_helpers.extract_data import (
     count_of_records_to_process,
@@ -34,7 +32,6 @@ from usaspending_api.etl.elasticsearch_loader_helpers.utilities import (
 from usaspending_api.etl.elasticsearch_loader_helpers.controller import Controller
 
 __all__ = [
-    "check_awards_for_deletes",
     "chunks",
     "Controller",
     "count_of_records_to_process",
@@ -47,7 +44,6 @@ __all__ = [
     "extract_records",
     "format_log",
     "gen_random_name",
-    "get_deleted_award_ids",
     "load_data",
     "obtain_extract_sql",
     "set_final_index_config",

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -146,9 +146,9 @@ def delete_docs_by_unique_key(client: Elasticsearch, key: str, value_list: list,
 def _lookup_deleted_award_ids(client: Elasticsearch, id_list: list, config: dict, index: Optional[str] = None) -> list:
     """Lookup deleted transactions to derive parent awards to be deleted
 
-    This fetches a list of all unique award keys compiled from the ``ES_ES_AWARDS_UNIQUE_KEY_FIELD`` field of
+    This fetches a list of all unique award keys compiled from the ``ES_AWARDS_UNIQUE_KEY_FIELD`` field of
     any document in the transaction index that matches the query, which looks up deleted transaction ES
-    documents by their ``ES_ES_TRANSACTIONS_UNIQUE_KEY_FIELD`` field.
+    documents by their ``ES_TRANSACTIONS_UNIQUE_KEY_FIELD`` field.
 
     Args:
         client (Elasticsearch): elasticsearch-dsl client for making calls to an ES cluster

--- a/usaspending_api/etl/elasticsearch_loader_helpers/index_config.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/index_config.py
@@ -9,6 +9,10 @@ from usaspending_api.etl.elasticsearch_loader_helpers.utilities import format_lo
 
 logger = logging.getLogger("script")
 
+ES_AWARDS_UNIQUE_KEY_FIELD = "generated_unique_award_id"
+ES_TRANSACTIONS_UNIQUE_KEY_FIELD = "generated_unique_transaction_id"
+ES_COVID19_FABA_UNIQUE_KEY_FIELD = "distinct_award_key"
+
 
 def create_index(index, client):
     try:

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -18,6 +18,11 @@ from usaspending_api.etl.elasticsearch_loader_helpers import (
     transform_covid19_faba_data,
     transform_transaction_data,
 )
+from usaspending_api.etl.elasticsearch_loader_helpers.index_config import (
+    ES_AWARDS_UNIQUE_KEY_FIELD,
+    ES_TRANSACTIONS_UNIQUE_KEY_FIELD,
+    ES_COVID19_FABA_UNIQUE_KEY_FIELD,
+)
 
 logger = logging.getLogger("script")
 
@@ -212,7 +217,7 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
             "required_index_name": settings.ES_AWARDS_NAME_SUFFIX,
             "sql_view": settings.ES_AWARDS_ETL_VIEW_NAME,
             "stored_date_key": "es_awards",
-            "unique_key_field": "generated_unique_award_id",
+            "unique_key_field": ES_AWARDS_UNIQUE_KEY_FIELD,
             "write_alias": settings.ES_AWARDS_WRITE_ALIAS,
         }
     elif arg_parse_options["load_type"] == "transaction":
@@ -233,7 +238,7 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
             "required_index_name": settings.ES_TRANSACTIONS_NAME_SUFFIX,
             "sql_view": settings.ES_TRANSACTIONS_ETL_VIEW_NAME,
             "stored_date_key": "es_transactions",
-            "unique_key_field": "generated_unique_transaction_id",
+            "unique_key_field": ES_TRANSACTIONS_UNIQUE_KEY_FIELD,
             "write_alias": settings.ES_TRANSACTIONS_WRITE_ALIAS,
         }
     elif arg_parse_options["load_type"] == "covid19-faba":
@@ -254,7 +259,7 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
             "required_index_name": settings.ES_COVID19_FABA_NAME_SUFFIX,
             "sql_view": settings.ES_COVID19_FABA_ETL_VIEW_NAME,
             "stored_date_key": ...,
-            "unique_key_field": "distinct_award_key",
+            "unique_key_field": ES_COVID19_FABA_UNIQUE_KEY_FIELD,
             "write_alias": settings.ES_COVID19_FABA_WRITE_ALIAS,
         }
     else:

--- a/usaspending_api/etl/tests/test_es_rapidloader.py
+++ b/usaspending_api/etl/tests/test_es_rapidloader.py
@@ -10,12 +10,14 @@ from usaspending_api.common.helpers.sql_helpers import execute_sql_to_ordered_di
 from usaspending_api.common.helpers.text_helpers import generate_random_string
 
 from usaspending_api.etl.elasticsearch_loader_helpers import (
-    check_awards_for_deletes,
-    get_deleted_award_ids,
     Controller,
     execute_sql_statement,
     transform_award_data,
     transform_transaction_data,
+)
+from usaspending_api.etl.elasticsearch_loader_helpers.delete_data import (
+    _check_awards_for_deletes,
+    _lookup_deleted_award_ids,
 )
 
 
@@ -182,11 +184,11 @@ def test_award_delete_sql(award_data_fixture, monkeypatch, db):
         "usaspending_api.etl.elasticsearch_loader_helpers.delete_data.execute_sql_statement", mock_execute_sql
     )
     id_list = ["CONT_AWD_IND12PB00323"]
-    awards = check_awards_for_deletes(id_list)
+    awards = _check_awards_for_deletes(id_list)
     assert awards == []
 
     id_list = ["CONT_AWD_WHATEVER", "CONT_AWD_IND12PB00323"]
-    awards = check_awards_for_deletes(id_list)
+    awards = _check_awards_for_deletes(id_list)
     assert awards == [OrderedDict([("generated_unique_award_id", "CONT_AWD_WHATEVER")])]
 
 
@@ -194,5 +196,5 @@ def test_get_award_ids(award_data_fixture, elasticsearch_award_index):
     elasticsearch_award_index.update_index()
     id_list = [{"key": 1, "col": "award_id"}]
     client = elasticsearch_award_index.client
-    ids = get_deleted_award_ids(client, id_list, award_config, index=elasticsearch_award_index.index_name)
+    ids = _lookup_deleted_award_ids(client, id_list, award_config, index=elasticsearch_award_index.index_name)
     assert ids == ["CONT_AWD_IND12PB00323"]


### PR DESCRIPTION
**Description:**
Fixes problem described in bug [DEV-6724](https://federal-spending-transparency.atlassian.net/browse/DEV-6724). 

Does so by fetching correcting the lookup of award keys from the transaction index to match related transactions by the **transaction key** (`generated_unique_transaction_id`).

**Technical details:**
- More details in the linked bug
- Also making it more clear which module functions are shared/used outside the module with underscore naming convention (weak protected)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6724](https://federal-spending-transparency.atlassian.net/browse/DEV-6724):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
