### PR TITLE
[DEV-6922] Fix outlay calculations

### DIFF
--- a/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
@@ -475,6 +475,8 @@ def disaster_account_data():
         transaction_obligated_amount=2,
         gross_outlay_amount_by_award_cpe=20000000,
         distinct_award_key=0,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -485,6 +487,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=2000000,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -495,6 +499,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=200000,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -505,6 +511,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=10000,
         award=a1,
         distinct_award_key=1,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -515,6 +523,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=10000,
         award=a1,
         distinct_award_key=1,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -525,6 +535,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=2000,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -535,6 +547,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=200,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -545,6 +559,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=20,
         award=a2,
         distinct_award_key=2,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -555,6 +571,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=2,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -565,6 +583,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=0,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -575,6 +595,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=2000000,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -585,6 +607,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=200000,
         award=a3,
         distinct_award_key=3,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -595,6 +619,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=200000000,
         award=a4,
         distinct_award_key=4,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         faba,
@@ -605,6 +631,8 @@ def disaster_account_data():
         gross_outlay_amount_by_award_cpe=20,
         award=a1,
         distinct_award_key=1,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
 
     mommy.make(

--- a/usaspending_api/disaster/tests/fixtures/federal_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/federal_account_data.py
@@ -162,6 +162,8 @@ def generic_account_data():
         disaster_emergency_fund=defc_m,
         treasury_account=tre_acct1,
         distinct_award_key="0wefjwe|3443r||",
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         "awards.FinancialAccountsByAwards",
@@ -175,6 +177,8 @@ def generic_account_data():
         disaster_emergency_fund=defc_l,
         treasury_account=tre_acct2,
         distinct_award_key="0wefjwe|3443r||",
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         "awards.FinancialAccountsByAwards",
@@ -187,6 +191,8 @@ def generic_account_data():
         disaster_emergency_fund=defc_9,
         treasury_account=tre_acct2,
         distinct_award_key="|||3298rhed",
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         "awards.FinancialAccountsByAwards",
@@ -199,6 +205,8 @@ def generic_account_data():
         disaster_emergency_fund=defc_o,
         treasury_account=tre_acct2,
         distinct_award_key="||43tgfvdvfv|",
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         "awards.FinancialAccountsByAwards",
@@ -211,6 +219,8 @@ def generic_account_data():
         disaster_emergency_fund=defc_n,
         treasury_account=tre_acct3,
         distinct_award_key="||woefhowe|",
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
     mommy.make(
         "references.GTASSF133Balances",

--- a/usaspending_api/disaster/tests/fixtures/object_class_data.py
+++ b/usaspending_api/disaster/tests/fixtures/object_class_data.py
@@ -21,6 +21,8 @@ def basic_faba_with_object_class(award_count_sub_schedule, award_count_submissio
         submission=SubmissionAttributes.objects.all().first(),
         object_class=basic_object_class[0],
         transaction_obligated_amount=1,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
 
 
@@ -165,6 +167,8 @@ def faba_with_object_class_and_two_awards(award_count_sub_schedule, award_count_
         submission=SubmissionAttributes.objects.all().first(),
         object_class=basic_object_class[0],
         transaction_obligated_amount=1,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=0,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=0,
     )
 
     mommy.make(

--- a/usaspending_api/disaster/tests/integration/test_federal_account_award.py
+++ b/usaspending_api/disaster/tests/integration/test_federal_account_award.py
@@ -1,8 +1,12 @@
 import pytest
+from model_mommy import mommy
 
 from rest_framework import status
 
+from usaspending_api.accounts.models import TreasuryAppropriationAccount
+from usaspending_api.references.models import DisasterEmergencyFundCode
 from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
+from usaspending_api.submissions.models import SubmissionAttributes
 
 url = "/api/v2/disaster/federal_account/spending/"
 
@@ -123,6 +127,59 @@ def test_federal_account_award_query(client, generic_account_data, monkeypatch, 
             "id": 21,
             "obligation": 100.0,
             "outlay": 111.0,
+            "total_budgetary_resources": None,
+        }
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+
+@pytest.mark.django_db
+def test_outlay_calculations(client, generic_account_data, monkeypatch, helpers, elasticsearch_account_index):
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
+
+    helpers.reset_dabs_cache()
+    sub = SubmissionAttributes.objects.get(
+        reporting_fiscal_year=2022, reporting_fiscal_quarter=3, reporting_fiscal_period=7
+    )
+    defc_l = DisasterEmergencyFundCode.objects.get(code="L")
+    ta = TreasuryAppropriationAccount.objects.get(account_title="flowers")
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        submission=sub,
+        fain="43tgfvdvfv",
+        award_id=333,
+        transaction_obligated_amount=1,
+        gross_outlay_amount_by_award_cpe=100,
+        disaster_emergency_fund=defc_l,
+        treasury_account=ta,
+        distinct_award_key="||43tgfvdvfv|",
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=-3,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=-6,
+    )
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
+    resp = helpers.post_for_spending_endpoint(
+        client, url, query="flowers", def_codes=["L"], spending_type="award", sort="outlay"
+    )
+    expected_results = [
+        {
+            "children": [
+                {
+                    "code": "2020/99",
+                    "award_count": 1,
+                    "description": "flowers",
+                    "id": 22,
+                    "obligation": 1.0,
+                    "outlay": 91.0,
+                    "total_budgetary_resources": None,
+                }
+            ],
+            "code": "000-0000",
+            "award_count": 1,
+            "description": "gifts",
+            "id": 21,
+            "obligation": 1.0,
+            "outlay": 91.0,
             "total_budgetary_resources": None,
         }
     ]

--- a/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
+++ b/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
@@ -1,8 +1,13 @@
 import pytest
+from model_mommy import mommy
 
 from rest_framework import status
 
+from usaspending_api.disaster.tests.fixtures.object_class_data import major_object_class_with_children
+from usaspending_api.disaster.v2.views.disaster_base import COVID_19_GROUP_NAME
+from usaspending_api.references.models import DisasterEmergencyFundCode
 from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
+from usaspending_api.submissions.models import SubmissionAttributes
 
 url = "/api/v2/disaster/object_class/spending/"
 
@@ -131,4 +136,51 @@ def test_object_class_query(client, elasticsearch_account_index, basic_faba_with
     assert resp.json()["results"] == expected_results
 
     expected_totals = {"award_count": 1, "obligation": 1.0, "outlay": 0}
+    assert resp.json()["totals"] == expected_totals
+
+
+@pytest.mark.django_db
+def test_outlay_calculations(client, elasticsearch_account_index, basic_faba_with_object_class, monkeypatch, helpers):
+    oc = major_object_class_with_children("001", [1])
+    mommy.make("references.DisasterEmergencyFundCode", code="L", group_name=COVID_19_GROUP_NAME),
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code="L").first(),
+        submission=SubmissionAttributes.objects.all().first(),
+        object_class=oc[0],
+        transaction_obligated_amount=1,
+        gross_outlay_amount_by_award_cpe=100,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=-3,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=-6,
+    )
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
+    helpers.reset_dabs_cache()
+
+    resp = helpers.post_for_spending_endpoint(client, url, query="001 name", def_codes=["L"], spending_type="award")
+    expected_results = [
+        {
+            "id": "001",
+            "code": "001",
+            "description": "001 name",
+            "award_count": 1,
+            "obligation": 1.0,
+            "outlay": 91.0,
+            "children": [
+                {
+                    "id": "1",
+                    "code": "0001",
+                    "description": "0001 name",
+                    "award_count": 1,
+                    "obligation": 1.0,
+                    "outlay": 91.0,
+                }
+            ],
+        }
+    ]
+    print(resp.json())
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+    expected_totals = {"award_count": 1, "obligation": 1.0, "outlay": 91.0}
     assert resp.json()["totals"] == expected_totals

--- a/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
@@ -110,9 +110,10 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         )
         sum_covid_outlay = A(
             "sum",
-            script="doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? ( ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0",
-            # field="gross_outlay_amount_by_award_cpe",
-            # script={"source": "doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? _value : 0"},
+            script="""doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? (
+             ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0)
+              + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
+              + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0""",
         )
         sum_covid_obligation = A("sum", field="financial_accounts_by_award.transaction_obligated_amount")
         count_awards_by_dim = A("reverse_nested", **{})
@@ -168,8 +169,9 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         )
         sub_sum_covid_outlay = A(
             "sum",
-            # field="financial_accounts_by_award.gross_outlay_amount_by_award_cpe",
-            script="doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? ( ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0",
+            script="""doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? ( ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0)
+             + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
+             + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0""",
         )
         sub_sum_covid_obligation = A("sum", field="financial_accounts_by_award.transaction_obligated_amount")
         sub_count_awards_by_dim = A("reverse_nested", **{})

--- a/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
@@ -110,8 +110,9 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         )
         sum_covid_outlay = A(
             "sum",
-            field="financial_accounts_by_award.gross_outlay_amount_by_award_cpe",
-            script={"source": "doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? _value : 0"},
+            script="doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? ( ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0",
+            # field="gross_outlay_amount_by_award_cpe",
+            # script={"source": "doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? _value : 0"},
         )
         sum_covid_obligation = A("sum", field="financial_accounts_by_award.transaction_obligated_amount")
         count_awards_by_dim = A("reverse_nested", **{})
@@ -167,8 +168,8 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         )
         sub_sum_covid_outlay = A(
             "sum",
-            field="financial_accounts_by_award.gross_outlay_amount_by_award_cpe",
-            script={"source": "doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? _value : 0"},
+            # field="financial_accounts_by_award.gross_outlay_amount_by_award_cpe",
+            script="doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? ( ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0) + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0",
         )
         sub_sum_covid_obligation = A("sum", field="financial_accounts_by_award.transaction_obligated_amount")
         sub_count_awards_by_dim = A("reverse_nested", **{})

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -97,7 +97,11 @@ def transform_covid19_faba_data(worker: TaskSpec, records: List[dict]) -> List[d
         generated_unique_award_id = record.pop("generated_unique_award_id")
         total_loan_value = record.pop("total_loan_value")
         obligated_sum = record.get("transaction_obligated_amount") or 0  # record value for key may be None
-        outlay_sum = record.get("gross_outlay_amount_by_award_cpe") or 0  # record value for key may be None
+        outlay_sum = (
+            (record.get("gross_outlay_amount_by_award_cpe") or 0)
+            + (record.get("ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe") or 0)
+            + (record.get("ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe") or 0)
+        )  # record value for key may be None
         temp_key = disinct_award_key
         if temp_key not in results:
             results[temp_key] = {

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -101,7 +101,7 @@ def transform_covid19_faba_data(worker: TaskSpec, records: List[dict]) -> List[d
             (record.get("gross_outlay_amount_by_award_cpe") or 0)
             + (record.get("ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe") or 0)
             + (record.get("ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe") or 0)
-        )  # record value for key may be None
+        )  # record value for any key may be None
         temp_key = disinct_award_key
         if temp_key not in results:
             results[temp_key] = {


### PR DESCRIPTION
**Description:**
Changes the method used to calculate how the outlay amounts are calculated on the COVID-19 profile page for endpoints using the Accounts ES index

**Technical details:**
Instead of just summing the `gross_outlay_amount_by_award_cpe` field, we also add the `ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe` and `ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe` fields
**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-6922](https://federal-spending-transparency.atlassian.net/browse/DEV-6922):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
