### PR TITLE
[DEV-8486] Recreate the partial COVID index

### DIFF
--- a/usaspending_api/awards/migrations/0090_add_back_faba_covid_index.py
+++ b/usaspending_api/awards/migrations/0090_add_back_faba_covid_index.py
@@ -1,0 +1,42 @@
+# Manually created to restore the FABA DB Index used to help COVID Profile Page queries
+# JIRA Ticket: DEV-8486
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('awards', '0089_auto_20211019_1755'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=(
+                "CREATE INDEX IF NOT EXISTS faba_subid_awardkey_sums_idx ON financial_accounts_by_awards ("
+                "submission_id, distinct_award_key, piid, transaction_obligated_amount, "
+                "gross_outlay_amount_by_award_cpe, ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe, "
+                "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe) "
+                "WHERE disaster_emergency_fund_code IN ('L', 'M', 'N', 'O', 'P', 'U', 'V');"
+            ),
+            reverse_sql="DROP INDEX IF EXISTS faba_subid_awardkey_sums_idx;",
+            state_operations=[
+                migrations.AddIndex(
+                    model_name='financialaccountsbyawards',
+                    index=models.Index(
+                        condition=models.Q(disaster_emergency_fund__in=["L", "M", "N", "O", "P", "U", "V"]),
+                        fields=[
+                            "submission",
+                            "distinct_award_key",
+                            "piid",
+                            "transaction_obligated_amount",
+                            "gross_outlay_amount_by_award_cpe",
+                            "ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe",
+                            "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe"
+                        ],
+                        name="faba_subid_awardkey_sums_idx"
+                    ),
+                ),
+            ]
+        ),
+    ]


### PR DESCRIPTION
**Description:**
Adds back a database index that was removed most likely by accident with a previous migration. Current thought is that the work to change the disaster_emergency_fund_code column from a `char` to `text` type removed this index.

**Technical details:**
The SQL queries for the COVID Profile Page on `financial_accounts_by_awards` rely on this database index to help performance. Most likely as an accident due to a previous migration this index was removed. To make sure the COVID Profile Page is performant this migration adds the index back, but leverages the `migrations.RunSQL` method to create the index manually via `CREATE INDEX IF NOT EXISTS`. This approach will help ensure that others who pull down the code base don't run into a potential conflict when running the migration. 

While this index could be created manually on the database, that would mean that new developers who standup their local environment would not have an index that exists in all environments. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8486](https://federal-spending-transparency.atlassian.net/browse/DEV-8486):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
