### PR TITLE
[HOTFIX] Change download limit to 10,000 rows

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -18,6 +18,7 @@ from ddtrace import tracer
 from ddtrace.ext import SpanTypes
 from django.conf import settings
 
+from usaspending_api.settings import MAX_DOWNLOAD_LIMIT
 from usaspending_api.awards.v2.filters.filter_helpers import add_date_range_comparison_types
 from usaspending_api.awards.v2.lookups.lookups import contract_type_mapping, assistance_type_mapping, idv_type_mapping
 from usaspending_api.common.csv_helpers import count_rows_in_delimited_file, partition_large_delimited_file
@@ -65,9 +66,9 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
     file_name = start_download(download_job)
     working_dir = None
     try:
-        if limit is not None and limit > settings.MAX_DOWNLOAD_SIZE:
+        if limit is not None and limit > MAX_DOWNLOAD_LIMIT:
             raise Exception(
-                f"Unable to process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
+                f"Unable to process this download because it includes more than the current limit of {MAX_DOWNLOAD_LIMIT} records"
             )
         # Create temporary files and working directory
         zip_file_path = settings.CSV_LOCAL_PATH + file_name

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -65,6 +65,10 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
     file_name = start_download(download_job)
     working_dir = None
     try:
+        if limit is not None and limit > settings.MAX_DOWNLOAD_SIZE:
+            raise Exception(
+                f"Unable to process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
+            )
         # Create temporary files and working directory
         zip_file_path = settings.CSV_LOCAL_PATH + file_name
         if not settings.IS_LOCAL and os.path.exists(zip_file_path):

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -314,6 +314,7 @@ def parse_source(source, columns, download_job, working_dir, piid, assistance_id
     try:
         # Create a separate process to run the PSQL command; wait
         psql_process = multiprocessing.Process(target=execute_psql, args=(temp_file_path, source_path, download_job))
+        write_to_log(message=f"Running {source.file_name} using psql", download_job=download_job)
         psql_process.start()
         wait_for_process(psql_process, start_time, download_job)
 

--- a/usaspending_api/download/helpers/elasticsearch_download_functions.py
+++ b/usaspending_api/download/helpers/elasticsearch_download_functions.py
@@ -67,7 +67,6 @@ class _ElasticsearchDownload(metaclass=ABCMeta):
         search = cls._search_type().filter(filter_query).source([cls._source_field])
         ids = cls._get_download_ids_generator(search, size)
         flat_ids = list(itertools.chain.from_iterable(ids))
-        logger.info(f"Found {len(flat_ids)} {cls._source_field} based on filters")
         write_to_log(message=f"Found {len(flat_ids)} {cls._source_field} based on filters")
 
         return flat_ids

--- a/usaspending_api/download/helpers/elasticsearch_download_functions.py
+++ b/usaspending_api/download/helpers/elasticsearch_download_functions.py
@@ -10,6 +10,7 @@ from elasticsearch_dsl import A
 from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch, TransactionSearch
 from usaspending_api.common.query_with_filters import QueryWithFilters
 from usaspending_api.search.models import AwardSearchView, TransactionSearch as TransactionSearchModel
+from usaspending_api.download.helpers import write_to_download_log as write_to_log
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,8 @@ class _ElasticsearchDownload(metaclass=ABCMeta):
         ids = cls._get_download_ids_generator(search, size)
         flat_ids = list(itertools.chain.from_iterable(ids))
         logger.info(f"Found {len(flat_ids)} {cls._source_field} based on filters")
+        write_to_log(message=f"Found {len(flat_ids)} {cls._source_field} based on filters")
+
         return flat_ids
 
     @classmethod

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -7,7 +7,6 @@ from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 
 from django.core.management.base import BaseCommand
 
-from usaspending_api import settings
 from usaspending_api.common.sqs.sqs_handler import get_sqs_queue
 from usaspending_api.common.sqs.sqs_work_dispatcher import (
     SQSWorkDispatcher,
@@ -97,11 +96,6 @@ def download_service_app(download_job_id):
             other_params=download_job_details,
         )
         span.set_tags(download_job_details)
-        limit = download_job.json_request.get("limit")
-        if limit is not None and limit > settings.MAX_DOWNLOAD_SIZE:
-            raise Exception(
-                f"Unable to process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
-            )
         generate_download(download_job=download_job)
 
 

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -88,11 +88,6 @@ def download_service_app(download_job_id):
         span_type=SpanTypes.WORKER,
     ) as span:
         download_job = _retrieve_download_job_from_db(download_job_id)
-        limit = download_job.json_request.get("limit")
-        if limit is not None and limit > settings.MAX_DOWNLOAD_SIZE:
-            raise Exception(
-                f"Unable to process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
-            )
         download_job_details = download_job_to_log_dict(download_job)
         log_job_message(
             logger=logger,
@@ -102,6 +97,11 @@ def download_service_app(download_job_id):
             other_params=download_job_details,
         )
         span.set_tags(download_job_details)
+        limit = download_job.json_request.get("limit")
+        if limit is not None and limit > settings.MAX_DOWNLOAD_SIZE:
+            raise Exception(
+                f"Unable to process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
+            )
         generate_download(download_job=download_job)
 
 

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -91,7 +91,7 @@ def download_service_app(download_job_id):
         limit = download_job.json_request.get("limit")
         if limit is not None and limit > settings.MAX_DOWNLOAD_SIZE:
             raise Exception(
-                f"Sorry, we cannot process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
+                f"Unable to process this download because it includes more than the current limit of {settings.MAX_DOWNLOAD_SIZE} records"
             )
         download_job_details = download_job_to_log_dict(download_job)
         log_job_message(

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -318,7 +318,7 @@ class AwardDownloadValidator(DownloadValidatorBase):
                 },
             ]
         )
-        self._json_request["limit"] = settings.MAX_DOWNLOAD_LIMIT
+        self._json_request["limit"] = self.request_data.get("limit", settings.MAX_DOWNLOAD_LIMIT)
         self._json_request = self.get_validated_request()
 
 

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -318,7 +318,7 @@ class AwardDownloadValidator(DownloadValidatorBase):
                 },
             ]
         )
-        self._json_request["limit"] = self.request_data.get("limit", settings.MAX_DOWNLOAD_LIMIT)
+        self._json_request["limit"] = settings.MAX_DOWNLOAD_LIMIT
         self._json_request = self.get_validated_request()
 
 

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -16,7 +16,7 @@ APP_DIR = Path(__file__).resolve().parent
 REPO_DIR = APP_DIR.parent
 
 # Row-limited download limit
-MAX_DOWNLOAD_LIMIT = 500000
+MAX_DOWNLOAD_LIMIT = 10000
 
 # Timeout limit for streaming downloads
 DOWNLOAD_TIMEOUT_MIN_LIMIT = 10


### PR DESCRIPTION
**Description:**
Lowers the maximum number of rows allowed for download to be 10,000 rather than 500,000 to mitigate the database issue coming from the downloads.

**Technical details:**
Tested locally to confirm that the limit worked for the elasticsearch downloads.
**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-8103](https://federal-spending-transparency.atlassian.net/browse/DEV-8103):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
