### PR TITLE
[DEV-8073] Fix typo that omitted PoP locations filter

### DIFF
--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -231,7 +231,7 @@ class AwardDownloadValidator(DownloadValidatorBase):
             if key in [
                 "recipient_locations",
                 "recipient_scope",
-                "place_of_performance_location",
+                "place_of_performance_locations",
                 "place_of_performance_scope",
             ]:
                 final_award_filters[key] = value


### PR DESCRIPTION
**Description:**
There was a typo on the request validation that resulted in an omission of the `place_of_performance_locations` filter. 

**Technical details:**
Minor typo that resulted in a filter always being ignored.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-8073](https://federal-spending-transparency.atlassian.net/browse/DEV-8073):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
