### PR TITLE
Updating marshmallow version

### DIFF
--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -25,6 +25,7 @@ et-xmlfile==1.0.1
 filelock==3.0.12
 fiscalyear==0.2.0
 Markdown<3.0
+marshmallow==3.14.1
 numpy==1.19.*
 openpyxl==2.4.7
 pandas==1.1.*


### PR DESCRIPTION
**Description:**
Newer version of `marshmallow` caused issues when deploying a new image. Need to set the version to avoid conflicts. 

**Technical details:**
`dataclasses-json` installs the latest version of `marshmallow`, but does not necessarily need the latest version. This issue came up with the newest version of `marshmallow==3.15.0` which is why the version is set to the previous latest version of `marshmallow==3.14.1`

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [ ] Jira Ticket (N/A)

**Area for explaining above N/A when needed:**
```
```
