### PR TITLE
[DEV-8117] add special DOD groupings

### DIFF
--- a/usaspending_api/agency/v2/views/bureau_federal_account.py
+++ b/usaspending_api/agency/v2/views/bureau_federal_account.py
@@ -57,9 +57,19 @@ class BureauFederalAccountList(PaginationMixin, AgencyBase):
         return totals
 
     def get_federal_account_list(self) -> List[dict]:
+        fed_account_filter = Q(bureau_slug=self.bureau_slug)
+        if self.bureau_slug == "air-force":
+            fed_account_filter = Q(federal_account_code__startswith="057")
+        elif self.bureau_slug == "army":
+            fed_account_filter = Q(federal_account_code__startswith="021")
+        elif self.bureau_slug == "navy-marine-corps":
+            fed_account_filter = Q(federal_account_code__startswith="017")
+        elif self.bureau_slug == "defense-wide":
+            fed_account_filter = Q(federal_account_code__startswith="097")
+
         federal_accounts = [
             x["federal_account_code"]
-            for x in BureauTitleLookup.objects.filter(bureau_slug=self.bureau_slug).values("federal_account_code")
+            for x in BureauTitleLookup.objects.filter(fed_account_filter).values("federal_account_code")
         ]
         filters = [
             Q(

--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -1,4 +1,4 @@
-from django.db.models import Q, Sum, OuterRef, Subquery, F, Value
+from django.db.models import Q, Sum, OuterRef, Subquery, F, Value, Case, When
 from rest_framework.request import Request
 from rest_framework.response import Response
 from typing import Any
@@ -70,7 +70,27 @@ class SubcomponentList(PaginationMixin, AgencyBase):
                             "treasury_account_identifier__federal_account__federal_account_code"
                         )
                     )
-                    .annotate(bureau_info=ConcatAll(F("bureau_title"), Value(";"), F("bureau_slug")))
+                    .annotate(
+                        bureau_info=Case(
+                            When(
+                                federal_account_code__startswith="057",
+                                then=ConcatAll(Value("Air Force"), Value(";"), Value("air-force")),
+                            ),
+                            When(
+                                federal_account_code__startswith="021",
+                                then=ConcatAll(Value("Army"), Value(";"), Value("army")),
+                            ),
+                            When(
+                                federal_account_code__startswith="017",
+                                then=ConcatAll(Value("Navy, Marine Corps"), Value(";"), Value("navy-marine-corps")),
+                            ),
+                            When(
+                                federal_account_code__startswith="097",
+                                then=ConcatAll(Value("Defense-wide"), Value(";"), Value("defense-wide")),
+                            ),
+                            default=ConcatAll(F("bureau_title"), Value(";"), F("bureau_slug")),
+                        )
+                    )
                     .values("bureau_info")
                 )
             )


### PR DESCRIPTION
**Description:**
Groups bureau codes by division of the military/defense-wide spending instead of having individual bureau codes all under the DOD toptier code.
**Technical details:**
We also had to add checks for the federal account endpoint so that clicking through one of the grouped bureaus will still return the federal accounts for that branch of the military

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-8117](https://federal-spending-transparency.atlassian.net/browse/DEV-8117):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
