### PR TITLE
[DEV-8317] Limit to quarterly periods prior to FY22

### DIFF
--- a/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
@@ -31,7 +31,7 @@ def data_fixture():
         reporting_fiscal_period=3,
         submission_window=dabs,
         toptier_code=ta1.toptier_code,
-        is_final_balances_for_fy=True,
+        is_final_balances_for_fy=False,
     )
     sa1_6 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -39,7 +39,15 @@ def data_fixture():
         reporting_fiscal_period=6,
         submission_window=dabs,
         toptier_code=ta1.toptier_code,
-        is_final_balances_for_fy=True,
+        is_final_balances_for_fy=False,
+    )
+    sa1_7 = mommy.make(
+        "submissions.SubmissionAttributes",
+        reporting_fiscal_year=FY,
+        reporting_fiscal_period=7,
+        submission_window=dabs,
+        toptier_code=ta1.toptier_code,
+        is_final_balances_for_fy=False,
     )
     sa1_9 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -47,7 +55,7 @@ def data_fixture():
         reporting_fiscal_period=9,
         submission_window=dabs,
         toptier_code=ta1.toptier_code,
-        is_final_balances_for_fy=True,
+        is_final_balances_for_fy=False,
     )
     sa1_12 = mommy.make(
         "submissions.SubmissionAttributes",
@@ -80,6 +88,14 @@ def data_fixture():
         obligations_incurred_total_by_tas_cpe=8886,
         treasury_account_identifier=tas1,
         submission=sa1_6,
+    )
+
+    mommy.make(
+        "accounts.AppropriationAccountBalances",
+        total_budgetary_resources_amount_cpe=9997,
+        obligations_incurred_total_by_tas_cpe=8887,
+        treasury_account_identifier=tas1,
+        submission=sa1_7,
     )
 
     mommy.make(
@@ -147,9 +163,9 @@ def test_budgetary_resources(client, data_fixture):
     expected_results = [
         {
             "fiscal_year": FY,
-            "agency_budgetary_resources": Decimal("29992.00"),
+            "agency_budgetary_resources": Decimal("4.00"),
             "total_budgetary_resources": Decimal(f"{FY}.00"),
-            "agency_total_obligated": Decimal("26661.00"),
+            "agency_total_obligated": Decimal("3.00"),
             "agency_obligation_by_period": [
                 {"obligated": Decimal("8883.00"), "period": 3},
                 {"obligated": Decimal("8886.00"), "period": 6},

--- a/usaspending_api/agency/v2/views/budgetary_resources.py
+++ b/usaspending_api/agency/v2/views/budgetary_resources.py
@@ -56,21 +56,28 @@ class BudgetaryResources(AgencyBase):
             )
         )
 
-        for abb in results:
-            if periods.get(abb["fiscal_year"]) is not None:
-                periods[abb["fiscal_year"]].append(
+        for aab in results:
+            # This "continue" logic is in place to prevent the case where multiple agencies have submitted a mixture of
+            # quarterly and monthly with a single agency listed as the funding agency. In this case the total
+            # obligations are not displayed correctly on the monthly submissions that do not line up with a
+            # corresponding quarterly submission.
+            # TODO: Update with logic that takes into account the time period before required monthly submissions
+            if aab["fiscal_year"] < 2022 and aab["submission__reporting_fiscal_period"] not in (3, 6, 9, 12):
+                continue
+            if periods.get(aab["fiscal_year"]) is not None:
+                periods[aab["fiscal_year"]].append(
                     {
-                        "period": abb["submission__reporting_fiscal_period"],
-                        "obligated": abb["sum"],
+                        "period": aab["submission__reporting_fiscal_period"],
+                        "obligated": aab["sum"],
                     }
                 )
             else:
                 periods.update(
                     {
-                        abb["fiscal_year"]: [
+                        aab["fiscal_year"]: [
                             {
-                                "period": abb["submission__reporting_fiscal_period"],
-                                "obligated": abb["sum"],
+                                "period": aab["submission__reporting_fiscal_period"],
+                                "obligated": aab["sum"],
                             }
                         ]
                     }


### PR DESCRIPTION
**Description:**
Limit `/api/v2/agency/<toptier_code>/budgetary_resources/` endpoint to only quarterly periods prior to FY 22.

**Technical details:**
It was noticed during testing that there are some cases (such as for DoD) where multiple agencies had submissions under the same funding agency. Prior to FY 22 monthly submissions were not required and you had some agencies submitting monthly and others quarterly. In some rare cases part of the agencies submitted under a funding agency might submit monthly while others have not made the switch yet. In those cases values such obligations drop drastically since they are a sum of `_cpe` values for that particular submission period. Ideally this logic will not be permanent, but will prevent odd looking data until we can get a more permanent fix out.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8317](https://federal-spending-transparency.atlassian.net/browse/DEV-8317):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
