### PR TITLE
[DEV-6942] Award summary page covid outlay correction

### DIFF
--- a/usaspending_api/awards/v2/data_layer/sql.py
+++ b/usaspending_api/awards/v2/data_layer/sql.py
@@ -1,7 +1,9 @@
 defc_sql = """
     SELECT
         DISTINCT disaster_emergency_fund_code,
-        COALESCE(sum(CASE WHEN sa.is_final_balances_for_fy = TRUE THEN faba.gross_outlay_amount_by_award_cpe END), 0) AS total_outlay,
+        COALESCE(sum(CASE WHEN sa.is_final_balances_for_fy = TRUE THEN (COALESCE(faba.gross_outlay_amount_by_award_cpe,0)
+            + COALESCE(faba.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe, 0)
+            + COALESCE(faba.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe, 0)) END), 0) AS total_outlay,
         COALESCE(sum(faba.transaction_obligated_amount), 0) AS obligated_amount
     FROM
         financial_accounts_by_awards faba


### PR DESCRIPTION
**Description:**
Corrects the calculation of the COVID-19 outlayed amount on the award summary page.

**Technical details:**
Adds the `ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe` and `ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe` to the `gross_outlay_amount_by_award_cpe` value.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3.  [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-6942](https://federal-spending-transparency.atlassian.net/browse/DEV-6942):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
