### PR TITLE
[DEV-8388] Fix ES download replication race condition

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -606,7 +606,10 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
         span_type=SpanTypes.SQL,
         source_path=source_path,
     ), tracer.trace(
-        name="postgres.query", service="db_downloaddb", resource=download_sql, span_type=SpanTypes.SQL
+        name="postgres.query",
+        service=f"{settings.DOWNLOAD_DATABASE_ALIAS}db",
+        resource=download_sql,
+        span_type=SpanTypes.SQL,
     ), tracer.trace(
         name="postgres.query", service="postgres", resource=download_sql, span_type=SpanTypes.SQL
     ):

--- a/usaspending_api/download/helpers/elasticsearch_download_functions.py
+++ b/usaspending_api/download/helpers/elasticsearch_download_functions.py
@@ -121,7 +121,7 @@ class _ElasticsearchDownload(metaclass=ABCMeta):
             else:
                 message = f"Download Lookup failed to replicate in under {time_to_wait_in_seconds} seconds"
                 write_to_log(message=message, is_error=True, download_job=download_job)
-                raise Exception(message)
+                raise TimeoutError(message)
 
     @classmethod
     @abstractmethod

--- a/usaspending_api/download/helpers/elasticsearch_download_functions.py
+++ b/usaspending_api/download/helpers/elasticsearch_download_functions.py
@@ -101,14 +101,14 @@ class _ElasticsearchDownload(metaclass=ABCMeta):
             wait_start_time = time.time()
             time_to_wait_in_seconds = 60 * 10
             is_lookup_replicated = (
-                DownloadJobLookup.objects.using("db_download")
+                DownloadJobLookup.objects.using(settings.DOWNLOAD_DATABASE_ALIAS)
                 .filter(download_job_id=download_job.download_job_id)
                 .exists()
             )
             while not is_lookup_replicated and time.time() - wait_start_time < time_to_wait_in_seconds:
                 time.sleep(30)  # Wait 30 seconds before checking again; should catch majority of cases
                 is_lookup_replicated = (
-                    DownloadJobLookup.objects.using("db_download")
+                    DownloadJobLookup.objects.using(settings.DOWNLOAD_DATABASE_ALIAS)
                     .filter(download_job_id=download_job.download_job_id)
                     .exists()
                 )
@@ -119,7 +119,7 @@ class _ElasticsearchDownload(metaclass=ABCMeta):
                     message="Download Lookup records have been replicated (if applicable)", download_job=download_job
                 )
             else:
-                message = f"Download Lookup failed to replicate in under {wait_start_time} seconds"
+                message = f"Download Lookup failed to replicate in under {time_to_wait_in_seconds} seconds"
                 write_to_log(message=message, is_error=True, download_job=download_job)
                 raise Exception(message)
 

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -302,9 +302,10 @@ else:
 
 # Initializing download DB as connection string (DOWNLOAD_DATABASE_URL) for PSQL command and
 # Django connection (DATABASES["db_download"]) to allow for Queryset directly against DB used for downloads
+DOWNLOAD_DATABASE_ALIAS = "db_download"
 if os.environ.get("DOWNLOAD_DATABASE_URL"):
     DOWNLOAD_DATABASE_URL = os.environ.get("DOWNLOAD_DATABASE_URL")
-    DATABASES["db_download"] = _configure_database_connection(
+    DATABASES[DOWNLOAD_DATABASE_ALIAS] = _configure_database_connection(
         "DOWNLOAD_DATABASE_URL", test_options={"MIRROR": DEFAULT_DB_ALIAS}
     )
 


### PR DESCRIPTION
**Description:**
Help to resolve issues with downloads having incomplete data.

**Technical details:**
It appears that replication might be causing issues with our downloads in environments that utilize a Primary/Replica structure for the API/Downloads. Since the replica is readonly the lookup IDs for the Elasticsearch based downloads are inserted into the Primary and then it would appear that they are not being replicated over to the replica in time for the first CSV downloaded. 

This PR adds a wait following the step that inserts lookup IDs to make sure they are on the DB designated for downloads prior to proceeding with the download.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-8338](https://federal-spending-transparency.atlassian.net/browse/DEV-8338):
    - [ ] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
