### PR TITLE
[DEV-6567] Fix an oversight with Keyword Search validation changes

### DIFF
--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -83,7 +83,7 @@ class AwardDownloadValidator(DownloadValidatorBase):
         self.set_filter_defaults({"award_type_codes": list(award_type_mapping.keys())})
 
         constraint_type = self.request_data.get("constraint_type")
-        if constraint_type == "year" and set(self._json_request["filters"].keys()) & {"keyword", "keywords"}:
+        if constraint_type == "year" and sorted(self._json_request["filters"]) == ["award_type_codes", "keywords"]:
             self._handle_keyword_search_download()
         elif constraint_type == "year":
             self._handle_custom_award_download()
@@ -94,17 +94,15 @@ class AwardDownloadValidator(DownloadValidatorBase):
 
     def _handle_keyword_search_download(self):
         # Overriding all other filters if the keyword filter is provided in year-constraint download
-        self._json_request["filters"] = {
-            "elasticsearch_keyword": self._json_request["filters"]["keyword"]
-            or self._json_request["filters"]["keywords"]
-        }
+        self._json_request["filters"] = {"elasticsearch_keyword": self._json_request["filters"]["keywords"]}
 
         self.tinyshield_models.extend(
             [
                 {
                     "name": "elasticsearch_keyword",
                     "key": "filters|elasticsearch_keyword",
-                    "type": "text",
+                    "type": "array",
+                    "array_type": "text",
                     "text_type": "search",
                 },
                 {


### PR DESCRIPTION
**Description:**
Keyword search currently fails due to an oversight in the validation.

**Technical details:**
The BaseDownloadViewset performs a data transformation on the request that was not previously effecting the `elasticsearch_keyword` filter. As a result a change needed to occur that takes that into account. In addition to this, the attempt to retrieve the filter should have been a `.get()` to avoid running issues of the "filter" not being present in the dictionary since the value is retrieved prior to validation.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-6567](https://federal-spending-transparency.atlassian.net/browse/DEV-6567):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
