### PR TITLE
[DEV-6923] Add new fields to Custom Account Download

### DIFF
--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -135,15 +135,8 @@ def get_submission_filter(account_type, filters):
     return submission_filter
 
 
-def generate_gross_outlay_amount_derived_field(filters, account_type):
-    column_name = {
-        "account_balances": "gross_outlay_amount_by_tas_cpe",
-        "object_class_program_activity": "gross_outlay_amount_by_program_object_class_cpe",
-        "award_financial": "gross_outlay_amount_by_award_cpe",
-    }[account_type]
-
+def _generate_closed_period_for_derived_field(filters, column_name):
     filter_year = filters.get("fy")
-
     closed_periods = get_last_closed_periods_per_year()
 
     q = Q()
@@ -163,6 +156,26 @@ def generate_gross_outlay_amount_derived_field(filters, account_type):
     return Cast(Value(None), DecimalField(max_digits=23, decimal_places=2))
 
 
+def generate_ussgl487200_derived_field(filters):
+    column_name = "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe"
+    return _generate_closed_period_for_derived_field(filters, column_name)
+
+
+def generate_ussgl497200_derived_field(filters):
+    column_name = "ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe"
+    return _generate_closed_period_for_derived_field(filters, column_name)
+
+
+def generate_gross_outlay_amount_derived_field(filters, account_type):
+    column_name = {
+        "account_balances": "gross_outlay_amount_by_tas_cpe",
+        "object_class_program_activity": "gross_outlay_amount_by_program_object_class_cpe",
+        "award_financial": "gross_outlay_amount_by_award_cpe",
+    }[account_type]
+
+    return _generate_closed_period_for_derived_field(filters, column_name)
+
+
 def generate_treasury_account_query(queryset, account_type, tas_id, filters):
     """ Derive necessary fields for a treasury account-grouped query """
     derived_fields = {
@@ -173,9 +186,24 @@ def generate_treasury_account_query(queryset, account_type, tas_id, filters):
         "submission_period": get_fyp_or_q_notation("submission"),
         "gross_outlay_amount": generate_gross_outlay_amount_derived_field(filters, account_type),
         "gross_outlay_amount_fyb_to_period_end": generate_gross_outlay_amount_derived_field(filters, account_type),
+        "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe": generate_ussgl487200_derived_field(filters),
+        "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe": generate_ussgl497200_derived_field(filters),
     }
 
     lmd = "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR
+
+    if account_type != "account_balances":
+        derived_fields.update(
+            {
+                "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe": Sum(
+                    generate_ussgl487200_derived_field(filters)
+                ),
+                "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe": Sum(
+                    generate_ussgl497200_derived_field(filters)
+                ),
+            }
+        )
+
     if account_type == "award_financial":
         # Separating out last_modified_date like this prevents unnecessary grouping in the full File
         # C TAS download.  Keeping it as MAX caused grouping on every single column in the SQL statement.
@@ -201,6 +229,17 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
         "gross_outlay_amount_fyb_to_period_end": Sum(generate_gross_outlay_amount_derived_field(filters, account_type)),
     }
 
+    if account_type != "account_balances":
+        derived_fields.update(
+            {
+                "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe": Sum(
+                    generate_ussgl487200_derived_field(filters)
+                ),
+                "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe": Sum(
+                    generate_ussgl497200_derived_field(filters)
+                ),
+            }
+        )
     if account_type == "award_financial":
         derived_fields = award_financial_derivations(derived_fields)
 

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -186,8 +186,6 @@ def generate_treasury_account_query(queryset, account_type, tas_id, filters):
         "submission_period": get_fyp_or_q_notation("submission"),
         "gross_outlay_amount": generate_gross_outlay_amount_derived_field(filters, account_type),
         "gross_outlay_amount_fyb_to_period_end": generate_gross_outlay_amount_derived_field(filters, account_type),
-        "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe": generate_ussgl487200_derived_field(filters),
-        "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe": generate_ussgl497200_derived_field(filters),
     }
 
     lmd = "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1678,6 +1678,14 @@ query_paths = {
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
                     "deobligations_recoveries_refund_pri_program_object_class_cpe",
                 ),
+                (
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                ),  # Column is annotated in account_download.py
+                (
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
+                ),  # Column is annotated in account_download.py
                 ("gross_outlay_amount", "gross_outlay_amount"),  # Column is annotated in account_download.py
                 (
                     "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR,
@@ -1707,6 +1715,14 @@ query_paths = {
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
                 ),
+                (
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                ),  # Column is annotated in account_download.py
+                (
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
+                ),  # Column is annotated in account_download.py
                 ("gross_outlay_amount", "gross_outlay_amount"),  # Column is annotated in account_download.py
                 (
                     "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR,
@@ -1751,6 +1767,14 @@ query_paths = {
                 (
                     "gross_outlay_amount_fyb_to_period_end",
                     "gross_outlay_amount_fyb_to_period_end",
+                ),  # Column is annotated in account_download.py
+                (
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                ),  # Column is annotated in account_download.py
+                (
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
                 ),  # Column is annotated in account_download.py
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_id_piid", "piid"),
@@ -1857,6 +1881,14 @@ query_paths = {
                 (
                     "gross_outlay_amount_fyb_to_period_end",
                     "gross_outlay_amount_fyb_to_period_end",
+                ),  # Column is annotated in account_download.py
+                (
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
+                ),  # Column is annotated in account_download.py
+                (
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
+                    "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
                 ),  # Column is annotated in account_download.py
                 ("award_unique_key", "award__generated_unique_award_id"),
                 ("award_id_piid", "piid"),


### PR DESCRIPTION
**Description:**
Add new columns to File B and File C downloads for Custom Account Download.

**Technical details:**
Broke out some common logic used for the gross outlay columns to allow similar handling of closed periods for the new columns added in this PR. The new columns are only added to File B and File C downloads.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6923](https://federal-spending-transparency.atlassian.net/browse/DEV-6923):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
