### PR TITLE
[DEV-7071] Fixed dearth of FKs in treasury_appropriation_account

### DIFF
--- a/usaspending_api/etl/operations/treasury_appropriation_account/update_agencies.py
+++ b/usaspending_api/etl/operations/treasury_appropriation_account/update_agencies.py
@@ -30,7 +30,8 @@ def update_treasury_appropriation_account_agencies():
                 left outer join toptier_agency as ata on
                     ata.toptier_code = case
                         when taa.allocation_transfer_agency_id in {DOD_SUBSUMED_AIDS} then '{DOD_AID}'
-                        else taa.allocation_transfer_agency_id
+                        when taa.allocation_transfer_agency_id is not null THEN taa.allocation_transfer_agency_id
+                        else taa.agency_id
                     end
         ),
         aid_mapping as (

--- a/usaspending_api/etl/tests/integration/test_account_update_agencies.py
+++ b/usaspending_api/etl/tests/integration/test_account_update_agencies.py
@@ -95,7 +95,7 @@ def test_federal_account_update_agency(data_fixture):
 
     assert TreasuryAppropriationAccount.objects.get(pk=1).awarding_toptier_agency_id == 1
     assert TreasuryAppropriationAccount.objects.get(pk=1).funding_toptier_agency_id == 1
-    assert TreasuryAppropriationAccount.objects.get(pk=2).awarding_toptier_agency_id is None
+    assert TreasuryAppropriationAccount.objects.get(pk=2).awarding_toptier_agency_id == 2
     assert TreasuryAppropriationAccount.objects.get(pk=2).funding_toptier_agency_id == 2
     assert TreasuryAppropriationAccount.objects.get(pk=3).funding_toptier_agency_id == 3
     assert TreasuryAppropriationAccount.objects.get(pk=4).funding_toptier_agency_id == 2

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -1,9 +1,8 @@
 from django.db.models import Subquery, OuterRef, DecimalField, Func, F, Q, IntegerField, Value
+from django.utils.functional import cached_property
 from rest_framework.response import Response
 
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
-from django.utils.functional import cached_property
-
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     get_final_period_of_quarter,
     calculate_last_completed_fiscal_quarter,


### PR DESCRIPTION
**Description:**
Many many issues appeared from #3014 after switching from "Funding Agency" to "Awarding Agency" for About the Data [DEV-6958](https://federal-spending-transparency.atlassian.net/browse/DEV-6958).

**Technical details:**
Updated the TAS ETL so `awarding_toptier_agency_id` wasn't null (went from over 90% null to 0% null). Fix was for `update_agencies.py`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7071](https://federal-spending-transparency.atlassian.net/browse/DEV-7071):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected Script (no observed change)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
No changes to API schema nor materialized views
```
