### PR TITLE
WARMFIX: [DEV-6756] Reducing batch size of the _delete_by_query on incremental index

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -31,7 +31,7 @@ def delete_docs_by_unique_key(
     task_id: str,
     index,
     refresh_after: bool = True,
-    delete_chunk_size: int = 10000,
+    delete_chunk_size: int = 1000,
 ) -> int:
     """
     Bulk delete a batch of documents whose field identified by ``key`` matches any value provided in the
@@ -55,8 +55,8 @@ def delete_docs_by_unique_key(
             errors-out during execution, in order to not leave un-refreshed deletes in the index.
         delete_chunk_size (int): the batch-size of terms value-array given to each _delete_by_query call. Needs to be
             less than 65536 (max values for any terms query), and less than index.max_results_window setting. Ideally
-            use ``config["partition_size"]`` (derived from --partition-siz) to set this to a calibrated value. If not
-            provided, uses 10,000 as the default which was measured as a good reasonable default.
+            use ``config["partition_size"]`` (derived from --partition-size) to set this to a calibrated value. If not
+            provided, uses 1000 as a safe default (10,000 resulted in some timeouts on a busy cluster).
 
     Returns: Number of ES documents deleted
     """

--- a/usaspending_api/etl/elasticsearch_loader_helpers/load_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/load_data.py
@@ -83,7 +83,6 @@ def streaming_post_to_es(
                 job_name,
                 index_name,
                 refresh_after=False,
-                delete_chunk_size=len(chunk),  # same size as this partition to process
             )
         for ok, item in helpers.streaming_bulk(
             client,


### PR DESCRIPTION
**Description:**
Smaller batch deletes to reduce incidence of the ES operation timing out. 

**Technical details:**
We've seen a few Elasticsearch incremental indexes that ran into a handful of server-side ES operation timeouts. Typically when running very deep (5M+) incremental loads. They seem to pile up and may even cause the whole ETL job to fail.

Originally, before using `_delete_by_query`, the batch size used was 1000 records. They were queried for, then deleted in two steps. This problem wasn't seen at that batch size so reducing from the current value of 10000 back down to 1000.

**Requirements for PR merge:**

1. [NA] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-6756](https://federal-spending-transparency.atlassian.net/browse/DEV-6756), [OPS-1732](https://federal-spending-transparency.atlassian.net/browse/OPS-1732):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
