### PR TITLE
[DEV-7191] Return None instead of 0.0 when null

### DIFF
--- a/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
+++ b/usaspending_api/reporting/tests/integration/test_agencies_publish_dates.py
@@ -204,7 +204,7 @@ def test_basic_success(client, publish_dates_data):
             "agency_name": "Test Agency 2",
             "abbreviation": "TA2",
             "toptier_code": "002",
-            "current_total_budget_authority_amount": 0.00,
+            "current_total_budget_authority_amount": None,
             "periods": [
                 {
                     "period": 3,

--- a/usaspending_api/reporting/v2/views/agencies/publish_dates.py
+++ b/usaspending_api/reporting/v2/views/agencies/publish_dates.py
@@ -122,7 +122,7 @@ class PublishDates(PaginationMixin, AgencyBase):
                     "agency_name": result["name"],
                     "abbreviation": result["abbreviation"],
                     "toptier_code": result["toptier_code"],
-                    "current_total_budget_authority_amount": result["current_total_budget_authority_amount"] or 0.00,
+                    "current_total_budget_authority_amount": result["current_total_budget_authority_amount"],
                     "periods": sorted(periods, key=lambda x: x["period"]),
                 }
             )
@@ -143,7 +143,10 @@ class PublishDates(PaginationMixin, AgencyBase):
         else:
             results = sorted(
                 self.get_agency_data(),
-                key=lambda x: x[self.pagination.sort_key],
+                key=lambda x: (
+                    (x[self.pagination.sort_key] is None) == (self.pagination.sort_order == "asc"),
+                    x[self.pagination.sort_key],
+                ),
                 reverse=(self.pagination.sort_order == "desc"),
             )
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)


### PR DESCRIPTION
**Description:**
Have `current_total_budget_authority_amount` return `None` instead of `0.0` when the value is NULL.

**Technical details:**
None cannot be compared to None so an issue was run into when sorting. To work around it a tuple is used for the sort functionality such that whenever the value of a field is `None` it will always be sorted at the bottom.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7191](https://federal-spending-transparency.atlassian.net/browse/DEV-7191):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
