### PR TITLE
[DEV-7362] Pull over correct toptier_flag and user_selectable for all agencies

### DIFF
--- a/usaspending_api/references/management/commands/load_agencies_sql/agency_query.sql
+++ b/usaspending_api/references/management/commands/load_agencies_sql/agency_query.sql
@@ -27,8 +27,8 @@ from (
     select
         ta.toptier_agency_id,
         null, -- subtier_agency_id
-        true, -- toptier_flag
-        false -- user_selectable
+        tlara.toptier_flag,
+        tlara.user_selectable
     from
         toptier_agency as ta
         inner join "{temp_table}" as tlara on


### PR DESCRIPTION
**Description:**
Agency Loader is not pulling over the exact values for `toptier_flag` and `user_selectable` for agencies without a subtier_agency listed. This fix makes sure that we pull over those values exactly as they appear in the CSV.

**Technical details:**
Update to the Agency Loader SQL to make sure that we grab the correct values and don't overwrite any.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7362](https://federal-spending-transparency.atlassian.net/browse/DEV-7362):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
