### PR TITLE
Mod/dev 7189 covid award spending totals

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/disaster/award/amount.md
+++ b/usaspending_api/api_contracts/contracts/v2/disaster/award/amount.md
@@ -26,14 +26,7 @@ This endpoint provides the Account obligation and outlay aggregations of Awards
                 "filter": {
                     "def_codes": ["L", "M", "N", "O", "P", "U"],
                     "award_type_codes": ["02", "03", "04", "05", "07", "08", "10", "06", "09", "11", "A", "B", "C", "D", "IDV_A", "IDV_B", "IDV_B_A", "IDV_B_B", "IDV_B_C", "IDV_C", "IDV_D", "IDV_E"]
-                },
-                "pagination": {
-                    "limit": 10,
-                    "page": 1,
-                    "sort": "award_count",
-                    "order": "desc"
-                },
-                "spending_type": "total"
+                }
             }
 
 + Response 200 (application/json)

--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -31,6 +31,9 @@ class AmountViewSet(ElasticsearchDisasterBase):
         response = search.handle_execute()
         response = response.aggs.to_dict()
 
-        totals = self.build_totals(response.get("totals", {}).get("filtered_aggs", {}))
+        aggregation = self.build_totals(response.get("totals", {}).get("filtered_aggs", {}))
 
-        return Response(totals)
+        if self.count_only:
+            return Response({"count": aggregation["award_count"]})
+        else:
+            return Response(aggregation)

--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -1,93 +1,36 @@
-from django.contrib.postgres.fields import ArrayField
-from django.db.models import Count, Sum, TextField, F
-from django.db.models.functions import Coalesce, Cast
+from rest_framework.request import Request
 from rest_framework.response import Response
-from usaspending_api.awards.models import FinancialAccountsByAwards, CovidFinancialAccountMatview
-from usaspending_api.awards.v2.lookups.lookups import loan_type_mapping
 from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.common.exceptions import UnprocessableEntityException
-from usaspending_api.common.validator import TinyShield
-from usaspending_api.disaster.v2.views.disaster_base import DisasterBase, AwardTypeMixin, FabaOutlayMixin
+
+from usaspending_api.common.query_with_filters import QueryWithFilters
+from usaspending_api.disaster.v2.views.elasticsearch_base import ElasticsearchDisasterBase
 
 
-class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
+class AmountViewSet(ElasticsearchDisasterBase):
     """Returns aggregated values of obligation, outlay, and count of Award records"""
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/award/amount.md"
     count_only = False
 
+    agg_key = "recipient_agg_key"
+    bucket_count = 1
+    sort_column_mapping = None
+
+    sum_column_mapping = {
+        "obligation": "total_covid_obligation",
+        "outlay": "total_covid_outlay",
+        "face_value_of_loan": "total_loan_value",
+    }
+
     @cache_response()
-    def post(self, request):
-        additional_models = [
-            {
-                "key": "filter|award_type",
-                "name": "award_type",
-                "type": "enum",
-                "enum_values": ("assistance", "procurement"),
-                "allow_nulls": False,
-                "optional": True,
-            }
-        ]
+    def post(self, request: Request) -> Response:
+        self.filter_query = QueryWithFilters.generate_awards_elasticsearch_query(self.filters)
 
-        f = TinyShield(additional_models).block(self.request.data).get("filter")
-        if f:
-            self.filters["award_type"] = f.get("award_type")
+        search = self.build_elasticsearch_search_with_aggregations()
 
-        if all(x in self.filters for x in ["award_type_codes", "award_type"]):
-            raise UnprocessableEntityException("Cannot provide both 'award_type_codes' and 'award_type'")
+        response = search.handle_execute()
+        response = response.aggs.to_dict()
 
-        if self.count_only:
-            return Response({"count": self.aggregation["award_count"]})
-        else:
-            return Response(self.aggregation)
+        totals = self.build_totals(response.get("totals", {}).get("filtered_aggs", {}))
 
-    @property
-    def aggregation(self):
-        return self._file_d_aggregation() if self.award_type_codes else self._file_c_aggregation()
-
-    def _file_d_aggregation(self):
-        aggregations = {
-            "award_count": Count("award_id"),
-            "obligation": Coalesce(Sum("obligation"), 0),
-            "outlay": Coalesce(Sum("outlay"), 0),
-        }
-
-        if set(self.award_type_codes) <= set(loan_type_mapping.keys()):
-            aggregations["face_value_of_loan"] = Coalesce(Sum("total_loan_value"), 0)
-
-        return (
-            CovidFinancialAccountMatview.objects.annotate(cast_def_codes=Cast("def_codes", ArrayField(TextField())))
-            .filter(type__in=self.award_type_codes, cast_def_codes__overlap=self.def_codes)
-            .values("award_id")
-            .aggregate(**aggregations)
-        )
-
-    def _file_c_aggregation(self):
-        filters = [
-            self.all_closed_defc_submissions,
-            self.has_award_of_classification,
-            self.is_in_provided_def_codes,
-        ]
-
-        group_by_annotations = {"award_identifier": F("distinct_award_key")}
-
-        dollar_annotations = {
-            "inner_obligation": self.obligated_field_annotation,
-            "inner_outlay": self.outlay_field_annotation,
-        }
-
-        all_annotations = {**group_by_annotations, **dollar_annotations}
-
-        return (
-            FinancialAccountsByAwards.objects.filter(*filters)
-            .annotate(**group_by_annotations)
-            .values(*group_by_annotations)
-            .annotate(**dollar_annotations)
-            .exclude(inner_obligation=0, inner_outlay=0)
-            .values(*all_annotations)
-            .aggregate(
-                award_count=Count("award_identifier"),
-                obligation=Coalesce(Sum("inner_obligation"), 0),
-                outlay=Coalesce(Sum("inner_outlay"), 0),
-            )
-        )
+        return Response(totals)


### PR DESCRIPTION
**Description:**
This PR refactors the `/v2/disaster/award/amount` endpoint to use the ElasticsearchDisasterBase class to query from Elasticsearch rather than postgres. This allows for filtering by DEFC.

**Technical details:**
This also includes removing some unused fields from the contract's request for this endpoint. No pagination info is needed because it does not return a list. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7189](https://federal-spending-transparency.atlassian.net/browse/DEV-7289):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
