### PR TITLE
[DEV-7281] Correct calculation of percent TBR on reporting/toptier/overview endpoint

### DIFF
--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -186,20 +186,29 @@ class AgencyOverview(PaginationMixin, AgencyBase):
         }
 
         if result["recent_publication_date"]:
+            percent_of_total_budgetary_resources = (
+                round(result["total_budgetary_resources"] * 100 / result["gtas_total_budgetary_resources"], 2)
+                if result["gtas_total_budgetary_resources"] and result["total_budgetary_resources"]
+                else None
+            )
+            unlinked_assistance_award_count = (
+                result["unlinked_assistance_c_awards"] + result["unlinked_assistance_d_awards"]
+                if result["unlinked_assistance_c_awards"] and result["unlinked_assistance_d_awards"]
+                else None
+            )
+            unlinked_contract_award_count = (
+                result["unlinked_procurement_c_awards"] + result["unlinked_procurement_d_awards"]
+                if result["unlinked_procurement_c_awards"] and result["unlinked_procurement_d_awards"]
+                else None
+            )
             formatted_result.update(
                 {
                     "current_total_budget_authority_amount": result["total_budgetary_resources"],
                     "total_budgetary_resources": result["gtas_total_budgetary_resources"],
-                    "percent_of_total_budgetary_resources": round(
-                        result["total_budgetary_resources"] * 100 / result["gtas_total_budgetary_resources"], 2
-                    )
-                    if result["gtas_total_budgetary_resources"] and result["total_budgetary_resources"]
-                    else 0,
+                    "percent_of_total_budgetary_resources": percent_of_total_budgetary_resources,
                     "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
-                    "unlinked_contract_award_count": (result["unlinked_procurement_c_awards"] or 0)
-                    + (result["unlinked_procurement_d_awards"] or 0),
-                    "unlinked_assistance_award_count": (result["unlinked_assistance_c_awards"] or 0)
-                    + (result["unlinked_assistance_c_awards"] or 0),
+                    "unlinked_contract_award_count": unlinked_contract_award_count,
+                    "unlinked_assistance_award_count": unlinked_assistance_award_count,
                     "assurance_statement_url": self.create_assurance_statement_url(result),
                 }
             )

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -193,7 +193,7 @@ class AgencyOverview(PaginationMixin, AgencyBase):
                     "percent_of_total_budgetary_resources": round(
                         result["total_budgetary_resources"] * 100 / result["gtas_total_budgetary_resources"], 2
                     )
-                    if result["gtas_total_budgetary_resources"]
+                    if result["gtas_total_budgetary_resources"] and result["total_budgetary_resources"]
                     else 0,
                     "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
                     "unlinked_contract_award_count": result["unlinked_procurement_c_awards"]

--- a/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
+++ b/usaspending_api/reporting/v2/views/agencies/toptier_code/overview.py
@@ -196,10 +196,10 @@ class AgencyOverview(PaginationMixin, AgencyBase):
                     if result["gtas_total_budgetary_resources"] and result["total_budgetary_resources"]
                     else 0,
                     "obligation_difference": result["total_diff_approp_ocpa_obligated_amounts"],
-                    "unlinked_contract_award_count": result["unlinked_procurement_c_awards"]
-                    + result["unlinked_procurement_d_awards"],
-                    "unlinked_assistance_award_count": result["unlinked_assistance_c_awards"]
-                    + result["unlinked_assistance_d_awards"],
+                    "unlinked_contract_award_count": (result["unlinked_procurement_c_awards"] or 0)
+                    + (result["unlinked_procurement_d_awards"] or 0),
+                    "unlinked_assistance_award_count": (result["unlinked_assistance_c_awards"] or 0)
+                    + (result["unlinked_assistance_c_awards"] or 0),
                     "assurance_statement_url": self.create_assurance_statement_url(result),
                 }
             )


### PR DESCRIPTION
**Description:**
A bug currently exists on the `/v2/reporting/agencies/toptier_code/overview` page. It is currently possible for the calculation of `percent_of_total_budgetary_resources` in the case that `total_budgetary_resources` is None. This PR corrects the calculation by setting the result to zero when `total_budgetary_resources` is None

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7281](https://federal-spending-transparency.atlassian.net/browse/DEV-7281):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
