### PR TITLE
[DEV-7894] Fix handling for generated download lookup

### DIFF
--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -40,7 +40,11 @@ class BaseDownloadViewSet(APIView):
         pre_generated_download = json_request.pop("pre_generated_download", None)
         if pre_generated_download:
             filename = (
-                DownloadJob.objects.filter(file_name__startswith=pre_generated_download, error_message__isnull=True)
+                DownloadJob.objects.filter(
+                    file_name__startswith=pre_generated_download["name_match"],
+                    json_request__contains=pre_generated_download["request_match"],
+                    error_message__isnull=True,
+                )
                 .order_by("-update_date")
                 .values_list("file_name", flat=True)
                 .first()

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -1,3 +1,4 @@
+import json
 from copy import deepcopy
 from datetime import datetime, MINYEAR, MAXYEAR
 from django.conf import settings
@@ -664,7 +665,10 @@ class DisasterDownloadValidator(DownloadValidatorBase):
         defc_filter = sorted(self._json_request["filters"]["def_codes"])
         if len(defc_filter) > 1:
             if set(defc_filter) == set(covid_defc):
-                self._json_request["pre_generated_download"] = settings.COVID19_DOWNLOAD_FILENAME_PREFIX
+                self._json_request["pre_generated_download"] = {
+                    "name_match": settings.COVID19_DOWNLOAD_FILENAME_PREFIX,
+                    "request_match": f'"def_codes": {json.dumps(covid_defc)}',
+                }
             else:
                 raise InvalidParameterException(
                     "The Disaster Download is currently limited to either all COVID-19 DEFC or a single COVID-19 DEFC."


### PR DESCRIPTION
**Description:**
Noticed while testing the COVID single DEFC download that after generating the single DEFC download the request to get all DEFC will look to the latest which is the download for only a single DEFC. This fixes that by paying attention to the download file name and the request.

**Technical details:**
Made updates to how the pre-generated download is looked up to make sure that the correct one is returned. The test case change fails without the adjustments to the base download viewset logic which means that it should be working as intended now.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
