### PR TITLE
[DEV-7787] - Adjust Date Range for ES Deletes

### DIFF
--- a/usaspending_api/broker/helpers/last_load_date.py
+++ b/usaspending_api/broker/helpers/last_load_date.py
@@ -38,6 +38,42 @@ def get_last_load_date(key, lookback_minutes=None, default=None):
     return last_load_date
 
 
+def get_earliest_load_date(keys, default=None):
+    earliest_date = default
+
+    for key in keys:
+        key_date = get_last_load_date(key)
+
+        if key_date:
+            if earliest_date is None:
+                earliest_date = key_date
+            elif key_date < earliest_date:
+                earliest_date = key_date
+
+    if earliest_date is None:
+        logger.warning(f"No earliest load date could be calculated because no dates for keys `{keys}` were found!")
+
+    return key_date
+
+
+def get_latest_load_date(keys, default=None):
+    latest_date = default
+
+    for key in keys:
+        key_date = get_last_load_date(key)
+
+        if key_date:
+            if latest_date is None:
+                latest_date = key_date
+            elif key_date < latest_date:
+                latest_date = key_date
+
+    if latest_date is None:
+        logger.warning(f"No latest load date could be calculated because no dates for keys `{keys}` were found!")
+
+    return key_date
+
+
 def update_last_load_date(key, last_load_date):
     """
     Save the provided last_load_date to the database as UTC (which is our standard timezone).

--- a/usaspending_api/broker/helpers/last_load_date.py
+++ b/usaspending_api/broker/helpers/last_load_date.py
@@ -39,6 +39,12 @@ def get_last_load_date(key, lookback_minutes=None, default=None):
 
 
 def get_earliest_load_date(keys, default=None):
+    """
+    Retrieve the earliest last_load_date from a supplied list of keys.
+
+    default will be returned if no last_load_date is found for any of the supplied
+    keys
+    """
     earliest_date = default
 
     for key in keys:
@@ -57,6 +63,12 @@ def get_earliest_load_date(keys, default=None):
 
 
 def get_latest_load_date(keys, default=None):
+    """
+    Retrieve the latest last_load_date from a supplied list of keys.
+
+    default will be returned if no last_load_date is found for any of the supplied
+    keys
+    """
     latest_date = default
 
     for key in keys:

--- a/usaspending_api/broker/lookups.py
+++ b/usaspending_api/broker/lookups.py
@@ -16,6 +16,7 @@ EXTERNAL_DATA_TYPE = [
     # "opposite" side of the broker data load, data from USAspending DB -> Elasticsearch
     LookupType(100, "es_transactions", "Load elasticsearch with transactions from USAspending"),
     LookupType(101, "es_awards", "Load elasticsearch with awards from USAspending"),
+    LookupType(102, "es_deletes", "Award and Transaction deletions from elasticsearch"),
     # Additional times to keep track of
     LookupType(120, "touch_last_period_awards", "Touch awards from last period, so they will be updated in ES"),
 ]

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -154,7 +154,8 @@ class Controller:
             delete_awards(client, self.config)
         elif self.config["data_type"] == "transaction":
             delete_transactions(client, self.config)
-            # TODO Add explanation here
+            # Use the lesser of the fabs/fpds load dates as the es_deletes load date. This
+            # ensures all records deleted since either job was run are taken into account
             last_db_delete_time = get_earliest_load_date(["fabs", "fpds"])
             update_last_load_date("es_deletes", last_db_delete_time)
         else:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -6,7 +6,7 @@ from multiprocessing import Pool, Event, Value
 from time import perf_counter
 from typing import Generator, List, Tuple
 
-from usaspending_api.broker.helpers.last_load_date import update_last_load_date
+from usaspending_api.broker.helpers.last_load_date import get_earliest_load_date, update_last_load_date
 from usaspending_api.common.elasticsearch.client import instantiate_elasticsearch_client
 from usaspending_api.etl.elasticsearch_loader_helpers import (
     count_of_records_to_process,
@@ -154,6 +154,9 @@ class Controller:
             delete_awards(client, self.config)
         elif self.config["data_type"] == "transaction":
             delete_transactions(client, self.config)
+            # TODO Add explanation here
+            last_db_delete_time = get_earliest_load_date(["fabs", "fpds"])
+            update_last_load_date("es_deletes", last_db_delete_time)
         else:
             raise RuntimeError(f"No delete function implemented for type {self.config['data_type']}")
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -10,6 +10,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.mapping import Mapping
 
+from usaspending_api.broker.helpers.last_load_date import get_last_load_date, get_latest_load_date
 from usaspending_api.common.helpers.s3_helpers import retrieve_s3_bucket_object_list, access_s3_object
 from usaspending_api.etl.elasticsearch_loader_helpers.index_config import (
     ES_AWARDS_UNIQUE_KEY_FIELD,
@@ -355,13 +356,23 @@ def _gather_deleted_transaction_keys(config: dict) -> Optional[Dict[Union[str, A
     bucket_objects = retrieve_s3_bucket_object_list(bucket_name=config["s3_bucket"])
     logger.info(format_log(f"{len(bucket_objects):,} files found in bucket '{config['s3_bucket']}'", action="Delete"))
 
+    start_date = get_last_load_date("es_deletes")
+    end_date = get_latest_load_date(["fabs", "fpds"])
+
     if config["verbose"]:
-        logger.info(format_log(f"CSV data from {config['starting_date']} to now", action="Delete"))
+        logger.info(format_log(f"CSV data from {start_date} to {end_date}", action="Delete"))
+
+    print(f"Starting date (gather_deletes): {start_date}")
 
     filtered_csv_list = [
         x
         for x in bucket_objects
-        if (x.key.endswith(".csv") and not x.key.startswith("staging") and x.last_modified >= config["starting_date"])
+        if (
+            x.key.endswith(".csv")
+            and not x.key.startswith("staging")
+            and x.last_modified >= start_date
+            and x.last_modified <= end_date
+        )
     ]
 
     if config["verbose"]:
@@ -416,5 +427,22 @@ def _check_awards_for_deletes(id_list: list) -> list:
         FROM (values {ids}) AS x(generated_unique_award_id)
         LEFT JOIN awards a ON a.generated_unique_award_id = x.generated_unique_award_id
         WHERE a.generated_unique_award_id IS NULL"""
+
+    return execute_sql_statement(sql.format(ids=formatted_value_ids[:-1]), results=True)
+
+
+def _check_transactions_for_deletes(id_list: list) -> list:
+    """Takes a list of transaction key values and returns them if they are NOT found in the
+    transaction_normalized DB table
+    """
+    formatted_value_ids = ""
+    for x in id_list:
+        formatted_value_ids += "('" + x + "'),"
+
+    sql = """
+        SELECT x.generated_unique_transaction_id
+        FROM (values {ids}) AS x(generated_unique_transaction_id)
+        LEFT JOIN awards a ON a.generated_unique_transaction_id = x.generated_unique_transaction_id
+        WHERE a.generated_unique_transaction_id IS NULL"""
 
     return execute_sql_statement(sql.format(ids=formatted_value_ids[:-1]), results=True)

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -420,8 +420,6 @@ def _gather_deleted_transaction_keys(config: dict) -> Optional[Dict[Union[str, A
 
 def _check_awards_for_deletes(id_list: list) -> list:
     """Takes a list of award key values and returns them if they are NOT found in the awards DB table"""
-    if len(id_list) < 1:
-        return []
 
     formatted_value_ids = ""
     for x in id_list:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -330,11 +330,10 @@ def delete_transactions(client: Elasticsearch, config: dict, task_id: str = "Syn
     Returns: Number of ES docs deleted in the index
     """
     deleted_tx_keys = _gather_deleted_transaction_keys(config)
-    deleted_tx_keys = _check_transactions_for_deletes([*deleted_tx_keys])
     return delete_docs_by_unique_key(
         client,
         key=config["unique_key_field"],
-        value_list=deleted_tx_keys,
+        value_list=[*deleted_tx_keys],
         task_id="Sync DB Deletes",
         index=config["index_name"],
         delete_chunk_size=config["partition_size"],
@@ -433,26 +432,5 @@ def _check_awards_for_deletes(id_list: list) -> list:
         FROM (values {ids}) AS x(generated_unique_award_id)
         LEFT JOIN awards a ON a.generated_unique_award_id = x.generated_unique_award_id
         WHERE a.generated_unique_award_id IS NULL"""
-
-    return execute_sql_statement(sql.format(ids=formatted_value_ids[:-1]), results=True)
-
-
-def _check_transactions_for_deletes(id_list: list) -> list:
-    """
-    Takes a list of transaction key values and returns them if they are NOT found in the
-    transaction_normalized DB table
-    """
-    if len(id_list) < 1:
-        return []
-
-    formatted_value_ids = ""
-    for x in id_list:
-        formatted_value_ids += "('" + x + "'),"
-
-    sql = """
-        SELECT x.generated_unique_transaction_id
-        FROM (values {ids}) AS x(generated_unique_transaction_id)
-        LEFT JOIN awards a ON a.generated_unique_transaction_id = x.generated_unique_transaction_id
-        WHERE a.generated_unique_transaction_id IS NULL"""
 
     return execute_sql_statement(sql.format(ids=formatted_value_ids[:-1]), results=True)

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
             "--start-datetime",
             type=datetime_command_line_argument_type(naive=False),
             help="Processes transactions updated on or after the UTC date/time provided. yyyy-mm-dd hh:mm:ss "
-            "is always a safe format. Wrap in quotes if date/time contains spaces.",
+            "is always a safe format. Wrap in quotes if date/time contains spaces. Does not apply to deletes",
             metavar="",
         )
         parser.add_argument(


### PR DESCRIPTION
**Description:**
This PR updates the start and end date range for Elasticsearch deletes to prevent deletes from Postgres being missed in ES

**Technical details:**
A new `external_data_load_date` is being used to keep track of this: `es_deletes`
When deletes finish, the earlier of the `fabs` and `fpds` load dates is set as the `es_deletes` date. 
When deletes are starting, the following range is used to query S3 for deletes:
- `start_date` - `es_deletes`
- `end_date` - The latter of `fabs` and `fpds` load dates

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7787](https://federal-spending-transparency.atlassian.net/browse/DEV-7787):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
