### PR TITLE
[DEV-6948] Stop generating assurance urls for non-existent submissions

### DIFF
--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -371,7 +371,7 @@ def test_pagination(setup_test_data, client):
             "toptier_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-07-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 20.0,
@@ -531,7 +531,7 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "toptier_code": "123",
             "agency_id": 1,
             "current_total_budget_authority_amount": 22478810.97,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,

--- a/usaspending_api/reporting/tests/integration/test_agencies_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_overview.py
@@ -13,7 +13,8 @@ from usaspending_api.common.helpers.fiscal_year_helpers import (
 url = "/api/v2/reporting/agencies/overview/"
 
 CURRENT_FISCAL_YEAR = current_fiscal_year()
-CURRENT_LAST_PERIOD = get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 3
+CURRENT_LAST_QUARTER = calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR) or 1
+CURRENT_LAST_PERIOD = get_final_period_of_quarter(CURRENT_LAST_QUARTER) or 3
 
 assurance_statement_1 = (
     f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/"
@@ -26,29 +27,40 @@ assurance_statement_2 = (
 )
 assurance_statement_3 = (
     f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/"
-    f"{CURRENT_FISCAL_YEAR}/P{CURRENT_LAST_PERIOD:02}/001%20-%20Test%20Agency%203%20(AAA)/"
-    f"{CURRENT_FISCAL_YEAR}-P{CURRENT_LAST_PERIOD:02}-001_Test%20Agency%203%20(AAA)-Assurance_Statement.txt"
+    f"{CURRENT_FISCAL_YEAR}/Q{CURRENT_LAST_QUARTER}/001%20-%20Test%20Agency%203%20(AAA)/"
+    f"{CURRENT_FISCAL_YEAR}-Q{CURRENT_LAST_QUARTER}-001_Test%20Agency%203%20(AAA)-Assurance_Statement.txt"
 )
-assurance_statement_1_2 = (
-    f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/"
-    f"{CURRENT_FISCAL_YEAR}/P{CURRENT_LAST_PERIOD:02}/123%20-%20Test%20Agency%20(ABC)/"
-    f"{CURRENT_FISCAL_YEAR}-P{CURRENT_LAST_PERIOD:02}-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
-)
-assurance_statement_2_2 = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2019/P06/987%20-%20Test%20Agency%202%20(XYZ)/2019-P06-987_Test%20Agency%202%20(XYZ)-Assurance_Statement.txt"
-assurance_statement_3_2 = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2019/P06/001%20-%20Test%20Agency%203%20(AAA)/2019-P06-001_Test%20Agency%203%20(AAA)-Assurance_Statement.txt"
 
 
 @pytest.fixture
 def setup_test_data(db):
     """ Insert data into DB for testing """
     sub = mommy.make(
-        "submissions.SubmissionAttributes", submission_id=1, reporting_fiscal_year=2019, reporting_fiscal_period=6
+        "submissions.SubmissionAttributes",
+        submission_id=1,
+        toptier_code="123",
+        quarter_format_flag=False,
+        reporting_fiscal_year=2019,
+        reporting_fiscal_period=6,
+        published_date="2019-07-03",
     )
     sub2 = mommy.make(
         "submissions.SubmissionAttributes",
         submission_id=2,
+        toptier_code="987",
+        quarter_format_flag=False,
         reporting_fiscal_year=CURRENT_FISCAL_YEAR,
         reporting_fiscal_period=CURRENT_LAST_PERIOD,
+        published_date=f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07",
+    )
+    sub3 = mommy.make(
+        "submissions.SubmissionAttributes",
+        submission_id=3,
+        toptier_code="001",
+        quarter_format_flag=True,
+        reporting_fiscal_year=CURRENT_FISCAL_YEAR,
+        reporting_fiscal_period=CURRENT_LAST_PERIOD,
+        published_date=f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07",
     )
     mommy.make("references.Agency", id=1, toptier_agency_id=1, toptier_flag=True)
     mommy.make("references.Agency", id=2, toptier_agency_id=2, toptier_flag=True)
@@ -95,8 +107,8 @@ def setup_test_data(db):
     ]
     approps = [
         {"sub_id": sub.submission_id, "treasury_account": treas_accounts[0], "total_resources": 50},
-        {"sub_id": sub.submission_id, "treasury_account": treas_accounts[1], "total_resources": 12},
-        {"sub_id": sub2.submission_id, "treasury_account": treas_accounts[1], "total_resources": 29},
+        {"sub_id": sub3.submission_id, "treasury_account": treas_accounts[1], "total_resources": 12},
+        {"sub_id": sub3.submission_id, "treasury_account": treas_accounts[1], "total_resources": 29},
         {"sub_id": sub2.submission_id, "treasury_account": treas_accounts[2], "total_resources": 15.5},
     ]
     for approp in approps:
@@ -144,7 +156,7 @@ def setup_test_data(db):
     mommy.make(
         "reporting.ReportingAgencyOverview",
         reporting_agency_overview_id=1,
-        toptier_code=123,
+        toptier_code="123",
         fiscal_year=2019,
         fiscal_period=6,
         total_dollars_obligated_gtas=1788370.03,
@@ -158,7 +170,7 @@ def setup_test_data(db):
     mommy.make(
         "reporting.ReportingAgencyOverview",
         reporting_agency_overview_id=2,
-        toptier_code=987,
+        toptier_code="987",
         fiscal_year=CURRENT_FISCAL_YEAR,
         fiscal_period=CURRENT_LAST_PERIOD,
         total_dollars_obligated_gtas=18.6,
@@ -185,7 +197,7 @@ def setup_test_data(db):
     )
     mommy.make(
         "reporting.ReportingAgencyMissingTas",
-        toptier_code=123,
+        toptier_code="123",
         fiscal_year=2019,
         fiscal_period=6,
         tas_rendering_label="TAS 1",
@@ -193,7 +205,7 @@ def setup_test_data(db):
     )
     mommy.make(
         "reporting.ReportingAgencyMissingTas",
-        toptier_code=123,
+        toptier_code="123",
         fiscal_year=2019,
         fiscal_period=6,
         tas_rendering_label="TAS 2",
@@ -201,7 +213,7 @@ def setup_test_data(db):
     )
     mommy.make(
         "reporting.ReportingAgencyMissingTas",
-        toptier_code=987,
+        toptier_code="987",
         fiscal_year=CURRENT_FISCAL_YEAR,
         fiscal_period=CURRENT_LAST_PERIOD,
         tas_rendering_label="TAS 2",
@@ -209,7 +221,7 @@ def setup_test_data(db):
     )
     mommy.make(
         "reporting.ReportingAgencyMissingTas",
-        toptier_code=987,
+        toptier_code="987",
         fiscal_year=current_fiscal_year(),
         fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(current_fiscal_year())) or 3,
         tas_rendering_label="TAS 3",
@@ -240,7 +252,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
+            "assurance_statement_url": None,
         },
         {
             "agency_name": "Test Agency 2",
@@ -248,7 +260,7 @@ def test_basic_success(setup_test_data, client):
             "toptier_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -267,7 +279,7 @@ def test_basic_success(setup_test_data, client):
             "toptier_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 20.0,
@@ -292,7 +304,7 @@ def test_filter(setup_test_data, client):
             "toptier_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -343,7 +355,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
+            "assurance_statement_url": None,
         }
     ]
     assert response["results"] == expected_results
@@ -359,7 +371,7 @@ def test_pagination(setup_test_data, client):
             "toptier_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -397,7 +409,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
+            "assurance_statement_url": None,
         },
         {
             "agency_name": "Test Agency 3",
@@ -405,7 +417,7 @@ def test_pagination(setup_test_data, client):
             "toptier_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 20.0,
@@ -424,7 +436,7 @@ def test_pagination(setup_test_data, client):
             "toptier_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -451,7 +463,7 @@ def test_pagination(setup_test_data, client):
             "toptier_code": "987",
             "agency_id": 2,
             "current_total_budget_authority_amount": 100.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -470,7 +482,7 @@ def test_pagination(setup_test_data, client):
             "toptier_code": "001",
             "agency_id": 3,
             "current_total_budget_authority_amount": 10.0,
-            "recent_publication_date": None,
+            "recent_publication_date": f"{CURRENT_FISCAL_YEAR}-{CURRENT_LAST_PERIOD+1:02}-07T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 20.0,
@@ -500,7 +512,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_1_2,
+            "assurance_statement_url": None,
         },
     ]
     assert response["results"] == expected_results
@@ -530,7 +542,7 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_2_2,
+            "assurance_statement_url": None,
         },
         {
             "agency_name": "Test Agency 3",
@@ -549,7 +561,7 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
-            "assurance_statement_url": assurance_statement_3_2,
+            "assurance_statement_url": None,
         },
         {
             "agency_name": "Test Agency",
@@ -557,7 +569,7 @@ def test_fiscal_year_period_selection(setup_test_data, client):
             "toptier_code": "123",
             "agency_id": 1,
             "current_total_budget_authority_amount": 22478810.97,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -13,10 +13,22 @@ url = "/api/v2/reporting/agencies/123/overview/"
 def setup_test_data(db):
     """ Insert data into DB for testing """
     sub = mommy.make(
-        "submissions.SubmissionAttributes", submission_id=1, reporting_fiscal_year=2019, reporting_fiscal_period=6
+        "submissions.SubmissionAttributes",
+        submission_id=1,
+        toptier_code="123",
+        quarter_format_flag=False,
+        reporting_fiscal_year=2019,
+        reporting_fiscal_period=6,
+        published_date="2019-07-03",
     )
     sub2 = mommy.make(
-        "submissions.SubmissionAttributes", submission_id=2, reporting_fiscal_year=2020, reporting_fiscal_period=12
+        "submissions.SubmissionAttributes",
+        submission_id=2,
+        toptier_code="123",
+        quarter_format_flag=False,
+        reporting_fiscal_year=2020,
+        reporting_fiscal_period=12,
+        published_date="2021-02-11",
     )
     agency = mommy.make("references.ToptierAgency", toptier_code="123", abbreviation="ABC", name="Test Agency")
 
@@ -192,11 +204,8 @@ def setup_test_data(db):
     )
 
 
-assurance_statement_2019_10 = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2019/P10/123%20-%20Test%20Agency%20(ABC)/2019-P10-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
-assurance_statement_2019_9 = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2019/P09/123%20-%20Test%20Agency%20(ABC)/2019-P09-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
 assurance_statement_2019_6 = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2019/P06/123%20-%20Test%20Agency%20(ABC)/2019-P06-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
 assurance_statement_2020_12 = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2020/P12/123%20-%20Test%20Agency%20(ABC)/2020-P12-123_Test%20Agency%20(ABC)-Assurance_Statement.txt"
-
 assurance_statement_quarter = f"{settings.FILES_SERVER_BASE_URL}/agency_submissions/Raw%20DATA%20Act%20Files/2019/Q3/123%20-%20Quarterly%20Agency%20(QA)/2019-Q3-123_Quarterly%20Agency%20(QA)-Assurance_Statement.txt"
 
 
@@ -223,7 +232,7 @@ def test_basic_success(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2019,
@@ -231,7 +240,7 @@ def test_basic_success(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,
@@ -250,7 +259,7 @@ def test_basic_success(setup_test_data, client):
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
             "percent_of_total_budgetary_resources": 0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-02-11T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -279,7 +288,7 @@ def test_pagination(setup_test_data, client):
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
             "percent_of_total_budgetary_resources": 0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-02-11T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -298,7 +307,7 @@ def test_pagination(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,
@@ -328,7 +337,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         },
     ]
     assert response["results"] == expected_results
@@ -354,7 +363,7 @@ def test_pagination(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         }
     ]
     assert response["results"] == expected_results
@@ -369,7 +378,7 @@ def test_pagination(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,
@@ -398,7 +407,7 @@ def test_secondary_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,
@@ -428,7 +437,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2020,
@@ -436,7 +445,7 @@ def test_secondary_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
             "percent_of_total_budgetary_resources": 0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-02-11T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -474,7 +483,7 @@ def test_secondary_sort(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2019,
@@ -482,7 +491,7 @@ def test_secondary_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,
@@ -501,7 +510,7 @@ def test_secondary_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000,
             "percent_of_total_budgetary_resources": 0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-02-11T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -567,7 +576,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000.0,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,
@@ -597,7 +606,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2019,
@@ -616,7 +625,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 4,
             "unlinked_assistance_award_count": 6,
-            "assurance_statement_url": assurance_statement_2019_10,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2020,
@@ -624,7 +633,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000.0,
             "percent_of_total_budgetary_resources": 0.0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-02-11T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -651,7 +660,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 100.0,
             "total_budgetary_resources": 100000000.0,
             "percent_of_total_budgetary_resources": 0.0,
-            "recent_publication_date": None,
+            "recent_publication_date": "2021-02-11T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 18.6,
@@ -681,7 +690,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "obligation_difference": 0.0,
             "unlinked_contract_award_count": 4,
             "unlinked_assistance_award_count": 6,
-            "assurance_statement_url": assurance_statement_2019_10,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2019,
@@ -700,7 +709,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "obligation_difference": 84931.96,
             "unlinked_contract_award_count": 400,
             "unlinked_assistance_award_count": 600,
-            "assurance_statement_url": assurance_statement_2019_9,
+            "assurance_statement_url": None,
         },
         {
             "fiscal_year": 2019,
@@ -708,7 +717,7 @@ def test_secondary_period_sort(setup_test_data, client):
             "current_total_budget_authority_amount": 22478810.97,
             "total_budgetary_resources": 200000000.0,
             "percent_of_total_budgetary_resources": 11.24,
-            "recent_publication_date": None,
+            "recent_publication_date": "2019-07-03T00:00:00Z",
             "recent_publication_date_certified": False,
             "tas_account_discrepancies_totals": {
                 "gtas_obligation_total": 1788370.03,

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -183,7 +183,9 @@ class AgenciesOverview(AgencyBase, PaginationMixin):
                 "obligation_difference": result["obligation_difference"],
                 "unlinked_contract_award_count": result["unlinked_contract_award_count"],
                 "unlinked_assistance_award_count": result["unlinked_assistance_award_count"],
-                "assurance_statement_url": self.create_assurance_statement_url(result),
+                "assurance_statement_url": self.create_assurance_statement_url(result)
+                if result["recent_publication_date"]
+                else None,
             }
             for result in result_list
         ]

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -145,7 +145,9 @@ class AgencyOverview(AgencyBase, PaginationMixin):
                 + result["unlinked_procurement_d_awards"],
                 "unlinked_assistance_award_count": result["unlinked_assistance_c_awards"]
                 + result["unlinked_assistance_d_awards"],
-                "assurance_statement_url": self.create_assurance_statement_url(result),
+                "assurance_statement_url": self.create_assurance_statement_url(result)
+                if result["recent_publication_date"]
+                else None,
             }
             for result in result_list
         ]


### PR DESCRIPTION
**Description:**
The logic to generate Assurance Statement (aka Agency Comment File) URLs was running regardless if the submission existed

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A, code matches contracts better now)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6948](https://federal-spending-transparency.atlassian.net/browse/DEV-6948):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected API (minimal impact, might have slightly helped)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to materialized views, operations, or API schema
```
