### PR TITLE
[DEV-7277] Removes check comparing deleted transaction_search and transaction_normalized counts

### DIFF
--- a/usaspending_api/etl/transaction_loaders/fpds_loader.py
+++ b/usaspending_api/etl/transaction_loaders/fpds_loader.py
@@ -71,7 +71,6 @@ def delete_stale_fpds(detached_award_procurement_ids):
         cursor.execute(
             f"delete from transaction_search where transaction_id in ({txn_id_str}) returning transaction_id"
         )
-        deleted_ts = set(cursor.fetchall())
 
         cursor.execute(f"delete from transaction_normalized where id in ({txn_id_str}) returning id")
         deleted_transactions = set(cursor.fetchall())
@@ -79,10 +78,6 @@ def delete_stale_fpds(detached_award_procurement_ids):
         if deleted_transactions != deleted_fpds:
             msg = "Delete Mismatch! Counts of transaction_normalized ({}) and transaction_fpds ({}) deletes"
             raise RuntimeError(msg.format(len(deleted_transactions), len(deleted_fpds)))
-
-        if deleted_transactions != deleted_ts:
-            msg = "Delete Mismatch! Counts of transaction_normalized ({}) and transaction_search ({}) deletes"
-            raise RuntimeError(msg.format(len(deleted_transactions), len(deleted_ts)))
 
         logger.info(f"{len(deleted_transactions):,} transactions deleted")
 


### PR DESCRIPTION
**Description:**
[DEV-6425: Replace `universal_transaction_matview` with a Django managed table](https://federal-spending-transparency.atlassian.net/browse/DEV-6425) introduced a change to the `fpds_loader.py` that deletes stale transactions from the `transaction_search` table to prevent Foreign Key constraint violations when deleting stale transactions from `transaction_normalized`. 

When this extra step to delete `transaction_search` records was added, a check was added to make sure the same number of records were deleted as were deleted from transaction_normalized to follow the same pattern used with deleting from `transaction_fpds`. 

This check, however, does not make sense because transaction_normalized contains more transactions than `transaction_search`, the ladder being restricted to transactions after `2000-10-01`. This is resulting in the check to throw an error even though the delete step is fulfilling its intended behavior of preventing FK violations.

**Technical details:**
The check along with the cursor to get the count of removed `transaction_search` records were removed from the `fpds_loader.py` file. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7277](https://federal-spending-transparency.atlassian.net/browse/DEV-7277):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
