### PR TITLE
[PIPE-192] Demonstrate migration and code changes for new schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ before_script:
   - ./cc-test-reporter before-build
   # Our Postgres DB provided by Travis needs to have the (super) users specified by our env var DB URLs used
   - psql -c "CREATE USER ${USASPENDING_DB_USER} PASSWORD '${USASPENDING_DB_PASSWORD}' SUPERUSER"
+  - psql -c "ALTER USER ${USASPENDING_DB_USER} SET search_path TO public,raw,int,temp,rpt"
   - psql -c "CREATE USER ${BROKER_DB_USER} PASSWORD '${BROKER_DB_PASSWORD}' SUPERUSER"
   - docker build -t ${BROKER_DOCKER_IMAGE} ${BROKER_REPO_FOLDER}  # Build image from which to call Broker scripts
   - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done

--- a/usaspending_api/awards/management/commands/load_subawards.py
+++ b/usaspending_api/awards/management/commands/load_subawards.py
@@ -48,8 +48,8 @@ class Command(mixins.ETLMixin, BaseCommand):
     def _perform_load(self):
         """ Grab the Broker subaward table and use it to update ours. """
 
-        broker_subaward = ETLTable("broker_subaward")
-        subaward = ETLTable("subaward")
+        broker_subaward = ETLTable("broker_subaward", schema_name="raw")
+        subaward = ETLTable("subaward", schema_name="int")
 
         remote_subaward = ETLDBLinkTable("subaward", settings.DATA_BROKER_DBLINK_NAME, broker_subaward.data_types)
 

--- a/usaspending_api/etl/migrations/0001_create_schemas.py
+++ b/usaspending_api/etl/migrations/0001_create_schemas.py
@@ -1,0 +1,217 @@
+# Manual created to handle creation of different schemas
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("awards", "0092_transactionfpds_entity_data_source"),
+        ("recipient", "0018_auto_20220325_1625"),
+        ("search", "0007_transactionsearch_parent_uei"),
+        ("transactions", "0008_sourceprocurementtransaction_entity_data_source")
+    ]
+
+    operations = [
+        # -----
+        # Create the different schemas
+        # -----
+        migrations.RunSQL(
+            sql="CREATE SCHEMA IF NOT EXISTS raw;",
+            reverse_sql="DROP SCHEMA raw;"
+        ),
+        migrations.RunSQL(
+            sql="CREATE SCHEMA IF NOT EXISTS int;",
+            reverse_sql="DROP SCHEMA int;"
+        ),
+        migrations.RunSQL(
+            sql="CREATE SCHEMA IF NOT EXISTS temp;",
+            reverse_sql="DROP SCHEMA temp;"
+        ),
+        migrations.RunSQL(
+            sql="CREATE SCHEMA IF NOT EXISTS rpt;",
+            reverse_sql="DROP SCHEMA rpt;"
+        ),
+
+        # -----
+        # Move Bronze tables into the "raw" schema
+        # -----
+        migrations.RunSQL(
+            sql="ALTER TABLE public.duns SET SCHEMA raw;",
+            reverse_sql="ALTER TABLE raw.duns SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.broker_subaward SET SCHEMA raw;",
+            reverse_sql="ALTER TABLE raw.broker_subaward SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.source_assistance_transaction SET SCHEMA raw;",
+            reverse_sql="ALTER TABLE raw.source_assistance_transaction SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.source_procurement_transaction SET SCHEMA raw;",
+            reverse_sql="ALTER TABLE raw.source_procurement_transaction SET SCHEMA public;"
+        ),
+        # -----
+        # Move Silver tables into the "int" schema
+        # -----
+        migrations.RunSQL(
+            sql="ALTER TABLE public.transaction_normalized SET SCHEMA int;",
+            reverse_sql="ALTER TABLE int.transaction_normalized SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.transaction_fabs SET SCHEMA int;",
+            reverse_sql="ALTER TABLE int.transaction_fabs SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.transaction_fpds SET SCHEMA int;",
+            reverse_sql="ALTER TABLE int.transaction_fpds SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.transaction_delta SET SCHEMA int;",
+            reverse_sql="ALTER TABLE int.transaction_delta SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.awards SET SCHEMA int;",
+            reverse_sql="ALTER TABLE int.awards SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.subaward SET SCHEMA int;",
+            reverse_sql="ALTER TABLE int.subaward SET SCHEMA public;"
+        ),
+
+        # -----
+        # Move Materialized Views into the "temp" schema
+        # -----
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.subaward_view SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.subaward_view SET SCHEMA public;"
+        ),
+        # migrations.RunSQL(
+        #     sql="ALTER TABLE IF EXISTS public.summary_state_view SET SCHEMA temp;",
+        #     reverse_sql="ALTER TABLE temp.summary_state_view SET SCHEMA public;"
+        # ),
+
+        # AwardSearch Materialized Views
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_contract_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_contract_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_idv_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_idv_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_loan_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_loan_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_grant_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_grant_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_directpayment_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_directpayment_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_other_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_other_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.mv_pre2008_award_search SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.mv_pre2008_award_search SET SCHEMA public;"
+        ),
+
+        # TransactionSearch Materialized Views
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_0 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_0 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_1 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_1 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_2 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_2 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_3 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_3 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_4 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_4 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_5 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_5 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_6 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_6 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_7 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_7 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_8 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_8 SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.transaction_search_9 SET SCHEMA temp;",
+            reverse_sql="ALTER TABLE temp.transaction_search_9 SET SCHEMA public;"
+        ),
+
+        # -----
+        # Move Gold tables into the "rpt" schema
+        # -----
+        migrations.RunSQL(
+            sql="ALTER TABLE public.recipient_lookup SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.recipient_lookup SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.recipient_profile SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.recipient_profile SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.recipient_agency SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.recipient_agency SET SCHEMA public;"
+        ),
+        #
+        # Need to determine the best path forward when two tables in different
+        # schemas need the same name? The "search_path" approach will not work
+        # as it would not see the second table. Since one of these lives in "temp"
+        # perhaps the name should be changed to reflect that:
+        #       "mv_summary_state_view"
+        #
+        # migrations.RunSQL(
+        #     sql="ALTER TABLE public.summary_state_view SET SCHEMA rpt;",
+        #     reverse_sql="ALTER TABLE rpt.summary_state_view SET SCHEMA public;"
+        # ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.summary_award_recipient SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.summary_award_recipient SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.transaction_search SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.transaction_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE public.parent_award SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.parent_award SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.vw_award_search SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.vw_award_search SET SCHEMA public;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE IF EXISTS public.vw_es_award_search SET SCHEMA rpt;",
+            reverse_sql="ALTER TABLE rpt.vw_es_award_search SET SCHEMA public;"
+        ),
+        # migrations.RunSQL(
+        #     sql="ALTER TABLE IF EXISTS public.subaward_search SET SCHEMA rpt;",
+        #     reverse_sql="ALTER TABLE rpt.subaward_search SET SCHEMA public;"
+        # ),
+    ]

--- a/usaspending_api/transactions/agnostic_transaction_loader.py
+++ b/usaspending_api/transactions/agnostic_transaction_loader.py
@@ -182,7 +182,7 @@ class AgnosticTransactionLoader:
 
     def copy_broker_table_data(self, source_tablename, dest_tablename, primary_key):
         """Loop through the batches of IDs and load using the ETL tables"""
-        destination = ETLTable(dest_tablename)
+        destination = ETLTable(dest_tablename, schema_name="raw")
         source = ETLDBLinkTable(source_tablename, settings.DATA_BROKER_DBLINK_NAME, destination.data_types)
         transactions_remaining_count = self.total_ids_to_process
 


### PR DESCRIPTION
# Approach
This Draft PR demonstrates the first option below. Django does not natively support schemas and so a workaround has to be used.

* Options:
   * Create minimum two Users on each Database (one for ETL and one for API / Downloads) that have different `search_path` 
      * PRO:
         * Minimal code changes with only a single migration and some ETL changes (specifically where a table, view, or materialized view is created)
         * As long as tables are queried without the schema name (e.g. `broker_subaward` instead of `raw.broker_subaward`) each user will only query the schemas in their `search_path`
      * CON:
         * Any time a new table is created an additional step will be required to change it to the correct schema since `public` will be the default (temp tables would not be an issue since they would be created in `public` and then removed)
   * Define additional Django connections that leverage different `search_paths` (example found in #3353)
      * PRO:
         * More clearly defined change since the router would be updated to say specifically which actions are taken against which connection (read, write, and migrations)
      * CON:
         * Would require that the router is kept up to date as new models are created otherwise this would need to be paired with the third option below where the schema name is combined with the table name
   * Define each Django model with the schema in the table name (e.g. `'"raw"."broker_subaward"'` instead of `"broker_subaward"` and set User permissions on what schema they are able to access
      * PRO:
         * Django migrations would automatically create new tables in the correct schema without any additional SQL
         
      * CON:
         * Would require some updates to ETL code where the schema name is added to the table name (e.g. would generate `public.raw.broker_subaward` without a change in `load_subawards`)
         * Would have to leverage Django's [SeparateDatabaseAndState](https://docs.djangoproject.com/en/3.2/ref/migration-operations/#separatedatabaseandstate) migration in order to prevent a table name change and instead move to another schema
         * This would allow a DB User to query against all tables regardless of `search_path` and thus a permission level change would be required to make sure that the API / Download User is only able to see `public` and `rpt` schemas

# Demonstration
In this Travis build (https://app.travis-ci.com/github/fedspendingtransparency/usaspending-api/builds/249099648) you will see all tests fail because in the migrations the Awards table is not defined.
```
E               psycopg2.errors.UndefinedTable: relation "awards" does not exist
E               LINE 5:     from awards 
E 
```
However, in this Travis build (https://app.travis-ci.com/github/fedspendingtransparency/usaspending-api/builds/249101392) all tests pass after the change was pushed to update the Travis DB user to contain the correct `search_path`.

The specific line added to the Travis build:
```
- psql -c "ALTER USER ${USASPENDING_DB_USER} SET search_path TO public,raw,int,temp,rpt"
```


# TODO
* Determine path forward for local development; should a developer be required to manually adjust their DB user's search_path or should something be changed in the Dockerfile to make that update?
* Break this up to match the JIRA tickets currently created for an easier review.
* Verify if any tables in the as-is plan for each schema have the same name. If the answer is yes, determine a new name to prevent conflict. Tables will the same name will be an issue when querying across different schemas with the use of `search_path`.
