### PR TITLE
[Fix] Fixed agency grouping of TAS data for About the Data

### DIFF
--- a/usaspending_api/etl/operations/treasury_appropriation_account/update_agencies.py
+++ b/usaspending_api/etl/operations/treasury_appropriation_account/update_agencies.py
@@ -30,8 +30,7 @@ def update_treasury_appropriation_account_agencies():
                 left outer join toptier_agency as ata on
                     ata.toptier_code = case
                         when taa.allocation_transfer_agency_id in {DOD_SUBSUMED_AIDS} then '{DOD_AID}'
-                        when taa.allocation_transfer_agency_id is not null THEN taa.allocation_transfer_agency_id
-                        else taa.agency_id
+                        else taa.allocation_transfer_agency_id
                     end
         ),
         aid_mapping as (

--- a/usaspending_api/etl/tests/integration/test_account_update_agencies.py
+++ b/usaspending_api/etl/tests/integration/test_account_update_agencies.py
@@ -95,7 +95,7 @@ def test_federal_account_update_agency(data_fixture):
 
     assert TreasuryAppropriationAccount.objects.get(pk=1).awarding_toptier_agency_id == 1
     assert TreasuryAppropriationAccount.objects.get(pk=1).funding_toptier_agency_id == 1
-    assert TreasuryAppropriationAccount.objects.get(pk=2).awarding_toptier_agency_id == 2
+    assert TreasuryAppropriationAccount.objects.get(pk=2).awarding_toptier_agency_id is None
     assert TreasuryAppropriationAccount.objects.get(pk=2).funding_toptier_agency_id == 2
     assert TreasuryAppropriationAccount.objects.get(pk=3).funding_toptier_agency_id == 3
     assert TreasuryAppropriationAccount.objects.get(pk=4).funding_toptier_agency_id == 2

--- a/usaspending_api/reporting/management/commands/populate_reporting_agency_overview.py
+++ b/usaspending_api/reporting/management/commands/populate_reporting_agency_overview.py
@@ -223,7 +223,7 @@ TEMP_TABLE_CONTENTS = {
                 SUM(obligations_incurred_total_cpe) AS total_dollars_obligated_gtas
             FROM
                 gtas_sf133_balances AS gtas
-             INNER JOIN dabs_submission_window_schedule dabs ON
+            INNER JOIN dabs_submission_window_schedule dabs ON
                 dabs.submission_fiscal_year = gtas.fiscal_year
                 AND dabs.submission_fiscal_month = gtas.fiscal_period
                 AND dabs.submission_reveal_date <= now()
@@ -380,7 +380,7 @@ CREATE_OVERVIEW_SQL = f"""
     FROM generate_series(
         '2017-03-01'::timestamp,
         (
-            SELECT MAX(submission_reveal_date)
+            SELECT MAX(period_end_date)
             FROM dabs_submission_window_schedule
             WHERE submission_reveal_date < now() AND is_quarter = FALSE
         ), '1 month'

--- a/usaspending_api/reporting/management/commands/populate_reporting_agency_overview.py
+++ b/usaspending_api/reporting/management/commands/populate_reporting_agency_overview.py
@@ -100,7 +100,7 @@ TEMP_TABLE_CONTENTS = {
         INNER JOIN
             treasury_appropriation_account AS taa ON (taa.treasury_account_identifier = faba.treasury_account_id)
         INNER JOIN
-            toptier_agency AS ta ON (taa.awarding_toptier_agency_id = ta.toptier_agency_id)
+            toptier_agency AS ta ON (taa.funding_toptier_agency_id = ta.toptier_agency_id)
         WHERE
             faba.transaction_obligated_amount IS NOT NULL
             AND sa.reporting_fiscal_year >= 2017
@@ -209,7 +209,7 @@ TEMP_TABLE_CONTENTS = {
                 treasury_appropriation_account AS taa
                     ON (aab.treasury_account_identifier = taa.treasury_account_identifier)
             INNER JOIN
-                toptier_agency AS ta ON (taa.awarding_toptier_agency_id = ta.toptier_agency_id)
+                toptier_agency AS ta ON (taa.funding_toptier_agency_id = ta.toptier_agency_id)
             GROUP BY
                 reporting_fiscal_year,
                 reporting_fiscal_period,
@@ -231,7 +231,7 @@ TEMP_TABLE_CONTENTS = {
                 treasury_appropriation_account AS taa
                     ON (gtas.treasury_account_identifier = taa.treasury_account_identifier)
             INNER JOIN
-                toptier_agency AS ta ON (taa.awarding_toptier_agency_id = ta.toptier_agency_id)
+                toptier_agency AS ta ON (taa.funding_toptier_agency_id = ta.toptier_agency_id)
             GROUP BY
                 fiscal_year,
                 fiscal_period,

--- a/usaspending_api/reporting/management/sql/populate_reporting_agency_missing_tas.sql
+++ b/usaspending_api/reporting/management/sql/populate_reporting_agency_missing_tas.sql
@@ -69,7 +69,7 @@ INNER JOIN missing
 INNER JOIN treasury_appropriation_account AS taa
     ON gtas.treasury_account_identifier = taa.treasury_account_identifier
 INNER JOIN toptier_agency AS ta
-    ON taa.awarding_toptier_agency_id = ta.toptier_agency_id
+    ON taa.funding_toptier_agency_id = ta.toptier_agency_id
 GROUP BY ta.toptier_code,
     gtas.fiscal_year,
     gtas.fiscal_period,

--- a/usaspending_api/reporting/management/sql/populate_reporting_agency_tas.sql
+++ b/usaspending_api/reporting/management/sql/populate_reporting_agency_tas.sql
@@ -54,5 +54,5 @@ FROM (
     INNER JOIN treasury_appropriation_account AS taa
         ON sa.tas_id = taa.treasury_account_identifier
     INNER JOIN toptier_agency AS ta
-        ON taa.awarding_toptier_agency_id = ta.toptier_agency_id
+        ON taa.funding_toptier_agency_id = ta.toptier_agency_id
 ) AS reporting_agency_tas_content;

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_missing_tas.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_missing_tas.py
@@ -70,13 +70,13 @@ def setup_test_data(db):
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
             treasury_account_identifier=1,
-            awarding_toptier_agency_id=agency.toptier_agency_id,
+            funding_toptier_agency=agency,
             tas_rendering_label="tas-1",
         ),
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
             treasury_account_identifier=2,
-            awarding_toptier_agency_id=agency.toptier_agency_id,
+            funding_toptier_agency=agency,
             tas_rendering_label="tas-2",
         ),
     ]

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
@@ -61,17 +61,17 @@ def setup_test_data(db):
     treas_accounts = [
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
-            awarding_toptier_agency=toptier_agencies[0],
+            funding_toptier_agency=toptier_agencies[0],
             tas_rendering_label="tas-1-overview",
         ),
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
-            awarding_toptier_agency=toptier_agencies[0],
+            funding_toptier_agency=toptier_agencies[0],
             tas_rendering_label="tas-2-overview",
         ),
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
-            awarding_toptier_agency=toptier_agencies[1],
+            funding_toptier_agency=toptier_agencies[1],
             tas_rendering_label="tas-3-overview",
         ),
     ]
@@ -271,7 +271,7 @@ def test_run_script(setup_test_data):
     """ Test that the populate_reporting_agency_tas script acts as expected """
     call_command("populate_reporting_agency_overview")
 
-    results = ReportingAgencyOverview.objects.filter(fiscal_year=2019, fiscal_period=3, toptier_code="987").all()
+    results = ReportingAgencyOverview.objects.filter(fiscal_year=2019, fiscal_period=3, toptier_code="987")
 
     assert len(results) == 1
     assert results[0].total_dollars_obligated_gtas == Decimal("-3.2")

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
@@ -271,7 +271,7 @@ def test_run_script(setup_test_data):
     """ Test that the populate_reporting_agency_tas script acts as expected """
     call_command("populate_reporting_agency_overview")
 
-    results = ReportingAgencyOverview.objects.filter(fiscal_year=2019, fiscal_period=3, toptier_code="987")
+    results = ReportingAgencyOverview.objects.filter(fiscal_year=2019, fiscal_period=3, toptier_code="987").all()
 
     assert len(results) == 1
     assert results[0].total_dollars_obligated_gtas == Decimal("-3.2")

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_overview.py
@@ -16,13 +16,17 @@ def setup_test_data(db):
             "submission_fiscal_year": 2019,
             "submission_fiscal_quarter": 1,
             "submission_fiscal_month": 3,
-            "submission_reveal_date": "2019-1-15",
+            "submission_reveal_date": "2019-3-15",
+            "is_quarter": False,
+            "period_end_date": "2019-1-15",
         },
         {
             "submission_fiscal_year": 2020,
             "submission_fiscal_quarter": 1,
             "submission_fiscal_month": 3,
-            "submission_reveal_date": "2020-01-09",
+            "submission_reveal_date": "2019-3-09",
+            "is_quarter": False,
+            "period_end_date": "2020-01-09",
         },
     ]
     dsws = [mommy.make("submissions.DABSSubmissionWindowSchedule", **dabs_window) for dabs_window in dsws_dicts]

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_tas.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_tas.py
@@ -61,19 +61,19 @@ def setup_test_data(db):
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
             treasury_account_identifier=1,
-            awarding_toptier_agency_id=agencies[0].toptier_agency_id,
+            funding_toptier_agency=agencies[0],
             tas_rendering_label="tas-1",
         ),
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
             treasury_account_identifier=2,
-            awarding_toptier_agency_id=agencies[0].toptier_agency_id,
+            funding_toptier_agency=agencies[0],
             tas_rendering_label="tas-2",
         ),
         mommy.make(
             "accounts.TreasuryAppropriationAccount",
             treasury_account_identifier=3,
-            awarding_toptier_agency_id=agencies[1].toptier_agency_id,
+            funding_toptier_agency=agencies[1],
             tas_rendering_label="tas-3",
         ),
     ]


### PR DESCRIPTION
**Description:**
This PR rolls back some changes from #3014 and #3057 and improving tests. Also fixing a minor issue of extra future submission periods being created in `reporting_agency_overview` which wasn't optimal.

**Technical details:**
While it may seem to make sense to use `treasury_appropriation_account.awarding_toptier_agency_id` when there is a desire to use "awarding agency" for grouping. However, `awarding_toptier_agency_id` isn't the same as "awarding" in File D data. Also `funding_toptier_agency_id` isn't "funding" like File D but closer to "owning." This has caused plenty of recent confusion.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created ()
8. [x] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
No changes to materialized views or API
```
