### PR TITLE
[DEV-8499] Increase download limit back to 500k

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -16,7 +16,7 @@ APP_DIR = Path(__file__).resolve().parent
 REPO_DIR = APP_DIR.parent
 
 # Row-limited download limit
-MAX_DOWNLOAD_LIMIT = 250000
+MAX_DOWNLOAD_LIMIT = 500000
 
 # Timeout limit for streaming downloads
 DOWNLOAD_TIMEOUT_MIN_LIMIT = 10


### PR DESCRIPTION
**Description:**
Updating the download max limit back to 500k following a series of improvements in the past few sprints.
