### PR TITLE
[DEV-8318] Use correct aggregation name

### DIFF
--- a/usaspending_api/agency/v2/views/sub_agency.py
+++ b/usaspending_api/agency/v2/views/sub_agency.py
@@ -168,5 +168,5 @@ class SubAgencyList(PaginationMixin, AgencyBase):
         search.update_from_dict({"size": 0})
         response = search.handle_execute()
         resp_as_dict = response.aggs.to_dict()
-        max_office_count = resp_as_dict.get("max_office_count", {}).get("value", 10)
+        max_office_count = resp_as_dict.get("max_office_count_agg", {}).get("value", 10)
         return {"office_size": max_office_count, "subtier_agency_size": max_subtier_agencies}


### PR DESCRIPTION
**Description:**
Use the correct aggregation name.

**Technical details:**
Previously the default value of 10 was being used incorrectly due to the wrong aggregation name referenced. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8318](https://federal-spending-transparency.atlassian.net/browse/DEV-8318):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
