### PR TITLE
[HOTFIX] Fix TAS filter 500 error

### DIFF
--- a/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/tas_filter_tree.py
@@ -112,7 +112,7 @@ class TASFilterTree(FilterTree):
         return sorted(retval, key=lambda x: x["id"])
 
     def toptier_search(self, filter_string=None, tier1_nodes=None):
-        filters = [Q(has_faba=True)]
+        filters = [Q(has_faba=True), Q(federal_account__parent_toptier_agency__isnull=False)]
         query = Q()
         if tier1_nodes:
             agency_ids = [node["ancestors"][0] for node in tier1_nodes]


### PR DESCRIPTION
**Description:**
Fixes bug that was causing a 500 error on the TAS filter endpoint

**Technical details:**
Adds filtering on `federal_account` fields being used by the `/references/filter_tree/tas/` endpoint to prevent the endpoint from pulling `null` values for the parent agency

