### PR TITLE
[PIPE-10] Spark S3AFileSystem config for Committer set back to defaults

### DIFF
--- a/usaspending_api/common/helpers/spark_helpers.py
+++ b/usaspending_api/common/helpers/spark_helpers.py
@@ -112,17 +112,34 @@ def configure_spark_session(
     # Assume that random errors are rare, and jobs have long runtimes, so fail fast, fix and retry manually.
     conf.set("spark.yarn.maxAppAttempts", "1")
     conf.set("spark.hadoop.fs.s3a.endpoint", CONFIG.AWS_S3_ENDPOINT)
+
     if not CONFIG.USE_AWS:
         # Set configs to allow the S3AFileSystem to work against a local MinIO object storage proxy
         conf.set("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
         # "Enable S3 path style access ie disabling the default virtual hosting behaviour.
         # Useful for S3A-compliant storage providers as it removes the need to set up DNS for virtual hosting."
         conf.set("spark.hadoop.fs.s3a.path.style.access", "true")
-        # Set Committer config compliant with MinIO
-        #   - (see: https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/committers.html)
-        conf.set("spark.hadoop.fs.s3a.committer.name", "directory")
-        conf.set("spark.hadoop.fs.s3a.committer.staging.conflict-mode", "replace")
-        conf.set("spark.hadoop.fs.s3a.committer.staging.tmp.path", "/tmp/staging")
+
+        # Documenting for Awareness:
+        # Originally it was thought that the S3AFileSystem "Committer" needed config changes to be compliant when
+        # hitting MinIO locally instead of AWS S3 service. However, those changs were proven unnecessary.
+        # - There is however an intermitten issue which we cannot quite identify the root cause (perhaps changing
+        #   back to defaults will keep it from happening again). See: https://github.com/minio/minio/issues/10744
+        #   - The error comes back as "FileAlreadyExists" ... or just: "<file/folder> already exists"
+        #   - It is either some cache purging of Docker or MinIO or both over time that fixes it
+        #   - Or some fiddling with these committer settings
+        # - For Committer Details: https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/committers.html
+        # - Findings:
+        #   - If USE_AWS = True, and you point it at an AWS bucket...
+        #     - s3a.path.style.access=true works, by itself as well as with no committer specified (falls back to
+        #      FileOutputCommitter) and any combo of conflict-mode and tmp.path
+        #     - However if committer.name="directory" (it uses the StagingOutputCommitter) AND conflict-mode=replace,
+        #       it will replace the whole directory at the last file write, which is the _SUCCESS file, and that's why
+        #       that's the only file you see
+        # - The below settings are the DEFAULT when not set, but documenting here FYI
+        # conf.set("spark.hadoop.fs.s3a.committer.name", "file")
+        # conf.set("spark.hadoop.fs.s3a.committer.staging.conflict-mode", "fail")
+        # conf.set("spark.hadoop.fs.s3a.committer.staging.tmp.path", "tmp/staging")
 
     # Set AWS credentials in the Spark config
     # Hint: If connecting to AWS resources when executing program from a local env, and you usually authenticate with


### PR DESCRIPTION
**Description:**
Removing custom config for the S3AFileSystem implementation when running a local S3 API via MinIO

**Technical details:**
Defaults are safest, and they appear to work. Previously they were thought not to work.
- This also solves the spurious issue of writing a CSV file from Spark in parts to a directory only landing the `_SUCCESS` file and not the `*.csv` part files as well.
- See also comments in the committed change

Also:
1. Added the lifecycle pytest fixture for a separate ephemeral and uniquely named unit test data bucket
2. Added a fixture that uses the bucket fixture which wipes the bucket clean of any data after each test
3. Extended the CSV write unit test to check to be sure objects with `.csv` are written to the bucket. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
4. [NA] API documentation updated
5. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
6. [NA] Matview impact assessment completed
7. [NA] Frontend impact assessment completed
8. [x] Data validation completed
9. [NA] Appropriate Operations ticket(s) created
10. [x] Jira Ticket [PIPE-10](https://federal-spending-transparency.atlassian.net/browse/PIPE-10):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
