### PR TITLE
[DEV-8434] Adds duns_or_uei to children endpoint in MD

### DIFF
--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -123,7 +123,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/idvs/funding/](/api/v2/idvs/funding/)|POST| Returns File C funding records associated with an IDV |
 |[/api/v2/idvs/funding_rollup/](/api/v2/idvs/funding_rollup/)|POST| Returns aggregated count of awarding agencies, federal accounts, and total transaction obligated amount for all contracts under an IDV |
 |[/api/v2/recipient/](/api/v2/recipient/)|POST| Returns a list of recipients in USAspending DB |
-|[/api/v2/recipient/children/<DUNS\>/](/api/v2/recipient/children/006928857/)|GET| Returns recipient details based on DUNS number |
+|[/api/v2/recipient/children/<DUNS_OR_UEI\>/](/api/v2/recipient/children/006928857/)|GET| Returns recipient details based on DUNS number |
 |[/api/v2/recipient/count/](/api/v2/recipient/count/)|POST| Returns the count of recipents for the given filters |
 |[/api/v2/recipient/duns/<HASH_VALUE\>/](/api/v2/recipient/duns/99a44eeb-23ef-e7c4-1f84-9a695b6f5d2e-R/)|GET| Returns a high-level overview of a specific recipient, given its id |
 |[/api/v2/recipient/duns/](/api/v2/recipient/duns/)|POST| Returns a list of recipients in USAspending DB |

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -123,7 +123,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/idvs/funding/](/api/v2/idvs/funding/)|POST| Returns File C funding records associated with an IDV |
 |[/api/v2/idvs/funding_rollup/](/api/v2/idvs/funding_rollup/)|POST| Returns aggregated count of awarding agencies, federal accounts, and total transaction obligated amount for all contracts under an IDV |
 |[/api/v2/recipient/](/api/v2/recipient/)|POST| Returns a list of recipients in USAspending DB |
-|[/api/v2/recipient/children/<DUNS_OR_UEI\>/](/api/v2/recipient/children/006928857/)|GET| Returns recipient details based on DUNS number |
+|[/api/v2/recipient/children/<DUNS_OR_UEI\>/](/api/v2/recipient/children/006928857/)|GET| Returns recipient details based on DUNS or UEI number |
 |[/api/v2/recipient/count/](/api/v2/recipient/count/)|POST| Returns the count of recipents for the given filters |
 |[/api/v2/recipient/duns/<HASH_VALUE\>/](/api/v2/recipient/duns/99a44eeb-23ef-e7c4-1f84-9a695b6f5d2e-R/)|GET| Returns a high-level overview of a specific recipient, given its id |
 |[/api/v2/recipient/duns/](/api/v2/recipient/duns/)|POST| Returns a list of recipients in USAspending DB |


### PR DESCRIPTION
**Description:**
The `/api/v2/recipient/children/<DUNS\>/` endpoint was recently updated to `/api/v2/recipient/children/<DUNS_OR_UEI\>/`, but the `endpoints.md` file was not updated to match. This PR addresses this inconsistency. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-8434](https://federal-spending-transparency.atlassian.net/browse/DEV-8434):
    - [x] Link to this Pull-Request
    - N/A - Performance evaluation of affected (API | Script | Download)
    - N/A - Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
