### PR TITLE
[HOTFIX] Fix UEI definition in restock_recipient_profile

### DIFF
--- a/usaspending_api/recipient/management/sql/restock_recipient_profile.sql
+++ b/usaspending_api/recipient/management/sql/restock_recipient_profile.sql
@@ -56,8 +56,8 @@ CREATE TABLE public.temporary_restock_recipient_profile (
   recipient_level character(1) NOT NULL,
   recipient_hash UUID,
   recipient_unique_id TEXT,
-  recipient_name TEXT,
   uei TEXT,
+  recipient_name TEXT,
   unused BOOLEAN DEFAULT true,
   recipient_affiliations TEXT[] DEFAULT '{}'::text[],
   award_types TEXT[] DEFAULT '{}'::text[],
@@ -350,6 +350,7 @@ WHERE NOT EXISTS (
 UPDATE public.recipient_profile rp
 SET
     recipient_unique_id = temp_p.recipient_unique_id,
+    uei = temp_p.uei,
     recipient_name = temp_p.recipient_name,
     recipient_affiliations = temp_p.recipient_affiliations,
     award_types = temp_p.award_types,
@@ -376,17 +377,18 @@ WHERE
         OR rp.last_12_direct_payments IS DISTINCT FROM temp_p.last_12_direct_payments
         OR rp.last_12_other IS DISTINCT FROM temp_p.last_12_other
         OR rp.last_12_months_count IS DISTINCT FROM temp_p.last_12_months_count
+        OR rp.uei IS DISTINCT FROM temp_p.uei
     )
 ;
 
 
 INSERT INTO public.recipient_profile (
-    recipient_level, recipient_hash, recipient_unique_id,
+    recipient_level, recipient_hash, recipient_unique_id, uei,
     recipient_name, recipient_affiliations, award_types, last_12_months,
     last_12_contracts, last_12_loans, last_12_grants, last_12_direct_payments, last_12_other,
     last_12_months_count
     )
-  SELECT recipient_level, recipient_hash, recipient_unique_id,
+  SELECT recipient_level, recipient_hash, recipient_unique_id, uei,
     recipient_name, recipient_affiliations, award_types, last_12_months,
     last_12_contracts, last_12_loans, last_12_grants, last_12_direct_payments, last_12_other,
     last_12_months_count


### PR DESCRIPTION
**Description:**
Adds UEI definition to `temporary_restock_recipient_profile`, which will fix the error we saw in the pipeline run

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8000](https://federal-spending-transparency.atlassian.net/browse/DEV-8000):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
