### PR TITLE
[WARMFIX] Fix "other" award category grouping

### DIFF
--- a/usaspending_api/agency/v2/views/obligations_by_award_category.py
+++ b/usaspending_api/agency/v2/views/obligations_by_award_category.py
@@ -69,8 +69,8 @@ class ObligationsByAwardCategory(AgencyBase):
                 results_map[key] = round(obligation_value, 2)
             else:
                 other_total += obligation_value
+        results_map["other"] += round(other_total)
 
-        results_map["other"] = round(other_total)
 
         # Convert Map back to list with extra categories
         for category, category_mapping in category_map.items():

--- a/usaspending_api/agency/v2/views/obligations_by_award_category.py
+++ b/usaspending_api/agency/v2/views/obligations_by_award_category.py
@@ -69,10 +69,13 @@ class ObligationsByAwardCategory(AgencyBase):
                 results_map[key] = round(obligation_value, 2)
             else:
                 other_total += obligation_value
-        results_map["other"] += round(other_total)
 
+        if results_map["other"] is not None:
+            results_map["other"] += round(other_total)
+        else:
+            results_map["other"] = round(other_total)
 
-        # Convert Map back to list with extra categories
+            # Convert Map back to list with extra categories
         for category, category_mapping in category_map.items():
             if category in results_map:
                 formatted_categories.append(self.format_category(category_mapping, results_map[category]))

--- a/usaspending_api/agency/v2/views/obligations_by_award_category.py
+++ b/usaspending_api/agency/v2/views/obligations_by_award_category.py
@@ -70,12 +70,12 @@ class ObligationsByAwardCategory(AgencyBase):
             else:
                 other_total += obligation_value
 
-        if results_map["other"] is not None:
+        if results_map.get("other") is not None:
             results_map["other"] += round(other_total)
         else:
             results_map["other"] = round(other_total)
 
-            # Convert Map back to list with extra categories
+        # Convert Map back to list with extra categories
         for category, category_mapping in category_map.items():
             if category in results_map:
                 formatted_categories.append(self.format_category(category_mapping, results_map[category]))


### PR DESCRIPTION
**Description:**
In the `obligations_by_award_category` endpoint, the "other" category both accounts for the defined award category "other" as well as anything that doesn't match one of the existing award categories. The endpoint was overriding the defined "other" category amount with the sum of non-matching categories, resulting in the "other" category to be 0 when it should not be.

**Technical details:**
Switched a `=` to a `+=` sign when formatting the "other" results. 

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [N/A] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
