### PR TITLE
[DEV-7191] Nulls more fields in the response if no submission is found

### DIFF
--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -185,29 +185,37 @@ class AgenciesOverview(PaginationMixin, AgencyBase):
             "abbreviation": result["abbreviation"],
             "toptier_code": result["toptier_code"],
             "agency_id": agencies.get(result["toptier_code"]),
-            "current_total_budget_authority_amount": result["current_total_budget_authority_amount"],
+            "current_total_budget_authority_amount": None,
             "recent_publication_date": result["recent_publication_date"],
             "recent_publication_date_certified": result["recent_publication_date_certified"] is not None,
             "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": result["total_dollars_obligated_gtas"],
+                "gtas_obligation_total": None,
                 "tas_accounts_total": None,
                 "tas_obligation_not_in_gtas_total": None,
                 "missing_tas_accounts_count": None,
             },
-            "obligation_difference": result["obligation_difference"],
-            "unlinked_contract_award_count": result["unlinked_contract_award_count"],
-            "unlinked_assistance_award_count": result["unlinked_assistance_award_count"],
+            "obligation_difference": None,
+            "unlinked_contract_award_count": None,
+            "unlinked_assistance_award_count": None,
             "assurance_statement_url": None,
         }
 
         if result["recent_publication_date"]:
+            formatted_result.update(
+                {
+                    "current_total_budget_authority_amount": result["current_total_budget_authority_amount"],
+                    "obligation_difference": result["obligation_difference"],
+                    "unlinked_contract_award_count": result["unlinked_contract_award_count"],
+                    "unlinked_assistance_award_count": result["unlinked_assistance_award_count"],
+                    "assurance_statement_url": self.create_assurance_statement_url(result),
+                }
+            )
             formatted_result["tas_account_discrepancies_totals"].update(
                 {
+                    "gtas_obligation_total": result["total_dollars_obligated_gtas"],
                     "tas_accounts_total": result["tas_accounts_total"],
                     "tas_obligation_not_in_gtas_total": (result["tas_obligation_not_in_gtas_total"] or 0.0),
                     "missing_tas_accounts_count": result["missing_tas_accounts_count"],
                 }
             )
-            formatted_result["assurance_statement_url"] = self.create_assurance_statement_url(result)
-
         return formatted_result

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -174,12 +174,12 @@ class AgencyOverview(PaginationMixin, AgencyBase):
             "recent_publication_date": result["recent_publication_date"],
             "recent_publication_date_certified": result["recent_publication_date_certified"] is not None,
             "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": result["total_dollars_obligated_gtas"],
-                "tas_accounts_total": result["tas_obligations"],
+                "gtas_obligation_total": None,
+                "tas_accounts_total": None,
                 "tas_obligation_not_in_gtas_total": None,
                 "missing_tas_accounts_count": None,
             },
-            "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
+            "obligation_difference": None,
             "unlinked_contract_award_count": None,
             "unlinked_assistance_award_count": None,
             "assurance_statement_url": None,
@@ -195,6 +195,7 @@ class AgencyOverview(PaginationMixin, AgencyBase):
                     )
                     if result["gtas_total_budgetary_resources"]
                     else 0,
+                    "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
                     "unlinked_contract_award_count": result["unlinked_procurement_c_awards"]
                     + result["unlinked_procurement_d_awards"],
                     "unlinked_assistance_award_count": result["unlinked_assistance_c_awards"]
@@ -205,6 +206,8 @@ class AgencyOverview(PaginationMixin, AgencyBase):
 
             formatted_result["tas_account_discrepancies_totals"].update(
                 {
+                    "gtas_obligation_total": result["total_dollars_obligated_gtas"],
+                    "tas_accounts_total": result["tas_obligations"],
                     "tas_obligation_not_in_gtas_total": (result["tas_obligation_not_in_gtas_total"] or 0.0),
                     "missing_tas_accounts_count": result["missing_tas_accounts"],
                 }


### PR DESCRIPTION
**Description:**
The last PR for this ticket updated the `reporting_agency_overview` table to default values to NULL instead of zero. The API endpoints were also updated to set fields not coming from that table to NULL if no submission is present. Under these conditions it was still possible for values to come through on period without submissions because rows in the `reporting_agency_overview` table are sometimes still populated without a submission.

This PR updates the endpoints to set Null values to zero even if those fields are coming from the `reporting_agency_overview` table. 


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7191](https://federal-spending-transparency.atlassian.net/browse/DEV-7191):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
