### PR TITLE
[DEV-7480] Ensure transaction download view is updated with table

### DIFF
--- a/usaspending_api/etl/management/commands/combine_transaction_search_chunks.py
+++ b/usaspending_api/etl/management/commands/combine_transaction_search_chunks.py
@@ -195,6 +195,7 @@ class Command(BaseCommand):
     def swap_tables(self, rename_indexes, rename_constraints):
 
         swap_sql = (self.matview_dir / "componentized" / f"{TABLE_NAME}__renames.sql").read_text()
+        transaction_download_view = Path("usaspending_api/download/sql/vw_transaction_search_download.sql").read_text()
 
         swap_sql += "\n".join(rename_indexes + rename_constraints)
 
@@ -202,3 +203,5 @@ class Command(BaseCommand):
 
         with connection.cursor() as cursor:
             cursor.execute(swap_sql)
+            # The transaction download view needs to be updated to the new transaction_search table
+            cursor.execute(transaction_download_view)


### PR DESCRIPTION
**Description:**
Need to ensure that the new download view for Transaction based downloads is up-to-date after matview recreate.

**Technical details:**
An oversight on my part resulted in the download view for transactions being dropped during a matview recreate since we swap in a new `transaction_search` table. This change will recreate the `vw_transaction_seach_download` View whenever the `transaction_search` table is swapped out to make sure it is up to date.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7480](https://federal-spending-transparency.atlassian.net/browse/DEV-7480):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
