### PR TITLE
[DEV-7854] Fix dabs window loader to allow new records

### DIFF
--- a/usaspending_api/submissions/tests/test_load_dabs_submission_window_schedule.py
+++ b/usaspending_api/submissions/tests/test_load_dabs_submission_window_schedule.py
@@ -71,3 +71,73 @@ def test_schedule_is_created(client):
 
     # Record exists and Submission Reveal Date is set to future date
     assert schedule.submission_reveal_date == FUTURE_DATE
+
+
+@pytest.mark.django_db
+def test_load_from_broker(client, monkeypatch):
+    """
+    Tests that both a new record is added and an old record is updated when loading from Broker.
+    Important to note that the "load_dabs_submission_window_schedule" does not control the "reveal"
+    of the Submission Window; that is controlled by "reveal_dabs_submission_window_schedules".
+    A default of datetime.max is used to ensure new Submission Windows are not revealed until intended.
+    """
+    mommy.make(
+        DABSSubmissionWindowSchedule,
+        id=2020121,
+        period_start_date="2020-07-01",
+        period_end_date="2020-09-30",
+        submission_start_date="2020-10-19",
+        submission_due_date="2020-11-17",
+        certification_due_date="2020-11-17",
+        submission_reveal_date="2021-08-15",
+        submission_fiscal_year="2020",
+        submission_fiscal_quarter=4,
+        submission_fiscal_month=12,
+        is_quarter=True,
+    )
+
+    def patched_generate_schedules_from_broker():
+        return [
+            DABSSubmissionWindowSchedule(
+                id=2020090,
+                period_start_date=datetime(2020, 6, 1, 0, 0, 0),
+                period_end_date=datetime(2020, 6, 30, 0, 0, 0),
+                submission_start_date=datetime(2020, 7, 17, 0, 0, 0),
+                submission_due_date=datetime(2020, 7, 31, 0, 0, 0),
+                certification_due_date=datetime(2020, 8, 15, 0, 0, 0),
+                submission_reveal_date=None,
+                submission_fiscal_year=2020,
+                submission_fiscal_quarter=3,
+                submission_fiscal_month=9,
+                is_quarter=False,
+            ),
+            DABSSubmissionWindowSchedule(
+                id=2020121,
+                period_start_date=datetime(2020, 7, 1, 0, 0, 0),
+                period_end_date=datetime(2020, 9, 30, 0, 0, 0),
+                submission_start_date=datetime(2020, 10, 19, 0, 0, 0),
+                submission_due_date=datetime(2020, 11, 17, 0, 0, 0),
+                certification_due_date=datetime(2020, 11, 30, 0, 0, 0),
+                submission_reveal_date=datetime(2021, 8, 15, 0, 0, 0),
+                submission_fiscal_year=2020,
+                submission_fiscal_quarter=4,
+                submission_fiscal_month=12,
+                is_quarter=True,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "usaspending_api.submissions.management.commands.load_dabs_submission_window_schedule.Command.generate_schedules_from_broker",
+        lambda _: patched_generate_schedules_from_broker(),
+    )
+
+    call_command("load_dabs_submission_window_schedule")
+
+    new_dabs_schedule = DABSSubmissionWindowSchedule.objects.filter(id=2020090).first()
+    updated_dabs_schedule = DABSSubmissionWindowSchedule.objects.filter(id=2020121).first()
+
+    # Check that the default values for "submission_reveal_date" was used appropriately
+    assert new_dabs_schedule.submission_reveal_date == FUTURE_DATE
+
+    # Check that the "certification_due_date" was updated for existing record
+    assert updated_dabs_schedule.certification_due_date == datetime(2020, 11, 30, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
**Description:**
There is a bug with the DABS Submission Window loader that will break when attempting to INSERT new records from Broker instead of UPDATE. This PR adds a default of the `datetime.max()` (since we have another job that handles the reveal logic) and adds test cases to cover this. 

**Technical details:**
A default value of `datetime.max()` was added in for `submission_reveal_date` for the case where we INSERT a new record instead of performing an UPDATE. I had a thought of adding a default on the field, but Django will only apply default values in the ORM. This means that any new records created with the ORM will use the default field, but any non-ORM created values will not utilize the default; I figured this would cause more confusion than it is worth.

The added test case patches the function used to load records from Broker to test the INSERT and UPDATE cases.

One small change was made to the loop logic to only read over the existing objects once as we slowly gross this table.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7854](https://federal-spending-transparency.atlassian.net/browse/DEV-7854):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
