### PR TITLE
[DEV-7191] Sort with nulls at the bottom of results

### DIFF
--- a/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
+++ b/usaspending_api/reporting/tests/integration/test_agency_code_overview.py
@@ -303,25 +303,6 @@ def test_pagination(setup_test_data, client):
     assert len(response["results"]) == 3
     expected_results = [
         {
-            "fiscal_year": 2019,
-            "fiscal_period": 9,
-            "current_total_budget_authority_amount": None,
-            "total_budgetary_resources": None,
-            "percent_of_total_budgetary_resources": None,
-            "recent_publication_date": None,
-            "recent_publication_date_certified": False,
-            "tas_account_discrepancies_totals": {
-                "gtas_obligation_total": None,
-                "tas_accounts_total": None,
-                "tas_obligation_not_in_gtas_total": None,
-                "missing_tas_accounts_count": None,
-            },
-            "obligation_difference": None,
-            "unlinked_contract_award_count": None,
-            "unlinked_assistance_award_count": None,
-            "assurance_statement_url": None,
-        },
-        {
             "fiscal_year": 2020,
             "fiscal_period": 12,
             "current_total_budget_authority_amount": 100.0,
@@ -358,6 +339,25 @@ def test_pagination(setup_test_data, client):
             "unlinked_contract_award_count": 4,
             "unlinked_assistance_award_count": 6,
             "assurance_statement_url": assurance_statement_2019_6,
+        },
+        {
+            "fiscal_year": 2019,
+            "fiscal_period": 9,
+            "current_total_budget_authority_amount": None,
+            "total_budgetary_resources": None,
+            "percent_of_total_budgetary_resources": None,
+            "recent_publication_date": None,
+            "recent_publication_date_certified": False,
+            "tas_account_discrepancies_totals": {
+                "gtas_obligation_total": None,
+                "tas_accounts_total": None,
+                "tas_obligation_not_in_gtas_total": None,
+                "missing_tas_accounts_count": None,
+            },
+            "obligation_difference": None,
+            "unlinked_contract_award_count": None,
+            "unlinked_assistance_award_count": None,
+            "assurance_statement_url": None,
         },
     ]
     assert response["results"] == expected_results

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -156,12 +156,17 @@ class AgenciesOverview(PaginationMixin, AgencyBase):
             )
         )
 
-        if self.pagination.sort_order == "desc":
-            result_list = result_list.order_by(F(self.pagination.sort_key).desc(nulls_last=True), "-toptier_code")
-        else:
-            result_list = result_list.order_by(F(self.pagination.sort_key).asc(nulls_last=True), "toptier_code")
+        formatted_results = sorted(
+            self.format_results(result_list),
+            key=lambda x: (
+                (x[self.pagination.sort_key] is None) == (self.pagination.sort_order == "asc"),
+                x[self.pagination.sort_key],
+                x["toptier_code"],
+            ),
+            reverse=(self.pagination.sort_order == "desc"),
+        )
 
-        return self.format_results(result_list)
+        return formatted_results
 
     def format_results(self, result_list):
         agencies = {

--- a/usaspending_api/reporting/v2/views/agencies/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/overview.py
@@ -159,8 +159,22 @@ class AgenciesOverview(PaginationMixin, AgencyBase):
         formatted_results = sorted(
             self.format_results(result_list),
             key=lambda x: (
-                (x[self.pagination.sort_key] is None) == (self.pagination.sort_order == "asc"),
-                x[self.pagination.sort_key],
+                *(
+                    (
+                        (x["tas_account_discrepancies_totals"][self.pagination.sort_key] is None)
+                        == (self.pagination.sort_order == "asc"),
+                        x["tas_account_discrepancies_totals"][self.pagination.sort_key],
+                    )
+                    if (
+                        self.pagination.sort_key == "missing_tas_accounts_count"
+                        or self.pagination.sort_key == "tas_accounts_total"
+                        or self.pagination.sort_key == "tas_obligation_not_in_gtas_total"
+                    )
+                    else (
+                        (x[self.pagination.sort_key] is None) == (self.pagination.sort_order == "asc"),
+                        x[self.pagination.sort_key],
+                    )
+                ),
                 x["toptier_code"],
             ),
             reverse=(self.pagination.sort_order == "desc"),


### PR DESCRIPTION
**Description:**
Better handling of NULLs in DEV-7191 caused a slight issue with how we were trying to sort results with the Django ORM but then manipulated some of the values to be NULL depending on the value of the publication date.

**Technical details:**
Removed the Django ORM Order By since it is no longer effective at sorting NULL values for our use case in the endpoint. Also adjust the sorting for both Overview endpoints to be consistent with NULLs sorted last. 

The approach to handle the NULLs sorted last is to create a tuple where the first value is True or False depending on the combination of selected sort order and if a field is NULL. The remaining fields of the tuple will sort the non-NULL results correctly.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7191](https://federal-spending-transparency.atlassian.net/browse/DEV-7191):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
