### PR TITLE
[DEV-8372] Add Agency Slug to IDV and Contract Award Summary Endpoints

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
+++ b/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
@@ -38,6 +38,7 @@ This endpoint returns a list of data that is associated with the award profile p
                 "parent_award": {
                     "agency_id": 1173,
                     "agency_name": "Department of Defense",
+                    "agency_slug": "department-of-defense",
                     "sub_agency_id": "9700",
                     "sub_agency_name": "Department of Defense",
                     "award_id": 69513842,
@@ -886,6 +887,8 @@ This endpoint returns a list of data that is associated with the award profile p
 ## ParentDetails (object)
 + `agency_id` (required, number)
 + `agency_name` (required, string)
++ `agency_slug` (required, string, nullable)
+    `agency_slug` is a string used to generate a link to the agency profile page. Will be `NULL` if the agency does not have a profile page.
 + `sub_agency_id` (required, string)
 + `sub_agency_name` (required, string)
 + `award_id` (required, number, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/idvs/activity.md
+++ b/usaspending_api/api_contracts/contracts/v2/idvs/activity.md
@@ -46,6 +46,7 @@ List child and grandchild awards for a given IDV
                         "award_id": 1867804,
                         "awarding_agency": "Department of Veterans Affairs",
                         "awarding_agency_id": 561,
+                        "awarding_agency_slug": "department-of-veterans-affairs,
                         "generated_unique_award_id": "CONT_AWD_00509200110C509C25044V509P6176_3600_V509P6176_3600",
                         "period_of_performance_potential_end_date": "2003-09-15 00:00:00",
                         "parent_award_id": 69001298,
@@ -63,6 +64,7 @@ List child and grandchild awards for a given IDV
                         "award_id": 1867504,
                         "awarding_agency": "Department of Veterans Affairs",
                         "awarding_agency_id": 561,
+                        "awarding_agency_slug": "department-of-veterans-affairs,
                         "generated_unique_award_id": "CONT_AWD_00509200010C509C15099V509P6176_3600_V509P6176_3600",
                         "period_of_performance_potential_end_date": "2003-09-15 00:00:00",
                         "parent_award_id": 69001298,
@@ -80,6 +82,7 @@ List child and grandchild awards for a given IDV
                         "award_id": 1867181,
                         "awarding_agency": "Department of Veterans Affairs",
                         "awarding_agency_id": 561,
+                        "awarding_agency_slug": "department-of-veterans-affairs,
                         "generated_unique_award_id": "CONT_AWD_00509199910C509C05018V509P6176_3600_V509P6176_3600",
                         "period_of_performance_potential_end_date": "2003-09-15 00:00:00",
                         "parent_award_id": 69001298,
@@ -125,6 +128,8 @@ List child and grandchild awards for a given IDV
     Unique internal natural identifier for an award.
 + `awarding_agency` (required, string)
 + `awarding_agency_id` (required, number)
++ `awarding_agency_slug` (required, string, nullable)
+    `agency_slug` is a string used to generate a link to the agency profile page. Will be `NULL` if the agency does not have a profile page.
 + `period_of_performance_potential_end_date` (required, string, nullable)
 + `parent_award_id` (required, number, nullable)
     Internal, surrogate id for the award's parent.  Deprecated.  Use `parent_generated_unique_award_id`.

--- a/usaspending_api/api_contracts/contracts/v2/idvs/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/idvs/awards.md
@@ -133,6 +133,10 @@ List child IDVs, child awards, or grandchild awards for IDV
 + `awarding_agency`: `GENERAL SERVICES ADMINISTRATION (GSA)` (required, string, nullable)
 + `funding_agency_id`: 634 (required, number, nullable)
 + `awarding_agency_id`: 634 (required, number, nullable)
++ `funding_agency_slug`: `general-services-administration-gsa` (required, string, nullable)
+    `funding_agency_slug` is a string used to generate a link to the funding agency's profile page. Will be `NULL` if the funding agency does not have a profile page.
++ `awarding_agency_slug`: `general-services-administration-gsa` (required, string, nullable)
+    `awarding_agency_slug` is a string used to generate a link to the awarding agency's profile page. Will be `NULL` if the awarding agency does not have a profile page.
 + `generated_unique_award_id`: `CONT_IDV_DJB30605051_1540` (required, string)
     Unique internal natural identifier for an award.
 + `last_date_to_order`: `2017-09-30` (required, string, nullable)

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -356,10 +356,16 @@ def _fetch_parent_award_details(parent_award_ids: dict) -> Optional[OrderedDict]
         else None
     )
 
+    agency_id = parent_agency["id"] if parent_agency else None
+    agency_name = parent_agency["toptier_agency__name"] if parent_agency else None
+
+    has_agency_page = agency_has_file_c_submission(agency_id)
+
     parent_object = OrderedDict(
         [
-            ("agency_id", parent_agency["id"] if parent_agency else None),
-            ("agency_name", parent_agency["toptier_agency__name"] if parent_agency else None),
+            ("agency_id", agency_id),
+            ("agency_name", agency_name),
+            ("agency_slug", slugify(agency_name) if has_agency_page else None),
             ("sub_agency_id", parent_award["latest_transaction__contract_data__agency_id"]),
             ("sub_agency_name", parent_sub_agency["name"] if parent_sub_agency else None),
             ("award_id", parent_award_award_id),

--- a/usaspending_api/idvs/tests/data/idv_test_data.py
+++ b/usaspending_api/idvs/tests/data/idv_test_data.py
@@ -181,9 +181,18 @@ def create_idv_test_data():
             recipient_unique_id="duns_%s" % (7000 + award_id),
         )
 
-        mommy.make("submissions.SubmissionAttributes", submission_window=dsws, toptier_code=str(award_id).zfill(3))
+        # reporting_fiscal_year is used to delete in an Agency Slug test
         mommy.make(
-            "submissions.SubmissionAttributes", submission_window=dsws, toptier_code=str(100 + award_id).zfill(3)
+            "submissions.SubmissionAttributes",
+            reporting_fiscal_year=2008,
+            submission_window=dsws,
+            toptier_code=awarding_toptier_agency.toptier_code,
+        )
+        mommy.make(
+            "submissions.SubmissionAttributes",
+            reporting_fiscal_year=2008,
+            submission_window=dsws,
+            toptier_code=funding_toptier_agency.toptier_code,
         )
 
     # We'll need some parent_awards.  We "hard code" values here rather than

--- a/usaspending_api/idvs/tests/test_awards_idvs_activity_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_activity_v2.py
@@ -1,8 +1,10 @@
 import json
 
 from django.test import TestCase
+from django.utils.text import slugify
 from rest_framework import status
 from usaspending_api.idvs.tests.data.idv_test_data import create_idv_test_data, PARENTS, RECIPIENT_HASH_PREFIX
+from usaspending_api.submissions.models.submission_attributes import SubmissionAttributes
 
 
 ENDPOINT = "/api/v2/idvs/activity/"
@@ -14,7 +16,7 @@ class IDVAwardsTestCase(TestCase):
         create_idv_test_data()
 
     @staticmethod
-    def _generate_expected_response(total, limit, page, *award_ids):
+    def _generate_expected_response(total, limit, page, no_submissions, *award_ids):
         """
         Rather than manually generate an insane number of potential responses
         to test the various parameter combinations, we're going to procedurally
@@ -28,11 +30,14 @@ class IDVAwardsTestCase(TestCase):
             string_award_id = str(award_id).zfill(3)
             parent_award_id = PARENTS.get(award_id)
             string_parent_award_id = str(parent_award_id).zfill(3)
+            awarding_agency_name = "Toptier Awarding Agency Name %s" % (8500 + award_id)
+            agency_slug = slugify(awarding_agency_name) if not no_submissions else None
             results.append(
                 {
                     "award_id": award_id,
-                    "awarding_agency": "Toptier Awarding Agency Name %s" % (8500 + award_id),
+                    "awarding_agency": awarding_agency_name,
                     "awarding_agency_id": 8000 + award_id,
+                    "awarding_agency_slug": agency_slug,
                     "generated_unique_award_id": "CONT_IDV_%s" % string_award_id,
                     "period_of_performance_potential_end_date": "2018-08-%02d" % award_id,
                     "parent_award_id": parent_award_id,
@@ -81,25 +86,27 @@ class IDVAwardsTestCase(TestCase):
 
     def test_defaults(self):
 
-        self._test_post({"award_id": 2}, (400002, 10, 1, 14, 13, 12, 11, 10, 9))
+        print(f"Submission attribute count: {SubmissionAttributes.objects.count()}")
 
-        self._test_post({"award_id": "CONT_IDV_002"}, (400002, 10, 1, 14, 13, 12, 11, 10, 9))
+        self._test_post({"award_id": 2}, (400002, 10, 1, False, 14, 13, 12, 11, 10, 9))
+
+        self._test_post({"award_id": "CONT_IDV_002"}, (400002, 10, 1, False, 14, 13, 12, 11, 10, 9))
 
     def test_with_nonexistent_id(self):
 
-        self._test_post({"award_id": 0}, (0, 10, 1))
+        self._test_post({"award_id": 0}, (0, 10, 1, False))
 
-        self._test_post({"award_id": "CONT_IDV_000"}, (0, 10, 1))
+        self._test_post({"award_id": "CONT_IDV_000"}, (0, 10, 1, False))
 
     def test_with_bogus_id(self):
 
-        self._test_post({"award_id": "BOGUS_ID"}, (0, 10, 1))
+        self._test_post({"award_id": "BOGUS_ID"}, (0, 10, 1, False))
 
     def test_limit_values(self):
 
-        self._test_post({"award_id": 2, "limit": 1}, (400002, 1, 1, 14))
+        self._test_post({"award_id": 2, "limit": 1}, (400002, 1, 1, False, 14))
 
-        self._test_post({"award_id": 2, "limit": 5}, (400002, 5, 1, 14, 13, 12, 11, 10))
+        self._test_post({"award_id": 2, "limit": 5}, (400002, 5, 1, False, 14, 13, 12, 11, 10))
 
         self._test_post({"award_id": 2, "limit": 0}, expected_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
@@ -109,11 +116,11 @@ class IDVAwardsTestCase(TestCase):
 
     def test_page_values(self):
 
-        self._test_post({"award_id": 2, "limit": 1, "page": 2}, (400002, 1, 2, 13))
+        self._test_post({"award_id": 2, "limit": 1, "page": 2}, (400002, 1, 2, False, 13))
 
-        self._test_post({"award_id": 2, "limit": 1, "page": 3}, (400002, 1, 3, 12))
+        self._test_post({"award_id": 2, "limit": 1, "page": 3}, (400002, 1, 3, False, 12))
 
-        self._test_post({"award_id": 2, "limit": 1, "page": 10}, (400002, 1, 10))
+        self._test_post({"award_id": 2, "limit": 1, "page": 10}, (400002, 1, 10, False))
 
         self._test_post(
             {"award_id": 2, "limit": 1, "page": 0}, expected_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -124,8 +131,14 @@ class IDVAwardsTestCase(TestCase):
         )
 
     def test_hide_edges(self):
-        self._test_post({"award_id": 2, "limit": 1, "hide_edge_cases": True}, (6, 1, 1, 14))
-        self._test_post({"award_id": 2, "limit": 1, "hide_edge_cases": False}, (400002, 1, 1, 14))
-        self._test_post({"award_id": "CONT_IDV_002", "hide_edge_cases": True}, (6, 10, 1, 14, 13, 12, 11, 10, 9))
+        self._test_post({"award_id": 2, "limit": 1, "hide_edge_cases": True}, (6, 1, 1, False, 14))
+        self._test_post({"award_id": 2, "limit": 1, "hide_edge_cases": False}, (400002, 1, 1, False, 14))
+        self._test_post({"award_id": "CONT_IDV_002", "hide_edge_cases": True}, (6, 10, 1, False, 14, 13, 12, 11, 10, 9))
 
-        self._test_post({"award_id": "CONT_IDV_002", "hide_edge_cases": False}, (400002, 10, 1, 14, 13, 12, 11, 10, 9))
+        self._test_post(
+            {"award_id": "CONT_IDV_002", "hide_edge_cases": False}, (400002, 10, 1, False, 14, 13, 12, 11, 10, 9)
+        )
+
+    def test_no_submission(self):
+        SubmissionAttributes.objects.filter(reporting_fiscal_year=2008).delete()
+        self._test_post({"award_id": 2}, (400002, 10, 1, True, 14, 13, 12, 11, 10, 9))

--- a/usaspending_api/idvs/v2/views/awards.py
+++ b/usaspending_api/idvs/v2/views/awards.py
@@ -12,6 +12,7 @@ from usaspending_api.common.helpers.sql_helpers import execute_sql_to_ordered_di
 from usaspending_api.common.validator.award import get_internal_or_generated_award_id_model
 from usaspending_api.common.validator.pagination import customize_pagination_with_sort_columns
 from usaspending_api.common.validator.tinyshield import TinyShield
+from usaspending_api.references.helpers import generate_agency_slugs_for_agency_list
 
 
 # Columns upon which the client is allowed to sort.
@@ -44,7 +45,9 @@ GET_CHILD_IDVS_SQL = SQL(
         ac.type_description                        award_type,
         ac.description,
         tta.name                                   funding_agency,
+        tta.toptier_agency_id                      funding_toptier_agency_id,
         ttb.name                                   awarding_agency,
+        ttb.toptier_agency_id                      awarding_toptier_agency_id,
         ac.funding_agency_id,
         ac.awarding_agency_id,
         ac.generated_unique_award_id,
@@ -78,7 +81,9 @@ GET_CHILD_AWARDS_SQL = SQL(
         ac.type_description                        award_type,
         ac.description,
         tta.name                                   funding_agency,
+        tta.toptier_agency_id                      funding_toptier_agency_id,
         ttb.name                                   awarding_agency,
+        ttb.toptier_agency_id                      awarding_toptier_agency_id,
         ac.funding_agency_id,
         ac.awarding_agency_id,
         ac.generated_unique_award_id,
@@ -113,7 +118,9 @@ GET_GRANDCHILD_AWARDS_SQL = SQL(
         ac.type_description                        award_type,
         ac.description,
         tta.name                                   funding_agency,
+        tta.toptier_agency_id                      funding_toptier_agency_id,
         ttb.name                                   awarding_agency,
+        ttb.toptier_agency_id                      awarding_toptier_agency_id,
         ac.funding_agency_id,
         ac.awarding_agency_id,
         ac.generated_unique_award_id,
@@ -199,8 +206,26 @@ class IDVAwardsViewSet(APIView):
             limit=Literal(request_data["limit"] + 1),
             offset=Literal((request_data["page"] - 1) * request_data["limit"]),
         )
+        results = execute_sql_to_ordered_dictionary(sql)
 
-        return execute_sql_to_ordered_dictionary(sql)
+        funding_agency_slugs = generate_agency_slugs_for_agency_list(
+            [res["funding_toptier_agency_id"] for res in results]
+        )
+
+        awarding_agency_slugs = generate_agency_slugs_for_agency_list(
+            [res["awarding_toptier_agency_id"] for res in results]
+        )
+
+        for res in results:
+            # Set Agency Slugs
+            res["funding_agency_slug"] = funding_agency_slugs.get(res.get("funding_toptier_agency_id"))
+            res["awarding_agency_slug"] = awarding_agency_slugs.get(res.get("awarding_toptier_agency_id"))
+
+            # Remove extra fields
+            del res["funding_toptier_agency_id"]
+            del res["awarding_toptier_agency_id"]
+
+        return results
 
     @cache_response()
     def post(self, request: Request) -> Response:


### PR DESCRIPTION
**Description:**
This adds agency slugs to three endpoints:
- `/v2/idvs/activity` - Adds `funding_agency_slug` and `awarding_agency_slug`
- `/v2/idvs/awards` - Adds `awarding_agency_slug`
- `/v2/awards/{award_id}` - Adds `agency_slug` to parent award details

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8372](https://federal-spending-transparency.atlassian.net/browse/DEV-8372):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
