### PR TITLE
TEMP: Seeing if the failing travis builds are fixed by declaring elasticsearch as a service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 
 services:
   - postgresql
+  # NOTE: This is added, but re-installed at a different version below
   - elasticsearch
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
   - sudo systemctl start elasticsearch
-  - sudo journalctl -u service-name.service -b
+  - sudo journalctl -u elasticsearch -b
   - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
   # Add dredd for API contract testing
   - travis_retry npm install --global dredd@13.1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,18 @@ before_install:
   - sudo systemctl stop elasticsearch
   - sudo dpkg --remove elasticsearch
   - sudo dpkg --purge elasticsearch
+  - sudo rm -rf /var/lib/elasticsearch
   - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
   - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
   - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
-  - sudo sed -i.old 's/-Xmx1g/-Xmx512m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
   - sudo systemctl start elasticsearch
+  - sudo journalctl -u service-name.service -b
+  - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
   # Add dredd for API contract testing
   - travis_retry npm install --global dredd@13.1.2
-
 
 install:
   - travis_retry pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo service elasticsearch restart
+  - sudo systemctl restart elasticsearch
   # Our Postgres DB provided by Travis needs to have the (super) users specified by our env var DB URLs used
   - psql -c "CREATE USER ${USASPENDING_DB_USER} PASSWORD '${USASPENDING_DB_PASSWORD}' SUPERUSER"
   - psql -c "CREATE USER ${BROKER_DB_USER} PASSWORD '${BROKER_DB_PASSWORD}' SUPERUSER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,14 +46,13 @@ before_install:
   - sudo dpkg --purge elasticsearch
   - sudo rm -rf /var/lib/elasticsearch
   - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
-  - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
+  - sudo dpkg --install elasticsearch-7.1.1-amd64.deb
   - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
   - sudo systemctl start elasticsearch
   - sudo journalctl -u elasticsearch -b
-  - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
   # Add dredd for API contract testing
   - travis_retry npm install --global dredd@13.1.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ env:
   - GRANTS_API_KEY=${GRANTS_API_KEY}
 
 before_install:
-  - travis_retry npm install --global dredd@13.1.2
-  # Run elasticsearch
-  # First, ensure "old" Elasticsearch that comes with Travis' xenial build image IS running
-  - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
+  # Re-install elasticsearch at the right version
+  - sudo systemctl stop elasticsearch
+  - sudo dpkg --remove elasticsearch
+  - sudo dpkg --purge elasticsearch
   - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
   - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
   - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
@@ -50,7 +50,10 @@ before_install:
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo systemctl restart elasticsearch
+  - sudo systemctl start elasticsearch
+  # Add dredd for API contract testing
+  - travis_retry npm install --global dredd@13.1.2
+
 
 install:
   - travis_retry pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,17 @@ env:
 
 before_install:
   - travis_retry npm install --global dredd@13.1.2
+  # Run elasticsearch
+  # First, ensure "old" Elasticsearch that comes with Travis' xenial build image IS running
+  - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
+  - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
+  - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
+  - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
+  - sudo sed -i.old 's/-Xmx1g/-Xmx512m/' /etc/elasticsearch/jvm.options
+  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+  - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+  - sudo systemctl restart elasticsearch
 
 install:
   - travis_retry pip install -r requirements/requirements.txt
@@ -53,15 +64,6 @@ before_script:
   - travis_retry curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  # Run elasticsearch
-  - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
-  - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
-  - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
-  - sudo sed -i.old 's/-Xmx1g/-Xmx512m/' /etc/elasticsearch/jvm.options
-  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
-  - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
-  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo systemctl restart elasticsearch
   # Our Postgres DB provided by Travis needs to have the (super) users specified by our env var DB URLs used
   - psql -c "CREATE USER ${USASPENDING_DB_USER} PASSWORD '${USASPENDING_DB_PASSWORD}' SUPERUSER"
   - psql -c "CREATE USER ${BROKER_DB_USER} PASSWORD '${BROKER_DB_PASSWORD}' SUPERUSER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 
 services:
   - postgresql
+  - elasticsearch
 
 addons:
   postgresql: '10'


### PR DESCRIPTION
**Description:**
Travis is not bringing up ES in builds, and they are failing. This is a test-PR to see if it fixes things. 

**Technical details:**
This seems to have something to do with them upgrading the included (available) `elasticsearch` service on their `xenial` build image from:
```
ElasticSearch version
5.5.0
```
to
```
ElasticSearch version
7.16.3
``` 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
