### PR TITLE
Updating .travis.yml and requirements-dev.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ before_install:
   - travis_retry npm install --global dredd@13.1.2
 
 install:
+  # setuptools is pinned to version 60.8.2 due to an error occurring with built-in version
+  - travis_retry pip install setuptools==60.8.2
   - travis_retry pip install -r requirements/requirements.txt
   - travis_retry pip install coveralls
   # Checkout dependent broker code used to spin up a broker integration test db. Put it in its own folder alongside this repo's code

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==20.8b1
+click==8.0.4
 docker==5.0.3
 dredd-hooks==0.2.0
 flake8==3.8.4


### PR DESCRIPTION
**Description:**
Updating the `.travis.yml` to include a pinned version of `setuptools` due to an error with the builtin version.

Additionally, pinning the version of `click` to prevent `black` from breaking.