### PR TITLE
Updating usages of VACUUM to match Postgres 13 changes

### DIFF
--- a/usaspending_api/common/management/commands/vacuum_table.py
+++ b/usaspending_api/common/management/commands/vacuum_table.py
@@ -38,13 +38,13 @@ class Command(BaseCommand):
         if options.get("all"):  # if parameter is not provided, run vacuum analyze on the entire database
             logger.info("Running VACUUM ANALZYE on entire database...")
             with connection.cursor() as cursor:
-                cursor.execute("VACUUM ANALYZE VERBOSE;")
+                cursor.execute("VACUUM VERBOSE ANALYZE;")
         else:
             tables = tables[0]
             for table in tables:
                 logger.info("Running VACUUM ANALYZE on the %s table" % table)
                 with connection.cursor() as cursor:
-                    cursor.execute("VACUUM ANALYZE VERBOSE %s;" % table)
+                    cursor.execute("VACUUM VERBOSE ANALYZE %s;" % table)
                 logger.info(
                     "Finished running VACUUM ANALYZE on the %s table in %s seconds"
                     % (table, str(datetime.now() - total_start))

--- a/usaspending_api/database_scripts/matview_generator/shared_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/shared_sql_generator.py
@@ -15,7 +15,7 @@ TEMPLATE = {
     "refresh_matview": "REFRESH MATERIALIZED VIEW {}{} WITH DATA;",
     "empty_matview": "REFRESH MATERIALIZED VIEW {} WITH NO DATA;",
     "analyze": "ANALYZE VERBOSE {};",
-    "vacuum": "VACUUM ANALYZE VERBOSE {};",
+    "vacuum": "VACUUM VERBOSE ANALYZE {};",
     "create_index": "CREATE {}INDEX {} ON {} USING {}({}){}{};",
     "create_stats": "CREATE STATISTICS {} ON {} FROM {};",
     "rename_index": "ALTER INDEX {}{} RENAME TO {};",


### PR DESCRIPTION
**Description:**
Make changes to usages of VACUUM to no longer run into syntax issues.

**Technical details:**
In Postgres 10 it is possible to say `VACUUM VERBOSE ANALYZE VERBOSE` which is redundant because the VERBOSE is on VACUUM and the VERBOSE after ANALYZE does nothing. To prevent confusion the grammar was updated in Postgres 11 to force usage to be `VACUUM VERBOSE ANALYZE (...options...)`.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
