### PR TITLE
Mod/dev 6718 allow search by agency acronym

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/overview.md
@@ -17,7 +17,7 @@ This endpoint returns an overview list of government agencies submission data.
         The fiscal period. Valid values: 2-12 (2 = November ... 12 = September)
         For retriving quarterly data, provide the period which equals 'quarter * 3' (e.g. Q2 = P6)
     + `filter` (optional, string)
-        The agency name to filter on.
+        The agency name or abbreviation to filter on (partial match, case insesitive).
     + `page` (optional, number)
         The page of results to return based on the limit.
         + Default: 1

--- a/usaspending_api/api_contracts/contracts/v2/reporting/agencies/publish_dates.md
+++ b/usaspending_api/api_contracts/contracts/v2/reporting/agencies/publish_dates.md
@@ -11,7 +11,7 @@ This endpoint is used to power USAspending.gov's About the Data \| Agencies subm
     + `fiscal_year`: 2020 (required, number)
         The fiscal year.
     + `filter` (optional, string)
-        The agency name to filter on.
+        The agency name or abbreviation to filter on (partial match, case insesitive).
     + `page` (optional, number)
         The page of results to return based on the limit.
         + Default: 1

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -229,10 +229,6 @@ def test_basic_success(setup_test_data, client):
 
 
 def test_filter(setup_test_data, client):
-    resp = client.get(url + "?filter=Test Agency 2")
-    assert resp.status_code == status.HTTP_200_OK
-    response = resp.json()
-    assert len(response["results"]) == 1
     expected_results = [
         {
             "agency_name": "Test Agency 2",
@@ -254,6 +250,17 @@ def test_filter(setup_test_data, client):
             "assurance_statement_url": assurance_statement_2,
         }
     ]
+
+    resp = client.get(url + "?filter=Test Agency 2")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
+    assert response["results"] == expected_results
+
+    resp = client.get(url + "?filter=xYz")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
     assert response["results"] == expected_results
 
 

--- a/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
@@ -443,10 +443,6 @@ def test_different_agencies(client, publish_dates_data):
 
 
 def test_filter(client, publish_dates_data):
-    resp = client.get(url + "?fiscal_year=2019&filter=Agency 2")
-    assert resp.status_code == status.HTTP_200_OK
-    response = resp.json()
-    assert len(response["results"]) == 1
     expected_results = [
         {
             "agency_name": "Test Agency 2",
@@ -526,6 +522,16 @@ def test_filter(client, publish_dates_data):
             ],
         }
     ]
+    resp = client.get(url + "?fiscal_year=2019&filter=Agency 2")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
+    assert response["results"] == expected_results
+
+    resp = client.get(url + "?fiscal_year=2019&filter=a2")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
     assert response["results"] == expected_results
 
 

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -43,7 +43,7 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
     def get_agency_overview(self):
         agency_filters = [Q(toptier_code=OuterRef("toptier_code"))]
         if self.filter is not None:
-            agency_filters.append(Q(name__icontains=self.filter))
+            agency_filters.append(Q(name__icontains=self.filter) | Q(abbreviation__icontains=self.filter))
         result_list = (
             ReportingAgencyOverview.objects.filter(fiscal_year=self.fiscal_year, fiscal_period=self.fiscal_period)
             .annotate(

--- a/usaspending_api/reporting/v2/views/agencies/publish_dates.py
+++ b/usaspending_api/reporting/v2/views/agencies/publish_dates.py
@@ -37,7 +37,7 @@ class PublishDates(AgencyBase, PaginationMixin):
 
         agency_filters = []
         if self.filter is not None:
-            agency_filters.append(Q(name__icontains=self.filter))
+            agency_filters.append(Q(name__icontains=self.filter) | Q(abbreviation__icontains=self.filter))
         results = (
             ToptierAgency.objects.account_agencies()
             .filter(*agency_filters)


### PR DESCRIPTION
**Description:**
expand About the Data searches filtering by agency name to allow agency abbreviations

**Technical details:**
add "or abbreviations contains" to agency name filter in agency overview, publish dates endpoints

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL> --N/A strictly backend update
    - [x] Operations <OPTIONAL> --N/A
    - [x] Domain Expert <OPTIONAL> --N/A
4. [x] Matview impact assessment completed --N/A
5. [x] Frontend impact assessment completed --N/A
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created --N/A
8. [x] Jira Ticket [DEV-6718](https://federal-spending-transparency.atlassian.net/browse/DEV-6718):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
