### PR TITLE
HOTFIX: [DEV-6763] Extend list of award keys needing to be deleted

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -178,7 +178,7 @@ def _lookup_deleted_award_ids(client: Elasticsearch, id_list: list, config: dict
             body = filter_query(column, v)
             response = client.search(index=index, body=json.dumps(body), size=config["max_query_size"])
             if response["hits"]["total"]["value"] != 0:
-                awards = [x["_source"][ES_AWARDS_UNIQUE_KEY_FIELD] for x in response["hits"]["hits"]]
+                awards += [x["_source"][ES_AWARDS_UNIQUE_KEY_FIELD] for x in response["hits"]["hits"]]
     return awards
 
 


### PR DESCRIPTION
**Description:**
Fixing bug that would limit award deletes to only ever process the last 1000 seen, if there are more than 1000 to delete.

**Technical details:**
- Discovered as part of working on [DEV-6756](https://federal-spending-transparency.atlassian.net/browse/DEV-6756)
- Solution: Extend the list by continuously concatenating the next chunk of results
- Analyzed recent data since last awards reindex, and did not find any syncs that had award deletes at that large of a number, so current data is not affected. 
    - However, this is a fault in the code that could lead to bad data if not fixed asap

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
    - See [DEV-6756](https://federal-spending-transparency.atlassian.net/browse/DEV-6756) and its PR's unit tests
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [x] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6763](https://federal-spending-transparency.atlassian.net/browse/DEV-6763):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
