### PR TITLE
[DEV-7787] Adjusts es delete timeframe

### DIFF
--- a/usaspending_api/broker/helpers/last_load_date.py
+++ b/usaspending_api/broker/helpers/last_load_date.py
@@ -38,6 +38,54 @@ def get_last_load_date(key, lookback_minutes=None, default=None):
     return last_load_date
 
 
+def get_earliest_load_date(keys, default=None):
+    """
+    Retrieve the earliest last_load_date from a supplied list of keys.
+
+    default will be returned if no last_load_date is found for any of the supplied
+    keys
+    """
+    earliest_date = default
+
+    for key in keys:
+        key_date = get_last_load_date(key)
+
+        if key_date:
+            if earliest_date is None:
+                earliest_date = key_date
+            elif key_date < earliest_date:
+                earliest_date = key_date
+
+    if earliest_date is None:
+        logger.warning(f"No earliest load date could be calculated because no dates for keys `{keys}` were found!")
+
+    return earliest_date
+
+
+def get_latest_load_date(keys, default=None):
+    """
+    Retrieve the latest last_load_date from a supplied list of keys.
+
+    default will be returned if no last_load_date is found for any of the supplied
+    keys
+    """
+    latest_date = default
+
+    for key in keys:
+        key_date = get_last_load_date(key)
+
+        if key_date:
+            if latest_date is None:
+                latest_date = key_date
+            elif key_date > latest_date:
+                latest_date = key_date
+
+    if latest_date is None:
+        logger.warning(f"No latest load date could be calculated because no dates for keys `{keys}` were found!")
+
+    return latest_date
+
+
 def update_last_load_date(key, last_load_date):
     """
     Save the provided last_load_date to the database as UTC (which is our standard timezone).

--- a/usaspending_api/broker/lookups.py
+++ b/usaspending_api/broker/lookups.py
@@ -16,6 +16,7 @@ EXTERNAL_DATA_TYPE = [
     # "opposite" side of the broker data load, data from USAspending DB -> Elasticsearch
     LookupType(100, "es_transactions", "Load elasticsearch with transactions from USAspending"),
     LookupType(101, "es_awards", "Load elasticsearch with awards from USAspending"),
+    LookupType(102, "es_deletes", "Award and Transaction deletions from elasticsearch"),
     # Additional times to keep track of
     LookupType(120, "touch_last_period_awards", "Touch awards from last period, so they will be updated in ES"),
 ]

--- a/usaspending_api/broker/tests/integration/test_last_load_date.py
+++ b/usaspending_api/broker/tests/integration/test_last_load_date.py
@@ -1,0 +1,45 @@
+import pytest
+import pytz
+
+from datetime import datetime
+from model_mommy import mommy
+
+from usaspending_api.broker.helpers.last_load_date import (
+    get_earliest_load_date,
+    get_latest_load_date,
+    get_last_load_date,
+)
+
+
+@pytest.fixture
+def load_dates():
+    # `name` and `external_data_type_id` must match those in `usaspending.broker.lookups`
+    edt = mommy.make("broker.ExternalDataType", name="fpds", external_data_type_id=1)
+    mommy.make("broker.ExternalDataLoadDate", last_load_date="2020-03-01", external_data_type=edt)
+
+    edt2 = mommy.make("broker.ExternalDataType", name="fabs", external_data_type_id=2)
+    mommy.make("broker.ExternalDataLoadDate", last_load_date="2020-08-01", external_data_type=edt2)
+
+
+@pytest.mark.django_db
+def test_last_load_date_happy(client, load_dates):
+    load_date = get_last_load_date("fpds")
+    assert load_date == datetime(2020, 3, 1, tzinfo=pytz.UTC)
+
+
+@pytest.mark.django_db
+def test_last_load_date_not_set(client, load_dates):
+    load_date = get_last_load_date("es_deletes")
+    assert load_date is None
+
+
+@pytest.mark.django_db
+def test_earliest_load_date_happy(client, load_dates):
+    load_date = get_earliest_load_date(["fpds", "fabs", "es_deletes"])
+    assert load_date == datetime(2020, 3, 1, tzinfo=pytz.UTC)
+
+
+@pytest.mark.django_db
+def test_latest_load_date_happy(client, load_dates):
+    load_date = get_latest_load_date(["fpds", "fabs", "es_deletes"])
+    assert load_date == datetime(2020, 8, 1, tzinfo=pytz.UTC)

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -6,7 +6,7 @@ from multiprocessing import Pool, Event, Value
 from time import perf_counter
 from typing import Generator, List, Tuple
 
-from usaspending_api.broker.helpers.last_load_date import update_last_load_date
+from usaspending_api.broker.helpers.last_load_date import get_earliest_load_date, update_last_load_date
 from usaspending_api.common.elasticsearch.client import instantiate_elasticsearch_client
 from usaspending_api.etl.elasticsearch_loader_helpers import (
     count_of_records_to_process,
@@ -154,6 +154,10 @@ class Controller:
             delete_awards(client, self.config)
         elif self.config["data_type"] == "transaction":
             delete_transactions(client, self.config)
+            # Use the lesser of the fabs/fpds load dates as the es_deletes load date. This
+            # ensures all records deleted since either job was run are taken into account
+            last_db_delete_time = get_earliest_load_date(["fabs", "fpds"])
+            update_last_load_date("es_deletes", last_db_delete_time)
         else:
             raise RuntimeError(f"No delete function implemented for type {self.config['data_type']}")
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -10,6 +10,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.mapping import Mapping
 
+from usaspending_api.broker.helpers.last_load_date import get_last_load_date, get_latest_load_date
 from usaspending_api.common.helpers.s3_helpers import retrieve_s3_bucket_object_list, access_s3_object
 from usaspending_api.etl.elasticsearch_loader_helpers.index_config import (
     ES_AWARDS_UNIQUE_KEY_FIELD,
@@ -355,13 +356,22 @@ def _gather_deleted_transaction_keys(config: dict) -> Optional[Dict[Union[str, A
     bucket_objects = retrieve_s3_bucket_object_list(bucket_name=config["s3_bucket"])
     logger.info(format_log(f"{len(bucket_objects):,} files found in bucket '{config['s3_bucket']}'", action="Delete"))
 
-    if config["verbose"]:
-        logger.info(format_log(f"CSV data from {config['starting_date']} to now", action="Delete"))
+    start_date = get_last_load_date("es_deletes")
+    # An `end_date` is used, so we don't try to delete records from ES that have not yet
+    # been deleted in postgres by the fabs/fpds loader
+    end_date = get_latest_load_date(["fabs", "fpds"])
+
+    logger.info(format_log(f"CSV data from {start_date} to {end_date}", action="Delete"))
 
     filtered_csv_list = [
         x
         for x in bucket_objects
-        if (x.key.endswith(".csv") and not x.key.startswith("staging") and x.last_modified >= config["starting_date"])
+        if (
+            x.key.endswith(".csv")
+            and not x.key.startswith("staging")
+            and x.last_modified >= start_date
+            and x.last_modified <= end_date
+        )
     ]
 
     if config["verbose"]:

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
             "--start-datetime",
             type=datetime_command_line_argument_type(naive=False),
             help="Processes transactions updated on or after the UTC date/time provided. yyyy-mm-dd hh:mm:ss "
-            "is always a safe format. Wrap in quotes if date/time contains spaces.",
+            "is always a safe format. Wrap in quotes if date/time contains spaces. Does not apply to deletes",
             metavar="",
         )
         parser.add_argument(


### PR DESCRIPTION
**Description:**
This PR updates the start and end date range for Elasticsearch deletes to prevent deletes from Postgres being missed in ES

**Technical details:**
A new `external_data_load_date` is being used to keep track of this: `es_deletes`
When deletes finish, the earlier of the `fabs` and `fpds` load dates is set as the `es_deletes` date. 
When deletes are starting, the following range is used to query S3 for deletes:
- `start_date` - `es_deletes`
- `end_date` - The latter of `fabs` and `fpds` load dates

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7787](https://federal-spending-transparency.atlassian.net/browse/DEV-7787):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```