### PR TITLE
[WARMFIX] Fix calculation of total_budgetary_resources for publish_dates

### DIFF
--- a/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
@@ -13,20 +13,24 @@ def publish_dates_data(db):
         submission_reveal_date="2020-01-01 00:00:00.000000+00",
         submission_fiscal_year=2020,
         submission_fiscal_month=7,
-        is_quarter=True,
     )
     dabs2 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
         submission_reveal_date="2020-01-02 00:00:00.000000+00",
         submission_fiscal_year=2019,
         submission_fiscal_month=12,
-        is_quarter=True,
     )
     dabs3 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2019-01-01 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date="2019-01-01 00:00:00.000000+00",
+        submission_fiscal_year=2019,
+        submission_fiscal_month=12,
     )
     dabs4 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2019-01-02 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date="2019-01-02 00:00:00.000000+00",
+        submission_fiscal_year=2019,
+        submission_fiscal_month=12,
     )
     tas1 = mommy.make("accounts.TreasuryAppropriationAccount")
     tas2 = mommy.make("accounts.TreasuryAppropriationAccount")

--- a/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
@@ -13,12 +13,14 @@ def publish_dates_data(db):
         submission_reveal_date="2020-01-01 00:00:00.000000+00",
         submission_fiscal_year=2020,
         submission_fiscal_month=7,
+        is_quarter=True,
     )
     dabs2 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
         submission_reveal_date="2020-01-02 00:00:00.000000+00",
         submission_fiscal_year=2019,
         submission_fiscal_month=12,
+        is_quarter=True,
     )
     dabs3 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2019-01-01 00:00:00.000000+00"
@@ -579,7 +581,7 @@ def test_publication_date_sort(client, publish_dates_data):
     )
     mommy.make(
         "reporting.ReportingAgencyOverview",
-        toptier_code="001" "",
+        toptier_code="001",
         fiscal_year=2019,
         fiscal_period=3,
         total_budgetary_resources=10.00,

--- a/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
@@ -9,10 +9,16 @@ url = "/api/v2/reporting/agencies/publish_dates/"
 @pytest.fixture
 def publish_dates_data(db):
     dabs1 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-01-01 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date="2020-01-01 00:00:00.000000+00",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=7,
     )
     dabs2 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-01-02 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date="2020-01-02 00:00:00.000000+00",
+        submission_fiscal_year=2019,
+        submission_fiscal_month=12,
     )
     dabs3 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2019-01-01 00:00:00.000000+00"
@@ -95,7 +101,7 @@ def publish_dates_data(db):
         "reporting.ReportingAgencyOverview",
         toptier_code="002",
         fiscal_year=2019,
-        fiscal_period=11,
+        fiscal_period=12,
         total_budgetary_resources=300.00,
     )
 
@@ -116,7 +122,7 @@ def test_basic_success(client, publish_dates_data):
             "agency_name": "Test Agency",
             "abbreviation": "TA",
             "toptier_code": "001",
-            "current_total_budget_authority_amount": 150.00,
+            "current_total_budget_authority_amount": 50.00,
             "periods": [
                 {
                     "period": 2,
@@ -573,7 +579,7 @@ def test_publication_date_sort(client, publish_dates_data):
     )
     mommy.make(
         "reporting.ReportingAgencyOverview",
-        toptier_code="001",
+        toptier_code="001" "",
         fiscal_year=2019,
         fiscal_period=3,
         total_budgetary_resources=10.00,
@@ -595,7 +601,7 @@ def test_publication_date_sort(client, publish_dates_data):
             "agency_name": "Test Agency",
             "abbreviation": "TA",
             "toptier_code": "001",
-            "current_total_budget_authority_amount": 210.00,
+            "current_total_budget_authority_amount": 200.00,
             "periods": [
                 {
                     "period": 2,
@@ -675,7 +681,7 @@ def test_publication_date_sort(client, publish_dates_data):
             "agency_name": "Test Agency 2",
             "abbreviation": "TA2",
             "toptier_code": "002",
-            "current_total_budget_authority_amount": 310.00,
+            "current_total_budget_authority_amount": 300.00,
             "periods": [
                 {
                     "period": 2,

--- a/usaspending_api/reporting/v2/views/agencies/publish_dates.py
+++ b/usaspending_api/reporting/v2/views/agencies/publish_dates.py
@@ -39,7 +39,7 @@ class PublishDates(AgencyBase, PaginationMixin):
         if self.filter is not None:
             agency_filters.append(Q(name__icontains=self.filter) | Q(abbreviation__icontains=self.filter))
         submission_window = DABSSubmissionWindowSchedule.objects.filter(
-            submission_reveal_date__lte=now(), submission_fiscal_year=self.fiscal_year
+            submission_reveal_date__lte=now(), submission_fiscal_year=self.fiscal_year, is_quarter=True
         ).aggregate(Max("submission_fiscal_month"))
         results = (
             ToptierAgencyPublishedDABSView.objects.filter(*agency_filters)


### PR DESCRIPTION
**Description:**
Fixes an issue with the publish_dates endpoint on the about the data page where the total_budgetary_resources amount was being summed per fiscal year when it should have been taking the latest entry for that fiscal year

The actual percentages on the website page will also require a frontend fix, since the total federal amount is also being summed per fiscal year, which is incorrect
**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
