### PR TITLE
[DEV-6910] Updates to Disaster Overview Calculations

### DIFF
--- a/usaspending_api/disaster/tests/conftest.py
+++ b/usaspending_api/disaster/tests/conftest.py
@@ -60,7 +60,6 @@ from usaspending_api.disaster.tests.fixtures.overview_data import (
     multi_period_faba,
     multi_period_faba_with_future,
     multi_year_faba,
-    non_covid_gtas,
     other_budget_authority_gtas,
     partially_completed_year,
     quarterly_gtas,

--- a/usaspending_api/disaster/tests/conftest.py
+++ b/usaspending_api/disaster/tests/conftest.py
@@ -120,7 +120,6 @@ __all__ = [
     "multi_period_faba",
     "multi_period_faba_with_future",
     "multi_year_faba",
-    "non_covid_gtas",
     "other_budget_authority_gtas",
     "partially_completed_year",
     "quarterly_gtas",

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -15,7 +15,7 @@ def calculate_values(input_dict):
     TOTAL_BUDGETARY_RESOURCES = input_dict["total_budgetary_resources_cpe"] - (
         input_dict["budget_authority_unobligated_balance_brought_forward_cpe"]
         + input_dict["deobligations_or_recoveries_or_refunds_from_prior_year_cpe"]
-        + input_dict["anticipated_prior_year_obligation_recoveries"]
+        + input_dict["prior_year_paid_obligation_recoveries"]
     )
     TOTAL_OBLIGATIONS = input_dict["obligations_incurred_total_cpe"] - (
         input_dict["deobligations_or_recoveries_or_refunds_from_prior_year_cpe"]

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -1,9 +1,34 @@
 import pytest
 
 from datetime import date
+from decimal import Decimal, setcontext, getcontext
 from model_mommy import mommy
 from usaspending_api.references.models import DisasterEmergencyFundCode
 from usaspending_api.disaster.v2.views.disaster_base import COVID_19_GROUP_NAME
+
+
+def to_decimal(input):
+    return Decimal(f"{round(input, 3)}")
+
+
+def calculate_values(input_dict):
+    TOTAL_BUDGETARY_RESOURCES = input_dict["total_budgetary_resources_cpe"] - (
+        input_dict["budget_authority_unobligated_balance_brought_forward_cpe"]
+        + input_dict["deobligations_or_recoveries_or_refunds_from_prior_year_cpe"]
+        + input_dict["anticipated_prior_year_obligation_recoveries"]
+    )
+    TOTAL_OBLIGATIONS = input_dict["obligations_incurred_total_cpe"] - (
+        input_dict["deobligations_or_recoveries_or_refunds_from_prior_year_cpe"]
+    )
+    TOTAL_OUTLAYS = input_dict["gross_outlay_amount_by_tas_cpe"] + input_dict["prior_year_paid_obligation_recoveries"]
+
+    return {
+        "total_budgetary_resources_cpe": to_decimal(input_dict["total_budgetary_resources_cpe"]),
+        "total_budgetary_resources": to_decimal(TOTAL_BUDGETARY_RESOURCES),
+        "total_obligations": to_decimal(TOTAL_OBLIGATIONS),
+        "total_outlays": to_decimal(TOTAL_OUTLAYS),
+    }
+
 
 NOT_COVID_NAME = "not_covid_19"
 
@@ -13,23 +38,65 @@ LATE_MONTH = 12
 EARLY_YEAR = 2021
 LATE_YEAR = 2022
 
-LATE_GTAS_BUDGETARY_RESOURCES = 0.3
-LATE_GTAS_UNOBLIGATED_BALANCE = 0.0
-LATE_GTAS_APPROPRIATION = 0.29
-LATE_GTAS_OUTLAY = 0.03
+
+LATE_GTAS = {
+    "total_budgetary_resources_cpe": 0.30,
+    "budget_authority_unobligated_balance_brought_forward_cpe": 0.0,
+    "gross_outlay_amount_by_tas_cpe": 0.03,
+    "obligations_incurred_total_cpe": 4.0,
+    "deobligations_or_recoveries_or_refunds_from_prior_year_cpe": 0.0,
+    "prior_year_paid_obligation_recoveries": 0.0,
+    "anticipated_prior_year_obligation_recoveries": 0.0,
+}
+LATE_GTAS_CALCULATIONS = calculate_values(LATE_GTAS)
+
+QUARTERLY_GTAS = {
+    "total_budgetary_resources_cpe": 0.26,
+    "budget_authority_unobligated_balance_brought_forward_cpe": 1.0,
+    "gross_outlay_amount_by_tas_cpe": 0.07,
+    "obligations_incurred_total_cpe": 0.08,
+    "deobligations_or_recoveries_or_refunds_from_prior_year_cpe": 0.5,
+    "prior_year_paid_obligation_recoveries": 0.3,
+    "anticipated_prior_year_obligation_recoveries": 0.2,
+}
+QUARTERLY_GTAS_CALCULATIONS = calculate_values(QUARTERLY_GTAS)
+
+EARLY_GTAS = {
+    "total_budgetary_resources_cpe": 0.20,
+    "budget_authority_unobligated_balance_brought_forward_cpe": 0.05,
+    "gross_outlay_amount_by_tas_cpe": 0.02,
+    "obligations_incurred_total_cpe": 4.0,
+    "deobligations_or_recoveries_or_refunds_from_prior_year_cpe": 0.0,
+    "prior_year_paid_obligation_recoveries": 0.0,
+    "anticipated_prior_year_obligation_recoveries": 0.0,
+}
+EARLY_GTAS_CALCULATIONS = calculate_values(EARLY_GTAS)
+
+YEAR_2_GTAS = {
+    "total_budgetary_resources_cpe": 0.32,
+    "budget_authority_unobligated_balance_brought_forward_cpe": 0.0,
+    "gross_outlay_amount_by_tas_cpe": 0.07,
+    "obligations_incurred_total_cpe": 3.0,
+    "deobligations_or_recoveries_or_refunds_from_prior_year_cpe": 0.3,
+    "prior_year_paid_obligation_recoveries": 0.1,
+    "anticipated_prior_year_obligation_recoveries": 0.1,
+}
+YEAR_2_GTAS_CALCULATIONS = calculate_values(YEAR_2_GTAS)
+
+UNOBLIGATED_BALANCE_GTAS = {
+    "total_budgetary_resources_cpe": 1.5,
+    "budget_authority_unobligated_balance_brought_forward_cpe": 0.0,
+    "gross_outlay_amount_by_tas_cpe": 0.0,
+    "obligations_incurred_total_cpe": 4.0,
+    "deobligations_or_recoveries_or_refunds_from_prior_year_cpe": 4.0,
+    "prior_year_paid_obligation_recoveries": 0.0,
+    "anticipated_prior_year_obligation_recoveries": 0.0,
+}
+UNOBLIGATED_BALANCE_GTAS_CALCULATIONS = calculate_values(YEAR_2_GTAS)
 
 QUARTERLY_GTAS_BUDGETARY_RESOURCES = 0.26
 
-EARLY_GTAS_BUDGETARY_RESOURCES = 0.20
-EARLY_GTAS_OUTLAY = 0.02
-EARLY_GTAS_BUDGET_AUTHORITY_UNOBLIGATED_BALANCE_BROUGHT_FORWARD_CPE = 0.05
-
 UNOBLIGATED_GTAS_BUDGETARY_RESOURCES = 1.5
-
-YEAR_TWO_GTAS_BUDGETARY_RESOURCES = 0.32
-YEAR_TWO_GTAS_UNOBLIGATED_BALANCE = 0.1
-YEAR_TWO_GTAS_APPROPRIATION = 0.31
-YEAR_TWO_OUTLAY = 0.07
 
 
 @pytest.fixture
@@ -58,13 +125,8 @@ def late_gtas(defc_codes):
         "references.GTASSF133Balances",
         fiscal_year=EARLY_YEAR,
         fiscal_period=LATE_MONTH,
-        unobligated_balance_cpe=0,
         disaster_emergency_fund_code="M",
-        total_budgetary_resources_cpe=LATE_GTAS_BUDGETARY_RESOURCES,
-        budget_authority_appropriation_amount_cpe=LATE_GTAS_APPROPRIATION,
-        other_budgetary_resources_amount_cpe=0.1,
-        budget_authority_unobligated_balance_brought_forward_cpe=0.0,
-        gross_outlay_amount_by_tas_cpe=LATE_GTAS_OUTLAY,
+        **LATE_GTAS,
     )
 
 
@@ -77,11 +139,7 @@ def quarterly_gtas(defc_codes):
         fiscal_period=LATE_MONTH,
         unobligated_balance_cpe=0,
         disaster_emergency_fund_code="M",
-        total_budgetary_resources_cpe=QUARTERLY_GTAS_BUDGETARY_RESOURCES,
-        budget_authority_appropriation_amount_cpe=0.25,
-        other_budgetary_resources_amount_cpe=0.0,
-        budget_authority_unobligated_balance_brought_forward_cpe=0.0,
-        gross_outlay_amount_by_tas_cpe=0.02,
+        **QUARTERLY_GTAS,
     )
 
 
@@ -93,11 +151,7 @@ def early_gtas(defc_codes):
         fiscal_period=EARLY_MONTH,
         unobligated_balance_cpe=0,
         disaster_emergency_fund_code="M",
-        total_budgetary_resources_cpe=EARLY_GTAS_BUDGETARY_RESOURCES,
-        budget_authority_appropriation_amount_cpe=0.19,
-        other_budgetary_resources_amount_cpe=0.0,
-        budget_authority_unobligated_balance_brought_forward_cpe=EARLY_GTAS_BUDGET_AUTHORITY_UNOBLIGATED_BALANCE_BROUGHT_FORWARD_CPE,
-        gross_outlay_amount_by_tas_cpe=0.02,
+        **EARLY_GTAS,
     )
 
 
@@ -125,11 +179,7 @@ def unobligated_balance_gtas(defc_codes):
         fiscal_period=LATE_MONTH,
         unobligated_balance_cpe=UNOBLIGATED_GTAS_BUDGETARY_RESOURCES,
         disaster_emergency_fund_code="A",
-        total_budgetary_resources_cpe=1.5,
-        budget_authority_appropriation_amount_cpe=0.74,
-        other_budgetary_resources_amount_cpe=0.74,
-        budget_authority_unobligated_balance_brought_forward_cpe=0.0,
-        gross_outlay_amount_by_tas_cpe=0.0,
+        **UNOBLIGATED_BALANCE_GTAS
     )
 
 
@@ -165,18 +215,12 @@ def year_2_gtas_non_covid(defc_codes):
 
 
 def _year_2_gtas(code):
-
     mommy.make(
         "references.GTASSF133Balances",
         fiscal_year=LATE_YEAR,
         fiscal_period=EARLY_MONTH,
-        unobligated_balance_cpe=YEAR_TWO_GTAS_UNOBLIGATED_BALANCE,
         disaster_emergency_fund_code=code,
-        total_budgetary_resources_cpe=YEAR_TWO_GTAS_BUDGETARY_RESOURCES,
-        budget_authority_appropriation_amount_cpe=YEAR_TWO_GTAS_APPROPRIATION,
-        other_budgetary_resources_amount_cpe=0.0,
-        budget_authority_unobligated_balance_brought_forward_cpe=0.0,
-        gross_outlay_amount_by_tas_cpe=YEAR_TWO_OUTLAY,
+        **YEAR_2_GTAS,
     )
 
 

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -167,7 +167,7 @@ def unobligated_balance_gtas(defc_codes):
         fiscal_year=EARLY_YEAR,
         fiscal_period=LATE_MONTH,
         disaster_emergency_fund_code="A",
-        **UNOBLIGATED_BALANCE_GTAS
+        **UNOBLIGATED_BALANCE_GTAS,
     )
 
 
@@ -178,7 +178,7 @@ def other_budget_authority_gtas(defc_codes):
         fiscal_year=EARLY_YEAR,
         fiscal_period=EARLY_MONTH,
         disaster_emergency_fund_code="M",
-        **OTHER_BUDGET_AUTHORITY_GTAS
+        **OTHER_BUDGET_AUTHORITY_GTAS,
     )
 
 

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -1,14 +1,14 @@
 import pytest
 
 from datetime import date
-from decimal import Decimal, setcontext, getcontext
+from decimal import Decimal
 from model_mommy import mommy
 from usaspending_api.references.models import DisasterEmergencyFundCode
 from usaspending_api.disaster.v2.views.disaster_base import COVID_19_GROUP_NAME
 
 
 def to_decimal(input):
-    return Decimal(f"{round(input, 3)}")
+    return Decimal(f"{round(input, 2)}")
 
 
 def calculate_values(input_dict):
@@ -94,9 +94,16 @@ UNOBLIGATED_BALANCE_GTAS = {
 }
 UNOBLIGATED_BALANCE_GTAS_CALCULATIONS = calculate_values(UNOBLIGATED_BALANCE_GTAS)
 
-QUARTERLY_GTAS_BUDGETARY_RESOURCES = 0.26
-
-UNOBLIGATED_GTAS_BUDGETARY_RESOURCES = 1.5
+OTHER_BUDGET_AUTHORITY_GTAS = {
+    "total_budgetary_resources_cpe": 0.85,
+    "budget_authority_unobligated_balance_brought_forward_cpe": 0.0,
+    "gross_outlay_amount_by_tas_cpe": 0.2,
+    "obligations_incurred_total_cpe": 4.0,
+    "deobligations_or_recoveries_or_refunds_from_prior_year_cpe": 4.0,
+    "prior_year_paid_obligation_recoveries": 0.0,
+    "anticipated_prior_year_obligation_recoveries": 0.0,
+}
+OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS = calculate_values(OTHER_BUDGET_AUTHORITY_GTAS)
 
 
 @pytest.fixture
@@ -137,7 +144,6 @@ def quarterly_gtas(defc_codes):
         "references.GTASSF133Balances",
         fiscal_year=EARLY_YEAR,
         fiscal_period=LATE_MONTH,
-        unobligated_balance_cpe=0,
         disaster_emergency_fund_code="M",
         **QUARTERLY_GTAS,
     )
@@ -149,25 +155,8 @@ def early_gtas(defc_codes):
         "references.GTASSF133Balances",
         fiscal_year=EARLY_YEAR,
         fiscal_period=EARLY_MONTH,
-        unobligated_balance_cpe=0,
         disaster_emergency_fund_code="M",
         **EARLY_GTAS,
-    )
-
-
-@pytest.fixture
-def non_covid_gtas(defc_codes):
-    mommy.make(
-        "references.GTASSF133Balances",
-        fiscal_year=EARLY_YEAR,
-        fiscal_period=LATE_MONTH,
-        unobligated_balance_cpe=0,
-        disaster_emergency_fund_code="A",
-        total_budgetary_resources_cpe=0.32,
-        budget_authority_appropriation_amount_cpe=0.31,
-        other_budgetary_resources_amount_cpe=0.0,
-        budget_authority_unobligated_balance_brought_forward_cpe=0.0,
-        gross_outlay_amount_by_tas_cpe=0.13,
     )
 
 
@@ -177,7 +166,6 @@ def unobligated_balance_gtas(defc_codes):
         "references.GTASSF133Balances",
         fiscal_year=EARLY_YEAR,
         fiscal_period=LATE_MONTH,
-        unobligated_balance_cpe=UNOBLIGATED_GTAS_BUDGETARY_RESOURCES,
         disaster_emergency_fund_code="A",
         **UNOBLIGATED_BALANCE_GTAS
     )
@@ -189,13 +177,8 @@ def other_budget_authority_gtas(defc_codes):
         "references.GTASSF133Balances",
         fiscal_year=EARLY_YEAR,
         fiscal_period=EARLY_MONTH,
-        unobligated_balance_cpe=0,
         disaster_emergency_fund_code="M",
-        total_budgetary_resources_cpe=0.85,
-        budget_authority_appropriation_amount_cpe=0.69,
-        other_budgetary_resources_amount_cpe=0.14,
-        budget_authority_unobligated_balance_brought_forward_cpe=0.0,
-        gross_outlay_amount_by_tas_cpe=0.02,
+        **OTHER_BUDGET_AUTHORITY_GTAS
     )
 
 

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -20,7 +20,9 @@ def calculate_values(input_dict):
     TOTAL_OBLIGATIONS = input_dict["obligations_incurred_total_cpe"] - (
         input_dict["deobligations_or_recoveries_or_refunds_from_prior_year_cpe"]
     )
-    TOTAL_OUTLAYS = input_dict["gross_outlay_amount_by_tas_cpe"] + input_dict["prior_year_paid_obligation_recoveries"]
+    TOTAL_OUTLAYS = (
+        input_dict["gross_outlay_amount_by_tas_cpe"] - input_dict["anticipated_prior_year_obligation_recoveries"]
+    )
 
     return {
         "total_budgetary_resources_cpe": to_decimal(input_dict["total_budgetary_resources_cpe"]),

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -25,7 +25,6 @@ def calculate_values(input_dict):
     )
 
     return {
-        "total_budgetary_resources_cpe": to_decimal(input_dict["total_budgetary_resources_cpe"]),
         "total_budgetary_resources": to_decimal(TOTAL_BUDGETARY_RESOURCES),
         "total_obligations": to_decimal(TOTAL_OBLIGATIONS),
         "total_outlays": to_decimal(TOTAL_OUTLAYS),

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -92,7 +92,7 @@ UNOBLIGATED_BALANCE_GTAS = {
     "prior_year_paid_obligation_recoveries": 0.0,
     "anticipated_prior_year_obligation_recoveries": 0.0,
 }
-UNOBLIGATED_BALANCE_GTAS_CALCULATIONS = calculate_values(YEAR_2_GTAS)
+UNOBLIGATED_BALANCE_GTAS_CALCULATIONS = calculate_values(UNOBLIGATED_BALANCE_GTAS)
 
 QUARTERLY_GTAS_BUDGETARY_RESOURCES = 0.26
 

--- a/usaspending_api/disaster/tests/integration/test_overview.py
+++ b/usaspending_api/disaster/tests/integration/test_overview.py
@@ -10,7 +10,7 @@ from usaspending_api.disaster.tests.fixtures.overview_data import (
     QUARTERLY_GTAS_CALCULATIONS,
     EARLY_GTAS_CALCULATIONS,
     YEAR_2_GTAS_CALCULATIONS,
-    OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS
+    OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS,
 )
 
 OVERVIEW_URL = "/api/v2/disaster/overview/"
@@ -141,7 +141,9 @@ def test_ignore_gtas_not_yet_revealed(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, EARLY_MONTH - 1, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["funding"] == [{"amount": LATE_GTAS_CALCULATIONS["total_budgetary_resources_cpe"], "def_code": "M"}]
+    assert resp.data["funding"] == [
+        {"amount": LATE_GTAS_CALCULATIONS["total_budgetary_resources_cpe"], "def_code": "M"}
+    ]
     assert resp.data["total_budget_authority"] == LATE_GTAS_CALCULATIONS["total_budgetary_resources"]
     assert resp.data["spending"]["total_obligations"] == LATE_GTAS_CALCULATIONS["total_obligations"]
     assert resp.data["spending"]["total_outlays"] == LATE_GTAS_CALCULATIONS["total_outlays"]
@@ -154,7 +156,9 @@ def test_ignore_funding_for_unselected_defc(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, EARLY_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL + "?def_codes=M,A")
-    assert resp.data["funding"] == [{"amount": YEAR_2_GTAS_CALCULATIONS["total_budgetary_resources_cpe"], "def_code": "M"}]
+    assert resp.data["funding"] == [
+        {"amount": YEAR_2_GTAS_CALCULATIONS["total_budgetary_resources_cpe"], "def_code": "M"}
+    ]
     assert resp.data["total_budget_authority"] == YEAR_2_GTAS_CALCULATIONS["total_budgetary_resources"]
     assert resp.data["spending"]["total_obligations"] == YEAR_2_GTAS_CALCULATIONS["total_obligations"]
     assert resp.data["spending"]["total_outlays"] == YEAR_2_GTAS_CALCULATIONS["total_outlays"]
@@ -174,7 +178,9 @@ def test_adds_budget_values(client, monkeypatch, helpers, defc_codes, basic_ref_
     helpers.patch_datetime_now(monkeypatch, EARLY_YEAR, EARLY_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["funding"] == [{"amount": OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS["total_budgetary_resources_cpe"], "def_code": "M"}]
+    assert resp.data["funding"] == [
+        {"amount": OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS["total_budgetary_resources_cpe"], "def_code": "M"}
+    ]
     assert resp.data["total_budget_authority"] == OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS["total_budgetary_resources"]
     assert resp.data["spending"]["total_obligations"] == OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS["total_obligations"]
     assert resp.data["spending"]["total_outlays"] == OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS["total_outlays"]

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -121,7 +121,7 @@ class OverviewViewSet(DisasterBase):
             latest_gtas_of_each_year_queryset()
             .filter(disaster_emergency_fund_code__in=self.defc)
             .values("gross_outlay_amount_by_tas_cpe", "prior_year_paid_obligation_recoveries")
-            .aggregate(total=(Sum("gross_outlay_amount_by_tas_cpe") - Sum("prior_year_paid_obligation_recoveries")))[
+            .aggregate(total=(Sum("gross_outlay_amount_by_tas_cpe") + Sum("prior_year_paid_obligation_recoveries")))[
                 "total"
             ]
         ) or 0.0

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -54,22 +54,19 @@ class OverviewViewSet(DisasterBase):
             .values("disaster_emergency_fund_code")
             .annotate(
                 def_code=F("disaster_emergency_fund_code"),
-                amount=Sum("total_budgetary_resources_cpe"),
-                total_budget_authority=(
-                    Sum("total_budgetary_resources_cpe") - (
-                        Sum("budget_authority_unobligated_balance_brought_forward_cpe") +
-                        Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe") +
-                        Sum("prior_year_paid_obligation_recoveries")
+                amount=(
+                    Sum("total_budgetary_resources_cpe")
+                    - (
+                        Sum("budget_authority_unobligated_balance_brought_forward_cpe")
+                        + Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe")
+                        + Sum("prior_year_paid_obligation_recoveries")
                     )
-                )
+                ),
             )
-            .values("def_code", "amount", "total_budget_authority")
+            .values("def_code", "amount")
         )
 
-        total_budget_authority = self.sum_values(funding, "total_budget_authority")
-
-        for entry in funding:
-            del entry["total_budget_authority"]
+        total_budget_authority = self.sum_values(funding, "amount")
 
         return funding, total_budget_authority
 

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -57,7 +57,7 @@ class OverviewViewSet(DisasterBase):
                 amount=Sum("total_budgetary_resources_cpe"),
                 unobligated_balance=Sum("budget_authority_unobligated_balance_brought_forward_cpe"),
                 deobligations=Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe"),
-                anticipated_recoveries=Sum("anticipated_prior_year_obligation_recoveries"),
+                obligation_recoveries=Sum("prior_year_paid_obligation_recoveries"),
             )
             .values("def_code", "amount", "unobligated_balance", "deobligations", "anticipated_recoveries")
         )
@@ -65,10 +65,10 @@ class OverviewViewSet(DisasterBase):
         total_amount = self.sum_values(funding, "amount")
         total_unobligated_balance = self.sum_values(funding, "unobligated_balance")
         total_deobligations = self.sum_values(funding, "deobligations")
-        total_anticipated_recoveries = self.sum_values(funding, "anticipated_recoveries")
+        total_obligation_recoveries = self.sum_values(funding, "obligation_recoveries")
 
         total_budget_authority = total_amount - (
-            total_unobligated_balance + total_deobligations + total_anticipated_recoveries
+            total_unobligated_balance + total_deobligations + total_obligation_recoveries
         )
 
         for entry in funding:

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -120,10 +120,10 @@ class OverviewViewSet(DisasterBase):
         return (
             latest_gtas_of_each_year_queryset()
             .filter(disaster_emergency_fund_code__in=self.defc)
-            .values("gross_outlay_amount_by_tas_cpe", "prior_year_paid_obligation_recoveries")
-            .aggregate(total=(Sum("gross_outlay_amount_by_tas_cpe") + Sum("prior_year_paid_obligation_recoveries")))[
-                "total"
-            ]
+            .values("gross_outlay_amount_by_tas_cpe", "anticipated_prior_year_obligation_recoveries")
+            .aggregate(
+                total=(Sum("gross_outlay_amount_by_tas_cpe") - Sum("anticipated_prior_year_obligation_recoveries"))
+            )["total"]
         ) or 0.0
 
     @staticmethod


### PR DESCRIPTION
**Description:**
This PR addresses the changes to the `total_budgetary_resources`, `total_obligations`, and `total_outlays` fields in the **Disaster Overview Endpoint**. 

Updated formulas for these fields can be found in the ticket. 

**Technical details:**
Unit tests were corrected to reflect the changes to the formulas, but new test cases were not optimized for new logic. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6910](https://federal-spending-transparency.atlassian.net/browse/DEV-6910):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
