### PR TITLE
[PIPE-248] Add deprecator tag to /agency/recipients/

### DIFF
--- a/usaspending_api/agency/v2/views/recipients.py
+++ b/usaspending_api/agency/v2/views/recipients.py
@@ -1,3 +1,4 @@
+from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 from rest_framework.response import Response
 from typing import Any
@@ -5,8 +6,10 @@ from usaspending_api.agency.v2.views.agency_base import AgencyBase
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.helpers.sql_helpers import execute_sql_to_ordered_dictionary
 from usaspending_api.recipient.models import RecipientAgency
+from usaspending_api.common.api_versioning import deprecated
 
 
+@method_decorator(deprecated, name="get")
 class RecipientList(AgencyBase):
     """
     Obtain the count of recipients for a specific agency in a single

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/recipients.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/recipients.md
@@ -3,6 +3,7 @@ HOST: https://api.usaspending.gov
 
 # Recipients [/api/v2/agency/{toptier_code}/recipients/{?fiscal_year}]
 
+Deprecated: This endpoint will be removed in the near future.
 Returns a list of data points of an agencies recipients for a given fiscal year
 
 ## GET

--- a/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
@@ -1,6 +1,7 @@
 import pytest
 
 from model_mommy import mommy
+from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_date
 
 
 @pytest.fixture
@@ -40,7 +41,7 @@ def disaster_account_data():
         submission_fiscal_year=2022,
         submission_fiscal_quarter=3,
         submission_fiscal_month=8,
-        submission_reveal_date="2022-4-15",
+        submission_reveal_date=f"{current_fiscal_date()}",
     )
     dsws3 = mommy.make(
         "submissions.DABSSubmissionWindowSchedule",


### PR DESCRIPTION
**Description:**
Adds a deprecation warning to the GET response for the `/api/v2/agency/{toptier_code}/recipients/` endpoint as it will be removed.


**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [PIPE-248](https://federal-spending-transparency.atlassian.net/browse/PIPE-248):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
