### PR TITLE
dev7741 add agency_slug to contract return

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
@@ -27,8 +27,8 @@ This endpoint returns a list of toptier agencies, their budgetary resources, and
 + `agency_id` (required, number)
     `agency_id` is the unique USAspending.gov identifier for the agency. You will need to use this ID in other endpoints when requesting detailed information about this specific agency.
 + `agency_name` (required, string)
-+ `url_name` (required, string)
-    `url_name` is the "URL-friendly" agency name (lower-case, hyphenated words)
++ `agency_slug` (required, string)
+    `agency_slug` is the "URL-friendly" agency name (lower-case, hyphenated words)
 + `budget_authority_amount` (required, number)
 + `congressional_justification_url` (required, string, nullable)
 + `current_total_budget_authority_amount` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
@@ -25,13 +25,15 @@ This endpoint returns a list of toptier agencies, their budgetary resources, and
 + `active_fq` (required, string)
 + `active_fy` (required, string)
 + `agency_id` (required, number)
-    `agency_id` is the unique USAspending.gov identifier for the agency. You will need to use this ID in other endpoints when requesting detailed information about this specific agency.
+    + `agency_id` is the unique USAspending.gov identifier for the agency. You will need to use this ID in other endpoints when requesting detailed information about this specific agency.
 + `agency_name` (required, string)
++ `url_name` (required, string)
+    + `url_name` is the "URL-friendly" agency name (lower-case, hyphenated words)
 + `budget_authority_amount` (required, number)
 + `congressional_justification_url` (required, string, nullable)
 + `current_total_budget_authority_amount` (required, number)
 + `obligated_amount` (required, number)
 + `outlay_amount` (required, number)
 + `percentage_of_total_budget_authority` (required, number)
-    `percentage_of_total_budget_authority` is the percentage of the agency's budget authority compared to the total government budget authority, expressed as a decimal value.
+    + `percentage_of_total_budget_authority` is the percentage of the agency's budget authority compared to the total government budget authority, expressed as a decimal value.
 + `toptier_code` (required, string)

--- a/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
@@ -25,15 +25,15 @@ This endpoint returns a list of toptier agencies, their budgetary resources, and
 + `active_fq` (required, string)
 + `active_fy` (required, string)
 + `agency_id` (required, number)
-    + `agency_id` is the unique USAspending.gov identifier for the agency. You will need to use this ID in other endpoints when requesting detailed information about this specific agency.
+    `agency_id` is the unique USAspending.gov identifier for the agency. You will need to use this ID in other endpoints when requesting detailed information about this specific agency.
 + `agency_name` (required, string)
 + `url_name` (required, string)
-    + `url_name` is the "URL-friendly" agency name (lower-case, hyphenated words)
+    `url_name` is the "URL-friendly" agency name (lower-case, hyphenated words)
 + `budget_authority_amount` (required, number)
 + `congressional_justification_url` (required, string, nullable)
 + `current_total_budget_authority_amount` (required, number)
 + `obligated_amount` (required, number)
 + `outlay_amount` (required, number)
 + `percentage_of_total_budget_authority` (required, number)
-    + `percentage_of_total_budget_authority` is the percentage of the agency's budget authority compared to the total government budget authority, expressed as a decimal value.
+    `percentage_of_total_budget_authority` is the percentage of the agency's budget authority compared to the total government budget authority, expressed as a decimal value.
 + `toptier_code` (required, string)


### PR DESCRIPTION
NOTE: review/discuss, but should be merged in conjunction with https://federal-spending-transparency.atlassian.net/browse/DEV-7751

**Description:**
Add URL-friendly agency name to API contract

**Technical details:**
just updating the contract

**Requirements for PR merge:**

1. na [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - na [x] Frontend <OPTIONAL>
    - na [x] Operations <OPTIONAL>
    - na [x] Domain Expert <OPTIONAL>
4. na [x] Matview impact assessment completed
5. na [x] Frontend impact assessment completed
6. na [x] Data validation completed
7. na [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7741](https://federal-spending-transparency.atlassian.net/browse/DEV-7741):
    - [x] Link to this Pull-Request
    - na [x] Performance evaluation of affected (API | Script | Download)
    - na [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
