### PR TITLE
[DEV-7118] Correcting conditional that omitted custom account downloads

### DIFF
--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -25,6 +25,8 @@ from usaspending_api.download.models.download_job import DownloadJob
 from usaspending_api.download.v2.request_validations import DownloadValidatorBase
 from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
+# Forcing a Travis build
+
 
 @api_transformations(api_version=settings.API_VERSION, function_list=API_TRANSFORM_FUNCTIONS)
 class BaseDownloadViewSet(APIView):

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -25,8 +25,6 @@ from usaspending_api.download.models.download_job import DownloadJob
 from usaspending_api.download.v2.request_validations import DownloadValidatorBase
 from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
-# Forcing a Travis build
-
 
 @api_transformations(api_version=settings.API_VERSION, function_list=API_TRANSFORM_FUNCTIONS)
 class BaseDownloadViewSet(APIView):

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -126,16 +126,13 @@ class BaseDownloadViewSet(APIView):
     def _get_cached_download(
         ordered_json_request: str, download_types: Optional[List[str]] = None
     ) -> Optional[QuerySet]:
-        external_data_type_name_list = []
-
         # External data types that directly affect download results
-        if download_types:
-            if "elasticsearch_awards" in download_types:
-                external_data_type_name_list.append("es_awards")
-            elif "elasticsearch_transactions" in download_types:
-                external_data_type_name_list.append("es_transactions")
+        if download_types and "elasticsearch_awards" in download_types:
+            external_data_type_name_list = ["es_awards"]
+        elif download_types and "elasticsearch_transactions" in download_types:
+            external_data_type_name_list = ["es_transactions"]
         else:
-            external_data_type_name_list.extend(["fpds", "fabs", "es_transactions", "es_awards"])
+            external_data_type_name_list = ["fpds", "fabs", "es_transactions", "es_awards"]
 
         external_data_type_id_list = [
             id for name, id in EXTERNAL_DATA_TYPE_DICT.items() if name in external_data_type_name_list


### PR DESCRIPTION
**Description:**
Custom Account Downloads are not being cached due to an oversight in the conditional that checks download_types.

**Technical details:**
Logic around the `download_types` check was adjusted for other downloads that provide a value that are not Elasticsearch downloads. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7118](https://federal-spending-transparency.atlassian.net/browse/DEV-7118):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
