### PR TITLE
[DEV-8143] Removes unused TBR aggregations after warmfix

### DIFF
--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -147,10 +147,7 @@ class OverviewViewSet(DisasterBase):
         ]
         outlay_values = ["gross_outlay_amount_by_tas_cpe", "anticipated_prior_year_obligation_recoveries"]
         total_budget_authority_values = [
-            "total_budgetary_resources_cpe",
-            "budget_authority_unobligated_balance_brought_forward_cpe",
             "deobligations_or_recoveries_or_refunds_from_prior_year_cpe",
-            "prior_year_paid_obligation_recoveries",
         ]
 
         filters = {
@@ -166,14 +163,6 @@ class OverviewViewSet(DisasterBase):
             ),
             "outlay_totals": (
                 Sum("gross_outlay_amount_by_tas_cpe") - Sum("anticipated_prior_year_obligation_recoveries")
-            ),
-            "total_budget_authority": (
-                Sum("total_budgetary_resources_cpe")
-                - (
-                    Sum("budget_authority_unobligated_balance_brought_forward_cpe")
-                    + Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe")
-                    + Sum("prior_year_paid_obligation_recoveries")
-                )
             ),
         }
         defc_o_values = (
@@ -191,6 +180,9 @@ class OverviewViewSet(DisasterBase):
         if not all([val is not None for val in list(total_values.values()) + list(defc_o_values.values())]):
             return None
 
+        # Obligation values are used to calculate the adjustment for TBR here to match the calculations
+        # in DataLab. This should be capped at a specific period once new appropriates from DOL are not
+        # associated with ARP.
         return {
             "spending": {
                 "total_obligations": total_values["obligation_totals"] - defc_o_values["obligation_totals"],

--- a/usaspending_api/disaster/v2/views/overview.py
+++ b/usaspending_api/disaster/v2/views/overview.py
@@ -146,9 +146,6 @@ class OverviewViewSet(DisasterBase):
             "deobligations_or_recoveries_or_refunds_from_prior_year_cpe",
         ]
         outlay_values = ["gross_outlay_amount_by_tas_cpe", "anticipated_prior_year_obligation_recoveries"]
-        total_budget_authority_values = [
-            "deobligations_or_recoveries_or_refunds_from_prior_year_cpe",
-        ]
 
         filters = {
             "tas_rendering_label__in": ["016-X-0168-000", "016-X-1801-000", "016-X-8042-000"],
@@ -167,7 +164,7 @@ class OverviewViewSet(DisasterBase):
         }
         defc_o_values = (
             GTASSF133Balances.objects.filter(**filters, fiscal_year=2021, fiscal_period=6)
-            .values(*obligation_values, *outlay_values, *total_budget_authority_values)
+            .values(*obligation_values, *outlay_values)
             .aggregate(**aggregates)
         )
 


### PR DESCRIPTION
**Description:**
Removes unused aggregations and selections from the calculation for additional values on the Disaster Overview endpoint. Includes a comment about the changed calculation.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8143](https://federal-spending-transparency.atlassian.net/browse/DEV-8143):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
