### PR TITLE
[FIX] Augment tempfile.SpooledTemporaryFile() for expected behavior

### DIFF
--- a/usaspending_api/common/tests/integration/test_retrieve_from_file_uri.py
+++ b/usaspending_api/common/tests/integration/test_retrieve_from_file_uri.py
@@ -6,6 +6,7 @@ from usaspending_api.common.retrieve_file_from_uri import RetrieveFileFromUri
 # Example.com exists for this very purpose.  I don't know about its uptime or
 # anything.  If downtime proves to be an issue, we can switch to something else.
 URL = "http://example.com/"
+SMALL_FILE_URL = "https://github.com/fedspendingtransparency/usaspending-api/blob/dev/README.md"
 
 
 def test_retrieve_from_file():
@@ -63,3 +64,25 @@ def test_http_copy(temp_file_path):
         c = f.read()
         assert type(c) is str
         assert len(c) > 0
+
+
+def test_iobase_api(temp_file_path):
+    """Testing IOBase API https://docs.python.org/3/library/io.html#io.IOBase
+    using a well-written standard library function, like open() will pass these
+    with flying colors. tempfile.SpooledTemporaryFile() is missing some expected
+    API which can cause issues. If you see an attribute error like below then
+    it might be good to leverage the custom class
+
+    ```AttributeError: 'SpooledTemporaryFile' object has no attribute 'readable'```
+    """
+
+    sources = (__file__, SMALL_FILE_URL)
+
+    def test_methods(f):
+        assert f.tell() == 0
+        assert f.readable() is True
+        assert f.seekable() is True
+
+    for source in sources:
+        with RetrieveFileFromUri(source).get_file_object() as f:
+            test_methods(f)


### PR DESCRIPTION
**Description:**
This PR creates a new class to give tempfile.SpooledTemporaryFile an uplift. The current implementation in the standard library isn't satisfying the expected API. Augmenting the class methods and importing io.IOBase should get the class close to where it needs to be. Until https://github.com/python/cpython/pull/3249 is merge, released, and used by this project we will need to keep this augmented class around.

**Technical details:**
While this issue has existed since Python 3.0, it was only recently felt in this project with the upgrade from pandas v0.45.x to pandas v1.0.2+ (pandas v1.0.0 and v1.0.1 introduced another bug which they fixed in v1.0.2, relying on API missing in the SpooledTemporaryFile implementation). See https://bugs.python.org/issue26175 and https://github.com/python/cpython/pull/3249

Locally `loadcfda`, `load_rosetta`, `load_city_county_state_code`, and downloads were tested to ensure the changes did not break other areas. FABS and FPDS ETL scripts also use the class for obtaining delete records and should be tested. Several other ETL scripts (load_tas, load_dabs_submission_window_schedule)  contain a path for loading a file which isn't used by the nightly pipeline which connects directly to broker for refreshing data.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Operations
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
PR is only a change to class used for retrieving temporary files
```
