### PR TITLE
[DEV-8269] Handle no action_date for a FY

### DIFF
--- a/usaspending_api/agency/tests/integration/test_awards.py
+++ b/usaspending_api/agency/tests/integration/test_awards.py
@@ -196,9 +196,25 @@ def test_alternate_agency(client, monkeypatch, transaction_search_1, elasticsear
 
 
 @pytest.mark.django_db
-def test_invalid_agency(client, monkeypatch, transaction_search_1, elasticsearch_account_index):
+def test_invalid_agency(client, monkeypatch, transaction_search_1, elasticsearch_transaction_index):
     resp = client.get(url.format(toptier_code="XXX", filter="?fiscal_year=2021"))
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
     resp = client.get(url.format(toptier_code="999", filter="?fiscal_year=2021"))
     assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_no_award_data_for_fy(client, transaction_search_1, elasticsearch_transaction_index):
+    resp = client.get(url.format(toptier_code="002", filter="?fiscal_year=2017"))
+    expected_result = {
+        "fiscal_year": 2017,
+        "latest_action_date": None,
+        "toptier_code": "002",
+        "transaction_count": 0,
+        "obligations": 0.0,
+        "messages": [],
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_result

--- a/usaspending_api/agency/v2/views/awards.py
+++ b/usaspending_api/agency/v2/views/awards.py
@@ -58,7 +58,9 @@ class Awards(AgencyBase):
         response = response.aggs.to_dict()
         latest_action_date_epoch = response.get("latest_action_date", {}).get("value")
         results = {
-            "latest_action_date": datetime.utcfromtimestamp(latest_action_date_epoch / 1000),
+            "latest_action_date": datetime.utcfromtimestamp(latest_action_date_epoch / 1000)
+            if latest_action_date_epoch is not None
+            else None,
             "obligations": round(response.get("total_obligation", {}).get("value", 0), 2),
         }
         return results


### PR DESCRIPTION
**Description:**
Need to handle the possibility of no action date for a FY. Came up in QAT when querying FY 2022.

**Technical details:**
Check for NULL `latest_action_date` before attempting to divide. Without this check the endpoint fails with a 500 since you cannot divide None.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8269](https://federal-spending-transparency.atlassian.net/browse/DEV-8269):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
