### PR TITLE
[DEV-7118] Use external load dates to determine cutoff for download cache

### DIFF
--- a/usaspending_api/download/tests/unit/test_base_download_helpers.py
+++ b/usaspending_api/download/tests/unit/test_base_download_helpers.py
@@ -1,0 +1,285 @@
+import json
+import pytest
+
+
+from datetime import datetime, timezone
+from model_mommy import mommy
+from unittest.mock import patch
+
+from usaspending_api.broker.lookups import EXTERNAL_DATA_TYPE_DICT
+from usaspending_api.download.lookups import JOB_STATUS
+from usaspending_api.download.v2.base_download_viewset import BaseDownloadViewSet
+
+
+JSON_REQUEST = {"dummy_key": "dummy_value"}
+
+
+@pytest.fixture
+def common_test_data(db):
+    for js in JOB_STATUS:
+        mommy.make("download.JobStatus", job_status_id=js.id, name=js.name, description=js.desc)
+
+    download_jobs = [
+        {
+            "download_job_id": 1,
+            "file_name": "oldest_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 15, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 2,
+            "file_name": "yesterday.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 16, 12, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for job in download_jobs:
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = job["update_date"]
+            mommy.make("download.DownloadJob", **job)
+
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=datetime(2021, 1, 1, 12, 0, 0, 0, timezone.utc),
+    )
+
+
+def test_elasticsearch_download_cached(common_test_data):
+    external_load_dates = [
+        # FABS and FPDS dates are much newer to show they aren't used for ES downloads
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fabs"],
+            "last_load_date": datetime(2021, 1, 30, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fpds"],
+            "last_load_date": datetime(2021, 1, 30, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_transactions"],
+            "last_load_date": datetime(2021, 1, 17, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_awards"],
+            "last_load_date": datetime(2021, 1, 17, 16, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for load_date in external_load_dates:
+        mommy.make("broker.ExternalDataLoadDate", **load_date)
+
+    es_transaction_request = {**JSON_REQUEST, "download_types": ["elasticsearch_transactions", "sub_awards"]}
+    es_award_request = {**JSON_REQUEST, "download_types": ["elasticsearch_awards", "sub_awards"]}
+
+    download_jobs = [
+        {
+            "download_job_id": 10,
+            "file_name": "es_transaction_job_wrong.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(es_transaction_request),
+            "update_date": datetime(2021, 1, 17, 10, 0, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 11,
+            "file_name": "es_transaction_job_right.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(es_transaction_request),
+            "update_date": datetime(2021, 1, 17, 12, 30, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 20,
+            "file_name": "es_award_job_wrong.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(es_award_request),
+            "update_date": datetime(2021, 1, 17, 13, 0, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 21,
+            "file_name": "es_award_job_right.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(es_award_request),
+            "update_date": datetime(2021, 1, 17, 17, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for job in download_jobs:
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = job["update_date"]
+            mommy.make("download.DownloadJob", **job)
+
+    result = BaseDownloadViewSet._get_cached_download(
+        json.dumps(es_transaction_request), es_transaction_request["download_types"]
+    )
+    assert result == {"download_job_id": 11, "file_name": "es_transaction_job_right.zip"}
+
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(es_award_request), es_award_request["download_types"])
+    assert result == {"download_job_id": 21, "file_name": "es_award_job_right.zip"}
+
+
+def test_elasticsearch_cached_download_not_found(common_test_data):
+    external_load_dates = [
+        # FABS and FPDS dates are much newer to show they aren't used for ES downloads
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fabs"],
+            "last_load_date": datetime(2021, 1, 30, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fpds"],
+            "last_load_date": datetime(2021, 1, 30, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_transactions"],
+            "last_load_date": datetime(2021, 1, 17, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_awards"],
+            "last_load_date": datetime(2021, 1, 17, 16, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for load_date in external_load_dates:
+        mommy.make("broker.ExternalDataLoadDate", **load_date)
+
+    result = BaseDownloadViewSet._get_cached_download(
+        json.dumps(JSON_REQUEST), ["elasticsearch_transactions", "sub_awards"]
+    )
+    assert result is None
+
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST), ["elasticsearch_awards", "sub_awards"])
+    assert result is None
+
+
+def test_non_elasticsearch_download_cached(common_test_data):
+    external_load_dates = [
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fabs"],
+            "last_load_date": datetime(2021, 1, 17, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fpds"],
+            "last_load_date": datetime(2021, 1, 17, 13, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_transactions"],
+            "last_load_date": datetime(2021, 1, 17, 14, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_awards"],
+            "last_load_date": datetime(2021, 1, 17, 16, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for load_date in external_load_dates:
+        mommy.make("broker.ExternalDataLoadDate", **load_date)
+
+    download_jobs = [
+        {
+            "download_job_id": 10,
+            "file_name": "10_download_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 17, 10, 0, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 11,
+            "file_name": "11_download_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 17, 12, 30, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 20,
+            "file_name": "20_download_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 17, 13, 0, 0, 0, timezone.utc),
+        },
+        {
+            "download_job_id": 21,
+            "file_name": "21_download_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 17, 17, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for job in download_jobs:
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = job["update_date"]
+            mommy.make("download.DownloadJob", **job)
+
+    # Grab latest valid download
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST))
+    assert result == {"download_job_id": 21, "file_name": "21_download_job.zip"}
+
+    # FABS date updated; download no longer cached
+    mommy.make(
+        "broker.ExternalDataLoadDate",
+        external_data_type__external_data_type_id=EXTERNAL_DATA_TYPE_DICT["fabs"],
+        last_load_date=datetime(2021, 1, 18, 12, 0, 0, 0, timezone.utc),
+    )
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST))
+    assert result is None
+
+    # New download comes through and is cached
+    with patch("django.utils.timezone.now") as mock_now:
+        job = {
+            "download_job_id": 30,
+            "file_name": "30_download_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 18, 13, 0, 0, 0, timezone.utc),
+        }
+        mock_now.return_value = job["update_date"]
+        mommy.make("download.DownloadJob", **job)
+
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST))
+    assert result == {"download_job_id": 30, "file_name": "30_download_job.zip"}
+
+    # New submission_reveal_date is set in DABSSubmissionWindowSchedule; clears the cache
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=datetime(2021, 1, 19, 6, 0, 0, 0, timezone.utc),
+    )
+
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST))
+    assert result is None
+
+    # Download after the new submission_reveal_date is cached
+    with patch("django.utils.timezone.now") as mock_now:
+        job = {
+            "download_job_id": 31,
+            "file_name": "31_download_job.zip",
+            "job_status_id": 1,
+            "json_request": json.dumps(JSON_REQUEST),
+            "update_date": datetime(2021, 1, 19, 6, 15, 0, 0, timezone.utc),
+        }
+        mock_now.return_value = job["update_date"]
+        mommy.make("download.DownloadJob", **job)
+
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST))
+    assert result == {"download_job_id": 31, "file_name": "31_download_job.zip"}
+
+
+def test_non_elasticsearch_cached_download_not_found(common_test_data):
+    external_load_dates = [
+        # FABS and FPDS dates are much newer to show they aren't used for ES downloads
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fabs"],
+            "last_load_date": datetime(2021, 1, 30, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["fpds"],
+            "last_load_date": datetime(2021, 1, 30, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_transactions"],
+            "last_load_date": datetime(2021, 1, 17, 12, 0, 0, 0, timezone.utc),
+        },
+        {
+            "external_data_type__external_data_type_id": EXTERNAL_DATA_TYPE_DICT["es_awards"],
+            "last_load_date": datetime(2021, 1, 17, 16, 0, 0, 0, timezone.utc),
+        },
+    ]
+    for load_date in external_load_dates:
+        mommy.make("broker.ExternalDataLoadDate", **load_date)
+
+    result = BaseDownloadViewSet._get_cached_download(json.dumps(JSON_REQUEST))
+    assert result is None

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -35,7 +35,6 @@ class BaseDownloadViewSet(APIView):
         special_request_type: Optional[str] = None,
         validator_type: Optional[Type[DownloadValidatorBase]] = None,
     ):
-        # commit to refresh codeclimate
         if special_request_type == "disaster":
             filename = (
                 DownloadJob.objects.filter(

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -147,11 +147,12 @@ class BaseDownloadViewSet(APIView):
         ).aggregate(Max("last_load_date"))["last_load_date__max"]
 
         # Conditional put in place for local development where the external dates may not be defined
+        cached_download = None
         if updated_date_timestamp:
             recent_submission_window_date = DABSSubmissionWindowSchedule.objects.filter(
                 submission_reveal_date__lt=datetime.max.replace(tzinfo=timezone.utc)
             ).aggregate(Max("submission_reveal_date"))["submission_reveal_date__max"]
-            return (
+            cached_download = (
                 DownloadJob.objects.filter(
                     json_request=ordered_json_request,
                     update_date__gte=max(updated_date_timestamp, recent_submission_window_date),
@@ -161,7 +162,7 @@ class BaseDownloadViewSet(APIView):
                 .values("download_job_id", "file_name")
                 .first()
             )
-        return None
+        return cached_download
 
 
 def get_file_path(file_name: str) -> str:

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -35,6 +35,7 @@ class BaseDownloadViewSet(APIView):
         special_request_type: Optional[str] = None,
         validator_type: Optional[Type[DownloadValidatorBase]] = None,
     ):
+        # commit to refresh codeclimate
         if special_request_type == "disaster":
             filename = (
                 DownloadJob.objects.filter(

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -1,14 +1,17 @@
 import json
 
 from datetime import datetime, timezone
-from typing import Optional, Type
+from typing import Optional, Type, List
 
 from django.conf import settings
+from django.db.models import QuerySet, Max
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from usaspending_api.broker.lookups import EXTERNAL_DATA_TYPE_DICT
+from usaspending_api.broker.models import ExternalDataLoadDate
 from usaspending_api.common.api_versioning import api_transformations, API_TRANSFORM_FUNCTIONS
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.dict_helpers import order_nested_object
@@ -20,6 +23,7 @@ from usaspending_api.download.helpers import write_to_download_log as write_to_l
 from usaspending_api.download.lookups import JOB_STATUS_DICT
 from usaspending_api.download.models import DownloadJob
 from usaspending_api.download.v2.request_validations import DownloadValidatorBase
+from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
 
 @api_transformations(api_version=settings.API_VERSION, function_list=API_TRANSFORM_FUNCTIONS)
@@ -53,14 +57,7 @@ class BaseDownloadViewSet(APIView):
         ordered_json_request = json.dumps(json_request)
 
         # Check if the same request has been called today
-        # TODO!!! Use external_data_load_date to determine data freshness
-        updated_date_timestamp = datetime.strftime(datetime.now(timezone.utc), "%Y-%m-%d")
-        cached_download = (
-            DownloadJob.objects.filter(json_request=ordered_json_request, update_date__gte=updated_date_timestamp)
-            .exclude(job_status_id=JOB_STATUS_DICT["failed"])
-            .values("download_job_id", "file_name")
-            .first()
-        )
+        cached_download = self._get_cached_download(ordered_json_request, json_request.get("download_types", []))
 
         if cached_download and not settings.IS_LOCAL:
             # By returning the cached files, there should be no duplicates on a daily basis
@@ -124,6 +121,47 @@ class BaseDownloadViewSet(APIView):
                 host = f"{settings.DOWNLOAD_ENV}-{host}"
 
         return f"{protocol}://{host}/api/v2/download/status?file_name={file_name}"
+
+    @staticmethod
+    def _get_cached_download(
+        ordered_json_request: str, download_types: Optional[List[str]] = None
+    ) -> Optional[QuerySet]:
+        external_data_type_name_list = []
+
+        # External data types that directly affect download results
+        if download_types:
+            if "elasticsearch_awards" in download_types:
+                external_data_type_name_list.append("es_awards")
+            elif "elasticsearch_transactions" in download_types:
+                external_data_type_name_list.append("es_transactions")
+        else:
+            external_data_type_name_list.extend(["fpds", "fabs", "es_transactions", "es_awards"])
+
+        external_data_type_id_list = [
+            id for name, id in EXTERNAL_DATA_TYPE_DICT.items() if name in external_data_type_name_list
+        ]
+
+        # Clear the download "cache" based on most recent date in the list of relevant ExternalDataLoadDate objects
+        updated_date_timestamp = ExternalDataLoadDate.objects.filter(
+            external_data_type_id__in=external_data_type_id_list
+        ).aggregate(Max("last_load_date"))["last_load_date__max"]
+
+        # Conditional put in place for local development where the external dates may not be defined
+        if updated_date_timestamp:
+            recent_submission_window_date = DABSSubmissionWindowSchedule.objects.filter(
+                submission_reveal_date__lt=datetime.max.replace(tzinfo=timezone.utc)
+            ).aggregate(Max("submission_reveal_date"))["submission_reveal_date__max"]
+            return (
+                DownloadJob.objects.filter(
+                    json_request=ordered_json_request,
+                    update_date__gte=max(updated_date_timestamp, recent_submission_window_date),
+                )
+                .order_by("-update_date")
+                .exclude(job_status_id=JOB_STATUS_DICT["failed"])
+                .values("download_job_id", "file_name")
+                .first()
+            )
+        return None
 
 
 def get_file_path(file_name: str) -> str:


### PR DESCRIPTION
**Description:**
Download "cache" is actually a reference to the DownloadJob table and the download .zip folder in S3. Previously the download was using a cutoff date of midnight every night, meaning any download after midnight would be a new download. Anything prior to midnight would first look to see if it had been previously run.

**Technical details:**
Use a combination of FPDS, FABS, ES Transactions, and ES Awards external load dates paired with the latest submission's reveal date. The goal is to have data as fresh as possible while still keeping the cache functionality. The download cache could be more granular but that would require adding a lot more external load dates to map each stage of the pipeline with a download.

The approach taken will compare the `update_date` of a DownloadJob to the most recent and relevant External Load Date. The "relevant" part comes into play only for Elasticsearch based downloads (Advanced Search Awards and Transactions) because we do not update the Elasticsearch Indexes until the end of the pipeline. 

This approach does mean the cache will be "cleared" multiple times through the pipeline, but it will help to guarantee the most fresh data possible and also help to prevent someone from downloading data that does not match the site. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7118](https://federal-spending-transparency.atlassian.net/browse/DEV-7118):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
