### PR TITLE
[DEV-7191] Fix sorting for non FY 2021 table views when sorting Fiscal Period

### DIFF
--- a/usaspending_api/reporting/v2/views/agencies/publish_dates.py
+++ b/usaspending_api/reporting/v2/views/agencies/publish_dates.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 from usaspending_api.common.helpers.date_helper import now
 from usaspending_api.common.data_classes import Pagination
-from usaspending_api.common.exceptions import UnprocessableEntityException, InvalidParameterException
+from usaspending_api.common.exceptions import UnprocessableEntityException
 from usaspending_api.common.helpers.fiscal_year_helpers import get_quarter_from_period
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.common.helpers.orm_helpers import ConcatAll
@@ -116,7 +116,7 @@ class PublishDates(PaginationMixin, AgencyBase):
                         "quarterly": False,
                     }
                 )
-            periods = filter(lambda period: is_valid_monthly_period(self.fiscal_year, period["period"]), periods)
+            periods = filter(lambda period: period["period"] in self.displayed_periods, periods)
             results.append(
                 {
                     "agency_name": result["name"],
@@ -129,20 +129,25 @@ class PublishDates(PaginationMixin, AgencyBase):
         return results
 
     def get(self, request):
+        self.displayed_periods = list(
+            filter(lambda period: is_valid_monthly_period(self.fiscal_year, period), list(range(2, 13)))
+        )
         if "publication_date" in self.pagination.sort_key:
             self.validate_publication_sort(self.pagination.sort_key)
-            displayed_periods = list(
-                filter(lambda period: is_valid_monthly_period(self.fiscal_year, period), list(range(2, 13)))
-            )
             sort_key = deepcopy(self.pagination.sort_key)
+            period_param = int(sort_key.split(",")[1])
             try:
-                pub_sort = displayed_periods.index(int(sort_key.split(",")[1]))
+                pub_sort = self.displayed_periods.index(period_param)
             except ValueError:
-                raise InvalidParameterException(f"invalid sort provided for 'publication_date'")
+                pub_sort = None
             self.pagination.sort_key = "publication_date"
+
+            # If not a valid period for the fiscal year fallback to the agency name
             results = sorted(
                 self.get_agency_data(),
-                key=lambda x: x["periods"][pub_sort]["submission_dates"]["publication_date"],
+                key=lambda x: x["periods"][pub_sort]["submission_dates"]["publication_date"]
+                if pub_sort is not None
+                else x["agency_name"],
                 reverse=(self.pagination.sort_order == "desc"),
             )
         else:


### PR DESCRIPTION
**Description:**
Handling of the publication_date sort was assuming that we always showed all fiscal periods in results. Changes that limited this to only valid fiscal periods for the Fiscal Year caused this sorting to break.

**Technical details:**
Determine the valid fiscal periods so that we can correlate it to a dictionary in the array of periods for each agency.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7191](https://federal-spending-transparency.atlassian.net/browse/DEV-7191):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
