### PR TITLE
dev-6982 reorder and change gross_outlay_amount to gross_outlay_amoun…

### DIFF
--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1679,6 +1679,10 @@ query_paths = {
                     "deobligations_recoveries_refund_pri_program_object_class_cpe",
                 ),
                 (
+                    "gross_outlay_amount_fyb_to_period_end",
+                    "gross_outlay_amount_fyb_to_period_end",
+                ),  # Column is annotated in account_download.py
+                (
                     "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
                     "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
                 ),  # Column is annotated in account_download.py
@@ -1686,7 +1690,6 @@ query_paths = {
                     "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
                     "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
                 ),  # Column is annotated in account_download.py
-                ("gross_outlay_amount", "gross_outlay_amount"),  # Column is annotated in account_download.py
                 (
                     "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR,
                     "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR,
@@ -1716,6 +1719,10 @@ query_paths = {
                     "deobligations_or_recoveries_or_refunds_from_prior_year",
                 ),
                 (
+                    "gross_outlay_amount_fyb_to_period_end",
+                    "gross_outlay_amount_fyb_to_period_end",
+                ),  # Column is annotated in account_download.py
+                (
                     "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
                     "downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe",
                 ),  # Column is annotated in account_download.py
@@ -1723,7 +1730,6 @@ query_paths = {
                     "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
                     "downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe",
                 ),  # Column is annotated in account_download.py
-                ("gross_outlay_amount", "gross_outlay_amount"),  # Column is annotated in account_download.py
                 (
                     "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR,
                     "last_modified_date" + NAMING_CONFLICT_DISCRIMINATOR,


### PR DESCRIPTION
**Description:**
update custom account download file b headers to match file c, specifically gross_outlay_amount_fyb_to_period_end, downward_adj_prior_yr_ppaid_undeliv_orders_oblig_refunds_cpe, and downward_adj_prior_yr_paid_delivered_orders_oblig_refunds_cpe in that order

**Technical details:**
none

**Requirements for PR merge:**

1. [x] Unit & integration tests updated -NA
2. [x] API documentation updated -NA
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL> -NA
    - [x] Operations <OPTIONAL> -NA
    - [x] Domain Expert <OPTIONAL> -NA
4. [x] Matview impact assessment completed -NA
5. [x] Frontend impact assessment completed -NA
6. [x] Data validation completed -NA
7. [x] Appropriate Operations ticket(s) created -NA
8. [ ] Jira Ticket [DEV-6982](https://federal-spending-transparency.atlassian.net/browse/DEV-6982):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download) -NA
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
