### PR TITLE
[DEV-6920] Updates award outlay calculation on disaster overview endpoint

### DIFF
--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -218,6 +218,8 @@ def basic_faba(defc_codes):
         "awards.FinancialAccountsByAwards",
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.all().first(),
         transaction_obligated_amount=0.0,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.1,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.2,
         submission=submission,
     )
 
@@ -267,6 +269,8 @@ def _year_1_faba(value, code):
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code=code).first(),
         transaction_obligated_amount=value,
         gross_outlay_amount_by_award_cpe=value / 2.0,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.1,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.2,
         submission=submission,
     )
 
@@ -286,6 +290,8 @@ def _year_2_faba_with_value(value):
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(group_name=COVID_19_GROUP_NAME).first(),
         transaction_obligated_amount=value,
         gross_outlay_amount_by_award_cpe=value / 2.0,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=9.1,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=10.2,
         submission=submission,
     )
 
@@ -305,6 +311,8 @@ def _year_2_late_faba_with_value(value):
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(group_name=COVID_19_GROUP_NAME).first(),
         transaction_obligated_amount=value,
         gross_outlay_amount_by_award_cpe=value / 2.0,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.1,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.1,
         submission=submission,
     )
 
@@ -324,6 +332,8 @@ def _year_3_faba_with_value(value):
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(group_name=COVID_19_GROUP_NAME).first(),
         transaction_obligated_amount=value,
         gross_outlay_amount_by_award_cpe=value / 2.0,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=7.1,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=8.2,
         submission=submission,
     )
 

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -217,7 +217,7 @@ def basic_faba(defc_codes):
     mommy.make(
         "awards.FinancialAccountsByAwards",
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.all().first(),
-        transaction_obligated_amount=0.0,
+        transaction_obligated_amount=0.0 - 0.3,
         ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.1,
         ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.2,
         submission=submission,
@@ -254,6 +254,11 @@ def multi_period_faba_with_future(defc_codes):
     _year_3_faba_with_value(2.2)
 
 
+@pytest.fixture
+def faba_with_values(defc_codes):
+    _year_1_faba(1.6, "M")
+    _year_1_faba(0.7, "M")
+
 def _year_1_faba(value, code):
     submission = mommy.make(
         "submissions.SubmissionAttributes",
@@ -268,7 +273,7 @@ def _year_1_faba(value, code):
         "awards.FinancialAccountsByAwards",
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code=code).first(),
         transaction_obligated_amount=value,
-        gross_outlay_amount_by_award_cpe=value / 2.0,
+        gross_outlay_amount_by_award_cpe=value / 2.0 - 0.3,
         ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.1,
         ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.2,
         submission=submission,
@@ -289,9 +294,9 @@ def _year_2_faba_with_value(value):
         "awards.FinancialAccountsByAwards",
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(group_name=COVID_19_GROUP_NAME).first(),
         transaction_obligated_amount=value,
-        gross_outlay_amount_by_award_cpe=value / 2.0,
-        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=9.1,
-        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=10.2,
+        gross_outlay_amount_by_award_cpe=value / 2.0 - 0.7,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.4,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.3,
         submission=submission,
     )
 
@@ -310,7 +315,7 @@ def _year_2_late_faba_with_value(value):
         "awards.FinancialAccountsByAwards",
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(group_name=COVID_19_GROUP_NAME).first(),
         transaction_obligated_amount=value,
-        gross_outlay_amount_by_award_cpe=value / 2.0,
+        gross_outlay_amount_by_award_cpe=value / 2.0 - 0.2,
         ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0.1,
         ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0.1,
         submission=submission,
@@ -331,7 +336,7 @@ def _year_3_faba_with_value(value):
         "awards.FinancialAccountsByAwards",
         disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(group_name=COVID_19_GROUP_NAME).first(),
         transaction_obligated_amount=value,
-        gross_outlay_amount_by_award_cpe=value / 2.0,
+        gross_outlay_amount_by_award_cpe=value / 2.0 - 15.3,
         ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=7.1,
         ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=8.2,
         submission=submission,

--- a/usaspending_api/disaster/tests/fixtures/overview_data.py
+++ b/usaspending_api/disaster/tests/fixtures/overview_data.py
@@ -254,11 +254,6 @@ def multi_period_faba_with_future(defc_codes):
     _year_3_faba_with_value(2.2)
 
 
-@pytest.fixture
-def faba_with_values(defc_codes):
-    _year_1_faba(1.6, "M")
-    _year_1_faba(0.7, "M")
-
 def _year_1_faba(value, code):
     submission = mommy.make(
         "submissions.SubmissionAttributes",

--- a/usaspending_api/disaster/tests/integration/test_overview.py
+++ b/usaspending_api/disaster/tests/integration/test_overview.py
@@ -188,7 +188,7 @@ def test_award_obligation_adds_values(
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
     assert resp.data["spending"]["award_obligations"] == Decimal("2.3")
-    assert resp.data["spending"]["award_outlays"] == Decimal("1.15")
+    assert resp.data["spending"]["award_outlays"] == Decimal("1.75")
 
 
 @pytest.mark.django_db
@@ -199,7 +199,7 @@ def test_faba_excludes_non_selected_defc(
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL + "?def_codes=M,N")
     assert resp.data["spending"]["award_obligations"] == Decimal("1.6")
-    assert resp.data["spending"]["award_outlays"] == Decimal("0.8")
+    assert resp.data["spending"]["award_outlays"] == Decimal("1.1")
 
 
 @pytest.mark.django_db
@@ -209,7 +209,7 @@ def test_award_outlays_sum_multiple_years(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, EARLY_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["spending"]["award_outlays"] == Decimal("1.15")
+    assert resp.data["spending"]["award_outlays"] == Decimal("1.65")
 
 
 @pytest.mark.django_db
@@ -219,7 +219,7 @@ def test_award_outlays_doesnt_sum_multiple_periods(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, LATE_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["spending"]["award_outlays"] == Decimal("0.8")
+    assert resp.data["spending"]["award_outlays"] == Decimal("1.0")
 
 
 @pytest.mark.django_db
@@ -229,4 +229,4 @@ def test_award_outlays_ignores_future_faba(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, LATE_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["spending"]["award_outlays"] == Decimal("0.35")
+    assert resp.data["spending"]["award_outlays"] == Decimal("0.55")

--- a/usaspending_api/disaster/tests/integration/test_overview.py
+++ b/usaspending_api/disaster/tests/integration/test_overview.py
@@ -188,7 +188,7 @@ def test_award_obligation_adds_values(
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
     assert resp.data["spending"]["award_obligations"] == Decimal("2.3")
-    assert resp.data["spending"]["award_outlays"] == Decimal("1.75")
+    assert resp.data["spending"]["award_outlays"] == Decimal("1.15")
 
 
 @pytest.mark.django_db
@@ -199,7 +199,7 @@ def test_faba_excludes_non_selected_defc(
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL + "?def_codes=M,N")
     assert resp.data["spending"]["award_obligations"] == Decimal("1.6")
-    assert resp.data["spending"]["award_outlays"] == Decimal("1.1")
+    assert resp.data["spending"]["award_outlays"] == Decimal("0.8")
 
 
 @pytest.mark.django_db
@@ -209,7 +209,7 @@ def test_award_outlays_sum_multiple_years(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, EARLY_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["spending"]["award_outlays"] == Decimal("1.65")
+    assert resp.data["spending"]["award_outlays"] == Decimal("1.15")
 
 
 @pytest.mark.django_db
@@ -219,7 +219,7 @@ def test_award_outlays_doesnt_sum_multiple_periods(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, LATE_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["spending"]["award_outlays"] == Decimal("1.0")
+    assert resp.data["spending"]["award_outlays"] == Decimal("0.8")
 
 
 @pytest.mark.django_db
@@ -229,4 +229,4 @@ def test_award_outlays_ignores_future_faba(
     helpers.patch_datetime_now(monkeypatch, LATE_YEAR, LATE_MONTH, 25)
     helpers.reset_dabs_cache()
     resp = client.get(OVERVIEW_URL)
-    assert resp.data["spending"]["award_outlays"] == Decimal("0.55")
+    assert resp.data["spending"]["award_outlays"] == Decimal("0.35")

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -92,7 +92,13 @@ class OverviewViewSet(DisasterBase):
         return (
             latest_faba_of_each_year_queryset()
             .filter(disaster_emergency_fund__in=self.defc)
-            .aggregate(total=Sum("gross_outlay_amount_by_award_cpe"))["total"]
+            .aggregate(
+                total=(
+                    Sum("gross_outlay_amount_by_award_cpe")
+                    + Sum("ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe")
+                    + Sum("ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe")
+                )
+            )["total"]
         ) or 0.0
 
     def total_obligations(self):


### PR DESCRIPTION
**Description:**
This PR updates the formula for award outlays on the `disaster/overview` based on the requirements in the ticket. Tests have also been updated

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6920](https://federal-spending-transparency.atlassian.net/browse/DEV-6920):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected API
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
