### PR TITLE
[DEV-8584] add UEI to subawards filter

### DIFF
--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -180,7 +180,11 @@ def subaward_filter(filters, for_downloads=False):
                 # recipient_name_ts_vector is a postgres TS_Vector
                 filter_obj = Q(recipient_name_ts_vector=upper_recipient_string)
                 if len(upper_recipient_string) == 9 and upper_recipient_string[:5].isnumeric():
+                    print("DUNS")
                     filter_obj |= Q(recipient_unique_id=upper_recipient_string)
+                elif len(upper_recipient_string) == 12:
+                    print("UEI")
+                    filter_obj |= Q(recipient_uei=upper_recipient_string)
                 return filter_obj
 
             filter_obj = Q()

--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -180,10 +180,8 @@ def subaward_filter(filters, for_downloads=False):
                 # recipient_name_ts_vector is a postgres TS_Vector
                 filter_obj = Q(recipient_name_ts_vector=upper_recipient_string)
                 if len(upper_recipient_string) == 9 and upper_recipient_string[:5].isnumeric():
-                    print("DUNS")
                     filter_obj |= Q(recipient_unique_id=upper_recipient_string)
                 elif len(upper_recipient_string) == 12:
-                    print("UEI")
                     filter_obj |= Q(recipient_uei=upper_recipient_string)
                 return filter_obj
 

--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -293,7 +293,7 @@ def spending_by_award_test_data():
         award_id=1,
         subaward_number=11111,
         awardee_or_recipient_uniqu="duns_1001",
-        sub_awardee_or_recipient_uei="uei_10010001",
+        sub_awardee_or_recipient_uei="UEI_10010001",
     )
     mommy.make(
         "awards.BrokerSubaward",
@@ -301,7 +301,7 @@ def spending_by_award_test_data():
         award_id=2,
         subaward_number=22222,
         awardee_or_recipient_uniqu="duns_1002",
-        sub_awardee_or_recipient_uei="uei_10010002",
+        sub_awardee_or_recipient_uei="UEI_10010002",
     )
     mommy.make(
         "awards.BrokerSubaward",
@@ -309,7 +309,7 @@ def spending_by_award_test_data():
         award_id=2,
         subaward_number=33333,
         awardee_or_recipient_uniqu="duns_1002",
-        sub_awardee_or_recipient_uei="uei_10010002",
+        sub_awardee_or_recipient_uei="UEI_10010002",
     )
     mommy.make(
         "awards.BrokerSubaward",
@@ -317,7 +317,7 @@ def spending_by_award_test_data():
         award_id=3,
         subaward_number=44444,
         awardee_or_recipient_uniqu="duns_1003",
-        sub_awardee_or_recipient_uei="uei_10010003",
+        sub_awardee_or_recipient_uei="UEI_10010003",
     )
     mommy.make(
         "awards.BrokerSubaward",
@@ -325,7 +325,7 @@ def spending_by_award_test_data():
         award_id=3,
         subaward_number=66666,
         awardee_or_recipient_uniqu="duns_1003",
-        sub_awardee_or_recipient_uei="uei_10010003",
+        sub_awardee_or_recipient_uei="UEI_10010003",
     )
 
     mommy.make(
@@ -344,7 +344,7 @@ def spending_by_award_test_data():
         awarding_toptier_agency_name="awarding toptier 8001",
         awarding_subtier_agency_name="awarding subtier 8001",
         product_or_service_code="PSC2",
-        recipient_uei="uei_10010001",
+        recipient_uei="UEI_10010001",
     )
     mommy.make(
         "awards.Subaward",
@@ -361,7 +361,7 @@ def spending_by_award_test_data():
         piid="PIID2001",
         awarding_toptier_agency_name="awarding toptier 8002",
         awarding_subtier_agency_name="awarding subtier 8002",
-        recipient_uei="uei_10010001",
+        recipient_uei="UEI_10010001",
     )
     mommy.make(
         "awards.Subaward",

--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -361,7 +361,6 @@ def spending_by_award_test_data():
         piid="PIID2001",
         awarding_toptier_agency_name="awarding toptier 8002",
         awarding_subtier_agency_name="awarding subtier 8002",
-        recipient_uei="UEI_10010001",
     )
     mommy.make(
         "awards.Subaward",

--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -287,11 +287,46 @@ def spending_by_award_test_data():
 
     mommy.make("awards.TransactionFABS", transaction_id=7, cfda_number="10.331", awardee_or_recipient_uniqu="duns_1001")
 
-    mommy.make("awards.BrokerSubaward", id=1, award_id=1, subaward_number=11111, awardee_or_recipient_uniqu="duns_1001")
-    mommy.make("awards.BrokerSubaward", id=2, award_id=2, subaward_number=22222, awardee_or_recipient_uniqu="duns_1002")
-    mommy.make("awards.BrokerSubaward", id=3, award_id=2, subaward_number=33333, awardee_or_recipient_uniqu="duns_1002")
-    mommy.make("awards.BrokerSubaward", id=4, award_id=3, subaward_number=44444, awardee_or_recipient_uniqu="duns_1003")
-    mommy.make("awards.BrokerSubaward", id=6, award_id=3, subaward_number=66666, awardee_or_recipient_uniqu="duns_1003")
+    mommy.make(
+        "awards.BrokerSubaward",
+        id=1,
+        award_id=1,
+        subaward_number=11111,
+        awardee_or_recipient_uniqu="duns_1001",
+        sub_awardee_or_recipient_uei="uei_10010001",
+    )
+    mommy.make(
+        "awards.BrokerSubaward",
+        id=2,
+        award_id=2,
+        subaward_number=22222,
+        awardee_or_recipient_uniqu="duns_1002",
+        sub_awardee_or_recipient_uei="uei_10010002",
+    )
+    mommy.make(
+        "awards.BrokerSubaward",
+        id=3,
+        award_id=2,
+        subaward_number=33333,
+        awardee_or_recipient_uniqu="duns_1002",
+        sub_awardee_or_recipient_uei="uei_10010002",
+    )
+    mommy.make(
+        "awards.BrokerSubaward",
+        id=4,
+        award_id=3,
+        subaward_number=44444,
+        awardee_or_recipient_uniqu="duns_1003",
+        sub_awardee_or_recipient_uei="uei_10010003",
+    )
+    mommy.make(
+        "awards.BrokerSubaward",
+        id=6,
+        award_id=3,
+        subaward_number=66666,
+        awardee_or_recipient_uniqu="duns_1003",
+        sub_awardee_or_recipient_uei="uei_10010003",
+    )
 
     mommy.make(
         "awards.Subaward",
@@ -309,6 +344,7 @@ def spending_by_award_test_data():
         awarding_toptier_agency_name="awarding toptier 8001",
         awarding_subtier_agency_name="awarding subtier 8001",
         product_or_service_code="PSC2",
+        recipient_uei="uei_10010001",
     )
     mommy.make(
         "awards.Subaward",
@@ -325,6 +361,7 @@ def spending_by_award_test_data():
         piid="PIID2001",
         awarding_toptier_agency_name="awarding toptier 8002",
         awarding_subtier_agency_name="awarding subtier 8002",
+        recipient_uei="uei_10010001",
     )
     mommy.make(
         "awards.Subaward",

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -1470,6 +1470,7 @@ def test_uei_recipient_filter_subaward(client, monkeypatch, spending_by_award_te
     )
     expected_result = [
         {
+            "internal_id": "11111",
             "prime_award_internal_id": 1,
             "Sub-Award ID": "11111",
             "prime_award_generated_internal_id": "CONT_AWD_TESTING_1",

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -1429,4 +1429,52 @@ def test_uei_keyword_filter(client, monkeypatch, spending_by_award_test_data, el
     expected_result = [{"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1"}]
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json().get("results")) == 1
-    assert resp.json().get("results") == expected_result, "DEFC filter does not match expected result"
+    assert resp.json().get("results") == expected_result, "UEI filter does not match expected result"
+
+
+@pytest.mark.django_db
+def test_uei_recipient_filter_subaward(client, monkeypatch, spending_by_award_test_data, elasticsearch_award_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+
+    resp = client.post(
+        "/api/v2/search/spending_by_award",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "filters": {
+                    "time_period": [{"start_date": "2007-10-01", "end_date": "2022-09-30"}],
+                    "award_type_codes": [
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "IDV_A",
+                        "IDV_B",
+                        "IDV_B_A",
+                        "IDV_B_B",
+                        "IDV_B_C",
+                        "IDV_C",
+                        "IDV_D",
+                        "IDV_E",
+                    ],
+                    "recipient_search_text": ["uei_10010001"],
+                },
+                "fields": ["Sub-Award ID"],
+                "page": 1,
+                "limit": 60,
+                "sort": "Sub-Award ID",
+                "order": "desc",
+                "subawards": True,
+            }
+        ),
+    )
+    expected_result = [
+        {
+            "prime_award_internal_id": 1,
+            "Sub-Award ID": "11111",
+            "prime_award_generated_internal_id": "CONT_AWD_TESTING_1",
+        }
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json().get("results")) == 1
+    assert resp.json().get("results") == expected_result, "UEI Recipient subaward filter does not match expected result"


### PR DESCRIPTION
**Description:**
Adds the `recipient_uei` field to the advanced search recipient filter

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-8584](https://federal-spending-transparency.atlassian.net/browse/DEV-8584):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
