### PR TITLE
Fix recipient sql GROUP BY

### DIFF
--- a/usaspending_api/recipient/management/sql/recipient_agency.sql
+++ b/usaspending_api/recipient/management/sql/recipient_agency.sql
@@ -10,27 +10,28 @@ INSERT INTO public.recipient_agency (
 )
 SELECT *
 FROM (
-	SELECT
-		fiscal_year, toptier_code, COALESCE(recipient_lookup.recipient_hash, MD5(UPPER(
+    SELECT
+        fiscal_year, toptier_code, COALESCE(recipient_lookup.recipient_hash, MD5(UPPER(
         CASE
           WHEN COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu) IS NOT NULL THEN CONCAT('duns-', COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu))
           WHEN COALESCE(transaction_fpds.awardee_or_recipient_uei, transaction_fabs.uei) IS NOT NULL THEN CONCAT('uei-', COALESCE(transaction_fpds.awardee_or_recipient_uei, transaction_fabs.uei))
           ELSE CONCAT('name-', COALESCE(transaction_fpds.awardee_or_recipient_legal, transaction_fabs.awardee_or_recipient_legal)) END
       ))::uuid) AS recipient_hash, recipient_lookup.legal_business_name as recipient_name,
       SUM(COALESCE(CASE WHEN transaction_normalized.type IN('07','08') THEN transaction_normalized.original_loan_subsidy_cost ELSE transaction_normalized.federal_action_obligation END, 0)) AS recipient_amount
-	FROM transaction_normalized
-		LEFT JOIN agency ON awarding_agency_id = agency.id
-		LEFT JOIN toptier_agency ta ON ta.toptier_agency_id = agency.toptier_agency_id
-		LEFT JOIN transaction_fabs ON (transaction_normalized.id = transaction_fabs.transaction_id AND transaction_normalized.is_fpds = false)
-		LEFT JOIN transaction_fpds ON (transaction_normalized.id = transaction_fpds.transaction_id AND transaction_normalized.is_fpds = true)
-		LEFT JOIN recipient_lookup ON recipient_lookup.duns = COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu) AND COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu) IS NOT NULL
+    FROM transaction_normalized
+        LEFT JOIN agency ON awarding_agency_id = agency.id
+        LEFT JOIN toptier_agency ta ON ta.toptier_agency_id = agency.toptier_agency_id
+        LEFT JOIN transaction_fabs ON (transaction_normalized.id = transaction_fabs.transaction_id AND transaction_normalized.is_fpds = false)
+        LEFT JOIN transaction_fpds ON (transaction_normalized.id = transaction_fpds.transaction_id AND transaction_normalized.is_fpds = true)
+        LEFT JOIN recipient_lookup ON recipient_lookup.duns = COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu) AND COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu) IS NOT NULL
 
-	WHERE fiscal_year >= 2017 and toptier_code is not NULL
+    WHERE fiscal_year >= 2017 and toptier_code is not NULL
 
-	GROUP BY toptier_code,  recipient_lookup.legal_business_name, COALESCE(recipient_lookup.recipient_hash, MD5(UPPER(
+    GROUP BY toptier_code,  recipient_lookup.legal_business_name, COALESCE(recipient_lookup.recipient_hash, MD5(UPPER(
         CASE
           WHEN COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu) IS NOT NULL THEN CONCAT('duns-', COALESCE(transaction_fpds.awardee_or_recipient_uniqu, transaction_fabs.awardee_or_recipient_uniqu))
+          WHEN COALESCE(transaction_fpds.awardee_or_recipient_uei, transaction_fabs.uei) IS NOT NULL THEN CONCAT('uei-', COALESCE(transaction_fpds.awardee_or_recipient_uei, transaction_fabs.uei))
           ELSE CONCAT('name-', COALESCE(transaction_fpds.awardee_or_recipient_legal, transaction_fabs.awardee_or_recipient_legal)) END
       ))::uuid), fiscal_year
-	HAVING SUM(COALESCE(CASE WHEN transaction_normalized.type IN('07','08') THEN transaction_normalized.original_loan_subsidy_cost ELSE transaction_normalized.federal_action_obligation END, 0)) > 0) as recipient_agency_content;
+    HAVING SUM(COALESCE(CASE WHEN transaction_normalized.type IN('07','08') THEN transaction_normalized.original_loan_subsidy_cost ELSE transaction_normalized.federal_action_obligation END, 0)) > 0) as recipient_agency_content;
 


### PR DESCRIPTION
**Description:**
Adding the UEI CASE to the GROUP BY was overlooked and caused the pipeline to fail.

**Technical details:**
UEI is now part of the recipient_hash logic. That same logic needed to get added into the GROUP BY.

Additional changes were changing tabs for spaces.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket N/A

**Area for explaining above N/A when needed:**
```
```
