### PR TITLE
[DEV-8341] Remove prior year values from calculations

### DIFF
--- a/usaspending_api/agency/v2/views/bureau_federal_account.py
+++ b/usaspending_api/agency/v2/views/bureau_federal_account.py
@@ -81,24 +81,15 @@ class BureauFederalAccountList(PaginationMixin, AgencyBase):
         ]
         last_period_results = (
             GTASSF133Balances.objects.filter(*filters)
-            .filter(*filters)
             .annotate(
                 name=F("treasury_account_identifier__federal_account__account_title"),
                 account_code=F("treasury_account_identifier__federal_account__federal_account_code"),
             )
             .values("name", "account_code")
             .annotate(
-                amount=Sum("total_budgetary_resources_cpe"),
-                unobligated_balance=Sum("budget_authority_unobligated_balance_brought_forward_cpe"),
-                deobligation=Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe"),
-                prior_year=Sum("prior_year_paid_obligation_recoveries"),
-            )
-            .annotate(
-                total_budgetary_resources=F("amount") - F("unobligated_balance") - F("deobligation") - F("prior_year"),
-                total_obligations=Sum("obligations_incurred_total_cpe")
-                - Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe"),
-                total_outlays=Sum("gross_outlay_amount_by_tas_cpe")
-                - Sum("anticipated_prior_year_obligation_recoveries"),
+                total_budgetary_resources=Sum("total_budgetary_resources_cpe"),
+                total_obligations=Sum("obligations_incurred_total_cpe"),
+                total_outlays=Sum("gross_outlay_amount_by_tas_cpe"),
             )
             .values("name", "account_code", "total_obligations", "total_outlays", "total_budgetary_resources")
         )

--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -96,17 +96,9 @@ class SubcomponentList(PaginationMixin, AgencyBase):
             )
             .values("bureau_info")
             .annotate(
-                amount=Sum("total_budgetary_resources_cpe"),
-                unobligated_balance=Sum("budget_authority_unobligated_balance_brought_forward_cpe"),
-                deobligation=Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe"),
-                prior_year=Sum("prior_year_paid_obligation_recoveries"),
-            )
-            .annotate(
-                total_budgetary_resources=F("amount") - F("unobligated_balance") - F("deobligation") - F("prior_year"),
-                total_obligations=Sum("obligations_incurred_total_cpe")
-                - Sum("deobligations_or_recoveries_or_refunds_from_prior_year_cpe"),
-                total_outlays=Sum("gross_outlay_amount_by_tas_cpe")
-                - Sum("anticipated_prior_year_obligation_recoveries"),
+                total_budgetary_resources=Sum("total_budgetary_resources_cpe"),
+                total_obligations=Sum("obligations_incurred_total_cpe"),
+                total_outlays=Sum("gross_outlay_amount_by_tas_cpe"),
             )
             .values("bureau_info", "total_obligations", "total_outlays", "total_budgetary_resources")
         )


### PR DESCRIPTION
**Description:**
Remove prior year values in TBR, Obligation, and Outlay calculations

**Technical details:**
During implementation we used prior year values to calculate TBR, Obligation, and Outlay. This was found to be incorrect for the purpose of Agency V2 as we are looking at a slice of a single FY instead of sums across many FY similar to what was done on the COVID profile page.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-8341](https://federal-spending-transparency.atlassian.net/browse/DEV-8341):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
