### PR TITLE
[PIPE-231] Remove constraints from Transaction Search to improve locking during swap

### DIFF
--- a/usaspending_api/etl/management/commands/combine_transaction_search_chunks.py
+++ b/usaspending_api/etl/management/commands/combine_transaction_search_chunks.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from django.db import connection, transaction
 from django.core.management.base import BaseCommand
 
-from psycopg2 import OperationalError
-
 from usaspending_api.common.data_connectors.async_sql_query import async_run_creates
 from usaspending_api.common.helpers.sql_helpers import execute_sql_simple
 from usaspending_api.common.helpers.timing_helpers import ConsoleTimer as Timer
@@ -60,8 +58,6 @@ class Command(BaseCommand):
 
         logger.info(f"Chunk Count: {chunk_count}")
 
-        # Constraints must be read first, so indexes created by pk/fk are not repeated
-        create_temp_constraints, rename_constraints, delete_constraints = self.read_constraint_definitions()
         create_temp_indexes, rename_indexes = self.read_index_definitions()
 
         with Timer("Recreating table"):
@@ -70,18 +66,15 @@ class Command(BaseCommand):
         with Timer("Inserting data into table"):
             self.insert_matview_data(chunk_count)
 
-        with Timer("Creating table constraints"):
-            self.create_constraints(create_temp_constraints)
-
         with Timer("Creating table indexes"):
             self.create_indexes(create_temp_indexes, index_concurrency)
 
         with Timer("Swapping Tables/Indexes"):
-            self.swap_tables(rename_indexes, rename_constraints, delete_constraints)
+            self.swap_tables(rename_indexes)
 
         if not options["keep_old_data"]:
             with Timer("Clearing old table"):
-                warnings.append(self.drop_old_data())
+                execute_sql_simple((self.matview_dir / "componentized" / f"{TABLE_NAME}__drops.sql").read_text())
 
         if not options["keep_matview_data"]:
             with Timer("Emptying Matviews"):
@@ -91,32 +84,6 @@ class Command(BaseCommand):
             execute_sql_simple((self.matview_dir / "componentized" / f"{TABLE_NAME}__mods.sql").read_text())
 
         return "\n".join(warnings)
-
-    def read_constraint_definitions(self):
-        indexes_sql = (self.matview_dir / "componentized" / f"{TABLE_NAME}__constraints.sql").read_text()
-
-        with connection.cursor() as cursor:
-            cursor.execute(indexes_sql)
-            rows = cursor.fetchall()
-
-        create_temp_constraints = []
-        rename_constraints_temp = []
-        delete_contraints_old = []
-        for row in rows:
-            constraint_name = row[0]
-            constraint_name_temp = constraint_name + "_temp"
-
-            create_temp_constraints.append(
-                f"ALTER TABLE public.{TABLE_NAME}_temp ADD CONSTRAINT {constraint_name_temp} {row[1]};"
-            )
-            rename_constraints_temp.append(
-                f"ALTER TABLE public.{TABLE_NAME} RENAME CONSTRAINT {constraint_name_temp} TO {constraint_name};"
-            )
-            delete_contraints_old.append(f"ALTER TABLE public.{TABLE_NAME}_old DROP CONSTRAINT {constraint_name};")
-
-            self.constraint_names.append(constraint_name)
-
-        return create_temp_constraints, rename_constraints_temp, delete_contraints_old
 
     def read_index_definitions(self):
         indexes_sql = (self.matview_dir / "componentized" / f"{TABLE_NAME}__indexes.sql").read_text()
@@ -168,15 +135,6 @@ class Command(BaseCommand):
         loop.run_until_complete(asyncio.gather(*tasks))
         loop.close()
 
-    def create_constraints(self, constraint_definitions):
-
-        constraint_sql = "\n".join(constraint_definitions)
-
-        logger.debug(constraint_sql)
-
-        with connection.cursor() as cursor:
-            cursor.execute(constraint_sql)
-
     def create_indexes(self, index_definitions, index_concurrency):
         loop = asyncio.new_event_loop()
         loop.run_until_complete(self.index_with_concurrency(index_definitions, index_concurrency))
@@ -200,35 +158,13 @@ class Command(BaseCommand):
         return await asyncio.gather(*tasks)
 
     @transaction.atomic
-    def swap_tables(self, rename_indexes, rename_constraints, delete_constraints):
+    def swap_tables(self, rename_indexes):
 
         swap_sql = (self.matview_dir / "componentized" / f"{TABLE_NAME}__renames.sql").read_text()
 
-        swap_sql += "\n".join(rename_indexes + delete_constraints + rename_constraints)
+        swap_sql += "\n".join(rename_indexes)
 
         logger.debug(swap_sql)
 
         with connection.cursor() as cursor:
             cursor.execute(swap_sql)
-
-    def drop_old_data(self):
-        retries_remaining = self.retry_count
-        table_is_dropped = False
-        warning = ""
-
-        while retries_remaining >= 0 and not table_is_dropped:
-            try:
-                execute_sql_simple((self.matview_dir / "componentized" / f"{TABLE_NAME}__drops.sql").read_text())
-                table_is_dropped = True
-            except OperationalError as e:
-                logger.warning(
-                    f"Error when attempting to drop ${TABLE_NAME}_old. {retries_remaining} retries remaining."
-                )
-                logger.warning(e)
-                retries_remaining -= 1
-
-        if retries_remaining < 0 and not table_is_dropped:
-            warning = f"Table ${TABLE_NAME}_old could not be dropped."
-            logger.error(warning + " No retries remaining.")
-
-        return warning

--- a/usaspending_api/search/migrations/0002_auto_20210121_2235.py
+++ b/usaspending_api/search/migrations/0002_auto_20210121_2235.py
@@ -17,8 +17,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TransactionSearch',
             fields=[
-                ('transaction', models.OneToOneField(on_delete=django.db.models.deletion.DO_NOTHING, primary_key=True, serialize=False, to='awards.TransactionNormalized')),
-                ('award', models.ForeignKey(null=True, on_delete=django.db.models.deletion.DO_NOTHING, to='awards.Award')),
+                ('transaction', models.BigIntegerField(primary_key=True, serialize=False, db_column="transaction_id")),
+                ('award', models.BigIntegerField(null=True, db_column="award_id")),
                 ('modification_number', models.TextField(null=True)),
                 ('detached_award_proc_unique', models.TextField(null=True)),
                 ('afa_generated_unique', models.TextField(null=True)),
@@ -112,6 +112,41 @@ class Migration(migrations.Migration):
             options={
                 'db_table': 'transaction_search',
             },
+        ),
+        # Trick Django into believing this is a one-to-one field for purposes of using the ORM,
+        # but avoid the headache that comes with foreign keys
+        migrations.RunSQL(
+            sql="",
+            reverse_sql="",
+            state_operations=[
+                migrations.AlterField(
+                    model_name='transactionsearch',
+                    name='transaction',
+                    field=models.OneToOneField(
+                        on_delete=django.db.models.deletion.DO_NOTHING,
+                        primary_key=True,
+                        serialize=False,
+                        to='awards.TransactionNormalized',
+                    ),
+                )
+            ]
+        ),
+        # Trick Django into believing this is a foreign key for purposes of using the ORM,
+        # but avoid the headache that comes with foreign keys
+        migrations.RunSQL(
+            sql="",
+            reverse_sql="",
+            state_operations=[
+                migrations.AlterField(
+                    model_name='transactionsearch',
+                    name='award',
+                    field=models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.DO_NOTHING,
+                        to='awards.Award',
+                    )
+                )
+            ]
         ),
         migrations.DeleteModel(
             name='UniversalTransactionView',

--- a/usaspending_api/search/models/transaction_search.py
+++ b/usaspending_api/search/models/transaction_search.py
@@ -10,6 +10,8 @@ class TransactionSearch(models.Model):
     may or may not be nullable, but those constraints are not enforced in this table.
     """
 
+    # "transaction" and "award" are actually models.BigIntegerField(), but left as OneToOneField and ForeignKey
+    # to allow for querying in the Django ORM
     transaction = models.OneToOneField("awards.TransactionNormalized", on_delete=models.DO_NOTHING, primary_key=True)
     award = models.ForeignKey("awards.Award", on_delete=models.DO_NOTHING, null=True)
     modification_number = models.TextField(null=True)


### PR DESCRIPTION
**Description:**
Improve locks that are taken during the combine transactions stage of the Nightly Pipeline to prevent deadlock scenarios.

**Technical details:**
Currently the Nightly Pipeline runs into a deadlock issue due to conflicting `AccessShareLock` and `AccessExclusiveLock`. The `AccessExclusiveLock` occurs when the combine transactions stage attempts to `DROP CONSTRAINT` for the two different FOREIGN KEYs (`awards` and `transaction_normalized`). One example of the `AccessShareLock` that has been problematic for this is a simple SELECT that joins `awards` and `transaction_normalized` since it takes an `AccessShareLock` on both of those tables. The deadlock scenario occurs when:
1. DROP CONSTRAINT for FOREIGN KEY to `awards` takes an `AccessExclusiveLock`
2. SELECT ... FROM ... takes an `AccessShareLock` on `awards` and `transaction_normalized`
3. DROP CONSTRAINT for FOREIGN KEY to `transaction_normalized` takes an `AccessExclusiveLock`

In the scenario above, Lock 1 will not let up until Lock 3 does since they are in a transaction. And Lock 2 will not let up until Lock 1 does since `AccessExclusiveLock` blocks all operations to the table under lock.

The reason this lock is taken on these tables is because of how Postgres handles FOREIGN KEY CONSTRAINTS. When a FOREIGN KEY CONSTRAINT is created it also creates a trigger on the underlying table (e.g. `transaction_search -> awards` and `transaction_search -> transaction_normalized`). When the CONSTRAINT is dropped it also needs to drop the trigger, which results in the `AccessExclusiveLock` on both Primary and Secondary table. This is also why attempts to resolve this in #3245 did not work. That PR added error handling on the DROP TABLE section fo the job, but also moved the DROP CONSTRAINTS to the Swap / Rename section. So while it appears that a new problem was created, it actually just moved to problem since the DROP TABLE would have also performed DROP CONSTRAINT via CASCADE. 

This leaves two solutions:
* Simply remove the DROP CONSTRAINT statements out of the DB transaction
   * Appears that having these statements in a DB transaction is actually bad practice for this deadlock reason
* OR, remove the CONSTRAINTS entirely from `transaction_search`
   * This PR takes this approach because really this table is a report built on top of tables that already have constraints
   * Also, the constraints are kinda needed for the Django ORM, but you can trick the Django ORM into thinking that the fields are Foreign Key or One-To-One fields even though they are simple data types AND NOT keys

Lastly, this PR removes changes around error handling since that is actually not a problem.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
5. [x] API documentation updated
6. [ ] Necessary PR reviewers:
    - [ ] Backend
7. [x] Matview impact assessment completed
8. [x] Frontend impact assessment completed
9. [x] Data validation completed
10. [ ] Appropriate Operations ticket(s) created
11. [x] Jira Ticket [PIPE-231](https://federal-spending-transparency.atlassian.net/browse/PIPE-231):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
