### PR TITLE
[DEV-8442] Fix FABS Loader Transaction Deletes

### DIFF
--- a/usaspending_api/broker/helpers/delete_stale_fabs.py
+++ b/usaspending_api/broker/helpers/delete_stale_fabs.py
@@ -24,11 +24,17 @@ def delete_stale_fabs(ids_to_delete):
     delete_transaction_str_ids = ",".join([str(deleted_result) for deleted_result in delete_transaction_ids])
 
     if delete_transaction_ids:
+        awards = (
+            "update awards set latest_transaction_id = null, earliest_transaction_id = null "
+            "where latest_transaction_id in ({ids}) or earliest_transaction_id in ({ids}) "
+            "returning id".format(ids=delete_transaction_str_ids)
+        )
         fabs = 'DELETE FROM "transaction_fabs" tf WHERE tf."transaction_id" IN ({});'
         tn = 'DELETE FROM "transaction_normalized" tn WHERE tn."id" IN ({});'
         ts = 'DELETE FROM "transaction_search" ts WHERE ts."transaction_id" IN ({});'
         td = "DELETE FROM transaction_delta td WHERE td.transaction_id in ({});"
         queries = [
+            awards,
             fabs.format(delete_transaction_str_ids),
             tn.format(delete_transaction_str_ids),
             ts.format(delete_transaction_str_ids),

--- a/usaspending_api/broker/helpers/delete_stale_fabs.py
+++ b/usaspending_api/broker/helpers/delete_stale_fabs.py
@@ -25,16 +25,15 @@ def delete_stale_fabs(ids_to_delete):
 
     if delete_transaction_ids:
         awards = (
-            "update awards set latest_transaction_id = null, earliest_transaction_id = null "
-            "where latest_transaction_id in ({ids}) or earliest_transaction_id in ({ids}) "
-            "returning id".format(ids=delete_transaction_str_ids)
+            "UPDATE awards SET latest_transaction_id = NULL, earliest_transaction_id = NULL "
+            "WHERE latest_transaction_id IN ({ids}) OR earliest_transaction_id IN ({ids});"
         )
         fabs = 'DELETE FROM "transaction_fabs" tf WHERE tf."transaction_id" IN ({});'
         tn = 'DELETE FROM "transaction_normalized" tn WHERE tn."id" IN ({});'
         ts = 'DELETE FROM "transaction_search" ts WHERE ts."transaction_id" IN ({});'
         td = "DELETE FROM transaction_delta td WHERE td.transaction_id in ({});"
         queries = [
-            awards,
+            awards.format(ids=delete_transaction_str_ids),
             fabs.format(delete_transaction_str_ids),
             tn.format(delete_transaction_str_ids),
             ts.format(delete_transaction_str_ids),


### PR DESCRIPTION
**Description:**
https://github.com/fedspendingtransparency/usaspending-api/pull/3378/files Updated the fabs loader to stop deleting awards before transactions, so awards were not recreated, causing duplicates in ES. This caused deletes of transactions to fail because awards had FKs to them. (see [http://jenkins-master-8ca0e1e199b2c8fc.elb.us-gov-west-1.amazonaws.com:8080/blue/organizations/jenkins/NonProd[…]Prod-Nightly-Pipeline/77/pipeline/](http://jenkins-master-8ca0e1e199b2c8fc.elb.us-gov-west-1.amazonaws.com:8080/blue/organizations/jenkins/NonProd-Nightly-Pipeline/detail/NonProd-Nightly-Pipeline/77/pipeline/))

This PR adds a step to remove transactions from awards that are about to be deleted before the actual deletion takes place to prevent FK violations on awards. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-8442](https://federal-spending-transparency.atlassian.net/browse/DEV-8442):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
