### PR TITLE
[WARMFIX] Updates Calculation for Additional TBR on ARP Page

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_overview.py
+++ b/usaspending_api/disaster/tests/integration/test_overview.py
@@ -279,7 +279,7 @@ def test_dol_defc_v_special_case(client, monkeypatch, helpers, defc_codes, basic
             "total_outlays": 5994000.0,
         },
         "additional": {
-            "total_budget_authority": 499445.0,
+            "total_budget_authority": 49999950.0,
             "spending": {"total_obligations": 49999950.0, "total_outlays": 4995000.0},
         },
     }

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -196,5 +196,5 @@ class OverviewViewSet(DisasterBase):
                 "total_obligations": total_values["obligation_totals"] - defc_o_values["obligation_totals"],
                 "total_outlays": total_values["outlay_totals"] - defc_o_values["outlay_totals"],
             },
-            "total_budget_authority": total_values["total_budget_authority"] - defc_o_values["total_budget_authority"],
+            "total_budget_authority": total_values["obligation_totals"] - defc_o_values["obligation_totals"],
         }


### PR DESCRIPTION
**Description:**
This updates the calculation of the `additional.total_budget_authority` value on the `/v2/disaster/overview` endpoint to align with Data Lab. 

Data Lab uses the same value as `additional. total_obligations` for this field, so we are updating to match. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
