### PR TITLE
[DEV-6612] fix budgetary resources fy

### DIFF
--- a/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
@@ -28,29 +28,33 @@ def data_fixture():
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=FY,
         reporting_fiscal_period=3,
-        submission_window_id=dabs.id,
+        submission_window=dabs,
         toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=True,
     )
     sa1_6 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=FY,
         reporting_fiscal_period=6,
-        submission_window_id=dabs.id,
+        submission_window=dabs,
         toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=True,
     )
     sa1_9 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=FY,
         reporting_fiscal_period=9,
-        submission_window_id=dabs.id,
+        submission_window=dabs,
         toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=True,
     )
     sa1_12 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=FY,
         reporting_fiscal_period=12,
-        submission_window_id=dabs.id,
+        submission_window=dabs,
         toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=True,
     )
     sa2_12 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -58,6 +62,7 @@ def data_fixture():
         reporting_fiscal_period=12,
         submission_window_id=dabs.id,
         toptier_code=ta2.toptier_code,
+        is_final_balances_for_fy=True,
     )
 
     mommy.make(

--- a/usaspending_api/agency/v2/views/budgetary_resources.py
+++ b/usaspending_api/agency/v2/views/budgetary_resources.py
@@ -48,6 +48,7 @@ class BudgetaryResources(AgencyBase):
             AppropriationAccountBalances.objects.filter(
                 treasury_account_identifier__funding_toptier_agency=self.toptier_agency,
                 submission__submission_window__submission_reveal_date__lte=now(),
+                submission__is_final_balances_for_fy=True
             )
             .values("submission__reporting_fiscal_year")
             .annotate(

--- a/usaspending_api/agency/v2/views/budgetary_resources.py
+++ b/usaspending_api/agency/v2/views/budgetary_resources.py
@@ -48,7 +48,7 @@ class BudgetaryResources(AgencyBase):
             AppropriationAccountBalances.objects.filter(
                 treasury_account_identifier__funding_toptier_agency=self.toptier_agency,
                 submission__submission_window__submission_reveal_date__lte=now(),
-                submission__is_final_balances_for_fy=True
+                submission__is_final_balances_for_fy=True,
             )
             .values("submission__reporting_fiscal_year")
             .annotate(


### PR DESCRIPTION
**Description:**
Fixes bug with the `bugdetary_resources` endpoint - should have been filtering with `is_final_balances_for_fy` per fiscal year, but was not

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-6612](https://federal-spending-transparency.atlassian.net/browse/DEV-6612):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
