### PR TITLE
Increase download limit to 250k

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -16,7 +16,7 @@ APP_DIR = Path(__file__).resolve().parent
 REPO_DIR = APP_DIR.parent
 
 # Row-limited download limit
-MAX_DOWNLOAD_LIMIT = 100000
+MAX_DOWNLOAD_LIMIT = 250000
 
 # Timeout limit for streaming downloads
 DOWNLOAD_TIMEOUT_MIN_LIMIT = 10


### PR DESCRIPTION
**Description:**
Small setting changes to allow downloads up to 250k rows.