### PR TITLE
[DEV-7004] Outlay calculation fix

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/mv_covid_financial_account.json
+++ b/usaspending_api/database_scripts/matview_generator/mv_covid_financial_account.json
@@ -24,7 +24,7 @@
     "    FABA.award_id,",
     "    ARRAY_AGG(DISTINCT FABA.disaster_emergency_fund_code ORDER BY FABA.disaster_emergency_fund_code) AS def_codes,",
     "    COALESCE(SUM(",
-    "      CASE WHEN SA.is_final_balances_for_fy = TRUE THEN FABA.gross_outlay_amount_by_award_cpe END",
+    "      CASE WHEN SA.is_final_balances_for_fy = TRUE THEN COALESCE(FABA.gross_outlay_amount_by_award_cpe,0) + COALESCE(FABA.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe,0) + COALESCE(FABA.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe,0) END",
     "    ), 0) AS outlay,",
     "    COALESCE(SUM(FABA.transaction_obligated_amount), 0) AS obligation",
     "  FROM",

--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -25,7 +25,6 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
                 "type": "enum",
                 "enum_values": ("assistance", "procurement"),
                 "allow_nulls": False,
-                "allow_nulls": False,
                 "optional": True,
             }
         ]

--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -25,6 +25,7 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
                 "type": "enum",
                 "enum_values": ("assistance", "procurement"),
                 "allow_nulls": False,
+                "allow_nulls": False,
                 "optional": True,
             }
         ]

--- a/usaspending_api/disaster/v2/views/disaster_base.py
+++ b/usaspending_api/disaster/v2/views/disaster_base.py
@@ -329,7 +329,14 @@ class FabaOutlayMixin:
         return Coalesce(
             Sum(
                 Case(
-                    When(self.final_period_submission_query_filters, then=F("gross_outlay_amount_by_award_cpe")),
+                    When(
+                        self.final_period_submission_query_filters,
+                        then=(
+                            Coalesce(F("gross_outlay_amount_by_award_cpe"), 0)
+                            + Coalesce(F("ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe"), 0)
+                            + Coalesce(F("ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe"), 0)
+                        ),
+                    ),
                     default=Value(0),
                 )
             ),


### PR DESCRIPTION
**Description:**
Fixes the calculation of outlays for the `/api/v2/disaster/award/amount` endpoint, updating it to match the other work done elsewhere on the site.

**Technical details:**
`/api/v2/disaster/award/amount` has two logic paths - one for File C and one for File D. The file C change can be done by just changing the query, but the File D change required an update to the  `CovidFinancialAccountMatview` where the outlay was being calculated

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-7004](https://federal-spending-transparency.atlassian.net/browse/DEV-7004):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
