### PR TITLE
[DEV-7025] Remove Financing Accounts from GTAS data

### DIFF
--- a/usaspending_api/references/management/commands/load_gtas.py
+++ b/usaspending_api/references/management/commands/load_gtas.py
@@ -121,8 +121,7 @@ class Command(mixins.ETLMixin, BaseCommand):
         return "\n".join(simple_fields + inverted_fields + year_specific_fields)
 
     @property
-    @staticmethod
-    def tas_fk_sql():
+    def tas_fk_sql(self):
         return f"""
             UPDATE {GTAS_TABLE}
             SET treasury_account_identifier = tas.treasury_account_identifier
@@ -132,6 +131,5 @@ class Command(mixins.ETLMixin, BaseCommand):
                 AND {GTAS_TABLE}.treasury_account_identifier IS DISTINCT FROM tas.treasury_account_identifier"""
 
     @property
-    @staticmethod
-    def financing_account_sql():
+    def financing_account_sql(self):
         return f"""DELETE FROM {GTAS_TABLE} WHERE treasury_account_identifier IS NULL"""

--- a/usaspending_api/references/management/commands/load_gtas.py
+++ b/usaspending_api/references/management/commands/load_gtas.py
@@ -38,6 +38,7 @@ DERIVED_COLUMNS_DYNAMIC = {
         "change_year": 2021,
     }
 }
+GTAS_TABLE = GTASSF133Balances.objects.model._meta.db_table
 
 
 class Command(mixins.ETLMixin, BaseCommand):
@@ -53,7 +54,7 @@ class Command(mixins.ETLMixin, BaseCommand):
         broker_cursor = connections["data_broker"].cursor()
 
         logger.info("Extracting data from Broker")
-        broker_cursor.execute(self.broker_fetch_sql())
+        broker_cursor.execute(self.broker_fetch_sql)
         total_obligation_values = dictfetchall(broker_cursor)
 
         logger.info("Deleting all existing GTAS total obligation records in website")
@@ -67,16 +68,19 @@ class Command(mixins.ETLMixin, BaseCommand):
         new_rec_count = len(GTASSF133Balances.objects.bulk_create(total_obligation_objs))
         logger.info(f"Loaded: {new_rec_count:,} records")
 
-        load_rec = self._execute_dml_sql(self.tas_fk_sql(), "Populating TAS foreign keys")
+        load_rec = self._execute_dml_sql(self.tas_fk_sql, "Populating TAS foreign keys")
         logger.info(f"Set {load_rec:,} TAS FKs in GTAS table, {new_rec_count - load_rec:,} NULLs")
+        delete_rec = self._execute_dml_sql(self.financing_account_sql, "Drop Financing Account TAS")
+        logger.info(f"Deleted {delete_rec:,} records in GTAS table due to invalid TAS")
         logger.info("Committing transaction to database")
 
+    @property
     def broker_fetch_sql(self):
         return f"""
             SELECT
                 fiscal_year,
                 period as fiscal_period,
-                {self.column_statements()}
+                {self.column_statements}
                 disaster_emergency_fund_code,
                 CONCAT(
                     CASE WHEN sf.allocation_transfer_agency is not null THEN CONCAT(sf.allocation_transfer_agency, '-') ELSE null END,
@@ -96,6 +100,7 @@ class Command(mixins.ETLMixin, BaseCommand):
                 fiscal_period;
         """
 
+    @property
     def column_statements(self):
         simple_fields = [
             f"COALESCE(SUM(CASE WHEN line IN ({','.join([str(elem) for elem in val])}) THEN sf.amount ELSE 0 END), 0.0) AS {key},"
@@ -115,11 +120,18 @@ class Command(mixins.ETLMixin, BaseCommand):
         ]
         return "\n".join(simple_fields + inverted_fields + year_specific_fields)
 
-    def tas_fk_sql(self):
-        return """
-            UPDATE gtas_sf133_balances
+    @property
+    @staticmethod
+    def tas_fk_sql():
+        return f"""
+            UPDATE {GTAS_TABLE}
             SET treasury_account_identifier = tas.treasury_account_identifier
             FROM treasury_appropriation_account tas
             WHERE
-                tas.tas_rendering_label = gtas_sf133_balances.tas_rendering_label
-                AND gtas_sf133_balances.treasury_account_identifier IS DISTINCT FROM tas.treasury_account_identifier"""
+                tas.tas_rendering_label = {GTAS_TABLE}.tas_rendering_label
+                AND {GTAS_TABLE}.treasury_account_identifier IS DISTINCT FROM tas.treasury_account_identifier"""
+
+    @property
+    @staticmethod
+    def financing_account_sql():
+        return f"""DELETE FROM {GTAS_TABLE} WHERE treasury_account_identifier IS NULL"""

--- a/usaspending_api/references/tests/data/broker_gtas.json
+++ b/usaspending_api/references/tests/data/broker_gtas.json
@@ -16,6 +16,7 @@
       "unobligated_balance_cpe": "-11",
       "total_budgetary_resources_cpe": "11",
       "disaster_emergency_fund_code": "A",
+      "tas_rendering_label": "999-X-111",
       "anticipated_prior_year_obligation_recoveries": "-111",
       "prior_year_paid_obligation_recoveries": "-110"
     },
@@ -36,6 +37,7 @@
       "unobligated_balance_cpe": "-12",
       "total_budgetary_resources_cpe": "12",
       "disaster_emergency_fund_code": "A",
+      "tas_rendering_label": "999-X-111",
       "anticipated_prior_year_obligation_recoveries": "-121",
       "prior_year_paid_obligation_recoveries": "-120"
     },
@@ -56,6 +58,7 @@
       "unobligated_balance_cpe": "-13",
       "total_budgetary_resources_cpe": "13",
       "disaster_emergency_fund_code": "A",
+      "tas_rendering_label": "999-X-111",
       "anticipated_prior_year_obligation_recoveries": "-131",
       "prior_year_paid_obligation_recoveries": "-130"
     }

--- a/usaspending_api/references/tests/integration/test_load_gtas_mgmt_cmd.py
+++ b/usaspending_api/references/tests/integration/test_load_gtas_mgmt_cmd.py
@@ -2,7 +2,9 @@ import pytest
 
 from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS
+from model_mommy import mommy
 from unittest.mock import MagicMock
+
 from usaspending_api.etl.broker_etl_helpers import PhonyCursor
 from usaspending_api.references.models import GTASSF133Balances
 
@@ -19,6 +21,8 @@ def test_program_activity_fresh_load(monkeypatch):
         DEFAULT_DB_ALIAS: MagicMock(),
         "data_broker": data_broker_mock,
     }
+
+    mommy.make("accounts.TreasuryAppropriationAccount", tas_rendering_label="999-X-111")
 
     monkeypatch.setattr("usaspending_api.references.management.commands.load_gtas.connections", mock_connections)
 


### PR DESCRIPTION
**Description:**
See ticket for some background and link to Slack conversation

**Technical details:**
`treasury_appropriation_account` stores all valid TAS in USAspending and does not include Financing Accounts. The GTAS ETL already created a FK from the GTAS data in `gtas_sf133_balances` to `treasury_appropriation_account`. While the business logic and SQL could have been altered to ignore all GTAS records without a FK, it was easier and more complete to simply drop all GTAS records without a FK to `treasury_appropriation_account`.

The question of "Is there ever a valid reason of a TAS in GTAS to not be located in TAS reference data" was answered with "No."

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7025](https://federal-spending-transparency.atlassian.net/browse/DEV-7025):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Script (local tests didn't show even 1s added to the ETL)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to API
No changes to Materialized Views
Data changes will automatically be applied by any pipeline runs
```
