### PR TITLE
[DEV-7831] Refactor /award/amount to use Elasticsearch

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_disaster_award_amount.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_award_amount.py
@@ -2,44 +2,50 @@ import pytest
 
 from rest_framework import status
 
+from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
+
 url = "/api/v2/disaster/award/amount/"
 
 
 @pytest.mark.django_db
-def test_award_amount_success(client, monkeypatch, generic_account_data, unlinked_faba_account_data, helpers):
+def test_award_amount_success(
+    client, monkeypatch, generic_account_data, unlinked_faba_account_data, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 
     resp = helpers.post_for_amount_endpoint(client, url, ["L"], ["A", "09", "10"])
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["award_count"] == 1
-    assert resp.data["outlay"] == 333
-    assert resp.data["obligation"] == 300
+    assert resp.data["outlay"] == 222.0
+    assert resp.data["obligation"] == 200.0
 
     resp = helpers.post_for_amount_endpoint(client, url, ["N", "O"], ["A", "07", "08"])
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["award_count"] == 2
-    assert resp.data["outlay"] == 334
-    assert resp.data["obligation"] == 4
+    assert resp.data["outlay"] == 334.0
+    assert resp.data["obligation"] == 4.0
 
     resp = helpers.post_for_amount_endpoint(client, url, ["9"], ["B"])
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["award_count"] == 0
-    assert resp.data["outlay"] == 0
-    assert resp.data["obligation"] == 0
+    assert resp.data["outlay"] == 0.0
+    assert resp.data["obligation"] == 0.0
 
     resp = helpers.post_for_amount_endpoint(client, url, ["L", "M", "N", "O", "P"], ["07", "08"])
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["award_count"] == 2
-    assert resp.data["outlay"] == 334
-    assert resp.data["obligation"] == 4
+    assert resp.data["outlay"] == 334.0
+    assert resp.data["obligation"] == 4.0
     assert resp.data["face_value_of_loan"] == 7777.0
 
 
 @pytest.mark.django_db
 def test_award_amount_no_award_type_success(
-    client, monkeypatch, generic_account_data, unlinked_faba_account_data, helpers
+    client, monkeypatch, generic_account_data, unlinked_faba_account_data, helpers, elasticsearch_account_index
 ):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
 
     resp = helpers.post_for_amount_endpoint(client, url, ["N"], None)
@@ -56,7 +62,10 @@ def test_award_amount_no_award_type_success(
 
 
 @pytest.mark.django_db
-def test_award_amount_on_sum_non_zero_toa(client, monkeypatch, multiple_file_c_to_same_award, helpers):
+def test_award_amount_on_sum_non_zero_toa(
+    client, monkeypatch, multiple_file_c_to_same_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 
@@ -68,7 +77,10 @@ def test_award_amount_on_sum_non_zero_toa(client, monkeypatch, multiple_file_c_t
 
 
 @pytest.mark.django_db
-def test_award_amount_on_sum_non_zero_outlay(client, monkeypatch, multiple_outlay_file_c_to_same_award, helpers):
+def test_award_amount_on_sum_non_zero_outlay(
+    client, monkeypatch, multiple_outlay_file_c_to_same_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 
@@ -80,7 +92,10 @@ def test_award_amount_on_sum_non_zero_outlay(client, monkeypatch, multiple_outla
 
 
 @pytest.mark.django_db
-def test_award_amount_on_sum_zero_toa(client, monkeypatch, multiple_file_c_to_same_award_that_cancel_out, helpers):
+def test_award_amount_on_sum_zero_toa(
+    client, monkeypatch, multiple_file_c_to_same_award_that_cancel_out, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 
@@ -114,7 +129,10 @@ def test_award_amount_bad_award_type_value(client, helpers):
 
 
 @pytest.mark.django_db
-def test_award_type_filters(client, monkeypatch, generic_account_data, unlinked_faba_account_data, helpers):
+def test_award_type_filters(
+    client, monkeypatch, generic_account_data, unlinked_faba_account_data, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 

--- a/usaspending_api/disaster/tests/integration/test_disaster_award_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_award_count.py
@@ -2,11 +2,14 @@ import pytest
 
 from rest_framework import status
 
+from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
+
 url = "/api/v2/disaster/award/count/"
 
 
 @pytest.mark.django_db
-def test_award_count_basic(client, monkeypatch, basic_award, helpers):
+def test_award_count_basic(client, monkeypatch, basic_award, helpers, elasticsearch_account_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 
@@ -15,7 +18,10 @@ def test_award_count_basic(client, monkeypatch, basic_award, helpers):
 
 
 @pytest.mark.django_db
-def test_award_count_quarterly(client, monkeypatch, award_with_quarterly_submission, helpers):
+def test_award_count_quarterly(
+    client, monkeypatch, award_with_quarterly_submission, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -23,7 +29,8 @@ def test_award_count_quarterly(client, monkeypatch, award_with_quarterly_submiss
 
 
 @pytest.mark.django_db
-def test_award_count_early(client, monkeypatch, award_with_early_submission, helpers):
+def test_award_count_early(client, monkeypatch, award_with_early_submission, helpers, elasticsearch_account_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -31,7 +38,10 @@ def test_award_count_early(client, monkeypatch, award_with_early_submission, hel
 
 
 @pytest.mark.django_db
-def test_award_count_obligations_incurred(client, monkeypatch, basic_award, obligations_incurred_award, helpers):
+def test_award_count_obligations_incurred(
+    client, monkeypatch, basic_award, obligations_incurred_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -39,7 +49,10 @@ def test_award_count_obligations_incurred(client, monkeypatch, basic_award, obli
 
 
 @pytest.mark.django_db
-def test_multiple_faba_per_award(client, monkeypatch, multiple_file_c_to_same_award, helpers):
+def test_multiple_faba_per_award(
+    client, monkeypatch, multiple_file_c_to_same_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -48,8 +61,9 @@ def test_multiple_faba_per_award(client, monkeypatch, multiple_file_c_to_same_aw
 
 @pytest.mark.django_db
 def test_multiple_faba_per_award_that_cancel_out(
-    client, monkeypatch, multiple_file_c_to_same_award_that_cancel_out, helpers
+    client, monkeypatch, multiple_file_c_to_same_award_that_cancel_out, helpers, elasticsearch_account_index
 ):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -57,7 +71,10 @@ def test_multiple_faba_per_award_that_cancel_out(
 
 
 @pytest.mark.django_db
-def test_award_count_non_matching_defc(client, monkeypatch, non_matching_defc_award, helpers):
+def test_award_count_non_matching_defc(
+    client, monkeypatch, non_matching_defc_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -65,7 +82,10 @@ def test_award_count_non_matching_defc(client, monkeypatch, non_matching_defc_aw
 
 
 @pytest.mark.django_db
-def test_award_count_non_matching_award_type(client, monkeypatch, non_matching_defc_award, helpers):
+def test_award_count_non_matching_award_type(
+    client, monkeypatch, non_matching_defc_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = helpers.post_for_count_endpoint(client, url, ["M"], ["B"])
@@ -73,7 +93,10 @@ def test_award_count_non_matching_award_type(client, monkeypatch, non_matching_d
 
 
 @pytest.mark.django_db
-def test_no_award_with_award_types_provided(client, monkeypatch, file_c_with_no_award, helpers):
+def test_no_award_with_award_types_provided(
+    client, monkeypatch, file_c_with_no_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
@@ -81,7 +104,10 @@ def test_no_award_with_award_types_provided(client, monkeypatch, file_c_with_no_
 
 
 @pytest.mark.django_db
-def test_no_award_with_award_types_not_provided(client, monkeypatch, file_c_with_no_award, helpers):
+def test_no_award_with_award_types_not_provided(
+    client, monkeypatch, file_c_with_no_award, helpers, elasticsearch_account_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     resp = helpers.post_for_count_endpoint(client, url, ["M"])
     assert resp.data["count"] == 2

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -243,7 +243,7 @@ def get_scaled_sum_aggregations(field_to_sum: str, pagination: Optional[Paginati
         return {"sum_field": sum_field}
 
 
-def get_summed_value_as_float(bucket: dict, field: str) -> float:
+def get_summed_value_as_float(bucket: dict, field: str) -> Decimal:
     """
     Elasticsearch commonly has problems handling the sum of floating point numbers (even if they are stored as
     "Scaled Float" type). Due to that the Elasticsearch sum aggregations handle the Scaled Floats as integers


### PR DESCRIPTION
**Description:**
The `/api/v2/disaster/award/amount/` consistently runs over 1 min and occasionally over 5 minutes. This means that it cannot cache and will stay in a failing state with each call. By switching to Elasticsearch this consistently takes under 1 minute.

**Technical details:**
Previously we have always tried to get a unique count with Elasticsearch `cardinality` aggregation. This does not work in many cases since it can only guarantee accuracy up to 10k. However, this new `scripted_metric` approach that has been used in a few different places has proven to be accurate (when testing against Staging and local) while completing in enough time to be cached.

The only test case that was updated is `def test_award_amount_success()`. This test case looked for results with Award Type Codes `["A", "09", "10"]` and DEF Codes `["L"]`. The issue is that it was getting the sum of Obligation and Outlay for all File C records under the Award as long as it had a single File C with DEF Code instead of only those values for File C with DEF Codes = "L". The change is that the returned Obligation and Outlay sum will only be for those File C records with the matching DEF Code to the filter that belong to an Award with with the correct Award Type Code.

Some additional notes around MATERIALIZED VIEWS and Table Partitions are added to the JIRA ticket as a comment.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7831](https://federal-spending-transparency.atlassian.net/browse/DEV-7831):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
