### PR TITLE
[Warmfix] Follows pattern for deleting stale fabs/fpds to also delete transaction_search

### DIFF
--- a/usaspending_api/broker/helpers/delete_stale_fabs.py
+++ b/usaspending_api/broker/helpers/delete_stale_fabs.py
@@ -30,11 +30,13 @@ def delete_stale_fabs(ids_to_delete):
     queries = []
     # Transaction FABS
     if delete_transaction_ids:
+        ts = 'DELETE FROM "transaction_search" tf WHERE tf."transaction_id" IN ({});'
         fabs = 'DELETE FROM "transaction_fabs" tf WHERE tf."transaction_id" IN ({});'
         tn = 'DELETE FROM "transaction_normalized" tn WHERE tn."id" IN ({});'
         td = "DELETE FROM transaction_delta td WHERE td.transaction_id in ({});"
         queries.extend(
             [
+                ts.format(delete_transaction_str_ids),
                 fabs.format(delete_transaction_str_ids),
                 tn.format(delete_transaction_str_ids),
                 td.format(delete_transaction_str_ids),

--- a/usaspending_api/etl/transaction_loaders/fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/fpds_loader.py
@@ -65,7 +65,9 @@ def delete_stale_fpds(detached_award_procurement_ids):
         deleted_awards = cursor.fetchall()
         logger.info(f"{len(deleted_awards):,} awards were unlinked from transactions due to pending deletes")
 
-        cursor.execute(f"delete from transaction_search where transaction_id in ({txn_id_str}) returning transaction_id")
+        cursor.execute(
+            f"delete from transaction_search where transaction_id in ({txn_id_str}) returning transaction_id"
+        )
         deleted_fpds = set(cursor.fetchall())
 
         cursor.execute(f"delete from transaction_fpds where transaction_id in ({txn_id_str}) returning transaction_id")

--- a/usaspending_api/etl/transaction_loaders/fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/fpds_loader.py
@@ -65,6 +65,9 @@ def delete_stale_fpds(detached_award_procurement_ids):
         deleted_awards = cursor.fetchall()
         logger.info(f"{len(deleted_awards):,} awards were unlinked from transactions due to pending deletes")
 
+        cursor.execute(f"delete from transaction_search where transaction_id in ({txn_id_str}) returning transaction_id")
+        deleted_fpds = set(cursor.fetchall())
+
         cursor.execute(f"delete from transaction_fpds where transaction_id in ({txn_id_str}) returning transaction_id")
         deleted_fpds = set(cursor.fetchall())
 

--- a/usaspending_api/search/models/transaction_search.py
+++ b/usaspending_api/search/models/transaction_search.py
@@ -12,7 +12,7 @@ class TransactionSearch(models.Model):
     may or may not be nullable, but those constraints are not enforced in this table.
     """
 
-    transaction = models.OneToOneField(TransactionNormalized, on_delete=models.DO_NOTHING, primary_key=True)
+    transaction = models.OneToOneField(TransactionNormalized, on_delete=models.CASCADE, primary_key=True)
     award = models.ForeignKey(Award, on_delete=models.DO_NOTHING, null=True)
     modification_number = models.TextField(null=True)
     detached_award_proc_unique = models.TextField(null=True)


### PR DESCRIPTION
**Description:**
The test pipeline recently failed during the `Broker -> USAspending (FABS/FPDS) ETL` phase. The pipeline is attempting to delete stale FPDS/FABS records along with records from related tables. One of those tables, `transaction_normalized` has a foreign key constraint from the `transaction_search` table, so the deletion of `transaction_normalized` is failing. 

This PR adds an extra step to delete `transaction_search` records in the delete stale fabs/fpds methods before `transaction_normalized` is deleted

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
