### PR TITLE
Ops 2229 add postgres version local env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+docker-compose-files/*

--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 ##  run docker-compose config to see the templated variables ##
 POSTGRES_USER=usaspending
 POSTGRES_PASSWORD=usaspender
+POSTGRES_CLIENT_VERSION=10
+POSTGRES_DB_VERSION=10.18
 
 ## Change to host.docker.internal if you are running a local Postgres. Otherwise leave as-is, so
 ## Docker will use the Postgres created by Compose.

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ prof/
 .lprof
 .pytest_cache/*
 pip-selfcheck.json
+
+# docker compose
+docker-compose-files/*

--- a/README.md
+++ b/README.md
@@ -64,13 +64,20 @@ See below for basic setup instructions. For help with Docker Compose:
 
 - **If you run a local database**, set `POSTGRES_HOST` in `.env` to `host.docker.internal`. `POSTGRES_PORT` should be changed if it isn't 5432.
 
-    - `docker-compose up usaspending-db` will create and run a Postgres database.
+    - Review the `POSTGRES_CLIENT_VERSION` and `POSTGRES_DB_VERSION` in `.env` to verify the version of PostgreSQL db and PostgreSQL client to use.
+
+    - `docker-compose up -d usaspending-db` will create and run a Postgres database.
 
     - `docker-compose run --rm usaspending-manage python3 -u manage.py migrate` will run Django migrations: [https://docs.djangoproject.com/en/2.2/topics/migrations/](https://docs.djangoproject.com/en/2.2/topics/migrations/).
 
     - `docker-compose run --rm usaspending-manage python3 -u manage.py load_reference_data` will load essential reference data (agencies, program activity codes, CFDA program data, country codes, and others).
 
     - `docker-compose run --rm usaspending-manage python3 -u manage.py matview_runner --dependencies`  will provision the materialized views which are required by certain API endpoints.
+
+    - The `docker-compose-files` directory can be used to add files, such as and ad-hoc sql files or pg_dumps, to be used against the database. For example, if the database subset is downloaded and unzipped into the directory `./docker-compose-files/pruned_data_store_api_dump` from the [USAspending Database Download](https://files.usaspending.gov/database_download/) page, the following can be run to populate the database: 
+       -  `docker exec usaspending-db /bin/bash -c "pg_restore -O -U usaspending -h 127.0.0.1 -d data_store_api -j 6 --verbose --exit-on-error /docker-compose-files/pruned_data_store_api_dump/`
+
+    - The PostgreSQL data volume will persist unless a `docker-compose down -v` or a `docker volume rm usaspending-api_local_pg_data` is run, with the former deleting any volume created by `docker-compose` and the latter deleting only the PostgreSQL volume.
 
 ##### Manual Database Setup
 - `docker-compose.yaml` contains the shell commands necessary to set up the database manually, if you prefer to have a more custom environment.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,20 +8,21 @@ volumes:
 
 # See run instructions in accompanying Dockerfile
 services:
-
   usaspending-db:
     container_name: usaspending-db
-    image: postgres:10.13-alpine
+    image: postgres:${POSTGRES_DB_VERSION}-alpine
     volumes:
       - type: volume
         source: local_pg_data
         target: /var/lib/postgresql/data
+      - ./docker-compose-files:/docker-compose-files
     ports:
       - ${POSTGRES_PORT}:5432
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: data_store_api
+    restart: always
 
   usaspending-manage:
     build: .
@@ -86,7 +87,10 @@ services:
       DATA_BROKER_SRC_PATH: "$PWD/../data-act-broker-backend"
 
   usaspending-api:
-    build: .
+    build:
+      context: .
+      args:
+        postgres_version: ${POSTGRES_CLIENT_VERSION}
     volumes:
       - .:/dockermount
     ports:
@@ -94,6 +98,8 @@ services:
     depends_on:
       - usaspending-db
       - usaspending-es
+    links:
+      - usaspending-db:usaspending-db
     restart: on-failure:3 # 3 max attempt, and then it will stop restarting
     # Must wait on postgres db to be up (~9s)
     command: /bin/sh -c "sleep 9s; python3 -u manage.py runserver --verbosity 2 0.0.0.0:8000"


### PR DESCRIPTION
**Description:**
High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

This just adds the ability to use a different version of PostgreSQL in your local environment. The version that was previously pinned was several minor versions behind the currently deployed version. Also, we're moving to the PostgreSQL 13 so we'll need to accommodate for that in the local env. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [OPS-2229](https://federal-spending-transparency.atlassian.net/browse/OPS-2229):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
