### PR TITLE
[DEV-7948] Ensure UEI related fields are available in subaward downloads

### DIFF
--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -451,7 +451,7 @@ def test_download_awards_with_all_award_types(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 9
-    assert resp.json()["total_columns"] == 586
+    assert resp.json()["total_columns"] == 590
 
 
 def test_download_awards_with_all_prime_awards(client, award_data):
@@ -517,7 +517,7 @@ def test_download_awards_with_all_sub_awards(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 3  # 2 awards, but 1 file with 2 rows and 1 file with 1
-    assert resp.json()["total_columns"] == 205
+    assert resp.json()["total_columns"] == 209
 
 
 def test_download_awards_with_some_sub_awards(client, award_data):
@@ -539,7 +539,7 @@ def test_download_awards_with_some_sub_awards(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 2
-    assert resp.json()["total_columns"] == 100
+    assert resp.json()["total_columns"] == 102
 
 
 def test_download_awards_with_domestic_scope(client, award_data):
@@ -564,7 +564,7 @@ def test_download_awards_with_domestic_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 586
+    assert resp.json()["total_columns"] == 590
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
@@ -587,7 +587,7 @@ def test_download_awards_with_domestic_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 586
+    assert resp.json()["total_columns"] == 590
 
 
 def test_download_awards_with_foreign_scope(client, award_data):
@@ -612,7 +612,7 @@ def test_download_awards_with_foreign_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 586
+    assert resp.json()["total_columns"] == 590
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=generate_test_db_connection_string())
@@ -635,7 +635,7 @@ def test_download_awards_with_foreign_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 586
+    assert resp.json()["total_columns"] == 590
 
 
 @pytest.mark.django_db

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1296,12 +1296,12 @@ query_paths = {
                 ("prime_award_federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("prime_award_object_classes_funding_this_award", None),  # Annotation is used to create this column
                 ("prime_award_program_activities_funding_this_award", None),  # Annotation is used to create this column
+                ("prime_awardee_uei", "broker_subaward__awardee_or_recipient_uei"),
                 ("prime_awardee_duns", "broker_subaward__awardee_or_recipient_uniqu"),
-                ("prime_awardee_uei", "award__latest_transaction__contract_data__awardee_or_recipient_uei"),
                 ("prime_awardee_name", "broker_subaward__awardee_or_recipient_legal"),
                 ("prime_awardee_dba_name", "broker_subaward__dba_name"),
+                ("prime_awardee_parent_uei", "broker_subaward__ultimate_parent_uei"),
                 ("prime_awardee_parent_duns", "broker_subaward__ultimate_parent_unique_ide"),
-                ("prime_awardee_parent_uei", "award__latest_transaction__contract_data__ultimate_parent_uei"),
                 ("prime_awardee_parent_name", "broker_subaward__ultimate_parent_legal_enti"),
                 ("prime_awardee_country_code", "broker_subaward__legal_entity_country_code"),
                 ("prime_awardee_country_name", "broker_subaward__legal_entity_country_name"),
@@ -1354,9 +1354,11 @@ query_paths = {
                 ("subaward_action_date", "broker_subaward__sub_action_date"),
                 ("subaward_action_date_fiscal_year", None),  # Annotation is used to create this column
                 ("subawardee_duns", "broker_subaward__sub_awardee_or_recipient_uniqu"),
+                ("subawardee_uei", "broker_subaward__sub_awardee_or_recipient_uei"),
                 ("subawardee_name", "broker_subaward__sub_awardee_or_recipient_legal"),
                 ("subawardee_dba_name", "broker_subaward__sub_dba_name"),
                 ("subawardee_parent_duns", "broker_subaward__sub_ultimate_parent_unique_ide"),
+                ("subawardee_parent_uei", "broker_subaward__sub_ultimate_parent_uei"),
                 ("subawardee_parent_name", "broker_subaward__sub_ultimate_parent_legal_enti"),
                 ("subawardee_country_code", "broker_subaward__sub_legal_entity_country_code"),
                 ("subawardee_country_name", "broker_subaward__sub_legal_entity_country_name"),
@@ -1445,12 +1447,12 @@ query_paths = {
                 ("prime_award_federal_accounts_funding_this_award", None),  # Annotation is used to create this column
                 ("prime_award_object_classes_funding_this_award", None),  # Annotation is used to create this column
                 ("prime_award_program_activities_funding_this_award", None),  # Annotation is used to create this column
+                ("prime_awardee_uei", "broker_subaward__awardee_or_recipient_uei"),
                 ("prime_awardee_duns", "broker_subaward__awardee_or_recipient_uniqu"),
-                ("prime_awardee_uei", "award__latest_transaction__assistance_data__uei"),
                 ("prime_awardee_name", "broker_subaward__awardee_or_recipient_legal"),
                 ("prime_awardee_dba_name", "broker_subaward__dba_name"),
+                ("prime_awardee_parent_uei", "broker_subaward__ultimate_parent_uei"),
                 ("prime_awardee_parent_duns", "broker_subaward__ultimate_parent_unique_ide"),
-                ("prime_awardee_parent_uei", "award__latest_transaction__assistance_data__ultimate_parent_uei"),
                 ("prime_awardee_parent_name", "broker_subaward__ultimate_parent_legal_enti"),
                 ("prime_awardee_country_code", "broker_subaward__legal_entity_country_code"),
                 ("prime_awardee_country_name", "broker_subaward__legal_entity_country_name"),
@@ -1493,9 +1495,11 @@ query_paths = {
                 ("subaward_amount", "broker_subaward__subaward_amount"),
                 ("subaward_action_date", "broker_subaward__sub_action_date"),
                 ("subaward_action_date_fiscal_year", None),  # Annotation is used to create this column
+                ("subawardee_uei", "broker_subaward__sub_awardee_or_recipient_uei"),
                 ("subawardee_duns", "broker_subaward__sub_awardee_or_recipient_uniqu"),
                 ("subawardee_name", "broker_subaward__sub_awardee_or_recipient_legal"),
                 ("subawardee_dba_name", "broker_subaward__sub_dba_name"),
+                ("subawardee_parent_uei", "broker_subaward__sub_ultimate_parent_uei"),
                 ("subawardee_parent_duns", "broker_subaward__sub_ultimate_parent_unique_ide"),
                 ("subawardee_parent_name", "broker_subaward__sub_ultimate_parent_legal_enti"),
                 ("subawardee_country_code", "broker_subaward__sub_legal_entity_country_code"),


### PR DESCRIPTION
**Description:**
Simple update to the reusable `lookups.py` file to ensure it includes appropriate UEI fields.



**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-7948](https://federal-spending-transparency.atlassian.net/browse/DEV-7948):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
