### PR TITLE
[DEV-6534] Add Missing Submission history to endpoint

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -167,19 +167,20 @@ class Command(load_base.Command):
                             )
                         ) AS history
                     from
-                        (select distinct
-                            submission_id,
-                            publish_history_id,
-                            certify_history_id
-                        from published_files_history
-                        where submission_id = %s) as distinct_pairings
-                    left join
-                        publish_history as ph
-                            on distinct_pairings.publish_history_id = ph.publish_history_id
-                    left join
-                        certify_history as ch
-                            on distinct_pairings.certify_history_id = ch.certify_history_id
-                    group by distinct_pairings.submission_id)
+                        (
+                            select distinct
+                                submission_id,
+                                publish_history_id,
+                                certify_history_id
+                            from published_files_history
+                            where submission_id = %s
+                        ) as distinct_pairings
+                    left outer join
+                        publish_history as ph using (publish_history_id)
+                    left outer join
+                        certify_history as ch using (certify_history_id)
+                    group by distinct_pairings.submission_id
+                )
                 select
                     s.submission_id,
                     (
@@ -203,9 +204,8 @@ class Command(load_base.Command):
                     pch.history
                 from
                     submission as s
-                join
-                    publish_certify_history as pch
-                        on pch.submission_id = s.submission_id
+                inner join
+                    publish_certify_history as pch using (submission_id)
             """,
             [self.submission_id],
         )

--- a/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
@@ -7,8 +7,6 @@ from rest_framework import status
 
 url = "/api/v2/reporting/agencies/{agency}/{fy}/{period}/submission_history/"
 
-DATETIME_STR_1 = ""
-
 
 @pytest.fixture
 def setup_test_data(db):

--- a/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
@@ -1,4 +1,6 @@
+import json
 import pytest
+
 from model_mommy import mommy
 from rest_framework import status
 
@@ -17,6 +19,9 @@ def setup_test_data(db):
         published_date="2019-07-16 16:09:52.125837-04",
         certified_date="2019-07-16 16:09:52.125837-04",
         toptier_code="020",
+        history=json.loads(
+            '[{"certified_date": "2019-07-16T16:09:52.125837Z", "published_date": "2019-07-16T16:09:52.125837Z"}]'
+        ),
     )
     mommy.make(
         "submissions.SubmissionAttributes",
@@ -26,15 +31,9 @@ def setup_test_data(db):
         published_date="2020-08-17 18:37:21.605023-04",
         certified_date="2020-08-17 18:37:21.605023-04",
         toptier_code="020",
-    )
-    mommy.make(
-        "submissions.SubmissionAttributes",
-        submission_id=3,
-        reporting_fiscal_year=2019,
-        reporting_fiscal_period=7,
-        published_date="2017-08-14 14:17:00.729315-04",
-        certified_date="2017-08-14 14:17:00.729315-04",
-        toptier_code="020",
+        history=json.loads(
+            '[{"certified_date": "2020-08-17T18:37:21.605023Z", "published_date": "2020-08-17T18:37:21.605023Z"}, {"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
+        ),
     )
     mommy.make(
         "submissions.SubmissionAttributes",
@@ -44,6 +43,9 @@ def setup_test_data(db):
         published_date="2017-08-14 14:17:00.729315-04",
         certified_date="2017-08-14 14:17:00.729315-04",
         toptier_code="075",
+        history=json.loads(
+            '[{"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
+        ),
     )
 
 
@@ -53,7 +55,7 @@ def test_basic_success(client, setup_test_data):
     response = resp.json()
     assert len(response["results"]) == 1
     assert response["results"] == [
-        {"publication_date": "2019-07-16T20:09:52.125837Z", "certification_date": "2019-07-16T20:09:52.125837Z"}
+        {"publication_date": "2019-07-16T16:09:52.125837Z", "certification_date": "2019-07-16T16:09:52.125837Z"}
     ]
 
 
@@ -63,13 +65,13 @@ def test_multiple_submissions(client, setup_test_data):
     response = resp.json()
     assert len(response["results"]) == 2
     assert response["results"] == [
-        {"publication_date": "2020-08-17T22:37:21.605023Z", "certification_date": "2020-08-17T22:37:21.605023Z"},
-        {"publication_date": "2017-08-14T18:17:00.729315Z", "certification_date": "2017-08-14T18:17:00.729315Z"},
+        {"publication_date": "2020-08-17T18:37:21.605023Z", "certification_date": "2020-08-17T18:37:21.605023Z"},
+        {"publication_date": "2017-08-14T14:17:00.729315Z", "certification_date": "2017-08-14T14:17:00.729315Z"},
     ]
     resp = client.get(url.format(agency_data="075/2019/7"))
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 1
     assert response["results"] == [
-        {"publication_date": "2017-08-14T18:17:00.729315Z", "certification_date": "2017-08-14T18:17:00.729315Z"}
+        {"publication_date": "2017-08-14T14:17:00.729315Z", "certification_date": "2017-08-14T14:17:00.729315Z"}
     ]

--- a/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
@@ -5,7 +5,9 @@ from model_mommy import mommy
 from rest_framework import status
 
 
-url = "/api/v2/reporting/agencies/{agency_data}/submission_history/"
+url = "/api/v2/reporting/agencies/{agency}/{fy}/{period}/submission_history/"
+
+DATETIME_STR_1 = ""
 
 
 @pytest.fixture
@@ -32,12 +34,13 @@ def setup_test_data(db):
         certified_date="2020-08-17 18:37:21.605023-04",
         toptier_code="020",
         history=json.loads(
-            '[{"certified_date": "2020-08-17T18:37:21.605023Z", "published_date": "2020-08-17T18:37:21.605023Z"}, {"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
+            '[{"certified_date": "2020-08-17T18:37:21.605023Z", "published_date": "2020-08-17T18:37:21.605023Z"},'
+            + '{"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
         ),
     )
     mommy.make(
         "submissions.SubmissionAttributes",
-        submission_id=4,
+        submission_id=3,
         reporting_fiscal_year=2019,
         reporting_fiscal_period=7,
         published_date="2017-08-14 14:17:00.729315-04",
@@ -47,10 +50,25 @@ def setup_test_data(db):
             '[{"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
         ),
     )
+    mommy.make(
+        "submissions.SubmissionAttributes",
+        submission_id=10,
+        reporting_fiscal_year=2020,
+        reporting_fiscal_period=12,
+        published_date="2021-02-16 18:20:00.729315-04",
+        certified_date="2021-02-16 18:17:00.729315-04",
+        toptier_code="222",
+        history=json.loads(
+            '[{"certified_date": null, "published_date": "2020-01-17T18:37:21.605023Z"},'
+            + '{"certified_date": null, "published_date": "2020-01-14T14:17:00.729315Z"},'
+            + '{"certified_date": "2021-02-14T14:17:00.729315Z", "published_date": "2021-02-14T14:16:00.729315Z"},'
+            + '{"certified_date": "2021-02-16T14:17:00.729315Z", "published_date": "2021-02-16T14:16:00.729315Z"}]'
+        ),
+    )
 
 
 def test_basic_success(client, setup_test_data):
-    resp = client.get(url.format(agency_data="020/2019/6"))
+    resp = client.get(url.format(agency="020", fy=2019, period=6))
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 1
@@ -58,9 +76,17 @@ def test_basic_success(client, setup_test_data):
         {"publication_date": "2019-07-16T16:09:52.125837Z", "certification_date": "2019-07-16T16:09:52.125837Z"}
     ]
 
+    resp = client.get(url.format(agency="075", fy=2019, period=7))
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 1
+    assert response["results"] == [
+        {"publication_date": "2017-08-14T14:17:00.729315Z", "certification_date": "2017-08-14T14:17:00.729315Z"}
+    ]
+
 
 def test_multiple_submissions(client, setup_test_data):
-    resp = client.get(url.format(agency_data="020/2019/7"))
+    resp = client.get(url.format(agency="020", fy=2019, period=7))
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
     assert len(response["results"]) == 2
@@ -68,10 +94,41 @@ def test_multiple_submissions(client, setup_test_data):
         {"publication_date": "2020-08-17T18:37:21.605023Z", "certification_date": "2020-08-17T18:37:21.605023Z"},
         {"publication_date": "2017-08-14T14:17:00.729315Z", "certification_date": "2017-08-14T14:17:00.729315Z"},
     ]
-    resp = client.get(url.format(agency_data="075/2019/7"))
+
+    resp = client.get(url.format(agency="020", fy=2019, period=7) + "?sort=publication_date&order=asc")
     assert resp.status_code == status.HTTP_200_OK
     response = resp.json()
-    assert len(response["results"]) == 1
+    assert len(response["results"]) == 2
     assert response["results"] == [
-        {"publication_date": "2017-08-14T14:17:00.729315Z", "certification_date": "2017-08-14T14:17:00.729315Z"}
+        {"publication_date": "2017-08-14T14:17:00.729315Z", "certification_date": "2017-08-14T14:17:00.729315Z"},
+        {"publication_date": "2020-08-17T18:37:21.605023Z", "certification_date": "2020-08-17T18:37:21.605023Z"},
+    ]
+
+
+def test_no_data(client, setup_test_data):
+    resp = client.get(url.format(agency="222", fy=2021, period=12))
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_certification_nulls(client, setup_test_data):
+    resp = client.get(url.format(agency="222", fy=2020, period=12) + "?sort=certification_date&order=desc")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 4
+    assert response["results"] == [
+        {"certification_date": "2021-02-16T14:17:00.729315Z", "publication_date": "2021-02-16T14:16:00.729315Z"},
+        {"certification_date": "2021-02-14T14:17:00.729315Z", "publication_date": "2021-02-14T14:16:00.729315Z"},
+        {"certification_date": None, "publication_date": "2020-01-17T18:37:21.605023Z"},
+        {"certification_date": None, "publication_date": "2020-01-14T14:17:00.729315Z"},
+    ]
+
+    resp = client.get(url.format(agency="222", fy=2020, period=12) + "?sort=certification_date&order=asc")
+    assert resp.status_code == status.HTTP_200_OK
+    response = resp.json()
+    assert len(response["results"]) == 4
+    assert response["results"] == [
+        {"certification_date": None, "publication_date": "2020-01-14T14:17:00.729315Z"},
+        {"certification_date": None, "publication_date": "2020-01-17T18:37:21.605023Z"},
+        {"certification_date": "2021-02-14T14:17:00.729315Z", "publication_date": "2021-02-14T14:16:00.729315Z"},
+        {"certification_date": "2021-02-16T14:17:00.729315Z", "publication_date": "2021-02-16T14:16:00.729315Z"},
     ]

--- a/usaspending_api/reporting/v2/views/submission_history.py
+++ b/usaspending_api/reporting/v2/views/submission_history.py
@@ -17,14 +17,26 @@ class SubmissionHistory(PaginationMixin, AgencyBase):
         self.sortable_columns = ["publication_date", "certification_date"]
         self.default_sort_column = "publication_date"
         self.validate_fiscal_period({"fiscal_period": int(fiscal_period)})
-        results = (
+        record = list(
             SubmissionAttributes.objects.filter(
                 toptier_code=toptier_code, reporting_fiscal_year=fiscal_year, reporting_fiscal_period=fiscal_period
             )
-            .annotate(publication_date=F("published_date"), certification_date=F("certified_date"))
-            .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
-            .values("publication_date", "certification_date")
+            .values_list("history", flat=True)
         )
+
+        print(record)
+        # if len(record) == 0:
+        #     return Response()
+
+        results = sorted(
+            [
+                {"publication_date": row["published_date"], "certification_date": row["certified_date"]}
+                for row in record[0]
+            ],
+            key=lambda x: x[self.pagination.sort_key],
+            reverse=self.pagination.sort_order == "desc",
+        )
+
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
         results = results[self.pagination.lower_limit : self.pagination.upper_limit]
         return Response(


### PR DESCRIPTION
**Description:**
Original implementation was only providing the most recent submission publication and certification instead of the full history of a submission

**Technical details:**
Implemented a HTTP 204 if there is no submission history  for the provided request

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6534](https://federal-spending-transparency.atlassian.net/browse/DEV-6534):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to Materialized Views or API Contracts
```

### Example
`/api/v2/reporting/agencies/070/2020/10/submission_history/?page=1&sort=certification_date&order=desc`

**Before on QAT**
```json
{
    "page_metadata": {
        "page": 1,
        "total": 1,
        "limit": 10,
        "next": null,
        "previous": null,
        "hasNext": false,
        "hasPrevious": false
    },
    "results": [
        {
            "publication_date": "2020-11-16T16:41:24.498721Z",
            "certification_date": "2020-11-16T16:43:01.206445Z"
        }
    ],
    "messages": []
}
```

**After on QAT**
```json
{
    "page_metadata": {
        "page": 1,
        "total": 5,
        "limit": 10,
        "next": null,
        "previous": null,
        "hasNext": false,
        "hasPrevious": false
    },
    "results": [
        {
            "publication_date": "2020-11-16T16:41:24.498721+00:00",
            "certification_date": "2020-11-16T16:43:01.206445+00:00"
        },
        {
            "publication_date": "2020-11-14T17:59:44.863938+00:00",
            "certification_date": null
        },
        {
            "publication_date": "2020-11-11T16:50:47.516629+00:00",
            "certification_date": null
        },
        {
            "publication_date": "2020-09-28T15:51:22.335969+00:00",
            "certification_date": null
        },
        {
            "publication_date": "2020-08-28T01:26:06.097561+00:00",
            "certification_date": null
        }
    ],
    "messages": []
}
```