### PR TITLE
[DEV-7156] Adds use-cache query param to submission_periods endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/references/submission_periods.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/submission_periods.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# DABS Submission Window Dates [/api/v2/references/submission_periods/]
+# DABS Submission Window Dates [/api/v2/references/submission_periods/{?use_cache}]
 
 This endpoint provides a list of all fields in the "dabs_submission_window_schedule" table except 'id'.   
 

--- a/usaspending_api/api_contracts/contracts/v2/references/submission_periods.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/submission_periods.md
@@ -7,6 +7,9 @@ This endpoint provides a list of all fields in the "dabs_submission_window_sched
 
 ## GET
 
++ Parameters
+    + `use_cache`: `false` (optional, boolean) - Whether or not to use a cache when retrieving values. Defaults to false. 
+
 + Response 200 (application/json)
     + Attributes (object)
         + `available_periods` (required, array[AvailablePeriod], fixed-type) 

--- a/usaspending_api/references/v2/views/submission_periods.py
+++ b/usaspending_api/references/v2/views/submission_periods.py
@@ -36,7 +36,7 @@ class SubmissionPeriodsViewSet(APIView):
         models = [{"name": "use_cache", "key": "use_cache", "type": "boolean", "default": False}]
         validated_payload = TinyShield(models).block(request.GET)
 
-        if validated_payload['use_cache']:
+        if validated_payload["use_cache"]:
             formatted_results = CachedSubmissionPeriodsViewSet.as_view()(request=request._request).data
         else:
             formatted_results = self.get_closed_submission_windows()
@@ -48,6 +48,7 @@ class CachedSubmissionPeriodsViewSet(APIView):
     """
     This ViewSet is only used internally to provided a cached version of the SubmissionPeriodsViewSet
     """
+
     @cache_response()
     def get(self, request):
         formatted_results = SubmissionPeriodsViewSet.get_closed_submission_windows()


### PR DESCRIPTION
**Description:**
This PR is adding a `use_cache` parameter to the `api/v2/references/submission_periods` endpoint. This specifies whether the django cache should be use to return the response. 

**Technical details:**
This is accomplished using an extra APIView. This APIView, `CachedSubmissionPeriodsViewSet` is not directly accessible via an endpoint and is called in code by `SubmissionPeriodsViewSet`. These two APIViews both use `get_closed_submission_windows` to create a list of closed submission window schedules. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7156](https://federal-spending-transparency.atlassian.net/browse/DEV-7156):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
