### PR TITLE
[PIPE-10] Use pydantic validators for lazily composed config vars

### DIFF
--- a/usaspending_api/common/helpers/spark_helpers.py
+++ b/usaspending_api/common/helpers/spark_helpers.py
@@ -234,7 +234,6 @@ def read_java_gateway_connection_info(gateway_conn_info_path):  # pragma: no cov
 def attach_java_gateway(
     gateway_port,
     gateway_auth_token,
-    # gateway_address=PYSPARK_GATEWAY_DEFAULT_ADDRESS
 ) -> JavaGateway:  # pragma: no cover -- useful development util
     """Create a new JavaGateway that latches onto the port of a running spark-submit process
 
@@ -245,7 +244,6 @@ def attach_java_gateway(
     Returns: The instantiated JavaGateway, which acts as a network interface for PySpark to submit spark jobs through
         to the JVM-based Spark runtime
     """
-    # os.environ["PYSPARK_GATEWAY_ADDRESS"] = gateway_address
     os.environ["PYSPARK_GATEWAY_PORT"] = str(gateway_port)
     os.environ["PYSPARK_GATEWAY_SECRET"] = gateway_auth_token
 

--- a/usaspending_api/config/__init__.py
+++ b/usaspending_api/config/__init__.py
@@ -5,8 +5,8 @@ from functools import lru_cache
 from typing import Type, Union
 
 from usaspending_api.config.envs import ENV_CODE_VAR, ENVS
-from usaspending_api.config.default import DefaultConfig
-from usaspending_api.config.local import LocalConfig
+from usaspending_api.config.envs.default import DefaultConfig
+from usaspending_api.config.envs.local import LocalConfig
 
 __all__ = [
     "CONFIG",

--- a/usaspending_api/config/envs/__init__.py
+++ b/usaspending_api/config/envs/__init__.py
@@ -1,4 +1,9 @@
-from usaspending_api.config.local import LocalConfig
+from usaspending_api.config.envs.local import LocalConfig
+
+__all__ = [
+    "ENV_CODE_VAR",
+    "ENVS",
+]
 
 # Environment Variable name which holds the runtime env code indicating the runtime environment to configure/deploy/run
 ENV_CODE_VAR = "ENV_CODE"

--- a/usaspending_api/config/envs/default.py
+++ b/usaspending_api/config/envs/default.py
@@ -3,7 +3,7 @@
 # - Config variables declared here should cover ALL expected config variables for a "production" run
 # - Non-Prod runtime env config may include additional config not defined here, to accommodate their different needs
 # - Set config var to non-placeholder values here that are acceptable defaults for any runtime environment
-# - Set config var to _ENV_SPECIFIC_OVERRIDE where there is expected to be a replacement config value
+# - Set config var to ENV_SPECIFIC_OVERRIDE where there is expected to be a replacement config value
 #   in every runtime environment config
 # - Values can be overridden if the same config variable is defined in a runtime-env-specific <env>.py file
 # - Values will be overridden by ENVIRONMENT variables declared in a user's .env file if present at ../.env
@@ -12,6 +12,7 @@
 import pathlib
 from typing import ClassVar
 
+from usaspending_api.config.utils import ENV_SPECIFIC_OVERRIDE
 from pydantic import (
     AnyHttpUrl,
     BaseSettings,
@@ -22,10 +23,6 @@ from pydantic import (
 _PROJECT_NAME = "usaspending-api"
 _PROJECT_ROOT_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
 _SRC_ROOT_DIR = _PROJECT_ROOT_DIR / _PROJECT_NAME.replace("-", "_")
-
-# Placeholder sentinel value indicating a config var that is expected to be overridden in a runtime-env-specific
-# config declaration. If this value emerges, it has not yet been set in the runtime env config and must be.
-_ENV_SPECIFIC_OVERRIDE = "?ENV_SPECIFIC_OVERRIDE?"
 
 
 class DefaultConfig(BaseSettings):
@@ -54,17 +51,17 @@ class DefaultConfig(BaseSettings):
         return super().__new__(cls)
 
     # ==== [Global] ====
-    ENV_CODE: ClassVar[str] = _ENV_SPECIFIC_OVERRIDE
+    ENV_CODE: ClassVar[str] = ENV_SPECIFIC_OVERRIDE
     COMPONENT_NAME = "USAspending API"
     PROJECT_LOG_DIR = str(_SRC_ROOT_DIR / "logs")
 
     # ==== [Postgres] ====
     POSTGRES_URL: str = None
     POSTGRES_DB = "data_store_api"
-    POSTGRES_USER = _ENV_SPECIFIC_OVERRIDE
-    POSTGRES_PASSWORD: SecretStr = _ENV_SPECIFIC_OVERRIDE
-    POSTGRES_HOST = _ENV_SPECIFIC_OVERRIDE
-    POSTGRES_PORT = _ENV_SPECIFIC_OVERRIDE
+    POSTGRES_USER = ENV_SPECIFIC_OVERRIDE
+    POSTGRES_PASSWORD: SecretStr = ENV_SPECIFIC_OVERRIDE
+    POSTGRES_HOST = ENV_SPECIFIC_OVERRIDE
+    POSTGRES_PORT = ENV_SPECIFIC_OVERRIDE
     # TODO: GET RID OF property(...) FIELDS! See note in comments in the tests/unit/test_config.py possibly look at
     #  pre/post load validator(...) or root_validator(...) functions as an alternative to composing other fields,
     #  or research more
@@ -93,7 +90,7 @@ class DefaultConfig(BaseSettings):
     # Where to connect to elasticsearch.
     ES_URL: str = None
     ES_SCHEME = "https"
-    ES_HOST = _ENV_SPECIFIC_OVERRIDE
+    ES_HOST = ENV_SPECIFIC_OVERRIDE
     ES_PORT = ""
     # TODO: GET RID OF property(...) FIELDS! See note in comments in the tests/unit/test_config.py possibly look at
     #  pre/post load validator(...) or root_validator(...) functions as an alternative to composing other fields,
@@ -152,10 +149,10 @@ class DefaultConfig(BaseSettings):
     # ==== [AWS] ====
     USE_AWS = True
     AWS_REGION = "us-gov-west-1"
-    AWS_ACCESS_KEY: SecretStr = _ENV_SPECIFIC_OVERRIDE
-    AWS_SECRET_KEY: SecretStr = _ENV_SPECIFIC_OVERRIDE
-    AWS_PROFILE: str = _ENV_SPECIFIC_OVERRIDE
-    AWS_S3_BUCKET = _ENV_SPECIFIC_OVERRIDE
+    AWS_ACCESS_KEY: SecretStr = ENV_SPECIFIC_OVERRIDE
+    AWS_SECRET_KEY: SecretStr = ENV_SPECIFIC_OVERRIDE
+    AWS_PROFILE: str = ENV_SPECIFIC_OVERRIDE
+    AWS_S3_BUCKET = ENV_SPECIFIC_OVERRIDE
     AWS_S3_OUTPUT_PATH = "output"  # path within AWS_S3_BUCKET where output data will accumulate
     # Must declare as property, so that the overriding impl that uses a property will still override this
     # TODO: GET RID OF property(...) FIELDS! See note in comments in the tests/unit/test_config.py possibly look at

--- a/usaspending_api/config/envs/default.py
+++ b/usaspending_api/config/envs/default.py
@@ -12,13 +12,15 @@
 import pathlib
 from typing import ClassVar
 
-from usaspending_api.config.utils import ENV_SPECIFIC_OVERRIDE
+from usaspending_api.config.utils import ENV_SPECIFIC_OVERRIDE, eval_default_factory
 from pydantic import (
     AnyHttpUrl,
     BaseSettings,
     PostgresDsn,
     SecretStr,
+    validator,
 )
+from pydantic.fields import ModelField
 
 _PROJECT_NAME = "usaspending-api"
 _PROJECT_ROOT_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
@@ -52,59 +54,67 @@ class DefaultConfig(BaseSettings):
 
     # ==== [Global] ====
     ENV_CODE: ClassVar[str] = ENV_SPECIFIC_OVERRIDE
-    COMPONENT_NAME = "USAspending API"
-    PROJECT_LOG_DIR = str(_SRC_ROOT_DIR / "logs")
+    COMPONENT_NAME: str = "USAspending API"
+    PROJECT_LOG_DIR: str = str(_SRC_ROOT_DIR / "logs")
 
     # ==== [Postgres] ====
     POSTGRES_URL: str = None
-    POSTGRES_DB = "data_store_api"
-    POSTGRES_USER = ENV_SPECIFIC_OVERRIDE
+    POSTGRES_DB: str = "data_store_api"
+    POSTGRES_USER: str = ENV_SPECIFIC_OVERRIDE
     POSTGRES_PASSWORD: SecretStr = ENV_SPECIFIC_OVERRIDE
-    POSTGRES_HOST = ENV_SPECIFIC_OVERRIDE
-    POSTGRES_PORT = ENV_SPECIFIC_OVERRIDE
-    # TODO: GET RID OF property(...) FIELDS! See note in comments in the tests/unit/test_config.py possibly look at
-    #  pre/post load validator(...) or root_validator(...) functions as an alternative to composing other fields,
-    #  or research more
-    POSTGRES_DSN: PostgresDsn = property(lambda self: self._get_postgres_dsn())
+    POSTGRES_HOST: str = ENV_SPECIFIC_OVERRIDE
+    POSTGRES_PORT: str = ENV_SPECIFIC_OVERRIDE
+    POSTGRES_DSN: PostgresDsn = None  # FACTORY_PROVIDED_VALUE. See below validator-factory
 
-    def _get_postgres_dsn(self) -> PostgresDsn:
-        """A derived property that assembles the full DSN URL to the Postgres DB.
+    @validator("POSTGRES_DSN")
+    def _POSTGRES_DSN_factory(cls, v, values, field: ModelField):
+        def factory_func() -> PostgresDsn:
+            """A factory that assembles the full DSN URL to the Postgres DB.
 
-        If ``POSTGRES_URL`` is provided, it will be used. Otherwise this URL is assembled from the other
-        ``POSTGRES_*`` config vars
-        """
-        path = None
-        if self.POSTGRES_DB:
-            path = "/" + self.POSTGRES_DB
-        return PostgresDsn(
-            url=self.POSTGRES_URL,
-            scheme="postgres",
-            user=self.POSTGRES_USER,
-            password=self.POSTGRES_PASSWORD.get_secret_value(),
-            host=self.POSTGRES_HOST,
-            port=self.POSTGRES_PORT,
-            path=path,
-        )
+            If ``POSTGRES_URL`` is provided e.g. as an env var, it will be used. Otherwise this URL is assembled from
+            the other ``POSTGRES_*`` config vars
+            """
+            path = None
+            if values["POSTGRES_DB"]:
+                path = "/" + values["POSTGRES_DB"]
+            return PostgresDsn(
+                url=values["POSTGRES_URL"],
+                scheme="postgres",
+                user=values["POSTGRES_USER"],
+                password=values["POSTGRES_PASSWORD"].get_secret_value(),
+                host=values["POSTGRES_HOST"],
+                port=values["POSTGRES_PORT"],
+                path=path,
+            )
+
+        return eval_default_factory(cls, v, values, field, factory_func)
 
     # ==== [Elasticsearch] ====
     # Where to connect to elasticsearch.
     ES_URL: str = None
-    ES_SCHEME = "https"
-    ES_HOST = ENV_SPECIFIC_OVERRIDE
-    ES_PORT = ""
-    # TODO: GET RID OF property(...) FIELDS! See note in comments in the tests/unit/test_config.py possibly look at
-    #  pre/post load validator(...) or root_validator(...) functions as an alternative to composing other fields,
-    #  or research more
-    ELASTICSEARCH_HOST: AnyHttpUrl = property(lambda self: self._get_elasticsearch_host())
+    ES_SCHEME: str = "https"
+    ES_HOST: str = ENV_SPECIFIC_OVERRIDE
+    ES_PORT: str = ""
 
-    def _get_elasticsearch_host(self) -> AnyHttpUrl:
-        """A derived property that assembles the full URL to a single Elasticsearch host, to which ES cluster
-        connections are made.
+    ELASTICSEARCH_HOST: AnyHttpUrl = None  # FACTORY_PROVIDED_VALUE. See below validator-factory
 
-            If ``ES_URL`` is provided, it will be used. Otherwise this URL is assembled from the other ``ES_*``
-            config vars
-        """
-        return AnyHttpUrl(url=self.ES_URL, scheme=self.ES_SCHEME, host=self.ES_HOST, port=self.ES_PORT)
+    @validator("ELASTICSEARCH_HOST")
+    def _ELASTICSEARCH_HOST_factory(cls, v, values, field: ModelField):
+        def factory_func() -> AnyHttpUrl:
+            """A factory that assembles the full URL to a single Elasticsearch host, to which ES cluster
+            connections are made.
+
+                If ``ES_URL`` is provided as e.g. an env var, it will be used. Otherwise this URL is assembled from the
+                other ``ES_*`` config vars
+            """
+            return AnyHttpUrl(
+                url=values["ES_URL"],
+                scheme=values["ES_SCHEME"],
+                host=values["ES_HOST"],
+                port=values["ES_PORT"],
+            )
+
+        return eval_default_factory(cls, v, values, field, factory_func)
 
     # ==== [Spark] ====
     # SPARK_SCHEDULER_MODE = "FAIR"  # if used with weighted pools, could allow round-robin tasking of simultaneous jobs
@@ -113,14 +123,14 @@ class DefaultConfig(BaseSettings):
     # order. To use fair scheduling, configure pools in fairscheduler.xml or set spark.scheduler.allocation.file to a
     # file that contains the configuration.
     # 01:58:26 INFO FairSchedulableBuilder: Created default pool: default, schedulingMode: FIFO, minShare: 0, weight: 1
-    SPARK_SCHEDULER_MODE = "FIFO"  # the default Spark scheduler mode
+    SPARK_SCHEDULER_MODE: str = "FIFO"  # the default Spark scheduler mode
 
     # Ideal partition size based on a single Executor's task execution, and what it can handle in memory: ~128MB
     # Given the density of this data, 128 MB bulk-index request to Elasticsearch is about 75,000 docs
     # However ES does not appear to be able too handle that when several Executors make that request in parallel
     # Good tips from ES: https:#www.elastic.co/guide/en/elasticsearch/reference/6.2/tune-for-indexing-speed.html
     # Reducing to 10,000 DB rows per bulk indexing operation
-    PARTITION_SIZE = 10000
+    PARTITION_SIZE: int = 10000
 
     # Spark is connecting JDBC to Elasticsearch here and this config calibrates the throughput from one to the other,
     # and have to accommodate limitations on either side of the pipe.
@@ -140,25 +150,21 @@ class DefaultConfig(BaseSettings):
     # Aiming for a batch that yields each ES cluster data-node handling max 0.3-1MB per vCPU per batch request
     # Ex: 3-data-node cluster of i3.large.elasticsearch = 2 vCPU * 3 nodes = 6 vCPU: .75MB*6 ~= 4.5MB batches
     # Ex: 5-data-node cluster of i3.xlarge.elasticsearch = 4 vCPU * 5 nodes = 20 vCPU: .75MB*20 ~= 15MB batches
-    ES_MAX_BATCH_BYTES = 10 * 1024 * 1024
+    ES_MAX_BATCH_BYTES: int = 10 * 1024 * 1024
     # Aiming for a batch that yields each ES cluster data-node handling max 100-400 doc entries per vCPU per request
     # Ex: 3-data-node cluster of i3.large.elasticsearch = 2 vCPU * 3 nodes = 6 vCPU: 300*6 = 1800 doc batches
     # Ex: 5-data-node cluster of i3.xlarge.elasticsearch = 4 vCPU * 5 nodes = 20 vCPU: 300*20 = 6000 doc batches
-    ES_BATCH_ENTRIES = 4000
+    ES_BATCH_ENTRIES: int = 4000
 
     # ==== [AWS] ====
-    USE_AWS = True
-    AWS_REGION = "us-gov-west-1"
+    USE_AWS: bool = True
+    AWS_REGION: str = "us-gov-west-1"
     AWS_ACCESS_KEY: SecretStr = ENV_SPECIFIC_OVERRIDE
     AWS_SECRET_KEY: SecretStr = ENV_SPECIFIC_OVERRIDE
     AWS_PROFILE: str = ENV_SPECIFIC_OVERRIDE
-    AWS_S3_BUCKET = ENV_SPECIFIC_OVERRIDE
-    AWS_S3_OUTPUT_PATH = "output"  # path within AWS_S3_BUCKET where output data will accumulate
-    # Must declare as property, so that the overriding impl that uses a property will still override this
-    # TODO: GET RID OF property(...) FIELDS! See note in comments in the tests/unit/test_config.py possibly look at
-    #  pre/post load validator(...) or root_validator(...) functions as an alternative to composing other fields,
-    #  or research more    AWS_S3_ENDPOINT: str = property(lambda self: "s3.us-gov-west-1.amazonaws.com")
-    AWS_STS_ENDPOINT = "sts.us-gov-west-1.amazonaws.com"
+    AWS_S3_BUCKET: str = ENV_SPECIFIC_OVERRIDE
+    AWS_S3_OUTPUT_PATH: str = "output"  # path within AWS_S3_BUCKET where output data will accumulate
+    AWS_STS_ENDPOINT: str = "sts.us-gov-west-1.amazonaws.com"
 
     class Config:
         pass

--- a/usaspending_api/config/envs/local.py
+++ b/usaspending_api/config/envs/local.py
@@ -9,14 +9,10 @@
 ########################################################################################################################
 from typing import ClassVar
 
+from usaspending_api.config.utils import USER_SPECIFIC_OVERRIDE
 from pydantic.types import SecretStr
 
-from usaspending_api.config.default import DefaultConfig
-
-# Placeholder sentinel value indicating a config var that is expected to be overridden from a runtime env to
-# accommodate a var value that is specific to an individual developer's local environment setup.
-# If this value emerges, it has not yet been set in the user's config (e.g. .env file) and and must be.
-_USER_SPECIFIC_OVERRIDE = "?USER_SPECIFIC_OVERRIDE?"
+from usaspending_api.config.envs.default import DefaultConfig
 
 
 class LocalConfig(DefaultConfig):
@@ -55,7 +51,7 @@ class LocalConfig(DefaultConfig):
     POSTGRES_PORT = "5432"
 
     # Should point to a path where data can be persistend beyond docker restarts, outside of the git source repository
-    POSTGRES_CLUSTER_DIR = _USER_SPECIFIC_OVERRIDE
+    POSTGRES_CLUSTER_DIR = USER_SPECIFIC_OVERRIDE
 
     # ==== [Elasticsearch] ====
     # Where to connect to elasticsearch.
@@ -64,7 +60,7 @@ class LocalConfig(DefaultConfig):
     ES_PORT = "9200"
 
     # Should point to a path where data can be persistend beyond docker restarts, outside of the git source repository
-    ES_CLUSTER_DIR = _USER_SPECIFIC_OVERRIDE
+    ES_CLUSTER_DIR = USER_SPECIFIC_OVERRIDE
 
     # ==== [MinIO] ====
     # MINIO_HOST = "host.docker.internal"
@@ -73,7 +69,7 @@ class LocalConfig(DefaultConfig):
     MINIO_ACCESS_KEY: SecretStr = _USASPENDING_USER  # likely overridden in .env
     MINIO_SECRET_KEY: SecretStr = _USASPENDING_PASSWORD  # likely overridden in .env
     # Should point to a path where data can be persistend beyond docker restarts, outside of the git source repository
-    MINIO_DATA_DIR = _USER_SPECIFIC_OVERRIDE
+    MINIO_DATA_DIR = USER_SPECIFIC_OVERRIDE
 
     # ==== [Spark] ====
     # Used for attaching to a spark-submit process to create a java_gateway for PySpark during unit test sessions

--- a/usaspending_api/config/tests/unit/test_config.py
+++ b/usaspending_api/config/tests/unit/test_config.py
@@ -209,7 +209,7 @@ class _UnitTestBaseConfig(DefaultConfig):
     @validator("UNITTEST_CFG_U")
     def _UNITTEST_CFG_U(cls, v, values, field: ModelField):
         def factory_func():
-            return lambda: values["UNITTEST_CFG_S"] + ":" + values["UNITTEST_CFG_T"]
+            return values["UNITTEST_CFG_S"] + ":" + values["UNITTEST_CFG_T"]
 
         return eval_default_factory(cls, v, values, field, factory_func)
 
@@ -374,23 +374,25 @@ def test_new_runtime_env_overrides_config():
         assert cfg.UNITTEST_CFG_G == "SUB_UNITTEST_CFG_G"
         # 7. Simple composition of values in the same class works
         assert cfg.SUB_UNITTEST_5 == "SUB_UNITTEST_3:SUB_UNITTEST_4"
-        # 8. Subclass-declared override will not only override parent class default, but any value provided by a
+        # 8. subclass with no overriding field or overriding validator will still get the parent class validator's value
+        assert cfg.UNITTEST_CFG_U == "UNITTEST_CFG_S" + ":" + "UNITTEST_CFG_T"
+        # 9. Subclass-declared override will not only override parent class default, but any value provided by a
         #    validator in the parent class
         assert cfg.UNITTEST_CFG_X == "SUB_UNITTEST_CFG_X"
-        # 9. Subclasses adding their own validator to a field in a parent class, USING THE SAME NAME as the validator
+        # 10. Subclasses adding their own validator to a field in a parent class, USING THE SAME NAME as the validator
         # function in the parent class, will yield the subclass's validator value (overriding the parent validator)
         assert cfg.UNITTEST_CFG_Y == "SUB_UNITTEST_CFG_Y"
-        # 10. Subclasses adding their own validator to a field in a parent class, USING A DIFFERENT NAME for the
+        # 11. Subclasses adding their own validator to a field in a parent class, USING A DIFFERENT NAME for the
         # validator than the validator function in the parent class, will end up taking the parent validator's
         # value as the "assigned" (i.e. assigned/overridden elsewhere) value
         assert cfg.UNITTEST_CFG_Z == "UNITTEST_CFG_V:UNITTEST_CFG_W"
-        # 11. Subclass validators DO NOT take precedence and override parent class default IF the field is not
+        # 12. Subclass validators DO NOT take precedence and override parent class default IF the field is not
         # re-declared on subclass
         # NOTE: Could not find a way to avoid this in the eval_default_factory function, because pydantic hijacks the
         # name of the field and replaces it with the validator name. So can't detect if the field exists on BOTH
         # subclass and parent class to determine if its being redeclared or not.
         assert cfg.UNITTEST_CFG_AC == "UNITTEST_CFG_AC"
-        # 12. Subclass validators DO take precedence and override parent class default IF the field IS RE-DECLARED on
+        # 13. Subclass validators DO take precedence and override parent class default IF the field IS RE-DECLARED on
         # subclass
         assert cfg.UNITTEST_CFG_AD == "UNITTEST_CFG_AA:UNITTEST_CFG_AB"
 

--- a/usaspending_api/config/utils.py
+++ b/usaspending_api/config/utils.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, Callable, Type
+from typing import Any, Dict, Callable, TypeVar
 
-from pydantic.main import ModelMetaclass
+from pydantic import BaseSettings
 from pydantic.fields import ModelField
 
 # Placeholder sentinel value indicating a config var that is expected to be overridden in a runtime-env-specific
@@ -12,13 +12,21 @@ ENV_SPECIFIC_OVERRIDE = "?ENV_SPECIFIC_OVERRIDE?"
 # If this value emerges, it has not yet been set in the user's config (e.g. .env file) and and must be.
 USER_SPECIFIC_OVERRIDE = "?USER_SPECIFIC_OVERRIDE?"
 
+# Placeholder sentinel value indicating that a default should NOT be provided for a field, because its default value
+# is provided by a factory function (likely one provided within a function annotated with @pydantic.validator)
+FACTORY_PROVIDED_VALUE = "?FACTORY_PROVIDED_VALUE?"
 
-def default_factory(
-    config_class: Type[ModelMetaclass],
+CONFIG_VAR_PLACEHOLDERS = [ENV_SPECIFIC_OVERRIDE, USER_SPECIFIC_OVERRIDE, FACTORY_PROVIDED_VALUE]
+
+TBaseSettings = TypeVar("TBaseSettings", bound=BaseSettings)
+
+
+def eval_default_factory(
+    config_class: TBaseSettings,
     assigned_or_sourced_value: Any,
     configured_vars: Dict[str, Any],
     config_var: ModelField,
-    factory_func: Callable[[ModelField, Any, Any, Dict[str, Any]], Any],
+    factory_func: Callable,
 ):
     """A delegate function that acts as a default factory to produce/derive (or transform) a config var value
 
@@ -26,6 +34,9 @@ def default_factory(
     from validator functions.
 
     Args:
+        config_class (TBaseSettings): The class inheriting from pydantic.BaseSettings who is being instantiated. It
+            is NOT (necessarily) the class on which this config_var (or its validator) resides.
+
         config_var (ModelField): The pydantic setting aka field aka configuration variable for which to
             factory-derive a value
 
@@ -37,36 +48,66 @@ def default_factory(
             ModelFields in the model being seen, this dictionary may not be inclusive of ALL fields in the model (of
             all configuration variables), simply because they haven't been seen/processed yet.
 
-        factory_func (Callable[[ModelField, Any, Any, Dict[str, Any]], Any]): A lambda or callable function passed in
-            which will be invoked with the
+        factory_func (Callable): A lambda or callable function passed in
+            which will be invoked to produce a value for the field. The provided factory function is assumed to be a
+            closure, enclosing variable values it needs in its scoped defniition so they don't need to be passed in.
+            See Example below for a no-param lambda closure
 
-        TODO: Can lambda functions use kwargs, so we pass everything to the lambda, but it only uses what it needs?
-         If so how do you show that in typing?
         Example:
             >>> @validator("MY_COMPOSED_FIELD")
-            >>> def _MY_COMPOSED_FIELD(cls, v, values, field: ModelField:
-            >>>     factory_func = lambda c, v, values, field: return values["MY_FIELD_1"] + ":" + values["MY_FIELD_2"]
-            >>>     return default_factory(cls, v, values, field, factory_func)
+            >>> def _MY_COMPOSED_FIELD(cls, v, values, field: ModelField):
+            >>>     def factory_func():
+            >>>         return values["MY_FIELD_1"] + ":" + values["MY_FIELD_2"]
+            >>>     return eval_default_factory(cls, v, values, field, factory_func)
     """
     # This "default_value" is the value that this field was declared with in python code. Note if it is
     #  overridden in a subclass, this will be the value assigned to the field in the subclass, which could differ
     #  from any 'default' value assigned in a super class.
     default_value = config_var.default
-    if default_value is not None:
+
+    # Get any parent config class fields, to determine if this field may be overriding it
+    overridable_config_base_classes = [
+        bc for bc in config_class.__bases__ if issubclass(bc, BaseSettings) and "__fields__" in dir(bc)
+    ]
+    overridable_config_fields = {k for bc in overridable_config_base_classes for k in bc.__fields__.keys()}
+    is_override = config_var.name in overridable_config_fields
+
+    if not is_override and default_value is not None and default_value not in CONFIG_VAR_PLACEHOLDERS:
         raise ValueError(
-            "This type of default-factory based validator requires that the field be set to None by "
-            "default. This is so that when a value is sourced or assigned elsewhere for this, "
-            "it will stick,."
+            "This field, which is tied to a default-factory-based validator, must have its default value set to None,"
+            "or to one of the CONFIG_VAR_PLACEHOLDERS. This is so that when a value is sourced or assigned "
+            "elsewhere for this field, it can easily be identified as a non-default value, and will take "
+            "precedence as the new value."
         )
-    if assigned_or_sourced_value and assigned_or_sourced_value not in [ENV_SPECIFIC_OVERRIDE, USER_SPECIFIC_OVERRIDE]:
+
+    # if (
+    #     is_override
+    #     # A non-placeholder default_value was provided somewhere (instantiated class, or parent class)
+    #     and default_value is not None
+    #     and default_value not in CONFIG_VAR_PLACEHOLDERS
+    #     and config_var.name not in declared_config_fields  # not a field (re)declared on the instantiated class
+    # ):
+    #     raise TypeError(
+    #         "You may be 'overriding' a parent class config var in a subclass by way of a validator, "
+    #         "without re-delcaring that config var in the subclass. If so, redeclare it above its validator in the "
+    #         "subclass as:\n\t"
+    #         "CONFIG_VAR = FACTORY_PROVIDED_VALUE"
+    #     )
+
+    if assigned_or_sourced_value and assigned_or_sourced_value not in CONFIG_VAR_PLACEHOLDERS:
         # The value of this field is being explicitly set in some source (initializer param, env var, etc.)
         # So honor it and don't use the default below
         return assigned_or_sourced_value
-    else:
-        # Otherwise let this validator be the field's default factory
-        # Lazily compose other fields' values
-        # NOTE: pydantic orders annotated (even fields annotated with their typing Type, like field_name: str)
-        #       BEFORE non-annotated fields. And the values dict ONLY has field values for fields it has seen,
-        #       seeing them IN ORDER. So for this composition of other fields to work, the other fields MUST ALSO
-        #       be type-annotated
-        return factory_func(config_var, default_value, assigned_or_sourced_value, configured_vars)
+
+    if is_override and default_value not in CONFIG_VAR_PLACEHOLDERS:
+        return default_value  # the value set on the overriding subclass is next in line for precedence
+
+    # Otherwise let this validator be the field's default factory
+    # The provided factory function is assumed to be a closure, enclosing variable values it needs in its scoped
+    # definition so they don't need to be passed in.
+    # NOTE: pydantic orders annotated (even fields annotated with their typing Type, like field_name: str)
+    #       BEFORE non-annotated fields. And the values dict ONLY has field values for fields it has seen,
+    #       seeing them IN ORDER. So if the provided factory function references OTHER fields to produced the
+    #       value for the field in question, AND the field in question is annotated, the other fields must be
+    #       [type] annotated as well for their values to be accessible, or an error will raise.
+    return factory_func()

--- a/usaspending_api/config/utils.py
+++ b/usaspending_api/config/utils.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, Callable, Type
+
+from pydantic.main import ModelMetaclass
+from pydantic.fields import ModelField
+
+# Placeholder sentinel value indicating a config var that is expected to be overridden in a runtime-env-specific
+# config declaration. If this value emerges, it has not yet been set in the runtime env config and must be.
+ENV_SPECIFIC_OVERRIDE = "?ENV_SPECIFIC_OVERRIDE?"
+
+# Placeholder sentinel value indicating a config var that is expected to be overridden from a runtime env to
+# accommodate a var value that is specific to an individual developer's local environment setup.
+# If this value emerges, it has not yet been set in the user's config (e.g. .env file) and and must be.
+USER_SPECIFIC_OVERRIDE = "?USER_SPECIFIC_OVERRIDE?"
+
+
+def default_factory(
+    config_class: Type[ModelMetaclass],
+    assigned_or_sourced_value: Any,
+    configured_vars: Dict[str, Any],
+    config_var: ModelField,
+    factory_func: Callable[[ModelField, Any, Any, Dict[str, Any]], Any],
+):
+    """A delegate function that acts as a default factory to produce/derive (or transform) a config var value
+
+    NOTE: This functions's signature follows that of pydantic validator functions, because it is to be delegated to
+    from validator functions.
+
+    Args:
+        config_var (ModelField): The pydantic setting aka field aka configuration variable for which to
+            factory-derive a value
+
+        assigned_or_sourced_value (Any): The value that pydantic found for this config var. It could be coming from
+            an assignment, or from a config source, like environment variables.
+
+        configured_vars (Dict[str, Any]): Dictionary of configuration variables that have been seen/processed (IN
+            ORDER) by pydantic already. Note: due to the fact that validators are processed in the order of
+            ModelFields in the model being seen, this dictionary may not be inclusive of ALL fields in the model (of
+            all configuration variables), simply because they haven't been seen/processed yet.
+
+        factory_func (Callable[[ModelField, Any, Any, Dict[str, Any]], Any]): A lambda or callable function passed in
+            which will be invoked with the
+
+        TODO: Can lambda functions use kwargs, so we pass everything to the lambda, but it only uses what it needs?
+         If so how do you show that in typing?
+        Example:
+            >>> @validator("MY_COMPOSED_FIELD")
+            >>> def _MY_COMPOSED_FIELD(cls, v, values, field: ModelField:
+            >>>     factory_func = lambda c, v, values, field: return values["MY_FIELD_1"] + ":" + values["MY_FIELD_2"]
+            >>>     return default_factory(cls, v, values, field, factory_func)
+    """
+    # This "default_value" is the value that this field was declared with in python code. Note if it is
+    #  overridden in a subclass, this will be the value assigned to the field in the subclass, which could differ
+    #  from any 'default' value assigned in a super class.
+    default_value = config_var.default
+    if default_value is not None:
+        raise ValueError(
+            "This type of default-factory based validator requires that the field be set to None by "
+            "default. This is so that when a value is sourced or assigned elsewhere for this, "
+            "it will stick,."
+        )
+    if assigned_or_sourced_value and assigned_or_sourced_value not in [ENV_SPECIFIC_OVERRIDE, USER_SPECIFIC_OVERRIDE]:
+        # The value of this field is being explicitly set in some source (initializer param, env var, etc.)
+        # So honor it and don't use the default below
+        return assigned_or_sourced_value
+    else:
+        # Otherwise let this validator be the field's default factory
+        # Lazily compose other fields' values
+        # NOTE: pydantic orders annotated (even fields annotated with their typing Type, like field_name: str)
+        #       BEFORE non-annotated fields. And the values dict ONLY has field values for fields it has seen,
+        #       seeing them IN ORDER. So for this composition of other fields to work, the other fields MUST ALSO
+        #       be type-annotated
+        return factory_func(config_var, default_value, assigned_or_sourced_value, configured_vars)

--- a/usaspending_api/config/utils.py
+++ b/usaspending_api/config/utils.py
@@ -80,26 +80,12 @@ def eval_default_factory(
             "precedence as the new value."
         )
 
-    # if (
-    #     is_override
-    #     # A non-placeholder default_value was provided somewhere (instantiated class, or parent class)
-    #     and default_value is not None
-    #     and default_value not in CONFIG_VAR_PLACEHOLDERS
-    #     and config_var.name not in declared_config_fields  # not a field (re)declared on the instantiated class
-    # ):
-    #     raise TypeError(
-    #         "You may be 'overriding' a parent class config var in a subclass by way of a validator, "
-    #         "without re-delcaring that config var in the subclass. If so, redeclare it above its validator in the "
-    #         "subclass as:\n\t"
-    #         "CONFIG_VAR = FACTORY_PROVIDED_VALUE"
-    #     )
-
     if assigned_or_sourced_value and assigned_or_sourced_value not in CONFIG_VAR_PLACEHOLDERS:
         # The value of this field is being explicitly set in some source (initializer param, env var, etc.)
         # So honor it and don't use the default below
         return assigned_or_sourced_value
 
-    if is_override and default_value not in CONFIG_VAR_PLACEHOLDERS:
+    if is_override and default_value and default_value not in CONFIG_VAR_PLACEHOLDERS:
         return default_value  # the value set on the overriding subclass is next in line for precedence
 
     # Otherwise let this validator be the field's default factory


### PR DESCRIPTION
**Description:**
Remove the subtle error-prone weakness of using property() fields with late-binding (lazily evaluated by way of its closure nature) lambda functions. Using them _excludes_ those fields from the set of fields that pydantic is tracking, and makes it so they can't be overridden as expected.

**Technical details:**
Looking into using [`validators`](https://pydantic-docs.helpmanual.io/usage/validators/) as a workaround and better approach for this. `validators` are perhaps poorly named. Yes they "validate" entries/assignments/sourced-values, but they can also be used as a way to pre or post-process values, e.g. to _transform_ them, and return a altered or different value than what was provided/sourced.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
