### PR TITLE
[DEV-7809] Agency slugs

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/toptier_agencies.md
@@ -35,3 +35,4 @@ This endpoint returns a list of toptier agencies, their budgetary resources, and
 + `percentage_of_total_budget_authority` (required, number)
     `percentage_of_total_budget_authority` is the percentage of the agency's budget authority compared to the total government budget authority, expressed as a decimal value.
 + `toptier_code` (required, string)
++ `agency_slug` (required, string) is the name of the agency in lowercase with dashes to be used for profile link construction

--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -10,13 +10,13 @@ def create_agency_data():
     # Create AGENCY AND TopTier AGENCY
     ttagency1 = mommy.make(
         "references.ToptierAgency",
-        name="tta_name",
+        name="TTA Name",
         toptier_code="100",
         abbreviation="tta_abrev",
         justification="test.com/cj",
     )
     ttagency2 = mommy.make(
-        "references.ToptierAgency", name="tta_name_2", toptier_code="200", abbreviation="tta_abrev_2"
+        "references.ToptierAgency", name="TTA Name 2", toptier_code="200", abbreviation="tta_abrev_2"
     )
 
     mommy.make("references.Agency", id=1, toptier_agency=ttagency1, toptier_flag=True)
@@ -130,7 +130,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "active_fq": "2",
                 "active_fy": "2017",
                 "agency_id": 1,
-                "agency_name": "tta_name",
+                "agency_name": "TTA Name",
                 "congressional_justification_url": "test.com/cj",
                 "budget_authority_amount": 2.0,
                 "current_total_budget_authority_amount": 200.00,
@@ -138,13 +138,14 @@ def test_award_type_endpoint(client, create_agency_data):
                 "outlay_amount": 2.0,
                 "percentage_of_total_budget_authority": 0.01,
                 "toptier_code": "100",
+                "agency_slug": "tta-name",
             },
             {
                 "abbreviation": "tta_abrev_2",
                 "active_fq": "2",
                 "active_fy": "2017",
                 "agency_id": 2,
-                "agency_name": "tta_name_2",
+                "agency_name": "TTA Name 2",
                 "congressional_justification_url": None,
                 "budget_authority_amount": 14.0,
                 "current_total_budget_authority_amount": 200.00,
@@ -152,6 +153,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "outlay_amount": 14.00,
                 "percentage_of_total_budget_authority": 0.07,
                 "toptier_code": "200",
+                "agency_slug": "tta-name-2",
             },
         ]
     }
@@ -165,7 +167,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "active_fq": "2",
                 "active_fy": "2017",
                 "agency_id": 2,
-                "agency_name": "tta_name_2",
+                "agency_name": "TTA name 2",
                 "congressional_justification_url": None,
                 "budget_authority_amount": 14.0,
                 "current_total_budget_authority_amount": 200.00,
@@ -173,13 +175,14 @@ def test_award_type_endpoint(client, create_agency_data):
                 "outlay_amount": 14.0,
                 "percentage_of_total_budget_authority": 0.07,
                 "toptier_code": "200",
+                "agency_slug": "tta-name-2",
             },
             {
                 "abbreviation": "tta_abrev",
                 "active_fq": "2",
                 "active_fy": "2017",
                 "agency_id": 1,
-                "agency_name": "tta_name",
+                "agency_name": "TTA Name",
                 "congressional_justification_url": "test.com/cj",
                 "budget_authority_amount": 2.0,
                 "current_total_budget_authority_amount": 200.00,
@@ -187,6 +190,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "outlay_amount": 2.0,
                 "percentage_of_total_budget_authority": 0.01,
                 "toptier_code": "100",
+                "agency_slug": "tta-name",
             },
         ]
     }

--- a/usaspending_api/references/tests/test_toptier_agency_v2.py
+++ b/usaspending_api/references/tests/test_toptier_agency_v2.py
@@ -167,7 +167,7 @@ def test_award_type_endpoint(client, create_agency_data):
                 "active_fq": "2",
                 "active_fy": "2017",
                 "agency_id": 2,
-                "agency_name": "TTA name 2",
+                "agency_name": "TTA Name 2",
                 "congressional_justification_url": None,
                 "budget_authority_amount": 14.0,
                 "current_total_budget_authority_amount": 200.00,

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -190,7 +190,7 @@ class ToptierAgenciesViewSet(APIView):
                         if total_budgetary_resources > 0
                         else None
                     ),
-                    "agency_slug": agency["toptier_name"].lower().replace(" ", "-")
+                    "agency_slug": agency["toptier_name"].lower().replace(" ", "-"),
                 }
             )
 

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -1,3 +1,5 @@
+import urllib
+
 from django.db.models import F, Sum, OuterRef, Max, Q
 from django.db.models.functions import Coalesce
 from rest_framework.response import Response
@@ -190,7 +192,7 @@ class ToptierAgenciesViewSet(APIView):
                         if total_budgetary_resources > 0
                         else None
                     ),
-                    "agency_slug": agency["toptier_name"].lower().replace(" ", "-"),
+                    "agency_slug": urllib.parse.quote_plus(agency["toptier_name"].lower().replace(" ", "-")),
                 }
             )
 

--- a/usaspending_api/references/v2/views/toptier_agencies.py
+++ b/usaspending_api/references/v2/views/toptier_agencies.py
@@ -190,6 +190,7 @@ class ToptierAgenciesViewSet(APIView):
                         if total_budgetary_resources > 0
                         else None
                     ),
+                    "agency_slug": agency["toptier_name"].lower().replace(" ", "-")
                 }
             )
 


### PR DESCRIPTION
**Description:**
Adds `agency_slug` field to the `/api/v2/references/toptier_agencies/` endpoint to be used by frontend to create links to new Agency v2 profile page.

**Technical details:**
`agency_slug` is based on the name of the toptier agency, all in lowercase and with the spaces replaced by `-`.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-7809](https://federal-spending-transparency.atlassian.net/browse/DEV-7809):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
