### PR TITLE
[Warmfix] Follows pattern for deleting stale fabs/fpds to also delete transaction_search

### DIFF
--- a/usaspending_api/broker/helpers/delete_stale_fabs.py
+++ b/usaspending_api/broker/helpers/delete_stale_fabs.py
@@ -32,11 +32,13 @@ def delete_stale_fabs(ids_to_delete):
     if delete_transaction_ids:
         fabs = 'DELETE FROM "transaction_fabs" tf WHERE tf."transaction_id" IN ({});'
         tn = 'DELETE FROM "transaction_normalized" tn WHERE tn."id" IN ({});'
+        ts = 'DELETE FROM "transaction_search" ts WHERE ts."transaction_id" IN ({});'
         td = "DELETE FROM transaction_delta td WHERE td.transaction_id in ({});"
         queries.extend(
             [
                 fabs.format(delete_transaction_str_ids),
                 tn.format(delete_transaction_str_ids),
+                ts.format(delete_transaction_str_ids),
                 td.format(delete_transaction_str_ids),
             ]
         )

--- a/usaspending_api/conftest.py
+++ b/usaspending_api/conftest.py
@@ -6,7 +6,7 @@ import tempfile
 
 from django.conf import settings
 from django.core.management import call_command
-from django.db import connections, connection
+from django.db import connections
 from django.test import override_settings
 from pathlib import Path
 

--- a/usaspending_api/etl/transaction_loaders/fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/fpds_loader.py
@@ -68,6 +68,11 @@ def delete_stale_fpds(detached_award_procurement_ids):
         cursor.execute(f"delete from transaction_fpds where transaction_id in ({txn_id_str}) returning transaction_id")
         deleted_fpds = set(cursor.fetchall())
 
+        cursor.execute(
+            f"delete from transaction_search where transaction_id in ({txn_id_str}) returning transaction_id"
+        )
+        deleted_ts = set(cursor.fetchall())
+
         cursor.execute(f"delete from transaction_normalized where id in ({txn_id_str}) returning id")
         deleted_transactions = set(cursor.fetchall())
 
@@ -75,7 +80,11 @@ def delete_stale_fpds(detached_award_procurement_ids):
             msg = "Delete Mismatch! Counts of transaction_normalized ({}) and transaction_fpds ({}) deletes"
             raise RuntimeError(msg.format(len(deleted_transactions), len(deleted_fpds)))
 
-        logger.info(f"{len(deleted_fpds):,} transactions deleted")
+        if deleted_transactions != deleted_ts:
+            msg = "Delete Mismatch! Counts of transaction_normalized ({}) and transaction_search ({}) deletes"
+            raise RuntimeError(msg.format(len(deleted_transactions), len(deleted_ts)))
+
+        logger.info(f"{len(deleted_transactions):,} transactions deleted")
 
         return awards_touched
 


### PR DESCRIPTION
**Description:**
The test pipeline recently failed during the `Broker -> USAspending (FABS/FPDS) ETL` phase. The pipeline is attempting to delete stale FPDS/FABS records along with records from related tables. One of those tables, `transaction_normalized` has a foreign key constraint from the `transaction_search` table, so the deletion of `transaction_normalized` is failing. 

This PR adds an extra step to delete `transaction_search` records in the delete stale fabs/fpds methods before `transaction_normalized` is deleted

**Technical Notes**
Extra logic is added to `conftest.py`. When unit testing, transaction_search is created as a single view. Views can't be deleted from, so a custom rule is added to transaction_search to prevent sql errors when deletes are attempted. This is done in the new `add_view_protection()` method


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. N/A API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6809](https://federal-spending-transparency.atlassian.net/browse/DEV-6809):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```