### PR TITLE
[DEV-6932] Update downloads to use new COVID outlay calculation

### DIFF
--- a/usaspending_api/download/helpers/disaster_filter_functions.py
+++ b/usaspending_api/download/helpers/disaster_filter_functions.py
@@ -46,7 +46,12 @@ def disaster_filter_function(filters: dict, download_type: str, values: List[str
         "inner_outlay": Coalesce(
             Sum(
                 Case(
-                    When(filter_by_latest_closed_periods(), then=F("gross_outlay_amount_by_award_cpe")),
+                    When(
+                        filter_by_latest_closed_periods(),
+                        then=Coalesce(F("gross_outlay_amount_by_award_cpe"), 0)
+                        + Coalesce(F("ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe"), 0)
+                        + Coalesce(F("ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe"), 0),
+                    ),
                     default=Value(0),
                 )
             ),


### PR DESCRIPTION
**Description:**
Many different downloads (excluding COVID Page Download and Custom Account Download) need to use the new COVID Outlay calculation.

**Technical details:**
Update the annotations to use the new calculation for COVID outlay. Also moved around the COVID Obligation and Outlay subqueries for Download Annotations for more re-use.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6932](https://federal-spending-transparency.atlassian.net/browse/DEV-6932):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
