### PR TITLE
Mod/dev 6552 add unlinked count to agencies overview

### DIFF
--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -446,25 +446,6 @@ def test_pagination(setup_test_data, client):
     assert len(response["results"]) == 3
     expected_results = [
         {
-            "agency_name": "Test Agency",
-            "abbreviation": "ABC",
-            "toptier_code": "123",
-            "agency_id": 1,
-            "current_total_budget_authority_amount": None,
-            "recent_publication_date": None,
-            "recent_publication_date_certified": False,
-            "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": None,
-                "tas_accounts_total": None,
-                "tas_obligation_not_in_gtas_total": 0.0,
-                "missing_tas_accounts_count": 0,
-            },
-            "obligation_difference": None,
-            "unlinked_contract_award_count": None,
-            "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
-        },
-        {
             "agency_name": "Test Agency 2",
             "abbreviation": "XYZ",
             "toptier_code": "987",
@@ -501,6 +482,25 @@ def test_pagination(setup_test_data, client):
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
             "assurance_statement_url": assurance_statement_3,
+        },
+        {
+            "agency_name": "Test Agency",
+            "abbreviation": "ABC",
+            "toptier_code": "123",
+            "agency_id": 1,
+            "current_total_budget_authority_amount": None,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": None,
+                "tas_accounts_total": None,
+                "tas_obligation_not_in_gtas_total": 0.0,
+                "missing_tas_accounts_count": 0,
+            },
+            "obligation_difference": None,
+            "unlinked_contract_award_count": None,
+            "unlinked_assistance_award_count": None,
+            "assurance_statement_url": assurance_statement_1_2,
         },
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -224,25 +224,6 @@ def test_basic_success(setup_test_data, client):
     assert len(response["results"]) == 3
     expected_results = [
         {
-            "agency_name": "Test Agency",
-            "abbreviation": "ABC",
-            "toptier_code": "123",
-            "agency_id": 1,
-            "current_total_budget_authority_amount": None,
-            "recent_publication_date": None,
-            "recent_publication_date_certified": False,
-            "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": None,
-                "tas_accounts_total": None,
-                "tas_obligation_not_in_gtas_total": 0.0,
-                "missing_tas_accounts_count": 0,
-            },
-            "obligation_difference": None,
-            "unlinked_contract_award_count": None,
-            "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
-        },
-        {
             "agency_name": "Test Agency 2",
             "abbreviation": "XYZ",
             "toptier_code": "987",
@@ -279,6 +260,25 @@ def test_basic_success(setup_test_data, client):
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
             "assurance_statement_url": assurance_statement_3,
+        },
+        {
+            "agency_name": "Test Agency",
+            "abbreviation": "ABC",
+            "toptier_code": "123",
+            "agency_id": 1,
+            "current_total_budget_authority_amount": None,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": None,
+                "tas_accounts_total": None,
+                "tas_obligation_not_in_gtas_total": 0.0,
+                "missing_tas_accounts_count": 0,
+            },
+            "obligation_difference": None,
+            "unlinked_contract_award_count": None,
+            "unlinked_assistance_award_count": None,
+            "assurance_statement_url": assurance_statement_1_2,
         },
     ]
     assert response["results"] == expected_results
@@ -327,23 +327,23 @@ def test_pagination(setup_test_data, client):
     assert len(response["results"]) == 1
     expected_results = [
         {
-            "agency_name": "Test Agency",
-            "abbreviation": "ABC",
-            "toptier_code": "123",
-            "agency_id": 1,
-            "current_total_budget_authority_amount": None,
+            "agency_name": "Test Agency 2",
+            "abbreviation": "XYZ",
+            "toptier_code": "987",
+            "agency_id": 2,
+            "current_total_budget_authority_amount": 100.0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": None,
-                "tas_accounts_total": None,
-                "tas_obligation_not_in_gtas_total": 0.0,
-                "missing_tas_accounts_count": 0,
+                "gtas_obligation_total": 18.6,
+                "tas_accounts_total": 100.00,
+                "tas_obligation_not_in_gtas_total": 12.0,
+                "missing_tas_accounts_count": 1,
             },
-            "obligation_difference": None,
-            "unlinked_contract_award_count": None,
-            "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
+            "obligation_difference": 0.0,
+            "unlinked_contract_award_count": 40,
+            "unlinked_assistance_award_count": 60,
+            "assurance_statement_url": assurance_statement_2,
         }
     ]
     assert response["results"] == expected_results
@@ -354,24 +354,24 @@ def test_pagination(setup_test_data, client):
     assert len(response["results"]) == 1
     expected_results = [
         {
-            "agency_name": "Test Agency 2",
-            "abbreviation": "XYZ",
-            "toptier_code": "987",
-            "agency_id": 2,
-            "current_total_budget_authority_amount": 100.0,
+            "agency_name": "Test Agency 3",
+            "abbreviation": "AAA",
+            "toptier_code": "001",
+            "agency_id": 3,
+            "current_total_budget_authority_amount": 10.0,
             "recent_publication_date": None,
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": 18.6,
+                "gtas_obligation_total": 20.0,
                 "tas_accounts_total": 100.00,
-                "tas_obligation_not_in_gtas_total": 12.0,
-                "missing_tas_accounts_count": 1,
+                "tas_obligation_not_in_gtas_total": 0.0,
+                "missing_tas_accounts_count": 0,
             },
-            "obligation_difference": 0.0,
-            "unlinked_contract_award_count": 40,
-            "unlinked_assistance_award_count": 60,
-            "assurance_statement_url": assurance_statement_2,
-        }
+            "obligation_difference": 10.0,
+            "unlinked_contract_award_count": 400,
+            "unlinked_assistance_award_count": 600,
+            "assurance_statement_url": assurance_statement_3,
+        },
     ]
     assert response["results"] == expected_results
 
@@ -380,25 +380,6 @@ def test_pagination(setup_test_data, client):
     response = resp.json()
     assert len(response["results"]) == 3
     expected_results = [
-        {
-            "agency_name": "Test Agency",
-            "abbreviation": "ABC",
-            "toptier_code": "123",
-            "agency_id": 1,
-            "current_total_budget_authority_amount": None,
-            "recent_publication_date": None,
-            "recent_publication_date_certified": False,
-            "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": None,
-                "tas_accounts_total": None,
-                "tas_obligation_not_in_gtas_total": 0.0,
-                "missing_tas_accounts_count": 0,
-            },
-            "obligation_difference": None,
-            "unlinked_contract_award_count": None,
-            "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
-        },
         {
             "agency_name": "Test Agency 3",
             "abbreviation": "AAA",
@@ -436,6 +417,25 @@ def test_pagination(setup_test_data, client):
             "unlinked_contract_award_count": 40,
             "unlinked_assistance_award_count": 60,
             "assurance_statement_url": assurance_statement_2,
+        },
+        {
+            "agency_name": "Test Agency",
+            "abbreviation": "ABC",
+            "toptier_code": "123",
+            "agency_id": 1,
+            "current_total_budget_authority_amount": None,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": None,
+                "tas_accounts_total": None,
+                "tas_obligation_not_in_gtas_total": 0.0,
+                "missing_tas_accounts_count": 0,
+            },
+            "obligation_difference": None,
+            "unlinked_contract_award_count": None,
+            "unlinked_assistance_award_count": None,
+            "assurance_statement_url": assurance_statement_1_2,
         },
     ]
     assert response["results"] == expected_results
@@ -446,6 +446,25 @@ def test_pagination(setup_test_data, client):
     assert len(response["results"]) == 3
     expected_results = [
         {
+            "agency_name": "Test Agency",
+            "abbreviation": "ABC",
+            "toptier_code": "123",
+            "agency_id": 1,
+            "current_total_budget_authority_amount": None,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": None,
+                "tas_accounts_total": None,
+                "tas_obligation_not_in_gtas_total": 0.0,
+                "missing_tas_accounts_count": 0,
+            },
+            "obligation_difference": None,
+            "unlinked_contract_award_count": None,
+            "unlinked_assistance_award_count": None,
+            "assurance_statement_url": assurance_statement_1_2,
+        },
+        {
             "agency_name": "Test Agency 2",
             "abbreviation": "XYZ",
             "toptier_code": "987",
@@ -482,25 +501,6 @@ def test_pagination(setup_test_data, client):
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
             "assurance_statement_url": assurance_statement_3,
-        },
-        {
-            "agency_name": "Test Agency",
-            "abbreviation": "ABC",
-            "toptier_code": "123",
-            "agency_id": 1,
-            "current_total_budget_authority_amount": None,
-            "recent_publication_date": None,
-            "recent_publication_date_certified": False,
-            "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": None,
-                "tas_accounts_total": None,
-                "tas_obligation_not_in_gtas_total": 0.0,
-                "missing_tas_accounts_count": 0,
-            },
-            "obligation_difference": None,
-            "unlinked_contract_award_count": None,
-            "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
         },
     ]
     assert response["results"] == expected_results
@@ -513,6 +513,25 @@ def test_fiscal_year_period_selection(setup_test_data, client):
     assert len(response["results"]) == 3
 
     expected_results = [
+        {
+            "agency_name": "Test Agency",
+            "abbreviation": "ABC",
+            "toptier_code": "123",
+            "agency_id": 1,
+            "current_total_budget_authority_amount": 22478810.97,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": 1788370.03,
+                "tas_accounts_total": 100.00,
+                "tas_obligation_not_in_gtas_total": 11.0,
+                "missing_tas_accounts_count": 2,
+            },
+            "obligation_difference": 84931.95,
+            "unlinked_contract_award_count": 4,
+            "unlinked_assistance_award_count": 6,
+            "assurance_statement_url": assurance_statement_1,
+        },
         {
             "agency_name": "Test Agency 2",
             "abbreviation": "XYZ",
@@ -550,25 +569,6 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
             "assurance_statement_url": assurance_statement_3_2,
-        },
-        {
-            "agency_name": "Test Agency",
-            "abbreviation": "ABC",
-            "toptier_code": "123",
-            "agency_id": 1,
-            "current_total_budget_authority_amount": 22478810.97,
-            "recent_publication_date": None,
-            "recent_publication_date_certified": False,
-            "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": 1788370.03,
-                "tas_accounts_total": 100.00,
-                "tas_obligation_not_in_gtas_total": 11.0,
-                "missing_tas_accounts_count": 2,
-            },
-            "obligation_difference": 84931.95,
-            "unlinked_contract_award_count": 4,
-            "unlinked_assistance_award_count": 6,
-            "assurance_statement_url": assurance_statement_1,
         },
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -161,7 +161,7 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
         if self.pagination.sort_order == "desc":
             result_list = result_list.order_by(F(self.pagination.sort_key).desc(nulls_last=True))
         else:
-            result_list = result_list.order_by(F(self.pagination.sort_key).asc(nulls_first=True))
+            result_list = result_list.order_by(F(self.pagination.sort_key).asc(nulls_last=True))
 
         return self.format_results(result_list)
 

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -156,8 +156,13 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
                 "unlinked_contract_award_count",
                 "unlinked_assistance_award_count",
             )
-            .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
         )
+
+        if self.pagination.sort_order == "desc":
+            result_list = result_list.order_by(F(self.pagination.sort_key).desc(nulls_last=True))
+        else:
+            result_list = result_list.order_by(F(self.pagination.sort_key).asc(nulls_first=True))
+
         return self.format_results(result_list)
 
     def format_results(self, result_list):


### PR DESCRIPTION
**Description:**
add unlinked award counts to api/v2/reporting/agencies/overview/ , replacing the "0" placeholders with actual data
NOTE: this PR simply extends https://github.com/fedspendingtransparency/usaspending-api/pull/2956 by sorting null values to the end in all cases

**Technical details:**
add the C & D missing values now being stored in ReportingAgencyOverview

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend na-no changes
    - [x] Operations na
    - [x] Domain Expert na
4. [x] Matview impact assessment completed na
5. [x] Frontend impact assessment completed na
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created na
8. [x] Jira Ticket [DEV-6552](https://federal-spending-transparency.atlassian.net/browse/DEV-6552):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download) na, simply adding table values to results
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
