### PR TITLE
[Staging] Fix travis by removing newer ES

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 
 services:
   - postgresql
+  # NOTE: This is added, but re-installed at a different version below
+  - elasticsearch
 
 addons:
   postgresql: '10'
@@ -38,6 +40,20 @@ env:
   - GRANTS_API_KEY=${GRANTS_API_KEY}
 
 before_install:
+  # Re-install elasticsearch at the right version
+  - sudo systemctl stop elasticsearch
+  - sudo dpkg --remove elasticsearch
+  - sudo dpkg --purge elasticsearch
+  - sudo rm -rf /var/lib/elasticsearch
+  - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
+  - sudo dpkg --install elasticsearch-7.1.1-amd64.deb
+  - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
+  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+  - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+  - sudo systemctl start elasticsearch
+  - sudo journalctl -u elasticsearch -b
+  # Add dredd for API contract testing
   - travis_retry npm install --global dredd@13.1.2
 
 install:
@@ -52,15 +68,6 @@ before_script:
   - travis_retry curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  # Run elasticsearch
-  - travis_retry curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.1-amd64.deb
-  - sudo dpkg -i --force-confnew elasticsearch-7.1.1-amd64.deb
-  - sudo sed -i.old 's/-Xms1g/-Xms512m/' /etc/elasticsearch/jvm.options
-  - sudo sed -i.old 's/-Xmx1g/-Xmx512m/' /etc/elasticsearch/jvm.options
-  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
-  - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-murmur3
-  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo service elasticsearch restart
   # Our Postgres DB provided by Travis needs to have the (super) users specified by our env var DB URLs used
   - psql -c "CREATE USER ${USASPENDING_DB_USER} PASSWORD '${USASPENDING_DB_PASSWORD}' SUPERUSER"
   - psql -c "CREATE USER ${BROKER_DB_USER} PASSWORD '${BROKER_DB_PASSWORD}' SUPERUSER"


### PR DESCRIPTION
**Description:**
Travis recently came default with ES 7.16 instead of the previous version of 5.5. For some reason the process of downgrading from 7.16 causes the install of our currently used version (7.1) to fail when starting. The fix created in #3343 is to remove the previously installed version of Elasticsearch prior to installing 7.1.

The PR mentioned above was created for testing purposes and branched off QAT. As a result, this new branch was created from `master` in order to get the Travis fix to all environments. 
