### PR TITLE
DDtrace Agent back to 0.37.1

### DIFF
--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -4,7 +4,7 @@ attrs==20.*
 boto3==1.16.*
 certifi==2020.12.5
 dataclasses-json==0.5.*
-ddtrace==0.45.*
+ddtrace==0.37.1
 dj-database-url==0.5.0
 django-cors-headers==2.5.3
 django-debug-toolbar==3.2


### PR DESCRIPTION
**Description:**
Apparently ddtrace is incredibly fragile and needs extensive testing before even very minor version updates

**Technical details:**
- Rollback version introduced in #2885
- Sorry Windows devs

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Operations
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Reverting version after 
```
