### PR TITLE
[DEV-5209 ]Fix long fiscal_year test

### DIFF
--- a/usaspending_api/download/tests/integration/test_populate_monthly_files.py
+++ b/usaspending_api/download/tests/integration/test_populate_monthly_files.py
@@ -612,6 +612,7 @@ def test_fiscal_years(client, monthly_download_data, monkeypatch):
     assert f"FY2020_001_Assistance_Full_{formatted_date}.zip" in file_list
     delete_files()
 
+
 def test_award_type(client, monthly_download_data, monkeypatch):
     call_command(
         "populate_monthly_files",

--- a/usaspending_api/download/tests/integration/test_populate_monthly_files.py
+++ b/usaspending_api/download/tests/integration/test_populate_monthly_files.py
@@ -602,14 +602,15 @@ def test_agency_no_data(client, monthly_download_data, monkeypatch):
 
 
 def test_fiscal_years(client, monthly_download_data, monkeypatch):
-    call_command("populate_monthly_files", "--local", "--clobber")
+    call_command("populate_monthly_files", "--agencies=1", "--fiscal_year=2020", "--local", "--clobber")
+    call_command("populate_monthly_files", "--agencies=1", "--fiscal_year=2004", "--local", "--clobber")
     file_list = os.listdir("csv_downloads")
     formatted_date = datetime.datetime.strftime(datetime.date.today(), "%Y%m%d")
-    for fiscal_year in range(2001, 2021):
-        assert f"FY{fiscal_year}_All_Contracts_Full_{formatted_date}.zip" in file_list
-        assert f"FY{fiscal_year}_All_Assistance_Full_{formatted_date}.zip" in file_list
+    assert f"FY2004_001_Contracts_Full_{formatted_date}.zip" in file_list
+    assert f"FY2004_001_Assistance_Full_{formatted_date}.zip" in file_list
+    assert f"FY2020_001_Contracts_Full_{formatted_date}.zip" in file_list
+    assert f"FY2020_001_Assistance_Full_{formatted_date}.zip" in file_list
     delete_files()
-
 
 def test_award_type(client, monthly_download_data, monkeypatch):
     call_command(


### PR DESCRIPTION
**Description:**
The `test_fiscal_years` test in `test_populate_monthly_files` was taking an overly long time,  ~five minutes. This should reduce the time this test takes to run by restricting the number of fiscal years in the test.


**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-5209](https://federal-spending-transparency.atlassian.net/browse/DEV-5209):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
