### PR TITLE
Fixed two annoying duplications

### DIFF
--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -130,16 +130,16 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
         return self.format_results(result_list)
 
     def format_results(self, result_list):
+        agencies = {
+            a["toptier_agency__toptier_code"]: a["id"]
+            for a in Agency.objects.filter(toptier_flag=True).values("toptier_agency__toptier_code", "id")
+        }
         results = [
             {
                 "agency_name": result["agency_name"],
                 "abbreviation": result["abbreviation"],
                 "agency_code": result["agency_code"],
-                "agency_id": Agency.objects.filter(
-                    toptier_agency__toptier_code=result["agency_code"], toptier_flag=True
-                )
-                .first()
-                .id,
+                "agency_id": agencies.get(result["agency_code"]),
                 "current_total_budget_authority_amount": result["current_total_budget_authority_amount"],
                 "recent_publication_date": result["recent_publication_date"],
                 "recent_publication_date_certified": result["recent_publication_date_certified"] is not None,

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -382,7 +382,7 @@ if DEBUG:
             LOGGING["loggers"][logger]["handlers"] += ["console"]
 
     LOGGING["handlers"]["console"]["level"] = "DEBUG"
-    LOGGING["loggers"]["django.db.backends"] = {"handlers": ["console"], "level": "DEBUG"}
+    LOGGING["loggers"]["django.db.backends"] = {"handlers": ["console"], "level": "DEBUG", "propagate": False}
 
 
 # If caches added or renamed, edit clear_caches in usaspending_api/etl/helpers.py


### PR DESCRIPTION
**Description:**
- Annoyance 1) Django's SQL output in debug mode was duplicated
- Annoyance 2) The SQL to obtain the Agency.id value was run 100+ times to fetch the id for each result which added 40+ seconds for local runs connected to a deployed RDS. Changing to a single query shaved 40s.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Minor edits to debug mode and de-duplicated a SQL query
```
