### PR TITLE
[DEV-8043] bureau agency endpoint

### DIFF
--- a/usaspending_api/agency/tests/fixtures/bureau_data.py
+++ b/usaspending_api/agency/tests/fixtures/bureau_data.py
@@ -1,0 +1,7 @@
+import pytest
+
+from model_mommy import mommy
+
+@pytest.fixure
+def bureau_data():
+    mommy.make()

--- a/usaspending_api/agency/tests/fixtures/bureau_data.py
+++ b/usaspending_api/agency/tests/fixtures/bureau_data.py
@@ -1,7 +1,0 @@
-import pytest
-
-from model_mommy import mommy
-
-@pytest.fixure
-def bureau_data():
-    mommy.make()

--- a/usaspending_api/agency/tests/integration/conftest.py
+++ b/usaspending_api/agency/tests/integration/conftest.py
@@ -73,6 +73,10 @@ def bureau_data():
         total_budgetary_resources_cpe=100,
         gross_outlay_amount_by_tas_cpe=10,
         obligations_incurred_total_cpe=1,
+        budget_authority_unobligated_balance_brought_forward_cpe=0,
+        deobligations_or_recoveries_or_refunds_from_prior_year_cpe=0,
+        prior_year_paid_obligation_recoveries=0,
+        anticipated_prior_year_obligation_recoveries=0,
     )
     ta2 = mommy.make("references.ToptierAgency", name="Agency 2", toptier_code="002")
     sa2 = mommy.make("references.SubtierAgency", name="Agency 2", subtier_code="0002")
@@ -95,6 +99,10 @@ def bureau_data():
         total_budgetary_resources_cpe=2000,
         gross_outlay_amount_by_tas_cpe=200,
         obligations_incurred_total_cpe=20,
+        budget_authority_unobligated_balance_brought_forward_cpe=0,
+        deobligations_or_recoveries_or_refunds_from_prior_year_cpe=0,
+        prior_year_paid_obligation_recoveries=0,
+        anticipated_prior_year_obligation_recoveries=0,
     )
     mommy.make(
         "references.GTASSF133Balances",
@@ -104,6 +112,10 @@ def bureau_data():
         total_budgetary_resources_cpe=2000,
         gross_outlay_amount_by_tas_cpe=200,
         obligations_incurred_total_cpe=20,
+        budget_authority_unobligated_balance_brought_forward_cpe=0,
+        deobligations_or_recoveries_or_refunds_from_prior_year_cpe=0,
+        prior_year_paid_obligation_recoveries=0,
+        anticipated_prior_year_obligation_recoveries=0,
     )
 
     mommy.make(

--- a/usaspending_api/agency/tests/integration/conftest.py
+++ b/usaspending_api/agency/tests/integration/conftest.py
@@ -74,15 +74,6 @@ def bureau_data():
         gross_outlay_amount_by_tas_cpe=10,
         obligations_incurred_total_cpe=1,
     )
-    mommy.make(
-        "references.GTASSF133Balances",
-        fiscal_year=2018,
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
-        treasury_account_identifier=taa1,
-        total_budgetary_resources_cpe=2000,
-        gross_outlay_amount_by_tas_cpe=200,
-        obligations_incurred_total_cpe=20,
-    )
     ta2 = mommy.make("references.ToptierAgency", name="Agency 2", toptier_code="002")
     sa2 = mommy.make("references.SubtierAgency", name="Agency 2", subtier_code="0002")
     mommy.make("references.Agency", id=2, toptier_flag=True, toptier_agency=ta2, subtier_agency=sa2)

--- a/usaspending_api/agency/tests/integration/conftest.py
+++ b/usaspending_api/agency/tests/integration/conftest.py
@@ -31,6 +31,117 @@ def helpers():
 
 
 @pytest.fixture
+def bureau_data():
+    dabs1 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=f"{CURRENT_FISCAL_YEAR}-01-01",
+        submission_fiscal_year=CURRENT_FISCAL_YEAR,
+        submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=True,
+        period_start_date=f"{CURRENT_FISCAL_YEAR}-09-01",
+        period_end_date=f"{CURRENT_FISCAL_YEAR}-10-01",
+    )
+    dabs2 = mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=f"2018-01-01",
+        submission_fiscal_year=2018,
+        submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=True,
+        period_start_date=f"2018-09-01",
+        period_end_date=f"2018-10-01",
+    )
+    ta1 = mommy.make("references.ToptierAgency", name="Agency 1", toptier_code="001")
+    sa1 = mommy.make("references.SubtierAgency", name="Agency 1", subtier_code="0001")
+    mommy.make("references.Agency", id=1, toptier_flag=True, toptier_agency=ta1, subtier_agency=sa1)
+    mommy.make(
+        "references.BureauTitleLookup",
+        federal_account_code="001-0000",
+        bureau_title="Test Bureau 1",
+        bureau_slug="test-bureau-1",
+    )
+    fa1 = mommy.make(
+        "accounts.FederalAccount", account_title="FA 1", federal_account_code="001-0000", parent_toptier_agency=ta1
+    )
+    taa1 = mommy.make("accounts.TreasuryAppropriationAccount", federal_account=fa1)
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=CURRENT_FISCAL_YEAR,
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
+        treasury_account_identifier=taa1,
+        total_budgetary_resources_cpe=100,
+        gross_outlay_amount_by_tas_cpe=10,
+        obligations_incurred_total_cpe=1,
+    )
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=2018,
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
+        treasury_account_identifier=taa1,
+        total_budgetary_resources_cpe=2000,
+        gross_outlay_amount_by_tas_cpe=200,
+        obligations_incurred_total_cpe=20,
+    )
+    ta2 = mommy.make("references.ToptierAgency", name="Agency 2", toptier_code="002")
+    sa2 = mommy.make("references.SubtierAgency", name="Agency 2", subtier_code="0002")
+    mommy.make("references.Agency", id=2, toptier_flag=True, toptier_agency=ta2, subtier_agency=sa2)
+    mommy.make(
+        "references.BureauTitleLookup",
+        federal_account_code="002-0000",
+        bureau_title="Test Bureau 2",
+        bureau_slug="test-bureau-2",
+    )
+    fa2 = mommy.make(
+        "accounts.FederalAccount", account_title="FA 2", federal_account_code="002-0000", parent_toptier_agency=ta2
+    )
+    taa2 = mommy.make("accounts.TreasuryAppropriationAccount", federal_account=fa2)
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=2018,
+        fiscal_period=12,
+        treasury_account_identifier=taa2,
+        total_budgetary_resources_cpe=2000,
+        gross_outlay_amount_by_tas_cpe=200,
+        obligations_incurred_total_cpe=20,
+    )
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=2018,
+        fiscal_period=12,
+        treasury_account_identifier=taa1,
+        total_budgetary_resources_cpe=2000,
+        gross_outlay_amount_by_tas_cpe=200,
+        obligations_incurred_total_cpe=20,
+    )
+
+    mommy.make(
+        "submissions.SubmissionAttributes",
+        reporting_fiscal_year=CURRENT_FISCAL_YEAR,
+        reporting_fiscal_period=12,
+        toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=True,
+        submission_window_id=dabs1.id,
+    )
+    mommy.make(
+        "submissions.SubmissionAttributes",
+        reporting_fiscal_year=2018,
+        reporting_fiscal_period=12,
+        toptier_code=ta2.toptier_code,
+        is_final_balances_for_fy=True,
+        submission_window_id=dabs2.id,
+    )
+    mommy.make(
+        "submissions.SubmissionAttributes",
+        reporting_fiscal_year=2018,
+        reporting_fiscal_period=12,
+        toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=True,
+        submission_window_id=dabs2.id,
+    )
+
+
+@pytest.fixture
 def agency_account_data():
     dabs = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",
@@ -339,83 +450,6 @@ def agency_account_data():
         submission=sub7,
         obligations_incurred_by_program_object_class_cpe=710,
         gross_outlay_amount_by_program_object_class_cpe=7100,
-    )
-
-
-@pytest.fixture
-def bureau_data():
-    mommy.make(
-        "submissions.DABSSubmissionWindowSchedule",
-        submission_reveal_date=f"{CURRENT_FISCAL_YEAR}-01-01",
-        submission_fiscal_year=CURRENT_FISCAL_YEAR,
-        submission_fiscal_month=12,
-        submission_fiscal_quarter=4,
-        is_quarter=True,
-        period_start_date=f"{CURRENT_FISCAL_YEAR}-09-01",
-        period_end_date=f"{CURRENT_FISCAL_YEAR}-10-01",
-    )
-    mommy.make(
-        "submissions.DABSSubmissionWindowSchedule",
-        submission_reveal_date=f"2018-01-01",
-        submission_fiscal_year=2018,
-        submission_fiscal_month=12,
-        submission_fiscal_quarter=4,
-        is_quarter=True,
-        period_start_date=f"2018-09-01",
-        period_end_date=f"2018-10-01",
-    )
-    ta1 = mommy.make("references.ToptierAgency", toptier_code="001")
-    sa1 = mommy.make("references.SubtierAgency", subtier_code="0001")
-    mommy.make("references.Agency", id=1, toptier_flag=True, toptier_agency=ta1, subtier_agency=sa1)
-    mommy.make(
-        "references.BureauTitleLookup",
-        federal_account_code="001-0000",
-        bureau_title="Test Bureau 1",
-        bureau_slug="test-bureau-1",
-    )
-    fa1 = mommy.make(
-        "accounts.FederalAccount", account_title="FA 1", federal_account_code="001-0000", parent_toptier_agency=ta1
-    )
-    taa1 = mommy.make("accounts.TreasuryAppropriationAccount", federal_account=fa1)
-    mommy.make(
-        "references.GTASSF133Balances",
-        fiscal_year=CURRENT_FISCAL_YEAR,
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
-        treasury_account_identifier=taa1,
-        total_budgetary_resources_cpe=100,
-        gross_outlay_amount_by_tas_cpe=10,
-        obligations_incurred_total_cpe=1,
-    )
-    mommy.make(
-        "references.GTASSF133Balances",
-        fiscal_year=2018,
-        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
-        treasury_account_identifier=taa1,
-        total_budgetary_resources_cpe=2000,
-        gross_outlay_amount_by_tas_cpe=200,
-        obligations_incurred_total_cpe=20,
-    )
-    ta2 = mommy.make("references.ToptierAgency", toptier_code="002")
-    sa2 = mommy.make("references.SubtierAgency", subtier_code="0002")
-    mommy.make("references.Agency", id=2, toptier_flag=True, toptier_agency=ta2, subtier_agency=sa2)
-    mommy.make(
-        "references.BureauTitleLookup",
-        federal_account_code="002-0000",
-        bureau_title="Test Bureau 2",
-        bureau_slug="test-bureau-2",
-    )
-    fa2 = mommy.make(
-        "accounts.FederalAccount", account_title="FA 2", federal_account_code="002-0000", parent_toptier_agency=ta2
-    )
-    taa2 = mommy.make("accounts.TreasuryAppropriationAccount", federal_account=fa2)
-    mommy.make(
-        "references.GTASSF133Balances",
-        fiscal_year=2018,
-        fiscal_period=12,
-        treasury_account_identifier=taa2,
-        total_budgetary_resources_cpe=100,
-        gross_outlay_amount_by_tas_cpe=10,
-        obligations_incurred_total_cpe=1,
     )
 
 

--- a/usaspending_api/agency/tests/integration/conftest.py
+++ b/usaspending_api/agency/tests/integration/conftest.py
@@ -2,6 +2,11 @@ import pytest
 
 from model_mommy import mommy
 
+from usaspending_api.common.helpers.fiscal_year_helpers import (
+    get_final_period_of_quarter,
+    calculate_last_completed_fiscal_quarter,
+)
+
 CURRENT_FISCAL_YEAR = 2020
 
 
@@ -337,4 +342,81 @@ def agency_account_data():
     )
 
 
-__all__ = ["agency_account_data", "helpers"]
+@pytest.fixture
+def bureau_data():
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=f"{CURRENT_FISCAL_YEAR}-01-01",
+        submission_fiscal_year=CURRENT_FISCAL_YEAR,
+        submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=True,
+        period_start_date=f"{CURRENT_FISCAL_YEAR}-09-01",
+        period_end_date=f"{CURRENT_FISCAL_YEAR}-10-01",
+    )
+    mommy.make(
+        "submissions.DABSSubmissionWindowSchedule",
+        submission_reveal_date=f"2018-01-01",
+        submission_fiscal_year=2018,
+        submission_fiscal_month=12,
+        submission_fiscal_quarter=4,
+        is_quarter=True,
+        period_start_date=f"2018-09-01",
+        period_end_date=f"2018-10-01",
+    )
+    ta1 = mommy.make("references.ToptierAgency", toptier_code="001")
+    sa1 = mommy.make("references.SubtierAgency", subtier_code="0001")
+    mommy.make("references.Agency", id=1, toptier_flag=True, toptier_agency=ta1, subtier_agency=sa1)
+    mommy.make(
+        "references.BureauTitleLookup",
+        federal_account_code="001-0000",
+        bureau_title="Test Bureau 1",
+        bureau_slug="test-bureau-1",
+    )
+    fa1 = mommy.make(
+        "accounts.FederalAccount", account_title="FA 1", federal_account_code="001-0000", parent_toptier_agency=ta1
+    )
+    taa1 = mommy.make("accounts.TreasuryAppropriationAccount", federal_account=fa1)
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=CURRENT_FISCAL_YEAR,
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
+        treasury_account_identifier=taa1,
+        total_budgetary_resources_cpe=100,
+        gross_outlay_amount_by_tas_cpe=10,
+        obligations_incurred_total_cpe=1,
+    )
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=2018,
+        fiscal_period=get_final_period_of_quarter(calculate_last_completed_fiscal_quarter(CURRENT_FISCAL_YEAR)) or 12,
+        treasury_account_identifier=taa1,
+        total_budgetary_resources_cpe=2000,
+        gross_outlay_amount_by_tas_cpe=200,
+        obligations_incurred_total_cpe=20,
+    )
+    ta2 = mommy.make("references.ToptierAgency", toptier_code="002")
+    sa2 = mommy.make("references.SubtierAgency", subtier_code="0002")
+    mommy.make("references.Agency", id=2, toptier_flag=True, toptier_agency=ta2, subtier_agency=sa2)
+    mommy.make(
+        "references.BureauTitleLookup",
+        federal_account_code="002-0000",
+        bureau_title="Test Bureau 2",
+        bureau_slug="test-bureau-2",
+    )
+    fa2 = mommy.make(
+        "accounts.FederalAccount", account_title="FA 2", federal_account_code="002-0000", parent_toptier_agency=ta2
+    )
+    taa2 = mommy.make("accounts.TreasuryAppropriationAccount", federal_account=fa2)
+    mommy.make(
+        "references.GTASSF133Balances",
+        fiscal_year=2018,
+        fiscal_period=12,
+        treasury_account_identifier=taa2,
+        total_budgetary_resources_cpe=100,
+        gross_outlay_amount_by_tas_cpe=10,
+        obligations_incurred_total_cpe=1,
+    )
+
+
+__all__ = ["agency_account_data", "helpers", "bureau_data"]

--- a/usaspending_api/agency/tests/integration/test_subcomponents.py
+++ b/usaspending_api/agency/tests/integration/test_subcomponents.py
@@ -1,0 +1,69 @@
+import pytest
+
+from rest_framework import status
+
+
+url = "/api/v2/agency/{toptier_code}/subcomponents/{filter}"
+
+
+@pytest.mark.django_db
+def test_all_categories(client):
+    resp = client.get(url.format(toptier_code="001", filter="?fiscal_year=2021"))
+
+    expected_results = [
+        {
+            "name": "Test Bureau 1",
+            "id": "test-bureau-1",
+            "total_obligations": 10.0,
+            "total_outlays": 100.0,
+            "total_budgetary_resources": 1000.0,
+        }
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+
+@pytest.mark.django_db
+def test_alternate_year(client):
+    resp = client.get(url.format(toptier_code="001", filter="?fiscal_year=2020"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    expected_results = [
+        {
+            "name": "Test Bureau 1",
+            "abbreviation": "test-bureau-1",
+            "total_obligations": 20.0,
+            "total_outlays": 200.0,
+            "total_budgetary_resources": 2000.0,
+        }
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+
+@pytest.mark.django_db
+def test_alternate_agency(client):
+    resp = client.get(url.format(toptier_code="002", filter="?fiscal_year=2021"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    expected_results = [
+        {
+            "name": "Test Bureau 2",
+            "abbreviation": "test-bureau-2",
+            "total_obligations": 20.0,
+            "total_outlays": 200.0,
+            "total_budgetary_resources": 2000.0,
+        }
+
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+
+@pytest.mark.django_db
+def test_invalid_agency(client):
+    resp = client.get(url.format(toptier_code="XXX", filter="?fiscal_year=2021"))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    resp = client.get(url.format(toptier_code="999", filter="?fiscal_year=2021"))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/usaspending_api/agency/tests/integration/test_subcomponents.py
+++ b/usaspending_api/agency/tests/integration/test_subcomponents.py
@@ -7,16 +7,16 @@ url = "/api/v2/agency/{toptier_code}/subcomponents/{filter}"
 
 
 @pytest.mark.django_db
-def test_all_categories(client):
-    resp = client.get(url.format(toptier_code="001", filter="?fiscal_year=2021"))
+def test_all_categories(client, bureau_data, helpers):
+    resp = client.get(url.format(toptier_code="001", filter=f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}"))
 
     expected_results = [
         {
             "name": "Test Bureau 1",
             "id": "test-bureau-1",
-            "total_obligations": 10.0,
-            "total_outlays": 100.0,
-            "total_budgetary_resources": 1000.0,
+            "total_obligations": 1.0,
+            "total_outlays": 10.0,
+            "total_budgetary_resources": 100.0,
         }
     ]
     assert resp.status_code == status.HTTP_200_OK
@@ -24,8 +24,8 @@ def test_all_categories(client):
 
 
 @pytest.mark.django_db
-def test_alternate_year(client):
-    resp = client.get(url.format(toptier_code="001", filter="?fiscal_year=2020"))
+def test_alternate_year(client, bureau_data):
+    resp = client.get(url.format(toptier_code="001", filter="?fiscal_year=2018"))
     assert resp.status_code == status.HTTP_200_OK
 
     expected_results = [
@@ -42,8 +42,8 @@ def test_alternate_year(client):
 
 
 @pytest.mark.django_db
-def test_alternate_agency(client):
-    resp = client.get(url.format(toptier_code="002", filter="?fiscal_year=2021"))
+def test_alternate_agency(client, bureau_data):
+    resp = client.get(url.format(toptier_code="002", filter="?fiscal_year=2018"))
     assert resp.status_code == status.HTTP_200_OK
 
     expected_results = [
@@ -54,14 +54,13 @@ def test_alternate_agency(client):
             "total_outlays": 200.0,
             "total_budgetary_resources": 2000.0,
         }
-
     ]
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["results"] == expected_results
 
 
 @pytest.mark.django_db
-def test_invalid_agency(client):
+def test_invalid_agency(client, bureau_data):
     resp = client.get(url.format(toptier_code="XXX", filter="?fiscal_year=2021"))
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 

--- a/usaspending_api/agency/tests/integration/test_subcomponents.py
+++ b/usaspending_api/agency/tests/integration/test_subcomponents.py
@@ -2,12 +2,11 @@ import pytest
 
 from rest_framework import status
 
-
 url = "/api/v2/agency/{toptier_code}/subcomponents/{filter}"
 
 
 @pytest.mark.django_db
-def test_all_categories(client, bureau_data, helpers):
+def test_success(client, bureau_data, helpers):
     resp = client.get(url.format(toptier_code="001", filter=f"?fiscal_year={helpers.get_mocked_current_fiscal_year()}"))
 
     expected_results = [
@@ -31,7 +30,7 @@ def test_alternate_year(client, bureau_data):
     expected_results = [
         {
             "name": "Test Bureau 1",
-            "abbreviation": "test-bureau-1",
+            "id": "test-bureau-1",
             "total_obligations": 20.0,
             "total_outlays": 200.0,
             "total_budgetary_resources": 2000.0,
@@ -49,7 +48,7 @@ def test_alternate_agency(client, bureau_data):
     expected_results = [
         {
             "name": "Test Bureau 2",
-            "abbreviation": "test-bureau-2",
+            "id": "test-bureau-2",
             "total_obligations": 20.0,
             "total_outlays": 200.0,
             "total_budgetary_resources": 2000.0,

--- a/usaspending_api/agency/tests/integration/test_subcomponents.py
+++ b/usaspending_api/agency/tests/integration/test_subcomponents.py
@@ -2,7 +2,7 @@ import pytest
 
 from rest_framework import status
 
-url = "/api/v2/agency/{toptier_code}/subcomponents/{filter}"
+url = "/api/v2/agency/{toptier_code}/sub_components/{filter}"
 
 
 @pytest.mark.django_db

--- a/usaspending_api/agency/v2/urls.py
+++ b/usaspending_api/agency/v2/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
                 path("recipients/", RecipientList.as_view()),
                 path("sub_agency/", SubAgencyList.as_view()),
                 path("sub_agency/count/", SubAgencyCount.as_view()),
-                path("subcomponents/", SubcomponentList.as_view()),
+                path("sub_components/", SubcomponentList.as_view()),
             ]
         ),
     )

--- a/usaspending_api/agency/v2/urls.py
+++ b/usaspending_api/agency/v2/urls.py
@@ -15,7 +15,7 @@ from usaspending_api.agency.v2.views.program_activity_list import ProgramActivit
 from usaspending_api.agency.v2.views.recipients import RecipientList
 from usaspending_api.agency.v2.views.sub_agency import SubAgencyList
 from usaspending_api.agency.v2.views.sub_agency_count import SubAgencyCount
-
+from usaspending_api.agency.v2.views.subcomponents import SubcomponentList
 
 urlpatterns = [
     re_path(
@@ -38,6 +38,7 @@ urlpatterns = [
                 path("recipients/", RecipientList.as_view()),
                 path("sub_agency/", SubAgencyList.as_view()),
                 path("sub_agency/count/", SubAgencyCount.as_view()),
+                path("subcomponents/", SubcomponentList.as_view()),
             ]
         ),
     )

--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -25,7 +25,7 @@ class SubcomponentList(PaginationMixin, AgencyBase):
 
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        self.sortable_columns = ["name", "total_obligations", "total_outlay_amount", "total_budgetary_resouces"]
+        self.sortable_columns = ["name", "total_obligations", "total_outlays", "total_budgetary_resouces"]
         self.default_sort_column = "total_obligations"
         results = self.format_results(self.get_subcomponents_queryset())
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
@@ -54,7 +54,6 @@ class SubcomponentList(PaginationMixin, AgencyBase):
             key=lambda x: x.get(self.pagination.sort_key),
             reverse=self.pagination.sort_order == "desc",
         )
-
         return results
 
     def get_subcomponents_queryset(self):

--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -1,0 +1,88 @@
+from django.db.models import Q, Sum, OuterRef, Subquery, F, Value
+from rest_framework.request import Request
+from rest_framework.response import Response
+from typing import Any
+from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
+from usaspending_api.common.helpers.orm_helpers import ConcatAll
+from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
+from usaspending_api.references.models import GTASSF133Balances, BureauTitleLookup
+from usaspending_api.submissions.helpers import get_latest_submission_ids_for_fiscal_year
+
+
+class SubcomponentList(PaginationMixin, AgencyBase):
+    """
+    Obtain the count of subcomponents (bureaus) for a specific agency in a single
+    fiscal year based on GTAS
+    """
+
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/subcomponents.md"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["toptier_code", "fiscal_year"]
+
+    @cache_response()
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        self.sortable_columns = ["name", "total_obligations", "total_outlay_amount", "total_budgetary_resouces"]
+        self.default_sort_column = "total_obligations"
+        results = self.format_results(self.get_subcomponents_queryset())
+        page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
+        return Response(
+            {
+                "toptier_code": self.toptier_code,
+                "fiscal_year": self.fiscal_year,
+                "results": results[self.pagination.lower_limit : self.pagination.upper_limit],
+                "messages": self.standard_response_messages,
+                "page_metadata": page_metadata,
+            }
+        )
+
+    def format_results(self, response):
+        results = sorted(
+            [
+                {
+                    "name": x["bureau_info"].split(";")[0],
+                    "id:": x["bureau_info"].split(";")[1],
+                    "total_obligations": x["total_obligations"],
+                    "total_outlays": x["total_outlays"],
+                    "total_budgetary_resouces": x["total_budgetary_resources"],
+                }
+                for x in response
+            ],
+            key=lambda x: x.get(self.pagination.sort_key),
+            reverse=self.pagination.sort_order == "desc",
+        )
+
+        return results
+
+    def get_subcomponents_queryset(self):
+        filters = [
+            Q(treasury_account_identifier__federal_account__parent_toptier_agency=self.toptier_agency),
+            Q(fiscal_year=self.fiscal_year),
+            Q(fiscal_period=self.fiscal_period),
+        ]
+
+        results = (
+            (GTASSF133Balances.objects.filter(*filters))
+            .annotate(
+                bureau_info=Subquery(
+                    BureauTitleLookup.objects.filter(
+                        federal_account_code=OuterRef(
+                            "treasury_account_identifier__federal_account__federal_account_code"
+                        )
+                    )
+                    .annotate(bureau_info=ConcatAll(F("bureau_title"), Value(";"), F("bureau_slug")))
+                    .values("bureau_info")
+                )
+            )
+            .values("bureau_info")
+            .annotate(
+                total_obligations=Sum("obligations_incurred_total_cpe"),
+                total_outlays=Sum("gross_outlay_amount_by_tas_cpe"),
+                total_budgetary_resources=Sum("total_budgetary_resources_cpe"),
+            )
+            .values("bureau_info", "total_obligations", "total_outlays", "total_budgetary_resources")
+        )
+        return results

--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -6,9 +6,7 @@ from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMi
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.common.helpers.orm_helpers import ConcatAll
-from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
 from usaspending_api.references.models import GTASSF133Balances, BureauTitleLookup
-from usaspending_api.submissions.helpers import get_latest_submission_ids_for_fiscal_year
 
 
 class SubcomponentList(PaginationMixin, AgencyBase):

--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -15,7 +15,7 @@ class SubcomponentList(PaginationMixin, AgencyBase):
     fiscal year based on GTAS
     """
 
-    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/subcomponents.md"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/sub_components.md"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -42,10 +42,10 @@ class SubcomponentList(PaginationMixin, AgencyBase):
             [
                 {
                     "name": x["bureau_info"].split(";")[0],
-                    "id:": x["bureau_info"].split(";")[1],
+                    "id": x["bureau_info"].split(";")[1],
                     "total_obligations": x["total_obligations"],
                     "total_outlays": x["total_outlays"],
-                    "total_budgetary_resouces": x["total_budgetary_resources"],
+                    "total_budgetary_resources": x["total_budgetary_resources"],
                 }
                 for x in response
             ],

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/sub_components.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/sub_components.md
@@ -68,6 +68,7 @@ Returns a list of Sub-Components in the Agency's appropriations for a single fis
                         "id": "bureau_of_the_census",
                         "total_budgetary_resources": 500000,
                         "total_obligations": 300000.72
+                        "total_outlays": 1000000.45                
                     }
                 ],
                 "messages": []
@@ -89,3 +90,4 @@ Returns a list of Sub-Components in the Agency's appropriations for a single fis
 + `id` (required, string) snake_case version of the Sub-Component name (bureau_slug)
 + `total_budgetary_resources` (required, number)
 + `total_obligations` (required, number)
++ `total_outlays` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/sub_components.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/sub_components.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# List Sub-Components [/api/v2/agency/{toptier_code}/sub_component/{?fiscal_year,agency_type,order,sort,page,limit}]
+# List Sub-Components [/api/v2/agency/{toptier_code}/sub_components/{?fiscal_year,agency_type,order,sort,page,limit}]
 
 Returns a list of Sub-Components in the Agency's appropriations for a single fiscal year
 

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -44,7 +44,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/program_activity/count/](/api/v2/agency/012/program_activity/count/)|GET| Returns the count of Program Activity categories for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/sub_agency/](/api/v2/agency/012/sub_agency/)|GET| Returns a list of sub-agencies and offices with obligated amounts, transaction counts and new award counts for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/sub_agency/count/](/api/v2/agency/012/sub_agency/count/)|GET| Returns the number of sub-agencies and offices for the agency in a single fiscal year |
-|[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/subcomponents/](/api/v2/agency/012/subcomponents/)|GET| Returns a list of bureaus for the agency in a single fiscal year |
+|[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/sub_components/](/api/v2/agency/012/sub_components/)|GET| Returns a list of bureaus for the agency in a single fiscal year |
 |[/api/v2/autocomplete/accounts/a/](/api/v2/autocomplete/accounts/a/)|POST| Returns Treasury Account Symbol Availability Type Code (A) filtered by other components provided in the request filter |
 |[/api/v2/autocomplete/accounts/aid/](/api/v2/autocomplete/accounts/aid/)|POST| Returns Treasury Account Symbol/Federal Account Agency Identifier (AID) filtered by other components provided in the request filter |
 |[/api/v2/autocomplete/accounts/ata/](/api/v2/autocomplete/accounts/ata/)|POST| Returns Treasury Account Symbol Allocation Transfer Agency Identifier (ATA) filtered by other components provided in the request filter |

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -44,6 +44,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/program_activity/count/](/api/v2/agency/012/program_activity/count/)|GET| Returns the count of Program Activity categories for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/sub_agency/](/api/v2/agency/012/sub_agency/)|GET| Returns a list of sub-agencies and offices with obligated amounts, transaction counts and new award counts for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/sub_agency/count/](/api/v2/agency/012/sub_agency/count/)|GET| Returns the number of sub-agencies and offices for the agency in a single fiscal year |
+|[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/subcomponents/](/api/v2/agency/012/subcomponents/)|GET| Returns a list of bureaus for the agency in a single fiscal year |
 |[/api/v2/autocomplete/accounts/a/](/api/v2/autocomplete/accounts/a/)|POST| Returns Treasury Account Symbol Availability Type Code (A) filtered by other components provided in the request filter |
 |[/api/v2/autocomplete/accounts/aid/](/api/v2/autocomplete/accounts/aid/)|POST| Returns Treasury Account Symbol/Federal Account Agency Identifier (AID) filtered by other components provided in the request filter |
 |[/api/v2/autocomplete/accounts/ata/](/api/v2/autocomplete/accounts/ata/)|POST| Returns Treasury Account Symbol Allocation Transfer Agency Identifier (ATA) filtered by other components provided in the request filter |


### PR DESCRIPTION
**Description:**
Adds `/api/v2/agency/{toptier_code}/subcomponents/` endpoint to return bureau titles and relevant spending.

**Technical details:**
Uses GTAS to generate the spending amounts, and joins from gtas->tas->fed account->bureau title lookup table to get the bureau names.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-8043](https://federal-spending-transparency.atlassian.net/browse/DEV-8043):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
