### PR TITLE
[DEV-8330] Handle case of no offices for filters

### DIFF
--- a/usaspending_api/agency/tests/fixtures/sub_agency_data.py
+++ b/usaspending_api/agency/tests/fixtures/sub_agency_data.py
@@ -21,10 +21,12 @@ def sub_agency_data_1():
     )
     mommy.make("submissions.SubmissionAttributes", toptier_code="001", submission_window=dsws)
     mommy.make("submissions.SubmissionAttributes", toptier_code="002", submission_window=dsws)
+    mommy.make("submissions.SubmissionAttributes", toptier_code="003", submission_window=dsws)
 
     # Toptier and Awarding Agency
     toptier_agency_1 = mommy.make("references.ToptierAgency", toptier_code="001", name="Agency 1")
     toptier_agency_2 = mommy.make("references.ToptierAgency", toptier_code="002", name="Agency 2")
+    toptier_agency_3 = mommy.make("references.ToptierAgency", toptier_code="003", name="Agency 3")
     subtier_agency_1 = mommy.make(
         "references.SubtierAgency",
         subtier_code="0001",
@@ -34,11 +36,17 @@ def sub_agency_data_1():
     subtier_agency_2 = mommy.make(
         "references.SubtierAgency", subtier_code="0002", name="Sub-Agency 2", abbreviation="A2"
     )
+    subtier_agency_3 = mommy.make(
+        "references.SubtierAgency", subtier_code="0003", name="Sub-Agency 3", abbreviation="A3"
+    )
     awarding_agency_1 = mommy.make(
         "references.Agency", toptier_agency=toptier_agency_1, subtier_agency=subtier_agency_1, toptier_flag=True
     )
     awarding_agency_2 = mommy.make(
         "references.Agency", toptier_agency=toptier_agency_2, subtier_agency=subtier_agency_2, toptier_flag=True
+    )
+    awarding_agency_3 = mommy.make(
+        "references.Agency", toptier_agency=toptier_agency_3, subtier_agency=subtier_agency_3, toptier_flag=True
     )
     mommy.make("references.Office", office_code="0001", office_name="Office 1")
     mommy.make("references.Office", office_code="0002", office_name="Office 2")
@@ -87,6 +95,25 @@ def sub_agency_data_1():
         awarding_office_code="0001",
         funding_office_name="Office 2",
         funding_office_code="0002",
+    )
+
+    no_office_transaction = mommy.make(
+        TransactionNormalized,
+        award=award_contract,
+        federal_action_obligation=110,
+        action_date="2021-04-01",
+        awarding_agency=awarding_agency_3,
+        funding_agency=awarding_agency_3,
+        is_fpds=True,
+        type="B",
+    )
+    mommy.make(
+        TransactionFPDS,
+        transaction=no_office_transaction,
+        awarding_office_name=None,
+        awarding_office_code=None,
+        funding_office_name=None,
+        funding_office_code=None,
     )
 
     idv_transaction = mommy.make(

--- a/usaspending_api/agency/tests/integration/test_sub_agency.py
+++ b/usaspending_api/agency/tests/integration/test_sub_agency.py
@@ -154,6 +154,26 @@ def test_agency_types(client, monkeypatch, sub_agency_data_1, elasticsearch_tran
 
 
 @pytest.mark.django_db
+def test_agency_without_office(client, monkeypatch, sub_agency_data_1, elasticsearch_transaction_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
+    resp = client.get(url.format(toptier_code="003", filter="?fiscal_year=2021&award_type_codes=[B]"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    expected_results = [
+        {
+            "name": "Sub-Agency 3",
+            "abbreviation": "A3",
+            "total_obligations": 110.0,
+            "transaction_count": 1,
+            "new_award_count": 1,
+            "children": [],
+        }
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+
+@pytest.mark.django_db
 def test_invalid_agency(client, monkeypatch, sub_agency_data_1, elasticsearch_account_index):
     resp = client.get(url.format(toptier_code="XXX", filter="?fiscal_year=2021"))
     assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/usaspending_api/agency/v2/views/sub_agency.py
+++ b/usaspending_api/agency/v2/views/sub_agency.py
@@ -156,7 +156,7 @@ class SubAgencyList(PaginationMixin, AgencyBase):
         ).count()
 
         unique_subtier_agg = A(
-            "terms", field=f"{self.agency_type}_subtier_agency_name.keyword", size=max_subtier_agencies + 100
+            "terms", field=f"{self.agency_type}_subtier_agency_name.keyword", size=max_subtier_agencies
         )
         unique_office_count_agg = A("cardinality", field=f"{self.agency_type}_office_code.keyword")
         max_office_count_agg = A("max_bucket", buckets_path="unique_subtier_agg>unique_office_count_agg")
@@ -168,5 +168,7 @@ class SubAgencyList(PaginationMixin, AgencyBase):
         search.update_from_dict({"size": 0})
         response = search.handle_execute()
         resp_as_dict = response.aggs.to_dict()
-        max_office_count = resp_as_dict.get("max_office_count_agg", {}).get("value", 10)
-        return {"office_size": max_office_count, "subtier_agency_size": max_subtier_agencies}
+        max_office_count = resp_as_dict.get("max_office_count_agg", {}).get("value")
+
+        # Default to Terms aggregation default of 10 to avoid parse error with size of 0
+        return {"office_size": max_office_count or 10, "subtier_agency_size": max_subtier_agencies or 10}


### PR DESCRIPTION
**Description:**
Handle case of no offices for provided filters.

**Technical details:**
No office came up if the Agency does not have any transactions for a particular type. In that case a `"size": None` was passed to Elasticsearch and resulted in a parser error. A new default size of 10 is used as passing 0 could also force a parser error if there was a case where a subagency existed on a transaction without an office.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8330](https://federal-spending-transparency.atlassian.net/browse/DEV-8330):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
