### PR TITLE
[DEV-7321] Spending by geography filtering by individual defc

### DIFF
--- a/usaspending_api/disaster/v2/views/spending_by_geography.py
+++ b/usaspending_api/disaster/v2/views/spending_by_geography.py
@@ -16,7 +16,6 @@ from usaspending_api.common.validator import TinyShield
 from usaspending_api.disaster.v2.views.disaster_base import DisasterBase
 from usaspending_api.references.abbreviations import code_to_state
 from usaspending_api.search.v2.elasticsearch_helper import (
-    get_scaled_sum_aggregations,
     get_number_of_unique_terms_for_awards,
 )
 
@@ -102,10 +101,13 @@ class SpendingByGeographyViewSet(DisasterBase):
         # Set which field will be the aggregation amount
         if self.spending_type == "obligation":
             self.metric_field = "total_covid_obligation"
+            self.metric_agg = A("sum", field="covid_spending_by_defc.obligation", script="_value * 100")
         elif self.spending_type == "outlay":
             self.metric_field = "total_covid_outlay"
+            self.metric_agg = A("sum", field="covid_spending_by_defc.outlay", script="_value * 100")
         elif self.spending_type == "face_value_of_loan":
             self.metric_field = "total_loan_value"
+            self.metric_agg = A("sum", field="total_loan_value", script="_value * 100")
         else:
             raise UnprocessableEntityException(
                 f"Unrecognized value '{self.spending_type}' for field " f"'spending_type'"
@@ -138,11 +140,11 @@ class SpendingByGeographyViewSet(DisasterBase):
 
         # Add 100 to make sure that we consider enough records in each shard for accurate results
         group_by_agg_key = A("terms", field=self.agg_key, size=bucket_count, shard_size=bucket_count + 100)
-        sum_aggregations = get_scaled_sum_aggregations(self.metric_field)
-        sum_field = sum_aggregations["sum_field"]
+        filter_agg_query = ES_Q("terms", **{"covid_spending_by_defc.defc": self.filters.get("def_codes")})
 
-        search.aggs.bucket("group_by_agg_key", group_by_agg_key).metric("sum_field", sum_field)
-
+        search.aggs.bucket("group_by_agg_key", group_by_agg_key).bucket(
+            "nested", A("nested", path="covid_spending_by_defc")
+        ).bucket("filtered_aggs", A("filter", filter_agg_query)).metric(self.spending_type, self.metric_agg)
         # Set size to 0 since we don't care about documents returned
         search.update_from_dict({"size": 0})
 
@@ -175,7 +177,9 @@ class SpendingByGeographyViewSet(DisasterBase):
                     shape_code = f"{state_fips}{geo_info['congressional_code']}"
 
             per_capita = None
-            amount = int(bucket.get("sum_field", {"value": 0})["value"]) / Decimal("100")
+            amount = int(
+                bucket.get("nested", {}).get("filtered_aggs", {}).get(f"{self.spending_type}", {"value": 0})["value"]
+            ) / Decimal("100")
 
             if population:
                 per_capita = (Decimal(amount) / Decimal(population)).quantize(Decimal(".01"))


### PR DESCRIPTION
**Description:**
Fixes the aggregation used by the `/disaster/spending_by_geography/` endpoint to allow for filtering by individual DEFC

**Technical details:**
Changes the aggregation used to be a nested aggregation filtering by the DEFC and summing the outlay/obligation/loan value from using the "total" value, which allows breaking down the covid amount by the specific DEFC
**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-7321](https://federal-spending-transparency.atlassian.net/browse/DEV-7321):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
