### PR TITLE
[PIPE-10] Fixing port conflict with minio and developer laptop proxies

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -54,8 +54,8 @@ SPARK_CLUSTER_DATA_DIR=${HOME}/Development/data/usaspending/docker/usaspending-s
 AWS_PROFILE=
 
 # ==== [MinIO] ====
-MINIO_PORT=9000
-MINIO_CONSOLE_PORT=9001
+MINIO_PORT=10001
+MINIO_CONSOLE_PORT=10002
 # Should point to a path where data can be persisted beyond docker restarts, outside of the git source repository
 # The specified directory needs to exist before Docker can mount it
 MINIO_DATA_DIR=${HOME}/Development/data/usaspending/docker/usaspending-s3

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -8,7 +8,8 @@ ARG SPARK_VERSION=3.1.2
 ARG PROJECT_LOG_DIR=/logs
 
 RUN yum -y update && yum clean all
-RUN yum -y install wget gcc openssl-devel bzip2-devel libffi libffi-devel zlib-devel
+# sqlite-devel added as prerequisite for coverage python lib, used by pytest-cov plugin
+RUN yum -y install wget gcc openssl-devel bzip2-devel libffi libffi-devel zlib-devel sqlite-devel
 RUN yum -y groupinstall "Development Tools"
 
 # Building Python 3.x

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ services:
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-usaspending}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-usaspender}
-    command: server --address ":${MINIO_PORT:-9000}" --console-address ":${MINIO_CONSOLE_PORT:-9001}" /data
+    command: server --address ":9000" --console-address ":9001" /data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://${MINIO_HOST:-localhost}:${MINIO_PORT:-9000}/minio/health/live"]
       interval: 30s

--- a/usaspending_api/config/envs/local.py
+++ b/usaspending_api/config/envs/local.py
@@ -56,7 +56,9 @@ class LocalConfig(DefaultConfig):
 
     # ==== [MinIO] ====
     MINIO_HOST: str = "localhost"
-    MINIO_PORT: str = "9000"
+    # Changing MinIO ports from defaults. Known to have port conflicts with proxies on developer laptops
+    MINIO_PORT: str = "10001"
+    MINIO_CONSOLE_PORT: str = "10002"
     MINIO_ACCESS_KEY: SecretStr = _USASPENDING_USER  # likely overridden in .env
     MINIO_SECRET_KEY: SecretStr = _USASPENDING_PASSWORD  # likely overridden in .env
     # Should point to a path where data can be persistend beyond docker restarts, outside of the git source repository


### PR DESCRIPTION
**Description:**
Fixing port conflict with minio and developer laptop proxies

**Technical details:**
- setting to port other than 9000 by default in LocalConfig and in the .env.template
- Also adding sqllite-devel to Dockerfile.spark in case pytest with coverage needs to run off the spark-base container

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [PIPE-10](https://federal-spending-transparency.atlassian.net/browse/PIPE-10):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
