### PR TITLE
[DEV-7239] Add DEFC filter to COVID Outlay and Obligation in downloads

### DIFF
--- a/usaspending_api/common/helpers/unit_test_helper.py
+++ b/usaspending_api/common/helpers/unit_test_helper.py
@@ -14,7 +14,7 @@ def mappings_test(download_type, sublevel):
             query_values = [
                 value for value in lookup_mapping.query_paths[table_name][sublevel].values() if value is not None
             ]
-            annotations = annotations_function()
+            annotations = annotations_function({})
         else:
             query_values = [value for value in lookup_mapping.query_paths[table_name][sublevel].values()]
             annotations = {}

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -192,14 +192,18 @@ def get_download_sources(json_request: dict, origination: Optional[str] = None):
                 or "procurement" in award_type_codes
             ):
                 # only generate d1 files if the user is asking for contract data
-                d1_source = DownloadSource(VALUE_MAPPINGS[download_type]["table_name"], "d1", download_type, agency_id)
+                d1_source = DownloadSource(
+                    VALUE_MAPPINGS[download_type]["table_name"], "d1", download_type, agency_id, filters
+                )
                 d1_filters = {f"{VALUE_MAPPINGS[download_type]['contract_data']}__isnull": False}
                 d1_source.queryset = queryset & download_type_table.objects.filter(**d1_filters)
                 download_sources.append(d1_source)
 
             if award_type_codes & set(assistance_type_mapping.keys()) or ("grant" in award_type_codes):
                 # only generate d2 files if the user is asking for assistance data
-                d2_source = DownloadSource(VALUE_MAPPINGS[download_type]["table_name"], "d2", download_type, agency_id)
+                d2_source = DownloadSource(
+                    VALUE_MAPPINGS[download_type]["table_name"], "d2", download_type, agency_id, filters
+                )
                 d2_filters = {f"{VALUE_MAPPINGS[download_type]['assistance_data']}__isnull": False}
                 d2_source.queryset = queryset & download_type_table.objects.filter(**d2_filters)
                 download_sources.append(d2_source)


### PR DESCRIPTION
**Description:**
Take the DEFC filter into consideration for the COVID Outlay and Obligation columns. 

**Technical details:**
Ended up being much more straight forward than had feared. Passed the filters down into the download annotations functions where it limits on the DEFC filter if it exists. Since the column is specifically COVID Outlay and Obligation the check for `covid_19` group name was left in place to ensure no mater what only COVID spending is represented.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7239](https://federal-spending-transparency.atlassian.net/browse/DEV-7239):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
