### PR TITLE
[DEV-7404] Use correct fiscal period for total budget

### DIFF
--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -299,3 +299,16 @@ END$$;"""
 def generate_test_db_connection_string():
     db = connection.cursor().db.settings_dict
     return "postgres://{}:{}@{}:5432/{}".format(db["USER"], db["PASSWORD"], db["HOST"], db["NAME"])
+
+
+def sort_with_null_last(to_sort, sort_key, sort_order, tie_breaker=None):
+    """
+    Use tuples to sort results so that None can be converted to a Boolean for comparison
+    """
+    if tie_breaker is None:
+        tie_breaker = sort_key
+    return sorted(
+        to_sort,
+        key=lambda x: ((x[sort_key] is None) == (sort_order == "asc"), x[sort_key], x[tie_breaker]),
+        reverse=(sort_order == "desc"),
+    )

--- a/usaspending_api/common/helpers/orm_helpers.py
+++ b/usaspending_api/common/helpers/orm_helpers.py
@@ -88,6 +88,18 @@ class ConcatAll(Func):
     function = "CONCAT"
 
 
+class AvoidSubqueryInGroupBy(Subquery):
+    """
+    Django currently adds Subqueries to the Group By clause by default when an Aggregation or Annotation is
+    used. This is not always needed and for those queries where it is not needed it can hurt performance.
+    The ability to avoid this was implemented in Django 3.2:
+    https://github.com/django/django/commit/fb3f034f1c63160c0ff13c609acd01c18be12f80
+    """
+
+    def get_group_by_cols(self):
+        return []
+
+
 def get_agency_name_annotation(relation_name: str, cgac_column_name: str) -> Subquery:
     """
     Accepts the Django foreign key relation name for the outer queryset to TreasuryAppropriationAccount

--- a/usaspending_api/references/tests/test_agency_v2.py
+++ b/usaspending_api/references/tests/test_agency_v2.py
@@ -28,6 +28,23 @@ def create_agency_data(db):
     mommy.make("references.GTASSF133Balances", fiscal_year=2017, fiscal_period=6, total_budgetary_resources_cpe=2000)
 
     # Create Submissions
+    dsws1 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2017,
+        submission_reveal_date="2017-02-01",
+        submission_fiscal_quarter=2,
+        submission_fiscal_month=4,
+        is_quarter=False,
+    )
+    dsws2 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2017,
+        submission_reveal_date="2017-04-01",
+        submission_fiscal_quarter=2,
+        submission_fiscal_month=6,
+        is_quarter=True,
+    )
+
     mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2017,
@@ -35,6 +52,7 @@ def create_agency_data(db):
         reporting_fiscal_period=4,
         toptier_code="100",
         is_final_balances_for_fy=False,
+        submission_window=dsws1,
     )
     submission_1 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -43,6 +61,7 @@ def create_agency_data(db):
         reporting_fiscal_period=6,
         toptier_code="100",
         is_final_balances_for_fy=True,
+        submission_window=dsws2,
     )
 
     # Create AppropriationAccountBalances

--- a/usaspending_api/references/tests/test_agency_v2.py
+++ b/usaspending_api/references/tests/test_agency_v2.py
@@ -6,8 +6,8 @@ from rest_framework import status
 
 @pytest.fixture
 def create_agency_data(db):
-    # Create agency - submission relationship
-    # Create AGENCY AND TopTier AGENCY
+    # Create Agency - Submission relationship
+    # Create Agency AND TopTier Agency
     ttagency1 = mommy.make(
         "references.ToptierAgency",
         name="tta_name",
@@ -20,21 +20,32 @@ def create_agency_data(db):
     )
     mommy.make("references.Agency", id=1, toptier_agency=ttagency1)
 
-    # create TAS
+    # Create TAS
     tas = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ttagency1)
 
-    # CREATE SUBMISSIONS
-    # submission_3 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2015, toptier_code='100')
+    # Create GTAS
+    mommy.make("references.GTASSF133Balances", fiscal_year=2017, fiscal_period=4, total_budgetary_resources_cpe=1000)
+    mommy.make("references.GTASSF133Balances", fiscal_year=2017, fiscal_period=6, total_budgetary_resources_cpe=2000)
+
+    # Create Submissions
+    mommy.make(
+        "submissions.SubmissionAttributes",
+        reporting_fiscal_year=2017,
+        reporting_fiscal_quarter=2,
+        reporting_fiscal_period=4,
+        toptier_code="100",
+        is_final_balances_for_fy=False,
+    )
     submission_1 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2017,
         reporting_fiscal_quarter=2,
+        reporting_fiscal_period=6,
         toptier_code="100",
         is_final_balances_for_fy=True,
     )
-    # submission_2 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2016, toptier_code='100')
 
-    # CREATE AppropriationAccountBalances
+    # Create AppropriationAccountBalances
     mommy.make(
         "accounts.AppropriationAccountBalances",
         final_of_fy=True,
@@ -46,7 +57,7 @@ def create_agency_data(db):
         treasury_account_identifier=tas,
     )
 
-    # CREATE OverallTotals
+    # Create OverallTotals
     mommy.make("references.OverallTotals", fiscal_year=2017, total_budget_authority=3860000000.00)
 
 
@@ -61,6 +72,7 @@ def test_agency_endpoint(client, create_agency_data):
     assert resp.data["results"]["obligated_amount"] == "2.00"
     assert resp.data["results"]["budget_authority_amount"] == "2.00"
     assert resp.data["results"]["congressional_justification_url"] == "test.com/cj"
+    assert resp.data["results"]["current_total_budget_authority_amount"] == "2000.00"
 
     # check for bad request due to missing params
     resp = client.get("/api/v2/references/agency/4/")

--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -26,7 +26,31 @@ def create_agency_data():
     tas = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ttagency1)
     tas2 = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ttagency2)
 
-    # CREATE SUBMISSIONS
+    # Create Submissions
+    dsws1 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2017,
+        submission_reveal_date="2017-02-01",
+        submission_fiscal_quarter=2,
+        submission_fiscal_month=4,
+        is_quarter=False,
+    )
+    dsws2 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2017,
+        submission_reveal_date="2017-04-01",
+        submission_fiscal_quarter=2,
+        submission_fiscal_month=6,
+        is_quarter=True,
+    )
+    dsws3 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_fiscal_year=2017,
+        submission_reveal_date="2017-04-01",
+        submission_fiscal_quarter=2,
+        submission_fiscal_month=6,
+        is_quarter=False,
+    )
     mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2017,
@@ -34,6 +58,7 @@ def create_agency_data():
         reporting_fiscal_period=4,
         toptier_code="100",
         is_final_balances_for_fy=False,
+        submission_window=dsws1,
     )
     submission_1 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -42,6 +67,7 @@ def create_agency_data():
         reporting_fiscal_period=6,
         toptier_code="100",
         is_final_balances_for_fy=True,
+        submission_window=dsws2,
     )
     submission_2 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -50,6 +76,7 @@ def create_agency_data():
         reporting_fiscal_period=6,
         toptier_code="200",
         is_final_balances_for_fy=True,
+        submission_window=dsws3,
     )
 
     # CREATE AppropriationAccountBalances

--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -27,7 +27,14 @@ def create_agency_data():
     tas2 = mommy.make("accounts.TreasuryAppropriationAccount", funding_toptier_agency=ttagency2)
 
     # CREATE SUBMISSIONS
-    # submission_3 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2015, toptier_code='100')
+    mommy.make(
+        "submissions.SubmissionAttributes",
+        reporting_fiscal_year=2017,
+        reporting_fiscal_quarter=2,
+        reporting_fiscal_period=4,
+        toptier_code="100",
+        is_final_balances_for_fy=False,
+    )
     submission_1 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2017,
@@ -36,7 +43,6 @@ def create_agency_data():
         toptier_code="100",
         is_final_balances_for_fy=True,
     )
-    # submission_2 = mommy.make('submissions.SubmissionAttributes', reporting_fiscal_year=2016, toptier_code='100')
     submission_2 = mommy.make(
         "submissions.SubmissionAttributes",
         reporting_fiscal_year=2017,
@@ -71,7 +77,14 @@ def create_agency_data():
     mommy.make(
         "references.GTASSF133Balances",
         total_budgetary_resources_cpe=100.00,
-        obligations_incurred_total_cpe=100.00,
+        obligations_incurred_total_cpe=1000.00,
+        fiscal_year=2017,
+        fiscal_period=4,
+    )
+    mommy.make(
+        "references.GTASSF133Balances",
+        total_budgetary_resources_cpe=200.00,
+        obligations_incurred_total_cpe=2000.00,
         fiscal_year=2017,
         fiscal_period=6,
     )
@@ -93,10 +106,10 @@ def test_award_type_endpoint(client, create_agency_data):
                 "agency_name": "tta_name",
                 "congressional_justification_url": "test.com/cj",
                 "budget_authority_amount": 2.0,
-                "current_total_budget_authority_amount": 100.00,
+                "current_total_budget_authority_amount": 200.00,
                 "obligated_amount": 2.0,
                 "outlay_amount": 2.0,
-                "percentage_of_total_budget_authority": 0.02,
+                "percentage_of_total_budget_authority": 0.01,
                 "toptier_code": "100",
             },
             {
@@ -107,10 +120,10 @@ def test_award_type_endpoint(client, create_agency_data):
                 "agency_name": "tta_name_2",
                 "congressional_justification_url": None,
                 "budget_authority_amount": 14.0,
-                "current_total_budget_authority_amount": 100.00,
+                "current_total_budget_authority_amount": 200.00,
                 "obligated_amount": 14.0,
                 "outlay_amount": 14.00,
-                "percentage_of_total_budget_authority": 0.14,
+                "percentage_of_total_budget_authority": 0.07,
                 "toptier_code": "200",
             },
         ]
@@ -128,10 +141,10 @@ def test_award_type_endpoint(client, create_agency_data):
                 "agency_name": "tta_name_2",
                 "congressional_justification_url": None,
                 "budget_authority_amount": 14.0,
-                "current_total_budget_authority_amount": 100.00,
+                "current_total_budget_authority_amount": 200.00,
                 "obligated_amount": 14.0,
                 "outlay_amount": 14.0,
-                "percentage_of_total_budget_authority": 0.14,
+                "percentage_of_total_budget_authority": 0.07,
                 "toptier_code": "200",
             },
             {
@@ -142,10 +155,10 @@ def test_award_type_endpoint(client, create_agency_data):
                 "agency_name": "tta_name",
                 "congressional_justification_url": "test.com/cj",
                 "budget_authority_amount": 2.0,
-                "current_total_budget_authority_amount": 100.00,
+                "current_total_budget_authority_amount": 200.00,
                 "obligated_amount": 2.0,
                 "outlay_amount": 2.0,
-                "percentage_of_total_budget_authority": 0.02,
+                "percentage_of_total_budget_authority": 0.01,
                 "toptier_code": "100",
             },
         ]

--- a/usaspending_api/references/v2/views/agency.py
+++ b/usaspending_api/references/v2/views/agency.py
@@ -1,21 +1,12 @@
 from django.db.models import F, Sum
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
 from usaspending_api.accounts.models import AppropriationAccountBalances
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.date_helper import now
 from usaspending_api.references.models import Agency, GTASSF133Balances
 from usaspending_api.submissions.models import SubmissionAttributes
-
-
-def get_total_budgetary_resources(fiscal_year, fiscal_period):
-    total_budgetary_resources = (
-        GTASSF133Balances.objects.filter(fiscal_year=fiscal_year, fiscal_period=fiscal_period)
-        .values("fiscal_year")
-        .annotate(total_budgetary_resources=Sum("total_budgetary_resources_cpe"))
-        .values("total_budgetary_resources")
-    )
-    return total_budgetary_resources[0]["total_budgetary_resources"] if len(total_budgetary_resources) > 0 else 0.0
 
 
 class AgencyViewSet(APIView):
@@ -75,6 +66,13 @@ class AgencyViewSet(APIView):
 
         cj = toptier_agency.justification if toptier_agency.justification else None
 
+        total_budgetary_resources = (
+            GTASSF133Balances.objects.filter(fiscal_year=active_fiscal_year, fiscal_period=active_fiscal_period)
+            .values("fiscal_year")
+            .aggregate(Sum("total_budgetary_resources_cpe"))
+        )
+        total_budgetary_resources = total_budgetary_resources.get("total_budgetary_resources_cpe__sum", 0)
+
         # craft response
         response["results"] = {
             "agency_name": toptier_agency.name,
@@ -83,9 +81,7 @@ class AgencyViewSet(APIView):
             "outlay_amount": str(aggregate_dict["outlay_amount"]),
             "obligated_amount": str(aggregate_dict["obligated_amount"]),
             "budget_authority_amount": str(aggregate_dict["budget_authority_amount"]),
-            "current_total_budget_authority_amount": str(
-                get_total_budgetary_resources(active_fiscal_year, active_fiscal_period)
-            ),
+            "current_total_budget_authority_amount": str(total_budgetary_resources),
             "mission": toptier_agency.mission,
             "website": toptier_agency.website,
             "icon_filename": toptier_agency.icon_filename,

--- a/usaspending_api/references/v2/views/agency.py
+++ b/usaspending_api/references/v2/views/agency.py
@@ -46,8 +46,8 @@ class AgencyViewSet(APIView):
             toptier_code=toptier_agency.toptier_code, submission_window__submission_reveal_date__lte=now()
         )
 
-        # get the most up to date fy and quarter
-        queryset = queryset.order_by("-reporting_fiscal_year", "-reporting_fiscal_quarter")
+        # get the most up to date fy, quarter, and period
+        queryset = queryset.order_by("-reporting_fiscal_year", "-reporting_fiscal_quarter", "-reporting_fiscal_period")
         queryset = queryset.annotate(
             fiscal_year=F("reporting_fiscal_year"), fiscal_quarter=F("reporting_fiscal_quarter")
         )

--- a/usaspending_api/references/v2/views/agency.py
+++ b/usaspending_api/references/v2/views/agency.py
@@ -55,8 +55,8 @@ class AgencyViewSet(APIView):
             .first()
         )
         if submission is None:
-            # If there is no Submission for the latest Quarter / Period then get Fiscal Date from latest submission;
-            # Not terminating early as we do above since the Agency does have at least one historical submission
+            # If there is no Submission for the latest Quarter / Period then get Fiscal Date from latest submission.
+            # Not terminating early as we do above since the Agency does have at least one historical submission.
             submission = (
                 SubmissionAttributes.objects.filter(submission_window__submission_reveal_date__lte=now())
                 .order_by("-reporting_fiscal_year", "-reporting_fiscal_quarter", "-reporting_fiscal_period")
@@ -68,11 +68,10 @@ class AgencyViewSet(APIView):
         active_fiscal_quarter = submission.fiscal_quarter
         active_fiscal_period = submission.reporting_fiscal_period
 
+        # If an Agency does not have a Submission in the recent FY, FQ, and FP combination then this query will be
+        # returning 0s for all sums since it does an INNER JOIN to the Submission pulled by the queries above.
         queryset = AppropriationAccountBalances.objects.filter(submission__is_final_balances_for_fy=True)
-        # get the incoming agency's toptier agency, because that's what we'll
-        # need to filter on
-        # (used filter() instead of get() b/c we likely don't want to raise an
-        # error on a bad agency id)
+
         aggregate_dict = queryset.filter(
             submission__reporting_fiscal_year=active_fiscal_year,
             submission__reporting_fiscal_quarter=active_fiscal_quarter,

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -99,8 +99,6 @@ class ToptierAgenciesViewSet(APIView):
             for val in latest_submission_by_toptier
         }
 
-        # Add a placeholder for Agencies that have submitted but not in recent Quarter / Period;
-        # Placeholder is most recent Period window to ensure accurate "current_total_budget_authority_amount"
         placeholder = {
             "fiscal_year": most_recent_period_window["submission_fiscal_year"],
             "fiscal_quarter": most_recent_period_window["submission_fiscal_quarter"],
@@ -108,6 +106,9 @@ class ToptierAgenciesViewSet(APIView):
         }
         for toptier_code in all_toptier_with_submission:
             submission_values = latest_submission_by_toptier.get(toptier_code)
+
+            # Add a placeholder for Agencies that have submitted but not in recent Quarter / Period;
+            # Placeholder is most recent Period window to ensure accurate "current_total_budget_authority_amount"
             if submission_values is None:
                 latest_submission_by_toptier[toptier_code] = placeholder
 
@@ -153,8 +154,10 @@ class ToptierAgenciesViewSet(APIView):
         for agency in agency_list:
             submission = latest_submission_by_toptier.get(agency["toptier_code"])
 
+            # This means we don't have any submissions for that Agency and therefore should not be showing them
             if submission is None:
                 continue
+
             active_fiscal_year = submission["fiscal_year"]
             active_fiscal_quarter = submission["fiscal_quarter"]
             active_fiscal_period = submission["fiscal_period"]

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -1,26 +1,16 @@
-from django.db.models import F, Sum
+from django.db.models import F, Sum, OuterRef, Max
 from django.db.models.functions import Coalesce
-
-from usaspending_api.common.helpers.date_helper import now
-from usaspending_api.references.models import Agency, GTASSF133Balances
-from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.references.v2.views.agency import get_total_budgetary_resources
-from usaspending_api.submissions.models import SubmissionAttributes
-
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from usaspending_api.common.exceptions import InvalidParameterException
+
 from usaspending_api.accounts.models import AppropriationAccountBalances
-
-
-def get_total_obligations_incurred(fiscal_year, fiscal_period):
-    total_obligations_incurred = (
-        GTASSF133Balances.objects.filter(fiscal_year=fiscal_year, fiscal_period=fiscal_period)
-        .values("fiscal_year")
-        .annotate(total_obligations=Sum("obligations_incurred_total_cpe"))
-        .values("total_obligations")
-    )
-    return total_obligations_incurred[0]["total_obligations"] if len(total_obligations_incurred) > 0 else 0.0
+from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.common.helpers.date_helper import now
+from usaspending_api.common.helpers.generic_helper import sort_with_null_last
+from usaspending_api.common.helpers.orm_helpers import AvoidSubqueryInGroupBy
+from usaspending_api.references.models import Agency, GTASSF133Balances
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.submissions.models import SubmissionAttributes
 
 
 class ToptierAgenciesViewSet(APIView):
@@ -59,73 +49,122 @@ class ToptierAgenciesViewSet(APIView):
                 "The order value provided is not a valid option. Please choose from the following: ['asc', 'desc']"
             )
 
-        # get agency queryset, distinct toptier id to avoid duplicates, take first ordered agency id for consistency
-        agency_queryset = Agency.objects.order_by("toptier_agency_id", "id").distinct("toptier_agency_id")
-        for agency in agency_queryset:
-            toptier_agency = agency.toptier_agency
-            # get corresponding submissions through cgac code
-            queryset = SubmissionAttributes.objects.all()
-            queryset = queryset.filter(
-                toptier_code=toptier_agency.toptier_code, submission_window__submission_reveal_date__lte=now()
+        # Subquery does not generate a Group By for the Queryset so "trigger_group_by" is added;
+        # Additionally "AvoidSubqueryInGroupBy" helps performance by keeping it from the Group By
+        tbr_by_year_and_period = (
+            GTASSF133Balances.objects.values("fiscal_year", "fiscal_period")
+            .annotate(
+                trigger_group_by=Max("fiscal_period"),
+                total_budgetary_resources=AvoidSubqueryInGroupBy(
+                    GTASSF133Balances.objects.filter(
+                        fiscal_year=OuterRef("fiscal_year"), fiscal_period=OuterRef("fiscal_period")
+                    )
+                    .values("fiscal_year")
+                    .annotate(total_budgetary_resources=Sum("total_budgetary_resources_cpe"))
+                    .values("total_budgetary_resources")
+                ),
             )
+            .values("fiscal_year", "fiscal_period", "total_budgetary_resources")
+        )
+        tbr_by_year_and_period = {
+            (val["fiscal_year"], val["fiscal_period"]): val["total_budgetary_resources"]
+            for val in tbr_by_year_and_period
+        }
 
-            # get the most up to date fy and quarter
-            queryset = queryset.order_by("-reporting_fiscal_year", "-reporting_fiscal_quarter")
-            queryset = queryset.annotate(
-                fiscal_year=F("reporting_fiscal_year"), fiscal_quarter=F("reporting_fiscal_quarter")
+        # get the most up to date fy and quarter
+        latest_sa_by_toptier = (
+            SubmissionAttributes.objects.filter(submission_window__submission_reveal_date__lte=now())
+            .values("toptier_code")
+            .annotate(
+                fiscal_year=Max("reporting_fiscal_year"),
+                fiscal_quarter=Max("reporting_fiscal_quarter"),
+                fiscal_period=Max("reporting_fiscal_period"),
             )
-            submission = queryset.first()
-            if submission is None:
-                continue
-            active_fiscal_year = submission.reporting_fiscal_year
-            active_fiscal_quarter = submission.fiscal_quarter
-            active_fiscal_period = submission.reporting_fiscal_period
+        )
+        latest_sa_by_toptier = {
+            val["toptier_code"]: {
+                "fiscal_year": val["fiscal_year"],
+                "fiscal_quarter": val["fiscal_quarter"],
+                "fiscal_period": val["fiscal_period"],
+            }
+            for val in latest_sa_by_toptier
+        }
 
-            queryset = AppropriationAccountBalances.objects.filter(submission__is_final_balances_for_fy=True)
-            # get the incoming agency's toptier agency, because that's what we'll
-            # need to filter on
-            # (used filter() instead of get() b/c we likely don't want to raise an
-            # error on a bad agency id)
-            aggregate_dict = queryset.filter(
-                submission__reporting_fiscal_year=active_fiscal_year,
-                submission__reporting_fiscal_quarter=active_fiscal_quarter,
-                treasury_account_identifier__funding_toptier_agency=toptier_agency,
-            ).aggregate(
+        aab_sums_by_toptier = (
+            AppropriationAccountBalances.objects.filter(submission__is_final_balances_for_fy=True)
+            .values(
+                "submission__reporting_fiscal_year",
+                "submission__reporting_fiscal_quarter",
+                "treasury_account_identifier__funding_toptier_agency",
+            )
+            .annotate(
                 budget_authority_amount=Coalesce(Sum("total_budgetary_resources_amount_cpe"), 0),
                 obligated_amount=Coalesce(Sum("obligations_incurred_total_by_tas_cpe"), 0),
                 outlay_amount=Coalesce(Sum("gross_outlay_amount_by_tas_cpe"), 0),
             )
+        )
+        aab_sums_by_toptier = {
+            val["treasury_account_identifier__funding_toptier_agency"]: {
+                "budget_authority_amount": val["budget_authority_amount"],
+                "obligated_amount": val["obligated_amount"],
+                "outlay_amount": val["outlay_amount"],
+            }
+            for val in aab_sums_by_toptier
+        }
 
-            abbreviation = ""
-            if toptier_agency.abbreviation is not None:
-                abbreviation = toptier_agency.abbreviation
+        # get agency queryset, distinct toptier id to avoid duplicates, take first ordered agency id for consistency
+        agency_list = (
+            Agency.objects.order_by("toptier_agency_id", "id")
+            .distinct("toptier_agency_id")
+            .values()
+            .annotate(
+                justification=F("toptier_agency__justification"),
+                toptier_abbreviation=F("toptier_agency__abbreviation"),
+                toptier_name=F("toptier_agency__name"),
+                toptier_code=F("toptier_agency__toptier_code"),
+            )
+        )
 
-            cj = toptier_agency.justification if toptier_agency.justification else None
+        for agency in agency_list:
+            submission = latest_sa_by_toptier.get(agency["toptier_code"])
+
+            if submission is None:
+                continue
+            active_fiscal_year = submission["fiscal_year"]
+            active_fiscal_quarter = submission["fiscal_quarter"]
+            active_fiscal_period = submission["fiscal_period"]
+
+            default_aab_sums = {"outlay_amount": 0, "obligated_amount": 0, "budget_authority_amount": 0}
+            aab_sums = aab_sums_by_toptier.get(agency["toptier_agency_id"], default_aab_sums)
+
+            abbreviation = agency.get("toptier_abbreviation", "")
+            cj = agency.get("justification")
+            total_budgetary_resources = tbr_by_year_and_period.get((active_fiscal_year, active_fiscal_period), 0)
+
             # craft response
-            total_obligated = get_total_obligations_incurred(active_fiscal_year, active_fiscal_period)
             response["results"].append(
                 {
-                    "agency_id": agency.id,
-                    "toptier_code": toptier_agency.toptier_code,
+                    "agency_id": agency["id"],
+                    "toptier_code": agency["toptier_code"],
                     "abbreviation": abbreviation,
-                    "agency_name": toptier_agency.name,
+                    "agency_name": agency["toptier_name"],
                     "congressional_justification_url": cj,
                     "active_fy": str(active_fiscal_year),
                     "active_fq": str(active_fiscal_quarter),
-                    "outlay_amount": float(aggregate_dict["outlay_amount"]),
-                    "obligated_amount": float(aggregate_dict["obligated_amount"]),
-                    "budget_authority_amount": float(aggregate_dict["budget_authority_amount"]),
-                    "current_total_budget_authority_amount": float(
-                        get_total_budgetary_resources(active_fiscal_year, active_fiscal_period)
-                    ),
+                    "outlay_amount": float(aab_sums["outlay_amount"]),
+                    "obligated_amount": float(aab_sums["obligated_amount"]),
+                    "budget_authority_amount": float(aab_sums["budget_authority_amount"]),
+                    "current_total_budget_authority_amount": float(total_budgetary_resources),
                     "percentage_of_total_budget_authority": (
-                        (float(aggregate_dict["budget_authority_amount"]) / float(total_obligated))
-                        if total_obligated > 0
+                        (float(aab_sums["budget_authority_amount"]) / float(total_budgetary_resources))
+                        if total_budgetary_resources > 0
                         else None
                     ),
                 }
             )
 
-        response["results"] = sorted(response["results"], key=lambda k: k[sort], reverse=(order == "desc"))
+        response["results"] = sort_with_null_last(
+            to_sort=response["results"], sort_key=sort, sort_order=order, tie_breaker="agency_id"
+        )
 
         return Response(response)


### PR DESCRIPTION
**Description:**
Currently the `% of the total U.S. federal budgetary resources ` on Agency Profile is incorrect. This is because the denominator (`current_total_budget_authority_amount`) is not the correct value; it is using an older value. Make sure to populate this with the right value so that the correct percent can be derived on the frontend. 

**Technical details:**
Additional sort by `reporting_fiscal_period` since a fiscal quarter can have multiple fiscal periods. Without this sort the wrong period is returned, which results in the wrong denominator.

Along with data corrections some changes were made to boost performance. Previously the toptier_agencies endpoint would take about 2 minutes 38 seconds and fire off about 700+ queries. The new changes reduce it to 3 seconds and 4 queries. Timing and query count were captured from local code (master branch vs this branch) both against QAT DB.

Current value on QAT:
<img width="933" alt="Screen Shot 2021-06-02 at 1 45 42 PM" src="https://user-images.githubusercontent.com/40359517/120549770-d7f4d180-c3a8-11eb-8ee8-a349363347c7.png">

Screenshot of local changes against QAT:
<img width="944" alt="Screen Shot 2021-06-02 at 1 43 26 PM" src="https://user-images.githubusercontent.com/40359517/120549548-995f1700-c3a8-11eb-8ae1-0da1084f7ee8.png">

The value now matches the value in Agency Stats page:
<img width="627" alt="Screen Shot 2021-06-02 at 1 44 47 PM" src="https://user-images.githubusercontent.com/40359517/120549642-b562b880-c3a8-11eb-873d-d930b7a0718c.png">

Current value on QAT:
![Screen Shot 2021-06-03 at 1 01 28 PM](https://user-images.githubusercontent.com/40359517/120704740-d50ee500-c46b-11eb-8968-6a2483fad2f6.png)


Screenshot of local changes against QAT:
![Screen Shot 2021-06-03 at 1 00 43 PM](https://user-images.githubusercontent.com/40359517/120704697-c7f1f600-c46b-11eb-8568-c0653e89e63d.png)




**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7404](https://federal-spending-transparency.atlassian.net/browse/DEV-7404) and [DEV-7392](https://federal-spending-transparency.atlassian.net/browse/DEV-7392):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
