### PR TITLE
[DEV-6936] Updates to DABS ETL for loading additional File C records

### DIFF
--- a/usaspending_api/etl/management/sql/dev3627_compare_dabs_row_counts.sql
+++ b/usaspending_api/etl/management/sql/dev3627_compare_dabs_row_counts.sql
@@ -104,11 +104,10 @@ INNER JOIN dblink(
             WHERE (
                 submission_id = s.submission_id
                 AND (
-                        COALESCE(caf.transaction_obligated_amou, 0) != 0
-                        OR COALESCE(caf.gross_outlay_amount_by_awa_cpe, 0) != 0
-                        OR COALESCE(caf.ussgl487200_downward_adjus_cpe, 0) != 0
-                        OR COALESCE(caf.ussgl497200_downward_adjus_cpe, 0) != 0
-                    )
+                    COALESCE(caf.transaction_obligated_amou, 0) != 0
+                    OR COALESCE(caf.gross_outlay_amount_by_awa_cpe, 0) != 0
+                    OR COALESCE(caf.ussgl487200_downward_adjus_cpe, 0) != 0
+                    OR COALESCE(caf.ussgl497200_downward_adjus_cpe, 0) != 0
                 )
             )
         ) AS count_file_c

--- a/usaspending_api/etl/management/sql/dev3627_compare_dabs_row_counts.sql
+++ b/usaspending_api/etl/management/sql/dev3627_compare_dabs_row_counts.sql
@@ -104,12 +104,10 @@ INNER JOIN dblink(
             WHERE (
                 submission_id = s.submission_id
                 AND (
-                    (
-                        caf.transaction_obligated_amou IS NOT NULL
-                        AND caf.transaction_obligated_amou != 0
-                    ) OR (
-                            caf.gross_outlay_amount_by_awa_cpe IS NOT NULL AND
-                            caf.gross_outlay_amount_by_awa_cpe != 0
+                        COALESCE(caf.transaction_obligated_amou, 0) != 0
+                        OR COALESCE(caf.gross_outlay_amount_by_awa_cpe, 0) != 0
+                        OR COALESCE(caf.ussgl487200_downward_adjus_cpe, 0) != 0
+                        OR COALESCE(caf.ussgl497200_downward_adjus_cpe, 0) != 0
                     )
                 )
             )

--- a/usaspending_api/etl/submission_loader_helpers/file_c.py
+++ b/usaspending_api/etl/submission_loader_helpers/file_c.py
@@ -99,13 +99,10 @@ class CertifiedAwardFinancial:
                     inner join submission s on s.submission_id = c.submission_id
             where   s.submission_id = {submission_id} and
                     (
-                        (
-                            c.transaction_obligated_amou is not null and
-                            c.transaction_obligated_amou != 0
-                        ) or (
-                            c.gross_outlay_amount_by_awa_cpe is not null and
-                            c.gross_outlay_amount_by_awa_cpe != 0
-                        )
+                        COALESCE(c.transaction_obligated_amou, 0) != 0
+                        or COALESCE(c.gross_outlay_amount_by_awa_cpe, 0) != 0
+                        or COALESCE(c.ussgl487200_downward_adjus_cpe, 0) != 0
+                        or COALESCE(c.ussgl497200_downward_adjus_cpe, 0) != 0
                     )
         """
 

--- a/usaspending_api/etl/tests/integration/test_load_multiple_submissions.py
+++ b/usaspending_api/etl/tests/integration/test_load_multiple_submissions.py
@@ -248,25 +248,27 @@ class TestWithMultipleDatabases(TransactionTestCase):
                     object_class,
                     gross_outlay_amount_by_awa_cpe,
                     transaction_obligated_amou,
+                    ussgl487200_downward_adjus_cpe,
+                    ussgl497200_downward_adjus_cpe,
                     disaster_emergency_fund_code
                 ) (values
-                    (1, 1, 1, '1101', 11111, 111110, null),
-                    (2, 1, 1, '1101', 22222, 222220, 'B'),
-                    (3, 1, 1, '1101', 33333, 333330, 'L'),
-                    (4, 2, 1, '1101', 44444, 444440, null),
-                    (5, 2, 1, '1101', 55555, 555550, null),
-                    (6, 2, 1, '1101', 66666, 666660, null),
-                    (7, 3, 2, '1101', 77777, 777770, 'L'),
-                    (8, 3, 2, '1101', 88888, 888880, 'L'),
-                    (9, 3, 2, '1101', 99999, 999990, 'L'),
-                    (10, 4, 2, '1101', 10101, 101010, null),
-                    (11, 5, 2, '1101', 11111, 111110, 'B'),
-                    (12, 5, 2, '1101', null, null, 'B'), -- this should not load because of 0/null values
-                    (13, 5, 2, '1101', 0, 0, 'B'), -- this should not load because of 0/null values
-                    (14, 5, 2, '1101', null, 0, 'B'), -- this should not load because of 0/null values
-                    (15, 5, 2, '1101', 0, null, 'B'), -- this should not load because of 0/null values
-                    (16, 6, 2, '1101', 12121, 121210, 'L'),
-                    (17, 7, 2, '1101', 13131, 131310, 'N')
+                    (1, 1, 1, '1101', 11111, 111110, -11, -111, null),
+                    (2, 1, 1, '1101', 22222, 222220, -22, -222, 'B'),
+                    (3, 1, 1, '1101', 33333, 333330, -33, -333, 'L'),
+                    (4, 2, 1, '1101', 44444, 444440, -44, -444, null),
+                    (5, 2, 1, '1101', 55555, 555550, -55, -555, null),
+                    (6, 2, 1, '1101', 66666, 666660, -66, -666, null),
+                    (7, 3, 2, '1101', 77777, 777770, -77, -777, 'L'),
+                    (8, 3, 2, '1101', 88888, 888880, -88, -888, 'L'),
+                    (9, 3, 2, '1101', 99999, 999990, -99, -999, 'L'),
+                    (10, 4, 2, '1101', 10101, 101010, -10, -101, null),
+                    (11, 5, 2, '1101', 11111, 111110, -11, -111, 'B'),
+                    (12, 5, 2, '1101', null, null, 0, 0, 'M'), -- this should not load because of 0/null values
+                    (13, 5, 2, '1101', 0, 0, null, 0, 'M'), -- this should not load because of 0/null values
+                    (14, 5, 2, '1101', null, 0, null, 0, 'M'), -- this should not load because of 0/null values
+                    (15, 5, 2, '1101', 0, null, 0, null, 'M'), -- this should not load because of 0/null values
+                    (16, 6, 2, '1101', 12121, 121210, -12, -121, 'L'),
+                    (17, 7, 2, '1101', 13131, 131310, -13, -131, 'N')
                 )
                 """
             )
@@ -395,11 +397,19 @@ class TestWithMultipleDatabases(TransactionTestCase):
                 """
                     select  sum(gross_outlay_amount_by_award_cpe),
                             sum(transaction_obligated_amount),
+                            sum(ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe),
+                            sum(ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe),
                             string_agg(disaster_emergency_fund_code, ',' order by disaster_emergency_fund_code)
                     from    financial_accounts_by_awards
                 """
             )
-            assert cursor.fetchone() == (Decimal("-521207.00"), Decimal("-5212070.00"), "B,B,L,L,L,L")
+            assert cursor.fetchone() == (
+                Decimal("-521207.00"),
+                Decimal("-5212070.00"),
+                Decimal("516.00"),
+                Decimal("5207.00"),
+                "B,B,L,L,L,L",
+            )
 
         # Nuke a submission.
         SubmissionAttributes.objects.filter(submission_id=1).delete()

--- a/usaspending_api/etl/tests/integration/test_load_multiple_submissions.py
+++ b/usaspending_api/etl/tests/integration/test_load_multiple_submissions.py
@@ -262,13 +262,14 @@ class TestWithMultipleDatabases(TransactionTestCase):
                     (8, 3, 2, '1101', 88888, 888880, -88, -888, 'L'),
                     (9, 3, 2, '1101', 99999, 999990, -99, -999, 'L'),
                     (10, 4, 2, '1101', 10101, 101010, -10, -101, null),
-                    (11, 5, 2, '1101', 11111, 111110, -11, -111, 'B'),
+                    (11, 5, 2, '1101', 11111, 111110, 0, 0, 'B'),
                     (12, 5, 2, '1101', null, null, 0, 0, 'M'), -- this should not load because of 0/null values
                     (13, 5, 2, '1101', 0, 0, null, 0, 'M'), -- this should not load because of 0/null values
                     (14, 5, 2, '1101', null, 0, null, 0, 'M'), -- this should not load because of 0/null values
                     (15, 5, 2, '1101', 0, null, 0, null, 'M'), -- this should not load because of 0/null values
                     (16, 6, 2, '1101', 12121, 121210, -12, -121, 'L'),
-                    (17, 7, 2, '1101', 13131, 131310, -13, -131, 'N')
+                    (17, 7, 2, '1101', 13131, 131310, -13, -131, 'N'),
+                    (18, 5, 2, '1101', 0, 0, 0, -1010, 'N')
                 )
                 """
             )
@@ -348,7 +349,7 @@ class TestWithMultipleDatabases(TransactionTestCase):
         assert SubmissionAttributes.objects.count() == 5
         assert AppropriationAccountBalances.objects.count() == 5
         assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 7
-        assert FinancialAccountsByAwards.objects.count() == 11
+        assert FinancialAccountsByAwards.objects.count() == 12
 
         # Now that we have everything loaded, let's make sure our data make sense.
         with connections[DEFAULT_DB_ALIAS].cursor() as cursor:
@@ -406,9 +407,9 @@ class TestWithMultipleDatabases(TransactionTestCase):
             assert cursor.fetchone() == (
                 Decimal("-521207.00"),
                 Decimal("-5212070.00"),
-                Decimal("516.00"),
-                Decimal("5207.00"),
-                "B,B,L,L,L,L",
+                Decimal("505.00"),
+                Decimal("6106.00"),
+                "B,B,L,L,L,L,N",
             )
 
         # Nuke a submission.
@@ -416,14 +417,14 @@ class TestWithMultipleDatabases(TransactionTestCase):
         assert SubmissionAttributes.objects.count() == 4
         assert AppropriationAccountBalances.objects.count() == 4
         assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 4
-        assert FinancialAccountsByAwards.objects.count() == 8
+        assert FinancialAccountsByAwards.objects.count() == 9
 
         # Make sure it reloads.
         call_command("load_multiple_submissions", "--incremental")
         assert SubmissionAttributes.objects.count() == 5
         assert AppropriationAccountBalances.objects.count() == 5
         assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 7
-        assert FinancialAccountsByAwards.objects.count() == 11
+        assert FinancialAccountsByAwards.objects.count() == 12
 
         # Make a change to a submission.
         SubmissionAttributes.objects.filter(submission_id=1).update(reporting_fiscal_year=1999)
@@ -445,7 +446,7 @@ class TestWithMultipleDatabases(TransactionTestCase):
         assert SubmissionAttributes.objects.count() == 4
         assert AppropriationAccountBalances.objects.count() == 4
         assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 4
-        assert FinancialAccountsByAwards.objects.count() == 8
+        assert FinancialAccountsByAwards.objects.count() == 9
 
         # Ok, after all the stuff we just did, let's make sure submissions 2 and 3 never got touched.
         assert SubmissionAttributes.objects.get(submission_id=2).update_date == update_date_sub_2


### PR DESCRIPTION
**Description:**
Added  non-null/non-zero checks to the values of two additional columns in File C checks which excluded rows in the DABS ETL. 

- `ussgl487200_downward_adjus_cpe` (`ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe` in USAspending)
- `ussgl497200_downward_adjus_cpe ` (`ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe` in USAspending)  

Originally only `transaction_obligated_amou ` and `gross_outlay_amount_by_awa_cpe ` were examined 

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6936](https://federal-spending-transparency.atlassian.net/browse/DEV-6936):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (N/A)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to API or materialized views
```
