### PR TITLE
[DEV-7012] Change how Awards with negated outlay are filtered out

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -469,23 +469,6 @@ class _NonzeroFields(_Filter):
         return ES_Q("bool", should=non_zero_queries, minimum_should_match=1)
 
 
-class _NonzeroNestedSumFields(_Filter):
-    """Query for when the sum of nested fields should not be zero"""
-
-    underscore_name = "nonzero_sum_fields"
-
-    @classmethod
-    def generate_elasticsearch_query(
-        cls, filter_values: List[str], query_type: _QueryType, nested_path: str = ""
-    ) -> ES_Q:
-        non_zero_queries = []
-        for field in filter_values:
-            field_name = f"{nested_path}{'.' if nested_path else ''}{field}"
-            non_zero_queries.append(ES_Q("range", **{field_name: {"gt": 0}}))
-            non_zero_queries.append(ES_Q("range", **{field_name: {"lt": 0}}))
-        return ES_Q("bool", should=non_zero_queries, minimum_should_match=1)
-
-
 class QueryWithFilters:
 
     filter_lookup = {

--- a/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
+++ b/usaspending_api/disaster/tests/integration/test_object_class_spending_award.py
@@ -178,9 +178,127 @@ def test_outlay_calculations(client, elasticsearch_account_index, basic_faba_wit
             ],
         }
     ]
-    print(resp.json())
+
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["results"] == expected_results
 
     expected_totals = {"award_count": 1, "obligation": 1.0, "outlay": 91.0}
+    assert resp.json()["totals"] == expected_totals
+
+
+@pytest.mark.django_db
+def test_filter_out_negated_values(
+    client, elasticsearch_account_index, basic_faba_with_object_class, monkeypatch, helpers
+):
+    oc = major_object_class_with_children("001", [1])
+    mommy.make("references.DisasterEmergencyFundCode", code="L", group_name=COVID_19_GROUP_NAME),
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code="L").first(),
+        submission=SubmissionAttributes.objects.all().first(),
+        object_class=oc[0],
+        transaction_obligated_amount=1,
+        gross_outlay_amount_by_award_cpe=100,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=-3,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=-6,
+        award_id=None,
+        piid="123",
+        fain=None,
+        uri=None,
+        distinct_award_key="123||",
+    )
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code="L").first(),
+        submission=SubmissionAttributes.objects.all().first(),
+        object_class=oc[0],
+        transaction_obligated_amount=-1,
+        gross_outlay_amount_by_award_cpe=-110,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=3,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=16,
+        award_id=None,
+        piid="123",
+        fain=None,
+        uri=None,
+        distinct_award_key="123||",
+    )
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
+    helpers.reset_dabs_cache()
+
+    resp = helpers.post_for_spending_endpoint(client, url, query="001 name", def_codes=["L"], spending_type="award")
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == []
+
+    expected_totals = {"award_count": 0, "obligation": 0, "outlay": 0}
+    assert resp.json()["totals"] == expected_totals
+
+
+@pytest.mark.django_db
+def test_nonzero_obligation_prevents_filter_out_negated_values(
+    client, elasticsearch_account_index, basic_faba_with_object_class, monkeypatch, helpers
+):
+    oc = major_object_class_with_children("001", [1])
+    mommy.make("references.DisasterEmergencyFundCode", code="L", group_name=COVID_19_GROUP_NAME),
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code="L").first(),
+        submission=SubmissionAttributes.objects.all().first(),
+        object_class=oc[0],
+        transaction_obligated_amount=1,
+        gross_outlay_amount_by_award_cpe=100,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=-3,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=-6,
+        award_id=None,
+        piid="123",
+        fain=None,
+        uri=None,
+        distinct_award_key="123||",
+    )
+    mommy.make(
+        "awards.FinancialAccountsByAwards",
+        disaster_emergency_fund=DisasterEmergencyFundCode.objects.filter(code="L").first(),
+        submission=SubmissionAttributes.objects.all().first(),
+        object_class=oc[0],
+        transaction_obligated_amount=5,
+        gross_outlay_amount_by_award_cpe=-110,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=3,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=16,
+        award_id=None,
+        piid="123",
+        fain=None,
+        uri=None,
+        distinct_award_key="123||",
+    )
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
+    helpers.reset_dabs_cache()
+
+    resp = helpers.post_for_spending_endpoint(client, url, query="001 name", def_codes=["L"], spending_type="award")
+    expected_results = [
+        {
+            "id": "001",
+            "code": "001",
+            "description": "001 name",
+            "award_count": 1,
+            "obligation": 6.0,
+            "outlay": 0,
+            "children": [
+                {
+                    "id": "1",
+                    "code": "0001",
+                    "description": "0001 name",
+                    "award_count": 1,
+                    "obligation": 6.0,
+                    "outlay": 0,
+                }
+            ],
+        }
+    ]
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+    expected_totals = {"award_count": 1, "obligation": 6.0, "outlay": 0}
     assert resp.json()["totals"] == expected_totals


### PR DESCRIPTION
**Description:**
Make sure that Awards with negated outlay (e.g. `100` and `-100`) are filtered out taking into account the addition of the new downward adjustment columns that are part of the calculation.

**Technical details:**
After going back and forth multiple times on how to implement I settled on this implementation for performance reasons. A search of Staging showed that the cases where the outlay is zero the negated File C records share the same DEFC (which make sense). I wanted to keep the functionality where a user is able to filter by a single DEFC on the endpoint. The shared DEFC between negated File C means that a user should not be able to filter by a single DEFC and be robbed of data they would otherwise be able to see if the implementation was granular to DEFC instead of the entire Award. 

The bulk of the work is not shown in code, but was in performance testing and trying to test different implementations. If we wanted to filter out by the sum of a single award and group by DEFC then that would require adding another `sum` and `bucket_selector` aggregation at the top level to filter on.

Two two tests are only on Object Class spending since the change is in a central part of the base class where all implementations (such as Object Class spending) will hit. They test to make sure that negated Obligation and Outlay (taking into account the downward adjustment columns) will filter out an Award and that a nonzero Obligation with a negated Outlay will be counted.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7012](https://federal-spending-transparency.atlassian.net/browse/DEV-7012):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
