### PR TITLE
[DEV-6872] Spending by geo nulls

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/aggregate_key_functions.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/aggregate_key_functions.py
@@ -106,12 +106,12 @@ def _county_agg_key(location_type, record: dict) -> Optional[str]:
         return None
     return json.dumps(
         {
-            "country_code": record[f"{location_type}_country_code"] or "",
-            "state_code": record[f"{location_type}_state_code"] or "",
-            "state_fips": record[f"{location_type}_state_fips"] or "",
-            "county_code": record[f"{location_type}_county_code"] or "",
-            "county_name": record[f"{location_type}_county_name"] or "",
-            "population": record[f"{location_type}_county_population"] or "",
+            "country_code": record[f"{location_type}_country_code"],
+            "state_code": record[f"{location_type}_state_code"],
+            "state_fips": record[f"{location_type}_state_fips"],
+            "county_code": record[f"{location_type}_county_code"],
+            "county_name": record[f"{location_type}_county_name"],
+            "population": record[f"{location_type}_county_population"],
         }
     )
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/aggregate_key_functions.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/aggregate_key_functions.py
@@ -106,12 +106,12 @@ def _county_agg_key(location_type, record: dict) -> Optional[str]:
         return None
     return json.dumps(
         {
-            "country_code": record[f"{location_type}_country_code"],
-            "state_code": record[f"{location_type}_state_code"],
-            "state_fips": record[f"{location_type}_state_fips"],
-            "county_code": record[f"{location_type}_county_code"],
-            "county_name": record[f"{location_type}_county_name"],
-            "population": record[f"{location_type}_county_population"],
+            "country_code": record[f"{location_type}_country_code"] or "",
+            "state_code": record[f"{location_type}_state_code"] or "",
+            "state_fips": record[f"{location_type}_state_fips"] or "",
+            "county_code": record[f"{location_type}_county_code"] or "",
+            "county_name": record[f"{location_type}_county_name"] or "",
+            "population": record[f"{location_type}_county_population"] or "",
         }
     )
 

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -48,7 +48,11 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
             if self.location_type == LocationType.STATE_TERRITORY:
                 name = name.title()
             else:
-                name = name.upper()
+                if name is not None:
+                    name = name.upper()
+                else:
+                    name = ""
+                    # continue
 
             results.append(
                 {

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -48,12 +48,7 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
             if self.location_type == LocationType.STATE_TERRITORY:
                 name = name.title()
             else:
-                if name is not None:
-                    name = name.upper()
-                else:
-                    name = ""
-                    # continue
-
+                name = name.upper()
             results.append(
                 {
                     "amount": int(bucket.get("sum_field", {"value": 0})["value"]) / Decimal("100"),

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -43,7 +43,7 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
                     congressional_code = location_info.get("congressional_code") or ""
                 name = f"{location_info.get('state_code') or ''}-{congressional_code}"
             else:
-                name = location_info.get(f"{self.location_type.value}_name")
+                name = location_info.get(f"{self.location_type.value}_name") or ""
 
             if self.location_type == LocationType.STATE_TERRITORY:
                 name = name.title()


### PR DESCRIPTION
**Description:**
Fixes bug described where the county name was set to `NULL` in the agg key used by the spending_by_category endpoint

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-6872](https://federal-spending-transparency.atlassian.net/browse/DEV-6872):
    - [X] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
