### PR TITLE
[DEV-5081] Add agency_slug to spending_by_category

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
@@ -95,7 +95,7 @@ This endpoint returns a list of the top results of Awarding Agencies sorted by t
     `code` is a user-displayable code (such as a program activity or NAICS code, but **not** a database ID). When no such code is relevant, return a `null`.
 + `amount` (required, number)
 + `agency_slug` (required, string, nullable)
-  `agency_slug` is a string used to generate a link to the agency profile page. Will be `NULL` if the agency does not have a profile page.
+    `agency_slug` is a string used to generate a link to the agency profile page. Will be `NULL` if the agency does not have a profile page.
 
 ## PageMetadataObject (object)
 + `page` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
@@ -94,6 +94,8 @@ This endpoint returns a list of the top results of Awarding Agencies sorted by t
 + `code` (required, string, nullable)
     `code` is a user-displayable code (such as a program activity or NAICS code, but **not** a database ID). When no such code is relevant, return a `null`.
 + `amount` (required, number)
++ `agency_slug` (required, string, nullable)
+  `agency_slug` is a string used to generate a link to the agency profile page. Will be `NULL` if the agency does not have a profile page.
 
 ## PageMetadataObject (object)
 + `page` (required, number)

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -52,6 +52,7 @@ def _setup_agency(id, subtiers, special_name):
         toptier_agency_id=id + 2000,
         name=f"{special_name} Toptier Agency {id}",
         abbreviation=f"TA{id}",
+        toptier_code=f"00{id}",
     )
     mommy.make(
         "references.SubtierAgency",

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
@@ -45,7 +45,7 @@ def test_correct_response_with_more_awards(
                 "name": "Awarding Toptier Agency 1",
                 "code": "TA1",
                 "id": 1001,
-                "agency_slug": "awarding-toptier-agency-1",
+                "agency_slug": None,
             },
         ],
         "messages": [get_time_period_message()],

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
@@ -1,5 +1,6 @@
 import json
 
+from model_mommy import mommy
 from rest_framework import status
 
 from usaspending_api.common.helpers.generic_helper import get_time_period_message
@@ -27,7 +28,7 @@ def test_correct_response_with_more_awards(
 ):
 
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
-
+    mommy.make("submissions.SubmissionAttributes", toptier_code="001")
     resp = client.post(
         "/api/v2/search/spending_by_category/awarding_agency",
         content_type="application/json",
@@ -38,8 +39,14 @@ def test_correct_response_with_more_awards(
         "limit": 10,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
         "results": [
-            {"amount": 10.0, "name": "Awarding Toptier Agency 3", "code": "TA3", "id": 1003},
-            {"amount": 5.0, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001},
+            {"amount": 10.0, "name": "Awarding Toptier Agency 3", "code": "TA3", "id": 1003, "agency_slug": None},
+            {
+                "amount": 5.0,
+                "name": "Awarding Toptier Agency 1",
+                "code": "TA1",
+                "id": 1001,
+                "agency_slug": "awarding-toptier-agency-1",
+            },
         ],
         "messages": [get_time_period_message()],
     }

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_awarding_agency.py
@@ -67,7 +67,9 @@ def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, 
         "category": "awarding_agency",
         "limit": 10,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 5.0, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001}],
+        "results": [
+            {"amount": 5.0, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001, "agency_slug": None}
+        ],
         "messages": [get_time_period_message()],
     }
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"

--- a/usaspending_api/search/tests/unit/test_spending_by_category.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_category.py
@@ -609,7 +609,9 @@ def test_category_awarding_agency_awards(agency_test_data, monkeypatch, elastics
         "category": "awarding_agency",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 15, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001, "agency_slug": None}],
+        "results": [
+            {"amount": 15, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001, "agency_slug": None}
+        ],
         "messages": [get_time_period_message()],
     }
 

--- a/usaspending_api/search/tests/unit/test_spending_by_category.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_category.py
@@ -609,7 +609,7 @@ def test_category_awarding_agency_awards(agency_test_data, monkeypatch, elastics
         "category": "awarding_agency",
         "limit": 50,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
-        "results": [{"amount": 15, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001}],
+        "results": [{"amount": 15, "name": "Awarding Toptier Agency 1", "code": "TA1", "id": 1001, "agency_slug": None}],
         "messages": [get_time_period_message()],
     }
 

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
@@ -1,5 +1,4 @@
 import json
-import urllib
 
 from abc import ABCMeta
 from decimal import Decimal

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
@@ -7,6 +7,8 @@ from django.db.models import QuerySet, F
 from enum import Enum
 from typing import List
 
+from django.utils.text import slugify
+
 from usaspending_api.references.models import Agency
 from usaspending_api.search.helpers.spending_by_category_helpers import fetch_agency_tier_id_by_agency
 from usaspending_api.search.v2.views.spending_by_category_views.spending_by_category import (
@@ -49,11 +51,7 @@ class AbstractAgencyViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMeta
                 submission = (
                     SubmissionAttributes.objects.filter(toptier_code=code).first() if code is not None else None
                 )
-                result["agency_slug"] = (
-                    urllib.parse.quote_plus(agency_info.get("name").lower().replace(" ", "-"))
-                    if submission is not None
-                    else None
-                )
+                result["agency_slug"] = slugify(agency_info.get("name")) if submission is not None else None
 
             results.append(result)
         return results

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_agency_types.py
@@ -46,11 +46,9 @@ class AbstractAgencyViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMeta
                     "toptier_agency__toptier_code"
                 )
                 code = agency_code[0].get("toptier_agency__toptier_code") if len(agency_code) > 0 else None
-                print(code)
                 submission = (
                     SubmissionAttributes.objects.filter(toptier_code=code).first() if code is not None else None
                 )
-                print(submission)
                 result["agency_slug"] = (
                     urllib.parse.quote_plus(agency_info.get("name").lower().replace(" ", "-"))
                     if submission is not None


### PR DESCRIPTION
**Description:**
Adds the `agency_slug` field to the API response for `spending_by_category/awarding_agency/` endpoint.

**Technical details:**
Only returns a non-null value if the agency has a profile page - meaning it is an agency that has at least one submission.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-5081](https://federal-spending-transparency.atlassian.net/browse/DEV-5081):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
