### PR TITLE
Small cleanup around ES ETL config

### DIFF
--- a/usaspending_api/etl/es_config_objects.json
+++ b/usaspending_api/etl/es_config_objects.json
@@ -1,13 +1,5 @@
 {
-	"cluster": {
-		"transient" : {},
-		"persistent": {
-			"action.destructive_requires_name": true
-		}
-	},
-	"settings": {
-		"index.max_result_window" : null
-	},
+	"cluster": {},
 	"final_index_settings": {
 		"number_of_replicas": 1,
 		"refresh_interval": "1s"

--- a/usaspending_api/etl/management/commands/es_configure.py
+++ b/usaspending_api/etl/management/commands/es_configure.py
@@ -52,15 +52,15 @@ class Command(BaseCommand):
         if options["load_type"] in ("award", "awards"):
             self.index_pattern = f"*{settings.ES_AWARDS_NAME_SUFFIX}"
             self.max_result_window = settings.ES_AWARDS_MAX_RESULT_WINDOW
-            self.template = "award_template"
+            self.template_name = "award_template"
         elif options["load_type"] in ("transaction", "transactions"):
             self.index_pattern = f"*{settings.ES_TRANSACTIONS_NAME_SUFFIX}"
             self.max_result_window = settings.ES_TRANSACTIONS_MAX_RESULT_WINDOW
-            self.template = "transaction_template"
+            self.template_name = "transaction_template"
         elif options["load_type"] == "covid19-faba":
             self.index_pattern = f"*{settings.ES_COVID19_FABA_NAME_SUFFIX}"
             self.max_result_window = settings.ES_COVID19_FABA_MAX_RESULT_WINDOW
-            self.template = "covid19_faba_template"
+            self.template_name = "covid19_faba_template"
         else:
             raise RuntimeError(f"No config for {options['load_type']}")
 
@@ -70,10 +70,8 @@ class Command(BaseCommand):
         if not options["template_only"] and cluster:
             self.run_curl_cmd(payload=cluster, url=CURL_COMMANDS["cluster"], host=settings.ES_HOSTNAME)
 
-        template_name = "{type}_template".format(type=self.load_type[:-1])
-
         self.run_curl_cmd(
-            payload=template, url=CURL_COMMANDS["template"], host=settings.ES_HOSTNAME, name=template_name
+            payload=template, url=CURL_COMMANDS["template"], host=settings.ES_HOSTNAME, name=self.template_name
         )
 
         logger.info(f"ES Configure took {perf_counter() - start:.2f}s")
@@ -93,7 +91,7 @@ class Command(BaseCommand):
         return es_config["cluster"]
 
     def get_index_template(self):
-        template = self.return_json_from_file(FILES[self.template])
+        template = self.return_json_from_file(FILES[self.template_name])
         template["index_patterns"] = [self.index_pattern]
         template["settings"]["index.max_result_window"] = self.max_result_window
         return template

--- a/usaspending_api/etl/management/commands/es_configure.py
+++ b/usaspending_api/etl/management/commands/es_configure.py
@@ -110,12 +110,3 @@ class Command(BaseCommand):
             json_to_dict = json.load(f)
 
         return json_to_dict
-
-
-def retrieve_index_template(template):
-    """This function is used for test configuration"""
-    with open(str(FILES[template])) as f:
-        mapping_dict = json.load(f)
-        template = json.dumps(mapping_dict)
-
-    return template


### PR DESCRIPTION
**Description:**
Elaticsearch template changes were not appearing in the correlating indexes due conflicting template names.

Additionally, some removed settings are not available for AWS managed Elasticsearch: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-es-operations.html#es_version_7_1

**Technical details:**
Taken from Staging --->
`_cat/templates`
> awar_template        [*awards]       0 
> transaction_template [*transactions] 0 
> covid19-fab_template [*covid19-faba] 0 
> transactio_template  [*transactions] 0 
> award_template       [*awards]       0 

`_template/transaction_template`
> ...
> "generated_unique_transaction_id" : {
>    "type" : "text"
> },
> ...

`_template/transactio_template`
> ...
> "generated_unique_transaction_id" : {
>    "type" : "keyword"
> },
> ...

Some minor cleanup to avoid these issues and remove settings from es_config that are no longer applicable since the move to AWS managed Elasticsearch a while back.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
