### PR TITLE
[DEV-8147] CFDA Autocomplete sorting

### DIFF
--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -132,7 +132,14 @@ class CFDAAutocompleteViewSet(BaseAutocompleteViewSet):
             popular_name_filter = queryset.filter(popular_name__icontains=search_text)
             queryset = title_filter | popular_name_filter
 
-        return Response({"results": list(queryset.values("program_number", "program_title", "popular_name")[:limit])})
+        return Response(
+            {
+                "results": sorted(
+                    list(queryset.values("program_number", "program_title", "popular_name")[:limit]),
+                    key=lambda x: x["program_number"],
+                )
+            }
+        )
 
 
 class NAICSAutocompleteViewSet(BaseAutocompleteViewSet):


### PR DESCRIPTION
**Description:**
Adds sorting to the CFDA autocomplete endpoint. While the endpoint has never actually had sorting, the previous limit of 10 results on the frontend made it appear that there was sorting, likely just due to the way that the results return from the database.

**Technical details:**
Sorts by program number

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [N/A] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-8147](https://federal-spending-transparency.atlassian.net/browse/DEV-8147):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
