### PR TITLE
[DEV-8300] Add Agency slug to Award Summary endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
+++ b/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
@@ -124,7 +124,8 @@ This endpoint returns a list of data that is associated with the award profile p
                     "toptier_agency": {
                         "name": "Department of Defense",
                         "code": "097",
-                        "abbreviation": "DOD"
+                        "abbreviation": "DOD",
+                        "slug": "department-of-defense"
                     },
                     "subtier_agency": {
                         "name": "Defense Logistics Agency",
@@ -139,7 +140,8 @@ This endpoint returns a list of data that is associated with the award profile p
                     "toptier_agency": {
                         "name": "Department of Defense",
                         "code": "097",
-                        "abbreviation": "DOD"
+                        "abbreviation": "DOD",
+                        "slug": "department-of-defense"
                     },
                     "subtier_agency": {
                         "name": "Defense Logistics Agency",
@@ -304,7 +306,8 @@ This endpoint returns a list of data that is associated with the award profile p
                     "toptier_agency": {
                         "name": "Department of Agriculture",
                         "code": "012",
-                        "abbreviation": "USDA"
+                        "abbreviation": "USDA",
+                        "slug": "department-of-agriculture"
                     },
                     "subtier_agency": {
                         "name": "Farm Service Agency",
@@ -319,7 +322,8 @@ This endpoint returns a list of data that is associated with the award profile p
                     "toptier_agency": {
                         "name": "Department of Agriculture",
                         "code": "012",
-                        "abbreviation": "USDA"
+                        "abbreviation": "USDA",
+                        "slug": "department-of-agriculture"
                     },
                     "subtier_agency": {
                         "name": "Farm Service Agency",
@@ -555,7 +559,8 @@ This endpoint returns a list of data that is associated with the award profile p
                     "toptier_agency": {
                         "name": "Department of Defense",
                         "code": "097",
-                        "abbreviation": "DOD"
+                        "abbreviation": "DOD",
+                        "slug": "department-of-defense"
                     },
                     "subtier_agency": {
                         "name": "Department of the Air Force",
@@ -570,7 +575,8 @@ This endpoint returns a list of data that is associated with the award profile p
                     "toptier_agency": {
                         "name": "Department of Defense",
                         "code": "097",
-                        "abbreviation": "DOD"
+                        "abbreviation": "DOD",
+                        "slug": "department-of-defense"
                     },
                     "subtier_agency": {
                         "name": "Department of the Air Force",
@@ -893,6 +899,7 @@ This endpoint returns a list of data that is associated with the award profile p
 + `name` (required, string, nullable)
 + `code` (required, string)
 + `abbreviation` (required, string, nullable)
++ `slug` (required, string, nullable)
 
 ## SubTierAgency (object)
 + `name` (required, string, nullable)

--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -929,6 +929,9 @@ def awards_and_transactions(db):
     mommy.make("awards.ParentAward", **parent_award_2)
     mommy.make("awards.ParentAward", **parent_award_3)
 
+    dsws1 = mommy.make("submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-01-01")
+    mommy.make("submissions.SubmissionAttributes", toptier_code="ABC", submission_window=dsws1)
+
 
 @pytest.fixture
 def update_awards(db):
@@ -1309,15 +1312,25 @@ expected_response_asst = {
     "transaction_obligated_amount": None,
     "awarding_agency": {
         "id": 1,
-        "has_agency_page": False,
-        "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
+        "has_agency_page": True,
+        "toptier_agency": {
+            "name": "TOPTIER AGENCY 1",
+            "abbreviation": "TA1",
+            "code": "ABC",
+            "slug": "toptier-agency-1",
+        },
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "awarding_office",
     },
     "funding_agency": {
         "id": 1,
-        "has_agency_page": False,
-        "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
+        "has_agency_page": True,
+        "toptier_agency": {
+            "name": "TOPTIER AGENCY 1",
+            "abbreviation": "TA1",
+            "code": "ABC",
+            "slug": "toptier-agency-1",
+        },
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "funding_office",
     },
@@ -1397,15 +1410,25 @@ expected_response_cont = {
     "description": "lorem ipsum",
     "awarding_agency": {
         "id": 1,
-        "has_agency_page": False,
-        "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
+        "has_agency_page": True,
+        "toptier_agency": {
+            "name": "TOPTIER AGENCY 1",
+            "abbreviation": "TA1",
+            "code": "ABC",
+            "slug": "toptier-agency-1",
+        },
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "awarding_office",
     },
     "funding_agency": {
         "id": 1,
-        "has_agency_page": False,
-        "toptier_agency": {"name": "TOPTIER AGENCY 1", "abbreviation": "TA1", "code": "ABC"},
+        "has_agency_page": True,
+        "toptier_agency": {
+            "name": "TOPTIER AGENCY 1",
+            "abbreviation": "TA1",
+            "code": "ABC",
+            "slug": "toptier-agency-1",
+        },
         "subtier_agency": {"name": "SUBTIER AGENCY 1", "abbreviation": "SA1", "code": "DEF"},
         "office_agency_name": "funding_office",
     },

--- a/usaspending_api/idvs/tests/test_awards_idv_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idv_v2.py
@@ -376,14 +376,14 @@ expected_response_idv = {
     "awarding_agency": {
         "id": 1,
         "has_agency_page": False,
-        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "abc"},
+        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "abc", "slug": None},
         "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "def"},
         "office_agency_name": "awarding_office",
     },
     "funding_agency": {
         "id": 1,
         "has_agency_page": False,
-        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "abc"},
+        "toptier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "abc", "slug": None},
         "subtier_agency": {"name": "agency name", "abbreviation": "some other stuff", "code": "def"},
         "office_agency_name": "funding_office",
     },


### PR DESCRIPTION
**Description:**
Need to add Agency slug to the Award summary endpoint to support linking from Award summary page to new Agency V2.

**Technical details:**
Add agency slug to both the Awarding and Funding agency sections for only the toptier agencies with a file C submission since those will be the agencies with an Agency profile page.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8300](https://federal-spending-transparency.atlassian.net/browse/DEV-8300):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
