### PR TITLE
[DEV-7197] Spending by Award DEFC filter updates

### DIFF
--- a/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
+++ b/usaspending_api/awards/v2/lookups/elasticsearch_lookups.py
@@ -49,8 +49,8 @@ base_mapping = {
     "prime_award_recipient_id": "prime_award_recipient_id",
     "generated_internal_id": "generated_unique_award_id",
     "def_codes": "disaster_emergency_fund_codes",
-    "COVID-19 Obligations": "total_covid_obligation",
-    "COVID-19 Outlays": "total_covid_outlay",
+    "COVID-19 Obligations": "covid_spending_by_defc",
+    "COVID-19 Outlays": "covid_spending_by_defc",
 }
 contracts_mapping = {
     **base_mapping,

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -365,7 +365,7 @@ class SpendingByAwardVisualizationViewSet(APIView):
                 )
             if row.get("def_codes"):
                 if self.filters.get("def_codes"):
-                    row["def_codes"] = filter(lambda x: x in self.filters.get("def_codes"), row["def_codes"])
+                    row["def_codes"] = list(filter(lambda x: x in self.filters.get("def_codes"), row["def_codes"]))
             row["generated_internal_id"] = hit["generated_unique_award_id"]
             row["recipient_id"] = hit.get("recipient_unique_id")
             row["parent_recipient_unique_id"] = hit.get("parent_recipient_unique_id")

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -363,6 +363,9 @@ class SpendingByAwardVisualizationViewSet(APIView):
                         for x in row.get("COVID-19 Outlays")
                     ]
                 )
+            if row.get("def_codes"):
+                if self.filters.get("def_codes"):
+                    row["def_codes"] = filter(lambda x: x in self.filters.get("def_codes"), row["def_codes"])
             row["generated_internal_id"] = hit["generated_unique_award_id"]
             row["recipient_id"] = hit.get("recipient_unique_id")
             row["parent_recipient_unique_id"] = hit.get("parent_recipient_unique_id")

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -346,14 +346,20 @@ class SpendingByAwardVisualizationViewSet(APIView):
             if row.get("COVID-19 Obligations"):
                 row["COVID-19 Obligations"] = sum(
                     [
-                        x["obligation"] if (self.filters.get("def_codes") is not None and x["defc"] in self.filters["def_codes"]) or self.filters.get("def_codes") is None else 0
+                        x["obligation"]
+                        if (self.filters.get("def_codes") is not None and x["defc"] in self.filters["def_codes"])
+                        or self.filters.get("def_codes") is None
+                        else 0
                         for x in row.get("COVID-19 Obligations")
                     ]
                 )
             if row.get("COVID-19 Outlays"):
                 row["COVID-19 Outlays"] = sum(
                     [
-                        x["outlay"] if (self.filters.get("def_codes") is not None and x["defc"] in self.filters["def_codes"]) or self.filters.get("def_codes") is None else 0
+                        x["outlay"]
+                        if (self.filters.get("def_codes") is not None and x["defc"] in self.filters["def_codes"])
+                        or self.filters.get("def_codes") is None
+                        else 0
                         for x in row.get("COVID-19 Outlays")
                     ]
                 )

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -343,6 +343,20 @@ class SpendingByAwardVisualizationViewSet(APIView):
             if row.get("Awarding Agency"):
                 code = row.pop("agency_code")
                 row["awarding_agency_id"] = self.get_agency_database_id(code)
+            if row.get("COVID-19 Obligations"):
+                row["COVID-19 Obligations"] = sum(
+                    [
+                        x["obligation"] if (self.filters.get("def_codes") is not None and x["defc"] in self.filters["def_codes"]) or self.filters.get("def_codes") is None else 0
+                        for x in row.get("COVID-19 Obligations")
+                    ]
+                )
+            if row.get("COVID-19 Outlays"):
+                row["COVID-19 Outlays"] = sum(
+                    [
+                        x["outlay"] if (self.filters.get("def_codes") is not None and x["defc"] in self.filters["def_codes"]) or self.filters.get("def_codes") is None else 0
+                        for x in row.get("COVID-19 Outlays")
+                    ]
+                )
             row["generated_internal_id"] = hit["generated_unique_award_id"]
             row["recipient_id"] = hit.get("recipient_unique_id")
             row["parent_recipient_unique_id"] = hit.get("parent_recipient_unique_id")


### PR DESCRIPTION
**Description:**
Adjusts the values returned by the `spending_by_award` endpoint to filter the Covid-19 related outlays and obligations by the provided DEFC filter.

**Technical details:**
If the COVID-19 Obligations or COVID-19 Outlays values are requested in a call to `spending_by_award`, the values returned will be filtered by the `def_codes` filter (if present). So if Award 1 has $100 in obligations under DEFC "L" and 
 $20 in obligations under DEFC "P", if the def_codes filter contains only "L", the value returned for Award 1's obligations will be $100, not $20.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-7197](https://federal-spending-transparency.atlassian.net/browse/DEV-7197):
    - [X] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
