### PR TITLE
[DEV-7579] Adds column definition to TS inserts

### DIFF
--- a/usaspending_api/data/daims_maps.py
+++ b/usaspending_api/data/daims_maps.py
@@ -24,6 +24,29 @@ cases. These must be numbered from 1, and store conditions in the "case_<INT>" a
 For an example, see TransactionNormalized.action_type_map
 """
 
+change_reasons = {
+    "A": "Additional Work (new agreement, FAR part 6 applies)",
+    "B": "Supplemental Agreement for work within scope",
+    "C": "Funding Only Action",
+    "D": "Change Order",
+    "E": "Terminate for Default (complete or partial)",
+    "F": "Terminate for Convenience (complete or partial)",
+    "G": "Exercise an Option",
+    "H": "Definitize Letter Contract",
+    "J": "Novation Agreement",
+    "K": "Close Out",
+    "L": "Definitize Change Order",
+    "M": "Other Administrative Action",
+    "N": "Legal Contract Cancellation",
+    "P": "Representation of Non-Novated Merger/Acquisition",
+    "R": "Representation",
+    "S": "Change PIID",
+    "T": "Transfer Action",
+    "V": "Vendor DUNS or Name Change - Non-Novation",
+    "W": "Vendor Address Change",
+    "X": "Terminate for Cause",
+}
+
 daims_maps = {
     # D1, D2 DAIMS MAPS - These are found in awards.models unless noted
     # This map is an example of how to have TWO different maps for the same field, on the same object, separated by a
@@ -39,28 +62,7 @@ daims_maps = {
         },
         # When we are a contract
         "case_2": {"assistance_data__isnull": True, "contract_data__isnull": False},
-        "case_2_map": {
-            "A": "Additional Work (new agreement, FAR part 6 applies)",
-            "B": "Supplemental Agreement for work within scope",
-            "C": "Funding Only Action",
-            "D": "Change Order",
-            "E": "Terminate for Default (complete or partial)",
-            "F": "Terminate for Convenience (complete or partial)",
-            "G": "Exercise an Option",
-            "H": "Definitize Letter Contract",
-            "J": "Novation Agreement",
-            "K": "Close Out",
-            "L": "Definitize Change Order",
-            "M": "Other Administrative Action",
-            "N": "Legal Contract Cancellation",
-            "P": "Representation of Non-Novated Merger/Acquisition",
-            "R": "Representation",
-            "S": "Change PIID",
-            "T": "Transfer Action",
-            "V": "Vendor DUNS or Name Change - Non-Novation",
-            "W": "Vendor Address Change",
-            "X": "Terminate for Cause",
-        },
+        "case_2_map": {**change_reasons},
     },
     "business_funds_indicator_map": {
         "REC": "Funds are provided by the Recovery Act",
@@ -234,28 +236,7 @@ daims_maps = {
         "L": "Manufactured outside U.S. - Qualifying County (DoD Only)",
     },
     # There is currently no field for this at the moment
-    "reason_for_modification_map": {
-        "A": "Additional Work (new agreement, FAR part 6 applies)",
-        "B": "Supplemental Agreement for work within scope",
-        "C": "Funding Only Action",
-        "D": "Change Order",
-        "E": "Terminate for Default (complete or partial)",
-        "F": "Terminate for Convenience (complete or partial)",
-        "G": "Exercise an Option",
-        "H": "Definitize Letter Contract",
-        "J": "Novation Agreement",
-        "K": "Close Out",
-        "L": "Definitize Change Order",
-        "M": "Other Administrative Action",
-        "N": "Legal Contract Cancellation",
-        "P": "Representation of Non-Novated Merger/Acquisition",
-        "R": "Representation",
-        "S": "Change PIID",
-        "T": "Transfer Action",
-        "V": "Vendor DUNS or Name Change - Non-Novation",
-        "W": "Vendor Address Change",
-        "X": "Terminate for Cause",
-    },
+    "reason_for_modification_map": {**change_reasons},
     # No field current exists for this
     "not_competed_reason_map": {
         "UNQ": "Unique Source (FAR 6.302-1(b)(1)) ",

--- a/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
@@ -121,15 +121,6 @@ def write_sql_file(str_list, filename):
         f.write("\n")
 
 
-def make_table_inserts(table_name, matview_name, chunk_count):
-    sql_strings = []
-    for i in range(chunk_count):
-        matview_chunk_name = f"{matview_name}_{i}"
-        sql_strings.append(TEMPLATE["insert_into_table"].format(table_name, matview_chunk_name))
-
-    return sql_strings
-
-
 def make_matview_empty(matview_name, chunk_count):
     sql_strings = []
     for i in range(chunk_count):
@@ -146,9 +137,6 @@ def create_componentized_files(sql_json):
 
     create_table = make_temp_table_create(matview_name, matview_temp_name)
     write_sql_file(create_table, filename_base + "__create")
-
-    insert_into_table = make_table_inserts(matview_temp_name, matview_name, GLOBAL_ARGS.chunk_count)
-    write_sql_file(insert_into_table, filename_base + "__inserts")
 
     sql_strings = make_rename_sql(matview_name)
     write_sql_file(sql_strings, filename_base + "__renames")

--- a/usaspending_api/database_scripts/matview_generator/shared_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/shared_sql_generator.py
@@ -22,7 +22,6 @@ TEMPLATE = {
     "rename_stats": "ALTER STATISTICS {} RENAME TO {};",
     "grant_select": "GRANT SELECT ON {} TO {};",
     "sql_print_output": "DO $$ BEGIN RAISE NOTICE '{}'; END $$;",
-    "insert_into_table": "INSERT INTO {} SELECT * FROM {};",
     "read_indexes": "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = '{}';",
     "read_constraints": "select conname, pg_get_constraintdef(oid) from pg_constraint where contype IN ('p', 'f') and conrelid = '{}'::regclass;",
 }

--- a/usaspending_api/etl/management/commands/combine_transaction_search_chunks.py
+++ b/usaspending_api/etl/management/commands/combine_transaction_search_chunks.py
@@ -1,6 +1,5 @@
 import logging
 import asyncio
-import sqlparse
 from pathlib import Path
 
 from django.db import connection, transaction
@@ -149,9 +148,7 @@ class Command(BaseCommand):
         column_string = ",".join(columns)
 
         for chunk in range(chunk_count):
-            sql = (
-                f"INSERT INTO {TABLE_NAME}_temp ({column_string}) SELECT {column_string} FROM {TABLE_NAME}_{chunk}"
-            )
+            sql = f"INSERT INTO {TABLE_NAME}_temp ({column_string}) SELECT {column_string} FROM {TABLE_NAME}_{chunk}"
             tasks.append(
                 asyncio.ensure_future(
                     async_run_creates(


### PR DESCRIPTION
**Description:**
This PR updates the SQL statements used to insert records from `transaction_search_*` matviews into the `transaction_search` table. It uses the column definition from the `TransactionSearch` model to specify a list of columns to insert.

**Technical details:**
This PR breaks the pattern of generating all SQL for chunked matviews in the `chunked_matview_sql_generator.py` script. This is because there isn't a great way to get a list of columns from that script. Here are the ideas that I had to do so along with why they won't work. 
- **Get the list of columns from `transaction_search.json`** - Contrary to what I originally remembered, the JSON doesn't have a good list of columns. The file contains a list of lines of the table DDL, but this would need complicated parsing logic in order to get the list of columns.
- **Get the list of columns from the TransactionSearch model (liked implemented in the combine command)** - This script is separate from our Django project, so models cannot be accessed. This script would need to be converted to a Django management command to access the models, which would require major a refactor.
- **Query the columns from the Database** - This method faces a similar issue to the last. Because the script is not part of the Django project, creating a connection to the database would not be easy.

**NOTE: A change `daims_map.py` was included to fix a codeclimate error.**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7579](https://federal-spending-transparency.atlassian.net/browse/DEV-7579):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
