### PR TITLE
[DEV-7114] Validate within revealed period, restructure, and tests

### DIFF
--- a/usaspending_api/agency/tests/integration/conftest.py
+++ b/usaspending_api/agency/tests/integration/conftest.py
@@ -1,12 +1,42 @@
 import pytest
 
 from model_mommy import mommy
-from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
+
+CURRENT_FISCAL_YEAR = 2020
+
+
+class Helpers:
+    @staticmethod
+    def get_mocked_current_fiscal_year():
+        return CURRENT_FISCAL_YEAR
+
+    @staticmethod
+    def mock_current_fiscal_year(monkeypatch, path=None):
+        def _mocked_fiscal_year():
+            return CURRENT_FISCAL_YEAR
+
+        if path is None:
+            path = "usaspending_api.agency.v2.views.agency_base.current_fiscal_year"
+        monkeypatch.setattr(path, _mocked_fiscal_year)
+
+
+@pytest.fixture
+def helpers():
+    return Helpers
 
 
 @pytest.fixture
 def agency_account_data():
-    dabs = mommy.make("submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-10-09")
+    dabs = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=f"{CURRENT_FISCAL_YEAR}-10-09",
+        submission_fiscal_year=CURRENT_FISCAL_YEAR,
+        submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=False,
+        period_start_date=f"{CURRENT_FISCAL_YEAR}-09-01",
+        period_end_date=f"{CURRENT_FISCAL_YEAR}-10-01",
+    )
 
     ta1 = mommy.make("references.ToptierAgency", toptier_code="007")
     ta2 = mommy.make("references.ToptierAgency", toptier_code="008")
@@ -20,7 +50,7 @@ def agency_account_data():
 
     sub1 = mommy.make(
         "submissions.SubmissionAttributes",
-        reporting_fiscal_year=current_fiscal_year(),
+        reporting_fiscal_year=CURRENT_FISCAL_YEAR,
         toptier_code=ta1.toptier_code,
         is_final_balances_for_fy=True,
         submission_window_id=dabs.id,
@@ -124,10 +154,10 @@ def agency_account_data():
         tas_rendering_label="003-2017/2018-0000-000",
     )
 
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas1)
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas2)
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas3)
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas4)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas1, submission=sub1)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas2, submission=sub2)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas3, submission=sub3)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas4, submission=sub4)
 
     pa1 = mommy.make("references.RefProgramActivity", program_activity_code="000", program_activity_name="NAME 1")
     pa2 = mommy.make("references.RefProgramActivity", program_activity_code="1000", program_activity_name="NAME 2")
@@ -261,4 +291,4 @@ def agency_account_data():
     )
 
 
-__all__ = ["agency_account_data"]
+__all__ = ["agency_account_data", "helpers"]

--- a/usaspending_api/agency/tests/integration/test_agency.py
+++ b/usaspending_api/agency/tests/integration/test_agency.py
@@ -12,7 +12,7 @@ URL = "/api/v2/agency/{code}/{filter}"
 
 
 @pytest.fixture
-def agency_data():
+def agency_data(helpers):
     ta1 = mommy.make(
         "references.ToptierAgency",
         toptier_code="001",
@@ -29,19 +29,29 @@ def agency_data():
     sa2 = mommy.make("references.SubtierAgency", subtier_code="ST2")
     a1 = mommy.make("references.Agency", id=1, toptier_flag=True, toptier_agency=ta1, subtier_agency=sa1)
     mommy.make("references.Agency", id=2, toptier_flag=True, toptier_agency=ta2, subtier_agency=sa2)
-    tas1 = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ta1)
-    tas2 = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ta2)
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas1)
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas2)
-    mommy.make("awards.TransactionNormalized", awarding_agency=a1, fiscal_year=current_fiscal_year())
-    dabs = mommy.make("submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-10-09")
+    dabs = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date="2020-10-09",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=False,
+        period_start_date="2020-09-01",
+        period_end_date="2020-10-01",
+    )
     sub1 = mommy.make(
         "submissions.SubmissionAttributes",
         toptier_code=ta1.toptier_code,
         submission_window_id=dabs.id,
-        reporting_fiscal_year=current_fiscal_year(),
+        reporting_fiscal_year=helpers.get_mocked_current_fiscal_year(),
     )
     mommy.make("submissions.SubmissionAttributes", toptier_code=ta2.toptier_code, submission_window_id=dabs.id)
+    tas1 = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ta1)
+    tas2 = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ta2)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas1, submission=sub1)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas2, submission=sub1)
+    mommy.make("awards.TransactionNormalized", awarding_agency=a1, fiscal_year=helpers.get_mocked_current_fiscal_year())
+
     defc = mommy.make(
         "references.DisasterEmergencyFundCode", code="L", group_name="covid_19", public_law="LAW", title="title"
     )
@@ -54,10 +64,11 @@ def agency_data():
 
 
 @pytest.mark.django_db
-def test_happy_path(client, agency_data):
+def test_happy_path(client, monkeypatch, agency_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(URL.format(code="001", filter=""))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["fiscal_year"] == current_fiscal_year()
+    assert resp.data["fiscal_year"] == helpers.get_mocked_current_fiscal_year()
     assert resp.data["toptier_code"] == "001"
     assert resp.data["abbreviation"] == "ABBR"
     assert resp.data["name"] == "NAME"
@@ -73,21 +84,21 @@ def test_happy_path(client, agency_data):
     ]
     assert resp.data["messages"] == []
 
-    resp = client.get(URL.format(code="001", filter=f"?fiscal_year={current_fiscal_year()}"))
+    resp = client.get(URL.format(code="001", filter=f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}"))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["fiscal_year"] == current_fiscal_year()
+    assert resp.data["fiscal_year"] == helpers.get_mocked_current_fiscal_year()
     assert resp.data["toptier_code"] == "001"
     assert resp.data["subtier_agency_count"] == 1
 
-    resp = client.get(URL.format(code="001", filter=f"?fiscal_year={current_fiscal_year() - 1}"))
+    resp = client.get(URL.format(code="001", filter=f"?fiscal_year={helpers.get_mocked_current_fiscal_year() - 1}"))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["fiscal_year"] == current_fiscal_year() - 1
+    assert resp.data["fiscal_year"] == helpers.get_mocked_current_fiscal_year() - 1
     assert resp.data["toptier_code"] == "001"
     assert resp.data["subtier_agency_count"] == 1
 
     resp = client.get(URL.format(code="002", filter=""))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["fiscal_year"] == current_fiscal_year()
+    assert resp.data["fiscal_year"] == helpers.get_mocked_current_fiscal_year()
     assert resp.data["toptier_code"] == "002"
     assert resp.data["agency_id"] == 2
     assert resp.data["subtier_agency_count"] == 0

--- a/usaspending_api/agency/tests/integration/test_agency_budget_function.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budget_function.py
@@ -9,10 +9,11 @@ url = "/api/v2/agency/{code}/budget_function/{query_params}"
 
 
 @pytest.mark.django_db
-def test_budget_function_list_success(client, agency_account_data):
+def test_budget_function_list_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -130,11 +131,12 @@ def test_budget_function_list_bad_order(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_budget_function_list_sort_by_name(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
+def test_budget_function_list_sort_by_name(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -171,10 +173,10 @@ def test_budget_function_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -213,11 +215,12 @@ def test_budget_function_list_sort_by_name(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_budget_function_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
+def test_budget_function_list_sort_by_obligated_amount(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -254,10 +257,10 @@ def test_budget_function_list_sort_by_obligated_amount(client, agency_account_da
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -287,89 +290,6 @@ def test_budget_function_list_sort_by_obligated_amount(client, agency_account_da
                 "name": "NAME 5",
                 "obligated_amount": 10.0,
                 "children": [{"gross_outlay_amount": 1000000.0, "name": "NAME 5A", "obligated_amount": 10.0}],
-            },
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-
-@pytest.mark.django_db
-def test_budget_function_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-            "limit": 10,
-        },
-        "results": [
-            {
-                "gross_outlay_amount": 100000.0,
-                "name": "NAME 6",
-                "obligated_amount": 100.0,
-                "children": [{"gross_outlay_amount": 100000.0, "name": "NAME 6A", "obligated_amount": 100.0}],
-            },
-            {
-                "gross_outlay_amount": 1000000.0,
-                "name": "NAME 5",
-                "obligated_amount": 10.0,
-                "children": [{"gross_outlay_amount": 1000000.0, "name": "NAME 5A", "obligated_amount": 10.0}],
-            },
-            {
-                "gross_outlay_amount": 11100000.0,
-                "name": "NAME 1",
-                "obligated_amount": 111.0,
-                "children": [{"gross_outlay_amount": 11100000.0, "name": "NAME 1A", "obligated_amount": 111.0}],
-            },
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-            "limit": 10,
-        },
-        "results": [
-            {
-                "gross_outlay_amount": 11100000.0,
-                "name": "NAME 1",
-                "obligated_amount": 111.0,
-                "children": [{"gross_outlay_amount": 11100000.0, "name": "NAME 1A", "obligated_amount": 111.0}],
-            },
-            {
-                "gross_outlay_amount": 1000000.0,
-                "name": "NAME 5",
-                "obligated_amount": 10.0,
-                "children": [{"gross_outlay_amount": 1000000.0, "name": "NAME 5A", "obligated_amount": 10.0}],
-            },
-            {
-                "gross_outlay_amount": 100000.0,
-                "name": "NAME 6",
-                "obligated_amount": 100.0,
-                "children": [{"gross_outlay_amount": 100000.0, "name": "NAME 6A", "obligated_amount": 100.0}],
             },
         ],
     }
@@ -379,11 +299,96 @@ def test_budget_function_list_sort_by_gross_outlay_amount(client, agency_account
 
 
 @pytest.mark.django_db
-def test_budget_function_list_search(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=NAME 6"
+def test_budget_function_list_sort_by_gross_outlay_amount(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+            "limit": 10,
+        },
+        "results": [
+            {
+                "gross_outlay_amount": 100000.0,
+                "name": "NAME 6",
+                "obligated_amount": 100.0,
+                "children": [{"gross_outlay_amount": 100000.0, "name": "NAME 6A", "obligated_amount": 100.0}],
+            },
+            {
+                "gross_outlay_amount": 1000000.0,
+                "name": "NAME 5",
+                "obligated_amount": 10.0,
+                "children": [{"gross_outlay_amount": 1000000.0, "name": "NAME 5A", "obligated_amount": 10.0}],
+            },
+            {
+                "gross_outlay_amount": 11100000.0,
+                "name": "NAME 1",
+                "obligated_amount": 111.0,
+                "children": [{"gross_outlay_amount": 11100000.0, "name": "NAME 1A", "obligated_amount": 111.0}],
+            },
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+            "limit": 10,
+        },
+        "results": [
+            {
+                "gross_outlay_amount": 11100000.0,
+                "name": "NAME 1",
+                "obligated_amount": 111.0,
+                "children": [{"gross_outlay_amount": 11100000.0, "name": "NAME 1A", "obligated_amount": 111.0}],
+            },
+            {
+                "gross_outlay_amount": 1000000.0,
+                "name": "NAME 5",
+                "obligated_amount": 10.0,
+                "children": [{"gross_outlay_amount": 1000000.0, "name": "NAME 5A", "obligated_amount": 10.0}],
+            },
+            {
+                "gross_outlay_amount": 100000.0,
+                "name": "NAME 6",
+                "obligated_amount": 100.0,
+                "children": [{"gross_outlay_amount": 100000.0, "name": "NAME 6A", "obligated_amount": 100.0}],
+            },
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+
+@pytest.mark.django_db
+def test_budget_function_list_search(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=NAME 6"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -408,10 +413,10 @@ def test_budget_function_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=AME 5"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=AME 5"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -439,10 +444,10 @@ def test_budget_function_list_search(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_budget_function_list_pagination(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
+    query_params = f"?fiscal_year=2020&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": 2020,
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -473,10 +478,10 @@ def test_budget_function_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
+    query_params = f"?fiscal_year=2020&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": 2020,
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_agency_budget_function_count.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budget_function_count.py
@@ -8,7 +8,8 @@ url = "/api/v2/agency/{code}/budget_function/count/{filter}"
 
 
 @pytest.mark.django_db
-def test_budget_function_count_success(client, agency_account_data):
+def test_budget_function_count_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", filter=""))
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["budget_function_count"] == 3

--- a/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
@@ -16,6 +16,7 @@ def data_fixture():
         "submissions.DABSSubmissionWindowSchedule",
         submission_fiscal_year=1995,
         submission_fiscal_month=2,
+        submission_fiscal_quarter=1,
         submission_reveal_date="2020-10-09",
     )
     ta1 = mommy.make("references.ToptierAgency", toptier_code="001")
@@ -134,6 +135,7 @@ def data_fixture():
             "submissions.DABSSubmissionWindowSchedule",
             submission_fiscal_year=fy,
             submission_fiscal_month=12,
+            submission_fiscal_quarter=4,
             submission_reveal_date="2020-10-09",
             is_quarter=True,
         )

--- a/usaspending_api/agency/tests/integration/test_agency_federal_account_count.py
+++ b/usaspending_api/agency/tests/integration/test_agency_federal_account_count.py
@@ -9,7 +9,8 @@ url = "/api/v2/agency/{code}/federal_account/count/{filter}"
 
 
 @pytest.mark.django_db
-def test_federal_account_count_success(client, agency_account_data):
+def test_federal_account_count_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", filter=""))
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["federal_account_count"] == 3

--- a/usaspending_api/agency/tests/integration/test_agency_federal_account_list.py
+++ b/usaspending_api/agency/tests/integration/test_agency_federal_account_list.py
@@ -9,10 +9,11 @@ url = "/api/v2/agency/{code}/federal_account/{query_params}"
 
 
 @pytest.mark.django_db
-def test_federal_account_list_success(client, agency_account_data):
+def test_federal_account_list_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -162,11 +163,11 @@ def test_federal_account_list_bad_order(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_federal_account_list_sort_by_name(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
+def test_federal_account_list_sort_by_name(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -227,10 +228,10 @@ def test_federal_account_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -293,11 +294,11 @@ def test_federal_account_list_sort_by_name(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_federal_account_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
+def test_federal_account_list_sort_by_obligated_amount(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -358,10 +359,10 @@ def test_federal_account_list_sort_by_obligated_amount(client, agency_account_da
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -413,137 +414,6 @@ def test_federal_account_list_sort_by_obligated_amount(client, agency_account_da
                         "name": "TA 5",
                         "code": "002-2008/2009-0000-000",
                         "obligated_amount": 10.0,
-                    }
-                ],
-            },
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-
-@pytest.mark.django_db
-def test_federal_account_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-            "limit": 10,
-        },
-        "results": [
-            {
-                "gross_outlay_amount": 100000.0,
-                "name": "FA 3",
-                "code": "003-0000",
-                "obligated_amount": 100.0,
-                "children": [
-                    {
-                        "gross_outlay_amount": 100000.0,
-                        "name": "TA 6",
-                        "code": "003-2017/2018-0000-000",
-                        "obligated_amount": 100.0,
-                    }
-                ],
-            },
-            {
-                "gross_outlay_amount": 1000000.0,
-                "name": "FA 2",
-                "code": "002-0000",
-                "obligated_amount": 10.0,
-                "children": [
-                    {
-                        "gross_outlay_amount": 1000000.0,
-                        "name": "TA 5",
-                        "code": "002-2008/2009-0000-000",
-                        "obligated_amount": 10.0,
-                    }
-                ],
-            },
-            {
-                "gross_outlay_amount": 11100000.0,
-                "name": "FA 1",
-                "code": "001-0000",
-                "obligated_amount": 111.0,
-                "children": [
-                    {
-                        "gross_outlay_amount": 11100000.0,
-                        "name": "TA 1",
-                        "code": "001-X-0000-000",
-                        "obligated_amount": 111.0,
-                    }
-                ],
-            },
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-            "limit": 10,
-        },
-        "results": [
-            {
-                "gross_outlay_amount": 11100000.0,
-                "name": "FA 1",
-                "code": "001-0000",
-                "obligated_amount": 111.0,
-                "children": [
-                    {
-                        "gross_outlay_amount": 11100000.0,
-                        "name": "TA 1",
-                        "code": "001-X-0000-000",
-                        "obligated_amount": 111.0,
-                    }
-                ],
-            },
-            {
-                "gross_outlay_amount": 1000000.0,
-                "name": "FA 2",
-                "code": "002-0000",
-                "obligated_amount": 10.0,
-                "children": [
-                    {
-                        "gross_outlay_amount": 1000000.0,
-                        "name": "TA 5",
-                        "code": "002-2008/2009-0000-000",
-                        "obligated_amount": 10.0,
-                    }
-                ],
-            },
-            {
-                "gross_outlay_amount": 100000.0,
-                "name": "FA 3",
-                "code": "003-0000",
-                "obligated_amount": 100.0,
-                "children": [
-                    {
-                        "gross_outlay_amount": 100000.0,
-                        "name": "TA 6",
-                        "code": "003-2017/2018-0000-000",
-                        "obligated_amount": 100.0,
                     }
                 ],
             },
@@ -555,11 +425,142 @@ def test_federal_account_list_sort_by_gross_outlay_amount(client, agency_account
 
 
 @pytest.mark.django_db
-def test_federal_account_list_search(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=FA 3"
+def test_federal_account_list_sort_by_gross_outlay_amount(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+            "limit": 10,
+        },
+        "results": [
+            {
+                "gross_outlay_amount": 100000.0,
+                "name": "FA 3",
+                "code": "003-0000",
+                "obligated_amount": 100.0,
+                "children": [
+                    {
+                        "gross_outlay_amount": 100000.0,
+                        "name": "TA 6",
+                        "code": "003-2017/2018-0000-000",
+                        "obligated_amount": 100.0,
+                    }
+                ],
+            },
+            {
+                "gross_outlay_amount": 1000000.0,
+                "name": "FA 2",
+                "code": "002-0000",
+                "obligated_amount": 10.0,
+                "children": [
+                    {
+                        "gross_outlay_amount": 1000000.0,
+                        "name": "TA 5",
+                        "code": "002-2008/2009-0000-000",
+                        "obligated_amount": 10.0,
+                    }
+                ],
+            },
+            {
+                "gross_outlay_amount": 11100000.0,
+                "name": "FA 1",
+                "code": "001-0000",
+                "obligated_amount": 111.0,
+                "children": [
+                    {
+                        "gross_outlay_amount": 11100000.0,
+                        "name": "TA 1",
+                        "code": "001-X-0000-000",
+                        "obligated_amount": 111.0,
+                    }
+                ],
+            },
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+            "limit": 10,
+        },
+        "results": [
+            {
+                "gross_outlay_amount": 11100000.0,
+                "name": "FA 1",
+                "code": "001-0000",
+                "obligated_amount": 111.0,
+                "children": [
+                    {
+                        "gross_outlay_amount": 11100000.0,
+                        "name": "TA 1",
+                        "code": "001-X-0000-000",
+                        "obligated_amount": 111.0,
+                    }
+                ],
+            },
+            {
+                "gross_outlay_amount": 1000000.0,
+                "name": "FA 2",
+                "code": "002-0000",
+                "obligated_amount": 10.0,
+                "children": [
+                    {
+                        "gross_outlay_amount": 1000000.0,
+                        "name": "TA 5",
+                        "code": "002-2008/2009-0000-000",
+                        "obligated_amount": 10.0,
+                    }
+                ],
+            },
+            {
+                "gross_outlay_amount": 100000.0,
+                "name": "FA 3",
+                "code": "003-0000",
+                "obligated_amount": 100.0,
+                "children": [
+                    {
+                        "gross_outlay_amount": 100000.0,
+                        "name": "TA 6",
+                        "code": "003-2017/2018-0000-000",
+                        "obligated_amount": 100.0,
+                    }
+                ],
+            },
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+
+@pytest.mark.django_db
+def test_federal_account_list_search(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=FA 3"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -592,10 +593,10 @@ def test_federal_account_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=TA 5"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=TA 5"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -630,11 +631,11 @@ def test_federal_account_list_search(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_federal_account_list_pagination(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
+def test_federal_account_list_pagination(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -681,10 +682,10 @@ def test_federal_account_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_agency_object_class_count.py
+++ b/usaspending_api/agency/tests/integration/test_agency_object_class_count.py
@@ -8,7 +8,8 @@ url = "/api/v2/agency/{code}/object_class/count/{filter}"
 
 
 @pytest.mark.django_db
-def test_object_class_count_success(client, agency_account_data):
+def test_object_class_count_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", filter=""))
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["object_class_count"] == 3

--- a/usaspending_api/agency/tests/integration/test_agency_object_class_list.py
+++ b/usaspending_api/agency/tests/integration/test_agency_object_class_list.py
@@ -9,10 +9,11 @@ url = "/api/v2/agency/{code}/object_class/{query_params}"
 
 
 @pytest.mark.django_db
-def test_object_class_list_success(client, agency_account_data):
+def test_object_class_list_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -175,10 +176,10 @@ def test_object_class_list_ignore_duplicates(client, agency_account_data):
 
 @pytest.mark.django_db
 def test_object_class_list_sort_by_name(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
+    query_params = f"?fiscal_year={2020}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": 2020,
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -200,63 +201,10 @@ def test_object_class_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
+    query_params = f"?fiscal_year={2020}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "limit": 10,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-        },
-        "results": [
-            {"gross_outlay_amount": 100000.0, "name": "supplies", "obligated_amount": 100.0},
-            {"gross_outlay_amount": 1000000.0, "name": "hvac", "obligated_amount": 10.0},
-            {"gross_outlay_amount": 10000000.0, "name": "equipment", "obligated_amount": 1.0},
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-
-@pytest.mark.django_db
-def test_object_class_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "limit": 10,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-        },
-        "results": [
-            {"gross_outlay_amount": 10000000.0, "name": "equipment", "obligated_amount": 1.0},
-            {"gross_outlay_amount": 1000000.0, "name": "hvac", "obligated_amount": 10.0},
-            {"gross_outlay_amount": 100000.0, "name": "supplies", "obligated_amount": 100.0},
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": 2020,
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -280,11 +228,36 @@ def test_object_class_list_sort_by_obligated_amount(client, agency_account_data)
 
 
 @pytest.mark.django_db
-def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
+def test_object_class_list_sort_by_obligated_amount(client, monkeypatch, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "limit": 10,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+        },
+        "results": [
+            {"gross_outlay_amount": 10000000.0, "name": "equipment", "obligated_amount": 1.0},
+            {"gross_outlay_amount": 1000000.0, "name": "hvac", "obligated_amount": 10.0},
+            {"gross_outlay_amount": 100000.0, "name": "supplies", "obligated_amount": 100.0},
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=obligated_amount"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -306,10 +279,38 @@ def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_da
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
+
+@pytest.mark.django_db
+def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "limit": 10,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+        },
+        "results": [
+            {"gross_outlay_amount": 100000.0, "name": "supplies", "obligated_amount": 100.0},
+            {"gross_outlay_amount": 1000000.0, "name": "hvac", "obligated_amount": 10.0},
+            {"gross_outlay_amount": 10000000.0, "name": "equipment", "obligated_amount": 1.0},
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -333,11 +334,11 @@ def test_object_class_list_sort_by_gross_outlay_amount(client, agency_account_da
 
 
 @pytest.mark.django_db
-def test_object_class_list_search(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=supplies"
+def test_object_class_list_search(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=supplies"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -355,10 +356,10 @@ def test_object_class_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=uipm"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=uipm"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -378,11 +379,11 @@ def test_object_class_list_search(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_object_class_list_pagination(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
+def test_object_class_list_pagination(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -403,10 +404,10 @@ def test_object_class_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_agency_program_acccount_count.py
+++ b/usaspending_api/agency/tests/integration/test_agency_program_acccount_count.py
@@ -9,7 +9,8 @@ url = "/api/v2/agency/{code}/program_activity/count/{filter}"
 
 
 @pytest.mark.django_db
-def test_program_activity_count_success(client, agency_account_data):
+def test_program_activity_count_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", filter=""))
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["program_activity_count"] == 3

--- a/usaspending_api/agency/tests/integration/test_agency_program_activity_list.py
+++ b/usaspending_api/agency/tests/integration/test_agency_program_activity_list.py
@@ -9,10 +9,11 @@ url = "/api/v2/agency/{code}/program_activity/{query_params}"
 
 
 @pytest.mark.django_db
-def test_program_activity_list_success(client, agency_account_data):
+def test_program_activity_list_success(client, monkeypatch, agency_account_data, helpers):
+    helpers.mock_current_fiscal_year(monkeypatch)
     resp = client.get(url.format(code="007", query_params=""))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -174,11 +175,11 @@ def test_program_activity_list_ignore_duplicates(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_program_activity_list_sort_by_name(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=name"
+def test_program_activity_list_sort_by_name(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -200,63 +201,10 @@ def test_program_activity_list_sort_by_name(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=name"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=name"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "limit": 10,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-        },
-        "results": [
-            {"gross_outlay_amount": 100000.0, "name": "NAME 3", "obligated_amount": 100.0},
-            {"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0},
-            {"gross_outlay_amount": 10000000.0, "name": "NAME 1", "obligated_amount": 1.0},
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-
-@pytest.mark.django_db
-def test_program_activity_list_sort_by_obligated_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=obligated_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
-        "toptier_code": "007",
-        "messages": [],
-        "page_metadata": {
-            "hasNext": False,
-            "hasPrevious": False,
-            "limit": 10,
-            "next": None,
-            "page": 1,
-            "previous": None,
-            "total": 3,
-        },
-        "results": [
-            {"gross_outlay_amount": 10000000.0, "name": "NAME 1", "obligated_amount": 1.0},
-            {"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0},
-            {"gross_outlay_amount": 100000.0, "name": "NAME 3", "obligated_amount": 100.0},
-        ],
-    }
-
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == expected_result
-
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=obligated_amount"
-    resp = client.get(url.format(code="007", query_params=query_params))
-    expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -280,11 +228,36 @@ def test_program_activity_list_sort_by_obligated_amount(client, agency_account_d
 
 
 @pytest.mark.django_db
-def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
+def test_program_activity_list_sort_by_obligated_amount(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=obligated_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "limit": 10,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+        },
+        "results": [
+            {"gross_outlay_amount": 10000000.0, "name": "NAME 1", "obligated_amount": 1.0},
+            {"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0},
+            {"gross_outlay_amount": 100000.0, "name": "NAME 3", "obligated_amount": 100.0},
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=obligated_amount"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -306,10 +279,38 @@ def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_accoun
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
+
+@pytest.mark.django_db
+def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=asc&sort=gross_outlay_amount"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
+        "toptier_code": "007",
+        "messages": [],
+        "page_metadata": {
+            "hasNext": False,
+            "hasPrevious": False,
+            "limit": 10,
+            "next": None,
+            "page": 1,
+            "previous": None,
+            "total": 3,
+        },
+        "results": [
+            {"gross_outlay_amount": 100000.0, "name": "NAME 3", "obligated_amount": 100.0},
+            {"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0},
+            {"gross_outlay_amount": 10000000.0, "name": "NAME 1", "obligated_amount": 1.0},
+        ],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result
+
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&order=desc&sort=gross_outlay_amount"
+    resp = client.get(url.format(code="007", query_params=query_params))
+    expected_result = {
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -333,11 +334,11 @@ def test_program_activity_list_sort_by_gross_outlay_amount(client, agency_accoun
 
 
 @pytest.mark.django_db
-def test_program_activity_list_search(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=NAME%203"
+def test_program_activity_list_search(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=NAME%203"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -355,10 +356,10 @@ def test_program_activity_list_search(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&filter=AME%202"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&filter=AME%202"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -378,11 +379,11 @@ def test_program_activity_list_search(client, agency_account_data):
 
 
 @pytest.mark.django_db
-def test_program_activity_list_pagination(client, agency_account_data):
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=1"
+def test_program_activity_list_pagination(client, agency_account_data, helpers):
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&limit=2&page=1"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {
@@ -403,10 +404,10 @@ def test_program_activity_list_pagination(client, agency_account_data):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_result
 
-    query_params = f"?fiscal_year={current_fiscal_year()}&limit=2&page=2"
+    query_params = f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}&limit=2&page=2"
     resp = client.get(url.format(code="007", query_params=query_params))
     expected_result = {
-        "fiscal_year": current_fiscal_year(),
+        "fiscal_year": helpers.get_mocked_current_fiscal_year(),
         "toptier_code": "007",
         "messages": [],
         "page_metadata": {

--- a/usaspending_api/agency/tests/integration/test_obligations_by_award_category.py
+++ b/usaspending_api/agency/tests/integration/test_obligations_by_award_category.py
@@ -14,7 +14,16 @@ url = "/api/v2/agency/{toptier_code}/obligations_by_award_category/{filter}"
 def transaction_search_1():
 
     # Submission
-    dsws = mommy.make("submissions.DABSSubmissionWindowSchedule", id=444, submission_reveal_date="2020-10-09")
+    dsws = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date="2021-04-09",
+        submission_fiscal_year=2021,
+        submission_fiscal_month=7,
+        submission_fiscal_quarter=3,
+        is_quarter=False,
+        period_start_date="2021-03-01",
+        period_end_date="2021-04-01",
+    )
     mommy.make("submissions.SubmissionAttributes", toptier_code="001", submission_window=dsws)
     mommy.make("submissions.SubmissionAttributes", toptier_code="002", submission_window=dsws)
 

--- a/usaspending_api/agency/v2/views/agency_overview.py
+++ b/usaspending_api/agency/v2/views/agency_overview.py
@@ -17,6 +17,10 @@ class AgencyOverview(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year"]
+
     @cache_response()
     def get(self, request, *args, **kwargs):
         return Response(

--- a/usaspending_api/agency/v2/views/budget_function.py
+++ b/usaspending_api/agency/v2/views/budget_function.py
@@ -17,6 +17,10 @@ class BudgetFunctionList(PaginationMixin, AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/budget_function.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "filter"]
+
     def format_results(self, rows):
         order = self.pagination.sort_order == "desc"
         names = set([row["treasury_account__budget_function_title"] for row in rows])

--- a/usaspending_api/agency/v2/views/budget_function_count.py
+++ b/usaspending_api/agency/v2/views/budget_function_count.py
@@ -17,6 +17,10 @@ class BudgetFunctionCount(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/budget_function/count.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         rows = list(self.get_budget_function_queryset())

--- a/usaspending_api/agency/v2/views/federal_account_count.py
+++ b/usaspending_api/agency/v2/views/federal_account_count.py
@@ -16,6 +16,10 @@ class FederalAccountCount(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/federal_account/count.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(

--- a/usaspending_api/agency/v2/views/federal_account_list.py
+++ b/usaspending_api/agency/v2/views/federal_account_list.py
@@ -17,6 +17,10 @@ class FederalAccountList(PaginationMixin, AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/federal_account.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "filter"]
+
     def format_results(self, rows):
         non_distinct = [
             {

--- a/usaspending_api/agency/v2/views/object_class_count.py
+++ b/usaspending_api/agency/v2/views/object_class_count.py
@@ -17,6 +17,10 @@ class ObjectClassCount(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/object_class/count.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(

--- a/usaspending_api/agency/v2/views/object_class_list.py
+++ b/usaspending_api/agency/v2/views/object_class_list.py
@@ -17,6 +17,10 @@ class ObjectClassList(PaginationMixin, AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/object_class.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "filter"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         self.sortable_columns = ["name", "obligated_amount", "gross_outlay_amount"]

--- a/usaspending_api/agency/v2/views/obligations_by_award_category.py
+++ b/usaspending_api/agency/v2/views/obligations_by_award_category.py
@@ -17,6 +17,10 @@ class ObligationsByAwardCategory(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/obligations_by_award_category.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
 

--- a/usaspending_api/agency/v2/views/program_activity_count.py
+++ b/usaspending_api/agency/v2/views/program_activity_count.py
@@ -17,6 +17,10 @@ class ProgramActivityCount(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/program_activity/count.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(

--- a/usaspending_api/agency/v2/views/program_activity_list.py
+++ b/usaspending_api/agency/v2/views/program_activity_list.py
@@ -17,6 +17,10 @@ class ProgramActivityList(PaginationMixin, AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/program_activity.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "filter"]
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         self.sortable_columns = ["name", "obligated_amount", "gross_outlay_amount"]

--- a/usaspending_api/common/helpers/dict_helpers.py
+++ b/usaspending_api/common/helpers/dict_helpers.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+from typing import List
+
 from usaspending_api.search.filters.elasticsearch.naics import NaicsCodes
 from usaspending_api.search.filters.elasticsearch.tas import TasCodes
 from usaspending_api.search.filters.mixins.psc import PSCCodesMixin
@@ -76,3 +78,15 @@ def order_nested_object(nested_object):
         )
     else:
         return nested_object
+
+
+def update_list_of_dictionaries(to_update: List[dict], update_with: List[dict], common_term: str) -> dict:
+    """
+    Returns a copy of the "to_update" dictionary with the updates from the "update_with" dict.
+    The "common_term" is what the two list of dictionaries will be updated around; assumes that the common_term
+    should be unique to a list of dictionaries.
+    """
+    to_update = {val[common_term]: val for val in to_update}
+    update_with = {val[common_term]: val for val in update_with}
+    to_update.update(update_with)
+    return [val for val in to_update.values()]

--- a/usaspending_api/common/tests/unit/test_fiscal_year_helpers.py
+++ b/usaspending_api/common/tests/unit/test_fiscal_year_helpers.py
@@ -84,6 +84,7 @@ def test_calculate_last_completed_fiscal_quarter():
         submission_fiscal_year=2000,
         submission_reveal_date=now,
         submission_fiscal_quarter=1,
+        submission_fiscal_month=3,
         is_quarter=True,
     )
     mommy.make(
@@ -91,6 +92,7 @@ def test_calculate_last_completed_fiscal_quarter():
         submission_fiscal_year=2000,
         submission_reveal_date=now,
         submission_fiscal_quarter=2,
+        submission_fiscal_month=4,
         is_quarter=False,
     )
     mommy.make(
@@ -98,6 +100,7 @@ def test_calculate_last_completed_fiscal_quarter():
         submission_fiscal_year=2010,
         submission_reveal_date=tomorrow,
         submission_fiscal_quarter=2,
+        submission_fiscal_month=6,
         is_quarter=True,
     )
     mommy.make(
@@ -105,6 +108,7 @@ def test_calculate_last_completed_fiscal_quarter():
         submission_fiscal_year=current_fy,
         submission_reveal_date=yesterday,
         submission_fiscal_quarter=3,
+        submission_fiscal_month=9,
         is_quarter=True,
     )
     mommy.make(
@@ -112,6 +116,7 @@ def test_calculate_last_completed_fiscal_quarter():
         submission_fiscal_year=current_fy,
         submission_reveal_date=now,
         submission_fiscal_quarter=4,
+        submission_fiscal_month=12,
         is_quarter=True,
     )
 

--- a/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
+++ b/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
@@ -44,6 +44,7 @@ class TestWithMultipleDatabases(TestCase):
             id="2000060",
             submission_fiscal_year=0,
             submission_fiscal_month=0,
+            submission_fiscal_quarter=0,
             is_quarter=False,
         )
 

--- a/usaspending_api/reporting/tests/conftest.py
+++ b/usaspending_api/reporting/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+CURRENT_FISCAL_YEAR = 2020
+
+
+class Helpers:
+    @staticmethod
+    def get_mocked_current_fiscal_year():
+        return CURRENT_FISCAL_YEAR
+
+    @staticmethod
+    def mock_current_fiscal_year(monkeypatch, path=None):
+        def _mocked_fiscal_year():
+            return CURRENT_FISCAL_YEAR
+
+        if path is None:
+            path = "usaspending_api.agency.v2.views.agency_base.current_fiscal_year"
+        monkeypatch.setattr(path, _mocked_fiscal_year)
+
+
+@pytest.fixture
+def helpers():
+    return Helpers
+
+
+__all__ = ["helpers"]

--- a/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
@@ -10,44 +10,50 @@ url = "/api/v2/reporting/agencies/publish_dates/"
 def publish_dates_data(db):
     dabs1 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
-        submission_reveal_date="2020-01-01 00:00:00.000000+00",
+        submission_reveal_date="2020-01-30 00:00:00.000000+00",
         submission_fiscal_year=2020,
-        submission_fiscal_month=7,
+        submission_fiscal_month=6,
+        submission_fiscal_quarter=2,
+        is_quarter=True,
     )
     dabs2 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
-        submission_reveal_date="2020-01-02 00:00:00.000000+00",
-        submission_fiscal_year=2019,
-        submission_fiscal_month=12,
+        submission_reveal_date="2020-05-02 00:00:00.000000+00",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=7,
+        submission_fiscal_quarter=3,
+        is_quarter=False,
     )
     dabs3 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
-        submission_reveal_date="2019-01-01 00:00:00.000000+00",
+        submission_reveal_date="2019-10-01 00:00:00.000000+00",
         submission_fiscal_year=2019,
         submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=True,
     )
-    dabs4 = mommy.make(
+    mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
-        submission_reveal_date="2019-01-02 00:00:00.000000+00",
-        submission_fiscal_year=2019,
-        submission_fiscal_month=12,
+        submission_reveal_date="2020-09-02 00:00:00.000000+00",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=11,
+        submission_fiscal_quarter=1,
+        is_quarter=False,
     )
     tas1 = mommy.make("accounts.TreasuryAppropriationAccount")
     tas2 = mommy.make("accounts.TreasuryAppropriationAccount")
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas1)
-    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas2)
-    mommy.make(
+    sub1 = mommy.make(
         "submissions.SubmissionAttributes",
         toptier_code="001",
         reporting_fiscal_year=2020,
-        reporting_fiscal_period=3,
-        reporting_fiscal_quarter=1,
+        reporting_fiscal_period=6,
+        reporting_fiscal_quarter=2,
         quarter_format_flag=True,
-        published_date="2020-01-30 07:46:21.419796+00",
-        certified_date="2020-01-30 07:46:21.419796+00",
+        published_date="2020-04-30 07:46:21.419796+00",
+        certified_date="2020-04-30 07:46:21.419796+00",
         submission_window=dabs1,
     )
-    mommy.make(
+    sub2 = mommy.make(
         "submissions.SubmissionAttributes",
         toptier_code="001",
         reporting_fiscal_year=2020,
@@ -74,14 +80,15 @@ def publish_dates_data(db):
         "submissions.SubmissionAttributes",
         toptier_code="002",
         reporting_fiscal_year=2019,
-        reporting_fiscal_period=11,
+        reporting_fiscal_period=12,
         reporting_fiscal_quarter=4,
-        quarter_format_flag=False,
-        published_date="2020-08-02 07:46:21.419796+00",
-        certified_date="2020-08-02 07:46:21.419796+00",
-        submission_window=dabs4,
+        quarter_format_flag=True,
+        published_date="2020-10-02 07:46:21.419796+00",
+        certified_date="2020-10-02 07:46:21.419796+00",
+        submission_window=dabs3,
     )
-
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas1, submission=sub1)
+    mommy.make("accounts.AppropriationAccountBalances", treasury_account_identifier=tas2, submission=sub2)
     mommy.make(
         "reporting.ReportingAgencyOverview",
         toptier_code="001",
@@ -139,11 +146,8 @@ def test_basic_success(client, publish_dates_data):
                 {
                     "period": 3,
                     "quarter": 1,
-                    "submission_dates": {
-                        "publication_date": "2020-01-30 07:46:21.419796+00",
-                        "certification_date": "2020-01-30 07:46:21.419796+00",
-                    },
-                    "quarterly": True,
+                    "submission_dates": {"publication_date": "", "certification_date": ""},
+                    "quarterly": False,
                 },
                 {
                     "period": 4,
@@ -160,8 +164,11 @@ def test_basic_success(client, publish_dates_data):
                 {
                     "period": 6,
                     "quarter": 2,
-                    "submission_dates": {"publication_date": "", "certification_date": ""},
-                    "quarterly": False,
+                    "quarterly": True,
+                    "submission_dates": {
+                        "certification_date": "2020-04-30 " "07:46:21.419796+00",
+                        "publication_date": "2020-04-30 " "07:46:21.419796+00",
+                    },
                 },
                 {
                     "period": 7,
@@ -351,17 +358,17 @@ def test_different_agencies(client, publish_dates_data):
                 {
                     "period": 11,
                     "quarter": 4,
-                    "submission_dates": {
-                        "publication_date": "2020-08-02 07:46:21.419796+00",
-                        "certification_date": "2020-08-02 07:46:21.419796+00",
-                    },
+                    "submission_dates": {"certification_date": "", "publication_date": ""},
                     "quarterly": False,
                 },
                 {
                     "period": 12,
                     "quarter": 4,
-                    "submission_dates": {"publication_date": "", "certification_date": ""},
-                    "quarterly": False,
+                    "submission_dates": {
+                        "certification_date": "2020-10-02 " "07:46:21.419796+00",
+                        "publication_date": "2020-10-02 " "07:46:21.419796+00",
+                    },
+                    "quarterly": True,
                 },
             ],
         },
@@ -511,17 +518,17 @@ def test_filter(client, publish_dates_data):
                 {
                     "period": 11,
                     "quarter": 4,
-                    "submission_dates": {
-                        "publication_date": "2020-08-02 07:46:21.419796+00",
-                        "certification_date": "2020-08-02 07:46:21.419796+00",
-                    },
+                    "submission_dates": {"certification_date": "", "publication_date": ""},
                     "quarterly": False,
                 },
                 {
                     "period": 12,
                     "quarter": 4,
-                    "submission_dates": {"publication_date": "", "certification_date": ""},
-                    "quarterly": False,
+                    "submission_dates": {
+                        "certification_date": "2020-10-02 " "07:46:21.419796+00",
+                        "publication_date": "2020-10-02 " "07:46:21.419796+00",
+                    },
+                    "quarterly": True,
                 },
             ],
         }
@@ -554,10 +561,22 @@ def test_publication_date_sort(client, publish_dates_data):
         "detail": "publication_date sort param must be in the format 'publication_date,<fiscal_period>' where <fiscal_period> is in the range 2-12"
     }
     dabs5 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", pk=5, submission_reveal_date="2020-01-05 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        pk=5,
+        submission_reveal_date="2020-01-05 00:00:00.000000+00",
+        submission_fiscal_year=2020,
+        submission_fiscal_quarter=1,
+        submission_fiscal_month=3,
+        is_quarter=True,
     )
     dabs6 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", pk=6, submission_reveal_date="2020-01-06 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        pk=6,
+        submission_reveal_date="2020-01-06 00:00:00.000000+00",
+        submission_fiscal_year=2020,
+        submission_fiscal_quarter=1,
+        submission_fiscal_month=3,
+        is_quarter=False,
     )
     mommy.make(
         "submissions.SubmissionAttributes",
@@ -578,7 +597,7 @@ def test_publication_date_sort(client, publish_dates_data):
         reporting_fiscal_year=2019,
         reporting_fiscal_period=3,
         reporting_fiscal_quarter=1,
-        quarter_format_flag=True,
+        quarter_format_flag=False,
         published_date="2020-01-01 07:46:21.419796+00",
         certified_date="2020-01-28 07:46:21.419796+00",
         submission_window=dabs6,
@@ -702,7 +721,7 @@ def test_publication_date_sort(client, publish_dates_data):
                         "publication_date": "2020-01-01 07:46:21.419796+00",
                         "certification_date": "2020-01-28 07:46:21.419796+00",
                     },
-                    "quarterly": True,
+                    "quarterly": False,
                 },
                 {
                     "period": 4,
@@ -749,17 +768,17 @@ def test_publication_date_sort(client, publish_dates_data):
                 {
                     "period": 11,
                     "quarter": 4,
-                    "submission_dates": {
-                        "publication_date": "2020-08-02 07:46:21.419796+00",
-                        "certification_date": "2020-08-02 07:46:21.419796+00",
-                    },
                     "quarterly": False,
+                    "submission_dates": {"certification_date": "", "publication_date": ""},
                 },
                 {
                     "period": 12,
                     "quarter": 4,
-                    "submission_dates": {"publication_date": "", "certification_date": ""},
-                    "quarterly": False,
+                    "submission_dates": {
+                        "certification_date": "2020-10-02 " "07:46:21.419796+00",
+                        "publication_date": "2020-10-02 " "07:46:21.419796+00",
+                    },
+                    "quarterly": True,
                 },
             ],
         },

--- a/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
@@ -12,6 +12,15 @@ url = "/api/v2/reporting/agencies/{agency}/{fy}/{period}/submission_history/"
 def setup_test_data(db):
     """ Insert data into DB for testing """
     mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=4,
+        submission_fiscal_quarter=2,
+        is_quarter=False,
+        submission_reveal_date="2020-02-01",
+        period_start_date="2020-01-01",
+    )
+    mommy.make(
         "submissions.SubmissionAttributes",
         submission_id=1,
         reporting_fiscal_year=2019,
@@ -104,7 +113,7 @@ def test_multiple_submissions(client, setup_test_data):
 
 
 def test_no_data(client, setup_test_data):
-    resp = client.get(url.format(agency="222", fy=2021, period=12))
+    resp = client.get(url.format(agency="222", fy=2021, period=3))
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 

--- a/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_submission_history.py
@@ -11,9 +11,9 @@ url = "/api/v2/reporting/agencies/{agency}/{fy}/{period}/submission_history/"
 @pytest.fixture
 def setup_test_data(db):
     """ Insert data into DB for testing """
-    mommy.make(
+    dsws1 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
-        submission_fiscal_year=2020,
+        submission_fiscal_year=2021,
         submission_fiscal_month=4,
         submission_fiscal_quarter=2,
         is_quarter=False,
@@ -31,6 +31,7 @@ def setup_test_data(db):
         history=json.loads(
             '[{"certified_date": "2019-07-16T16:09:52.125837Z", "published_date": "2019-07-16T16:09:52.125837Z"}]'
         ),
+        submission_window=dsws1,
     )
     mommy.make(
         "submissions.SubmissionAttributes",
@@ -44,6 +45,7 @@ def setup_test_data(db):
             '[{"certified_date": "2020-08-17T18:37:21.605023Z", "published_date": "2020-08-17T18:37:21.605023Z"},'
             + '{"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
         ),
+        submission_window=dsws1,
     )
     mommy.make(
         "submissions.SubmissionAttributes",
@@ -56,6 +58,7 @@ def setup_test_data(db):
         history=json.loads(
             '[{"certified_date": "2017-08-14T14:17:00.729315Z", "published_date": "2017-08-14T14:17:00.729315Z"}]'
         ),
+        submission_window=dsws1,
     )
     mommy.make(
         "submissions.SubmissionAttributes",
@@ -71,6 +74,7 @@ def setup_test_data(db):
             + '{"certified_date": "2021-02-14T14:17:00.729315Z", "published_date": "2021-02-14T14:16:00.729315Z"},'
             + '{"certified_date": "2021-02-16T14:17:00.729315Z", "published_date": "2021-02-16T14:16:00.729315Z"}]'
         ),
+        submission_window=dsws1,
     )
 
 

--- a/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_discrepancies.py
@@ -10,6 +10,15 @@ url = "/api/v2/reporting/agencies/123/discrepancies/"
 def setup_test_data(db):
     """ Insert test data into DB """
     mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=6,
+        submission_fiscal_quarter=2,
+        is_quarter=True,
+        submission_reveal_date="2020-04-01",
+        period_start_date="2020-04-01",
+    )
+    mommy.make(
         "reporting.ReportingAgencyMissingTas",
         toptier_code=123,
         fiscal_year=2020,
@@ -78,3 +87,9 @@ def test_sort(setup_test_data, client):
     assert len(response["results"]) == 1
     expected_results = [{"tas": "TAS 1", "amount": 10.0}]
     assert response["results"] == expected_results
+
+
+def test_fiscal_period_without_revealed_submissions_fails(setup_test_data, client):
+    resp = client.get(f"{url}?fiscal_year=2020&fiscal_period=12")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json()["detail"] == "Value for fiscal_period is outside the range of current submissions"

--- a/usaspending_api/reporting/tests/integration/test_differences_endpoint.py
+++ b/usaspending_api/reporting/tests/integration/test_differences_endpoint.py
@@ -12,7 +12,13 @@ URL = "/api/v2/reporting/agencies/{code}/differences/{filter}"
 @pytest.fixture
 def differences_data():
     dabs1 = mommy.make(
-        "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-01-01 00:00:00.000000+00"
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=6,
+        submission_fiscal_quarter=2,
+        is_quarter=False,
+        submission_reveal_date="2020-04-01",
+        period_start_date="2020-04-01",
     )
     mommy.make(
         "submissions.SubmissionAttributes",

--- a/usaspending_api/reporting/tests/integration/test_unlinked_awards.py
+++ b/usaspending_api/reporting/tests/integration/test_unlinked_awards.py
@@ -9,6 +9,14 @@ url = "/api/v2/reporting/agencies/{toptier_code}/{fiscal_year}/{fiscal_period}/u
 @pytest.fixture
 def setup_test_data(db):
     mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2020,
+        submission_fiscal_month=8,
+        is_quarter=False,
+        submission_reveal_date="2020-06-01",
+        period_start_date="2020-04-01",
+    )
+    mommy.make(
         "reporting.ReportingAgencyOverview",
         toptier_code="043",
         fiscal_year=2020,
@@ -33,7 +41,7 @@ def test_assistance_success(setup_test_data, client):
         "total_linked_award_count": 6,
     }
 
-    assert expected_results == response
+    assert response == expected_results
 
 
 def test_procurement_success(setup_test_data, client):
@@ -47,7 +55,7 @@ def test_procurement_success(setup_test_data, client):
         "total_linked_award_count": 7,
     }
 
-    assert expected_results == response
+    assert response == expected_results
 
 
 def test_no_result_found(setup_test_data, client):

--- a/usaspending_api/reporting/v2/views/agencies/publish_dates.py
+++ b/usaspending_api/reporting/v2/views/agencies/publish_dates.py
@@ -21,10 +21,14 @@ from usaspending_api.reporting.models import ReportingAgencyOverview
 from usaspending_api.submissions.models import SubmissionAttributes
 
 
-class PublishDates(AgencyBase, PaginationMixin):
+class PublishDates(PaginationMixin, AgencyBase):
     """Returns list of agency submission information, included published and certified dates for the fiscal year"""
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/publish_dates.md"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "filter"]
 
     def validate_publication_sort(self, sort_key):
         regex_string = r"publication_date,([2-9]|1[0-2])"

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/differences.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/differences.py
@@ -1,44 +1,49 @@
-from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 from typing import Any
 from django.db.models import Q
 
-from usaspending_api.agency.v2.views.agency_base import AgencyBase
+from usaspending_api import settings
+from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 
 from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.common.data_classes import Pagination
+from usaspending_api.common.helpers.date_helper import fy
+from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
-from usaspending_api.common.validator import TinyShield, customize_pagination_with_sort_columns
-from usaspending_api.references.models import ToptierAgencyPublishedDABSView
 from usaspending_api.reporting.models import ReportingAgencyTas
 
 
-class Differences(AgencyBase):
+class Differences(PaginationMixin, AgencyBase):
     """
     Obtain the differences between file A obligations and file B obligations for a specific agency/period
     """
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/toptier_code/differences.md"
 
-    @staticmethod
-    def _parse_and_validate_request(request_dict) -> dict:
-        sortable_columns = ["difference", "file_a_obligation", "file_b_obligation", "tas"]
-        default_sort_column = "tas"
-        models = customize_pagination_with_sort_columns(sortable_columns, default_sort_column)
-        models.extend(
-            [
-                {"key": "fiscal_year", "name": "fiscal_year", "type": "integer", "optional": False},
-                {"key": "fiscal_period", "name": "fiscal_period", "type": "integer", "optional": False},
-            ]
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "fiscal_period"]
+        self.additional_models = [
+            {
+                "key": "fiscal_year",
+                "name": "fiscal_year",
+                "type": "integer",
+                "min": fy(settings.API_SEARCH_MIN_DATE),
+                "max": current_fiscal_year(),
+                "optional": False,
+            },
+            {
+                "key": "fiscal_period",
+                "name": "fiscal_period",
+                "type": "integer",
+                "min": 2,
+                "max": 12,
+                "optional": False,
+            },
+        ]
 
-        validated_request_data = TinyShield(models).block(request_dict)
-        return validated_request_data
-
-    @staticmethod
-    def format_results(rows, pagination):
-        order = pagination.sort_order == "desc"
+    def format_results(self, rows):
+        order = self.pagination.sort_order == "desc"
         formatted_results = []
         for row in rows:
             formatted_results.append(
@@ -49,42 +54,31 @@ class Differences(AgencyBase):
                     "difference": row["diff_approp_ocpa_obligated_amounts"],
                 }
             )
-        formatted_results = sorted(formatted_results, key=lambda x: x[pagination.sort_key], reverse=order)
+        formatted_results = sorted(formatted_results, key=lambda x: x[self.pagination.sort_key], reverse=order)
         return formatted_results
 
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        request_data = self._parse_and_validate_request(request.query_params)
+        self.sortable_columns = ["difference", "file_a_obligation", "file_b_obligation", "tas"]
+        self.default_sort_column = "tas"
 
-        toptier_agency = ToptierAgencyPublishedDABSView.objects.filter(toptier_code=self.toptier_code).first()
-        if not toptier_agency:
-            raise NotFound(f"Agency with a toptier code of '{self.toptier_code}' does not exist")
-        request_data["toptier_agency"] = toptier_agency
-        self.validate_fiscal_period(request_data)
-        pagination = Pagination(
-            page=request_data["page"],
-            limit=request_data["limit"],
-            lower_limit=(request_data["page"] - 1) * request_data["limit"],
-            upper_limit=(request_data["page"] * request_data["limit"]),
-            sort_key=request_data.get("sort", "tas"),
-            sort_order=request_data["order"],
-        )
-        results = self.get_differences_queryset(request_data)
-        formatted_results = self.format_results(results, pagination)
-        page_metadata = get_pagination_metadata(len(results), pagination.limit, pagination.page)
+        results = self.get_differences_queryset()
+        formatted_results = self.format_results(results)
+        page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
+
         return Response(
             {
                 "page_metadata": page_metadata,
-                "results": formatted_results[pagination.lower_limit : pagination.upper_limit],
+                "results": formatted_results[self.pagination.lower_limit : self.pagination.upper_limit],
                 "messages": self.standard_response_messages,
             }
         )
 
-    def get_differences_queryset(self, request_data):
+    def get_differences_queryset(self):
         filters = [
-            Q(toptier_code=request_data["toptier_agency"].toptier_code),
+            Q(toptier_code=self.toptier_agency.toptier_code),
             Q(fiscal_year=self.fiscal_year),
-            Q(fiscal_period=request_data["fiscal_period"]),
+            Q(fiscal_period=self.fiscal_period),
             ~Q(diff_approp_ocpa_obligated_amounts=0),
         ]
         results = (ReportingAgencyTas.objects.filter(*filters)).values(

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/discrepancies.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/discrepancies.py
@@ -1,47 +1,26 @@
 from rest_framework.response import Response
 from django.db.models import F
-from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.reporting.models import ReportingAgencyMissingTas
 
 
-class AgencyDiscrepancies(AgencyBase, PaginationMixin):
+class AgencyDiscrepancies(PaginationMixin, AgencyBase):
     """Returns TAS discrepancies of the specified agency's submission data for a specific FY/FP"""
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/toptier_code/discrepancies.md"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "fiscal_period"]
+
     def get(self, request, toptier_code):
-        model = [
-            {
-                "key": "fiscal_year",
-                "name": "fiscal_year",
-                "type": "integer",
-                "min": 2017,
-                "optional": False,
-                "default": None,
-                "allow_nulls": False,
-            },
-            {
-                "key": "fiscal_period",
-                "name": "fiscal_period",
-                "type": "integer",
-                "min": 2,
-                "max": 12,
-                "optional": False,
-                "default": None,
-                "allow_nulls": False,
-            },
-        ]
-        validated = TinyShield(model).block(request.query_params)
         self.sortable_columns = [
             "amount",
             "tas",
         ]
         self.default_sort_column = "amount"
-        results = self.get_agency_discrepancies(
-            fiscal_year=validated["fiscal_year"], fiscal_period=validated["fiscal_period"]
-        )
+        results = self.get_agency_discrepancies(fiscal_year=self.fiscal_year, fiscal_period=self.fiscal_period)
         return Response(
             {
                 "page_metadata": get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page),

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/fiscal_year/fiscal_period/unlinked_awards.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/fiscal_year/fiscal_period/unlinked_awards.py
@@ -1,12 +1,8 @@
-from django.conf import settings
 from django.db.models import F
 from rest_framework.response import Response
 
 from usaspending_api.agency.v2.views.agency_base import AgencyBase
 from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.common.helpers.date_helper import fy
-from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
-from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.reporting.models import ReportingAgencyOverview
 
 
@@ -15,68 +11,46 @@ class UnlinkedAwards(AgencyBase):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/toptier_code/fiscal_year/fiscal_period/unlinked_awards/type.md"
 
-    annotation_options = {
-        "assistance": {
-            "unlinked_file_c_award_count": F("unlinked_assistance_c_awards"),
-            "unlinked_file_d_award_count": F("unlinked_assistance_d_awards"),
-            "total_linked_award_count": F("linked_assistance_awards"),
-        },
-        "procurement": {
-            "unlinked_file_c_award_count": F("unlinked_procurement_c_awards"),
-            "unlinked_file_d_award_count": F("unlinked_procurement_d_awards"),
-            "total_linked_award_count": F("linked_procurement_awards"),
-        },
-    }
-
-    tinyshield_model = [
-        {
-            "key": "type",
-            "name": "type",
-            "type": "enum",
-            "enum_values": ["assistance", "procurement"],
-            "optional": False,
-            "default": None,
-            "allow_nulls": False,
-        },
-        {
-            "key": "fiscal_year",
-            "name": "fiscal_year",
-            "type": "integer",
-            "min": fy(settings.API_SEARCH_MIN_DATE),
-            "max": current_fiscal_year(),
-            "optional": False,
-            "default": None,
-            "allow_nulls": False,
-        },
-        {
-            "key": "fiscal_period",
-            "name": "fiscal_period",
-            "type": "integer",
-            "min": 2,
-            "max": 12,
-            "optional": False,
-            "default": None,
-            "allow_nulls": False,
-        },
-    ]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.annotation_options = {
+            "assistance": {
+                "unlinked_file_c_award_count": F("unlinked_assistance_c_awards"),
+                "unlinked_file_d_award_count": F("unlinked_assistance_d_awards"),
+                "total_linked_award_count": F("linked_assistance_awards"),
+            },
+            "procurement": {
+                "unlinked_file_c_award_count": F("unlinked_procurement_c_awards"),
+                "unlinked_file_d_award_count": F("unlinked_procurement_d_awards"),
+                "total_linked_award_count": F("linked_procurement_awards"),
+            },
+        }
+        self.additional_models = [
+            {
+                "key": "type",
+                "name": "type",
+                "type": "enum",
+                "enum_values": list(self.annotation_options),
+                "optional": False,
+            }
+        ]
 
     @cache_response()
     def get(self, request, toptier_code, fiscal_year, fiscal_period, type):
-        my_request = {"type": type, "fiscal_year": fiscal_year, "fiscal_period": fiscal_period}
-        validated = TinyShield(self.tinyshield_model).block(my_request)
+        validated = self.validated_url_params
+        filters = {
+            "toptier_code": self.toptier_code,
+            "fiscal_year": validated["fiscal_year"],
+            "fiscal_period": validated["fiscal_period"],
+        }
+        annotations = self.annotation_options[validated["type"]]
 
-        self.annotations = self.annotation_options[validated["type"]]
-        self.fiscal_year = validated["fiscal_year"]
-        self.fiscal_period = validated["fiscal_period"]
+        return Response(self.get_unlinked_awards(filters, annotations))
 
-        return Response(self.get_unlinked_awards())
-
-    def get_unlinked_awards(self):
+    def get_unlinked_awards(self, filters, annotations):
         result = (
-            ReportingAgencyOverview.objects.filter(
-                toptier_code=self.toptier_code, fiscal_year=self.fiscal_year, fiscal_period=self.fiscal_period
-            )
-            .annotate(**self.annotations)
+            ReportingAgencyOverview.objects.filter(**filters)
+            .annotate(**annotations)
             .values(
                 "unlinked_file_c_award_count",
                 "unlinked_file_d_award_count",

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -12,7 +12,7 @@ from usaspending_api.reporting.models import ReportingAgencyOverview, ReportingA
 from usaspending_api.submissions.models import SubmissionAttributes
 
 
-class AgencyOverview(AgencyBase, PaginationMixin):
+class AgencyOverview(PaginationMixin, AgencyBase):
     """Returns an overview of the specified agency's submission data"""
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/toptier_code/overview.md"

--- a/usaspending_api/reporting/v2/views/submission_history.py
+++ b/usaspending_api/reporting/v2/views/submission_history.py
@@ -13,10 +13,11 @@ class SubmissionHistory(PaginationMixin, AgencyBase):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/reporting/agencies/toptier_code/fiscal_year/fiscal_period/submission_history.md"
 
     def get(self, request, toptier_code, fiscal_year, fiscal_period):
-        self.fiscal_year = int(fiscal_year)
+        validated_params = self.validated_url_params
+        fiscal_year = validated_params["fiscal_year"]
+        fiscal_period = validated_params["fiscal_period"]
         self.sortable_columns = ["publication_date", "certification_date"]
         self.default_sort_column = "publication_date"
-        self.validate_fiscal_period({"fiscal_period": int(fiscal_period)})
         record = list(
             SubmissionAttributes.objects.filter(
                 toptier_code=toptier_code,

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -137,7 +137,7 @@ def type_filter(_type, filters, limit=None):
             submission_reveal_date__lte=datetime.now(timezone.utc),
         ).first()
     if submission_window is None:
-        return {"total": None}
+        raise InvalidParameterException("Fiscal parameters provided do not belong to a current submission period")
 
     fiscal_date = submission_window.period_end_date
     fiscal_period = submission_window.submission_fiscal_month


### PR DESCRIPTION
**Description:**
Add validation to make sure that endpoints which query using fiscal parameters are only using parameters for those submissions that have been revealed.

**Technical details:**
PR comes in three parts:
* Added validation with appropriate error message for endpoints that are querying revealed submissions
* Restructure `agency_base.py` since it was previously accomplishing similar functionality in different ways; this made adding the validation cleaner
* LOTS of tests updated (most of the tests update involve needing to rework how the DABSSubmissionWindowSchedule records were mocked to make sure it didn't trip the validation.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7114](https://federal-spending-transparency.atlassian.net/browse/DEV-7114):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
