### PR TITLE
[DEV-6657] Change how exit code 3 is handled

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/index_config.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/index_config.py
@@ -109,7 +109,7 @@ def swap_aliases(client, config):
                 time.sleep(90)
                 is_snapshot_conflict = is_snapshot_running(client, old_indexes)
             if is_snapshot_conflict:
-                config["pipeline_exit_code"] = 3
+                config["raise_status_code_3"] = True
                 logger.error(
                     format_log(
                         f"Unable to delete index(es) '{old_indexes}' due to in-progress snapshot", action="ES Alias"

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -147,7 +147,8 @@ class Command(BaseCommand):
             logger.info(format_log(headers))
 
         # Used to help pipeline determine when job passed but needs attention
-        return str(config["pipeline_exit_code"])
+        if config["raise_status_code_3"]:
+            raise SystemExit(3)
 
 
 def parse_cli_args(options: dict, es_client) -> dict:
@@ -280,7 +281,7 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
             "s3_bucket": settings.DELETED_TRANSACTION_JOURNAL_FILES,
             "processing_start_datetime": datetime.now(timezone.utc),
             "verbose": arg_parse_options["verbosity"] > 1,  # convert command's levels of verbosity to a bool
-            "pipeline_exit_code": 0,
+            "raise_status_code_3": False,
         }
     )
 


### PR DESCRIPTION
**Description:**
Minor adjustment to how Exit Code is handled for when a snapshot is ongoing for too long.

**Technical details:**
Change handling of Exit Code to match that of loadcfda.py such that the actual exit code is used in the Jenkins scripts.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6657](https://federal-spending-transparency.atlassian.net/browse/DEV-6657):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
