### PR TITLE
[FIX] corrected two issues in QAT

### DIFF
--- a/usaspending_api/references/tests/integration/test_load_gtas_mgmt_cmd.py
+++ b/usaspending_api/references/tests/integration/test_load_gtas_mgmt_cmd.py
@@ -108,7 +108,7 @@ def test_program_activity_fresh_load(monkeypatch):
                 "total_budgetary_resources_cpe",
                 "anticipated_prior_year_obligation_recoveries",
                 "prior_year_paid_obligation_recoveries",
-            )
+            ).order_by("-budget_authority_unobligated_balance_brought_forward_cpe")
         ),
     }
 

--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -276,6 +276,25 @@ def test_basic_success(setup_test_data, client):
     assert response["results"] == expected_results
 
 
+def test_all_sorts_are_http200(setup_test_data, client):
+    sort_fields = [
+        "current_total_budget_authority_amount",
+        "fiscal_year",
+        "missing_tas_accounts_count",
+        "tas_accounts_total",
+        "obligation_difference",
+        "percent_of_total_budgetary_resources",
+        "recent_publication_date",
+        "recent_publication_date_certified",
+        "tas_obligation_not_in_gtas_total",
+        "unlinked_contract_award_count",
+        "unlinked_assistance_award_count",
+    ]
+    for sort_field in sort_fields:
+        resp = client.get(f"{url}?sort={sort_field}&order=asc")
+        assert resp.status_code == status.HTTP_200_OK
+
+
 def test_pagination(setup_test_data, client):
     resp = client.get(url + "?sort=current_total_budget_authority_amount&order=asc")
     assert resp.status_code == status.HTTP_200_OK

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
@@ -157,9 +157,8 @@ def setup_test_data(db):
             obligations_incurred_total_cpe=sf133["ob_incur"],
         )
 
-    award_list = [
+    award_dicts = [
         {
-            "id": 1,
             "is_fpds": True,
             "awarding_agency": agencies[0],
             "type": "A",
@@ -167,7 +166,6 @@ def setup_test_data(db):
             "certified_date": "2019-12-15",
         },
         {
-            "id": 2,
             "is_fpds": False,
             "awarding_agency": agencies[0],
             "type": "08",
@@ -177,7 +175,6 @@ def setup_test_data(db):
             "total_subsidy_cost": 1000,
         },
         {
-            "id": 3,
             "is_fpds": False,
             "awarding_agency": agencies[0],
             "type": "07",
@@ -186,34 +183,28 @@ def setup_test_data(db):
             "total_subsidy_cost": 2000,
         },
     ]
-    for award in award_list:
-        mommy.make("awards.Award", **award)
-
+    award_list = [mommy.make("awards.Award", **award) for award in award_dicts]
     transaction_list = [
         {
-            "id": 1,
-            "award_id": award_list[0]["id"],
+            "award": award_list[0],
             "fiscal_year": 2019,
             "action_date": "2018-11-15",
             "awarding_agency": agencies[0],
         },
         {
-            "id": 2,
-            "award_id": award_list[0]["id"],
+            "award": award_list[0],
             "fiscal_year": 2019,
             "action_date": "2018-12-15",
             "awarding_agency": agencies[0],
         },
         {
-            "id": 3,
-            "award_id": award_list[1]["id"],
+            "award": award_list[1],
             "fiscal_year": 2019,
             "action_date": "2018-10-15",
             "awarding_agency": agencies[0],
         },
         {
-            "id": 4,
-            "award_id": award_list[2]["id"],
+            "award": award_list[2],
             "fiscal_year": 2019,
             "action_date": "2018-10-28",
             "awarding_agency": agencies[0],
@@ -224,9 +215,9 @@ def setup_test_data(db):
 
     faba_list = [
         {
-            "award_id": award_list[0]["id"],
+            "award": award_list[0],
             "distinct_award_key": "123|||",
-            "piid": award_list[0]["piid"],
+            "piid": award_list[0].piid,
             "fain": None,
             "uri": None,
             "submission": subs[0],
@@ -234,9 +225,9 @@ def setup_test_data(db):
             "transaction_obligated_amount": 1000,
         },
         {
-            "award_id": award_list[0]["id"],
+            "award": award_list[0],
             "distinct_award_key": "123|||",
-            "piid": award_list[0]["piid"],
+            "piid": award_list[0].piid,
             "fain": None,
             "uri": None,
             "submission": subs[0],
@@ -244,7 +235,6 @@ def setup_test_data(db):
             "transaction_obligated_amount": 2000,
         },
         {
-            "award_id": None,
             "distinct_award_key": "|456|789|",
             "piid": None,
             "fain": "456",
@@ -254,7 +244,6 @@ def setup_test_data(db):
             "transaction_obligated_amount": 3000,
         },
         {
-            "award_id": None,
             "distinct_award_key": "|456|789|",
             "piid": None,
             "fain": "456",
@@ -264,7 +253,6 @@ def setup_test_data(db):
             "transaction_obligated_amount": 4000,
         },
         {
-            "award_id": None,
             "distinct_award_key": "159|||",
             "piid": "159",
             "fain": None,
@@ -283,9 +271,7 @@ def test_run_script(setup_test_data):
     """ Test that the populate_reporting_agency_tas script acts as expected """
     call_command("populate_reporting_agency_overview")
 
-    results = ReportingAgencyOverview.objects.filter(fiscal_year=2019, fiscal_period=3, toptier_code="987").order_by(
-        "total_dollars_obligated_gtas"
-    )
+    results = ReportingAgencyOverview.objects.filter(fiscal_year=2019, fiscal_period=3, toptier_code="987").all()
 
     assert len(results) == 1
     assert results[0].total_dollars_obligated_gtas == Decimal("-3.2")

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -1,11 +1,12 @@
+from datetime import datetime, timezone
 from django.db.models import Subquery, OuterRef, DecimalField, Func, F, Q, IntegerField
 from rest_framework.response import Response
-from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 
+from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
+from usaspending_api.references.models import GTASSF133Balances
 from usaspending_api.references.models import ToptierAgency
 from usaspending_api.reporting.models import ReportingAgencyOverview, ReportingAgencyTas, ReportingAgencyMissingTas
-from usaspending_api.references.models import GTASSF133Balances
 from usaspending_api.submissions.models import SubmissionAttributes
 
 
@@ -28,7 +29,14 @@ class AgencyOverview(AgencyBase, PaginationMixin):
             "unlinked_contract_award_count",
             "unlinked_assistance_award_count",
         ]
+
         self.default_sort_column = "current_total_budget_authority_amount"
+        if self.pagination.sort_key in ("recent_publication_date"):
+            self.sort_value_when_null = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        elif self.pagination.sort_key in ("recent_publication_date_certified"):
+            self.sort_value_when_null = False
+        else:
+            self.sort_value_when_null = 0
         results = self.get_agency_overview()
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
         results = results[self.pagination.lower_limit : self.pagination.upper_limit]
@@ -157,15 +165,15 @@ class AgencyOverview(AgencyBase, PaginationMixin):
             self.pagination.secondary_sort_key = "fiscal_period"
         results = sorted(
             results,
-            key=lambda x: x["tas_account_discrepancies_totals"][self.pagination.sort_key]
+            key=lambda x: x["tas_account_discrepancies_totals"][self.pagination.sort_key] or self.sort_value_when_null
             if (
                 self.pagination.sort_key == "missing_tas_accounts_count"
                 or self.pagination.sort_key == "tas_accounts_total"
                 or self.pagination.sort_key == "tas_obligation_not_in_gtas_total"
             )
-            else (x[self.pagination.sort_key], x[self.pagination.secondary_sort_key])
+            else (x[self.pagination.sort_key] or self.sort_value_when_null, x[self.pagination.secondary_sort_key])
             if self.pagination.secondary_sort_key is not None
-            else x[self.pagination.sort_key],
+            else x[self.pagination.sort_key] or self.sort_value_when_null,
             reverse=self.pagination.sort_order == "desc",
         )
         return results

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -1,3 +1,5 @@
+import sys
+
 from datetime import datetime, timezone
 from django.db.models import Subquery, OuterRef, DecimalField, Func, F, Q, IntegerField
 from rest_framework.response import Response
@@ -36,7 +38,7 @@ class AgencyOverview(AgencyBase, PaginationMixin):
         elif self.pagination.sort_key in ("recent_publication_date_certified"):
             self.sort_value_when_null = False
         else:
-            self.sort_value_when_null = 0
+            self.sort_value_when_null = -sys.maxsize - 1  # greatest negative int value in Python
         results = self.get_agency_overview()
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
         results = results[self.pagination.lower_limit : self.pagination.upper_limit]


### PR DESCRIPTION
**Description:**
Three issues in this PR for expediency

- Sorting was broken for `v2/reporting/agencies/<toptier_code>/overview` when `null` was the value (since this endpoint sorts the results in Python instead of Postgres)
- Fragile test would fail due to result order from ORM queryset results
- Fragile test would fail due to PKs being hardcoded in model mommy

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
Fixed 1 endpoint from 500 exception and fixed 1 test
```
