### PR TITLE
[PIPE-284] Updates minio default ports and adds docker-compose-run profiles option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,23 +161,12 @@ docker-compose-up-spark: ## Deploy containerized version of spark cluster infras
 .PHONY: docker-compose-run
 docker-compose-run: ## Use docker-compose run <args> to run one or more Docker Compose services with options
 	# NOTE: [See NOTE in docker-compose rule about .env file]
-	docker-compose --project-directory . --file ${docker_compose_file} run ${args}
-
-.PHONY: docker-compose-run-spark
-docker-compose-run-spark: ## Use docker-compose run <args> to run one or more Docker Compose services with options with the spark profile
-	# NOTE: [See NOTE in docker-compose rule about .env file]
-	docker-compose --profile spark --project-directory . --file ${docker_compose_file} run ${args}
+	docker-compose ${profiles} --project-directory . --file ${docker_compose_file} run ${args}
 
 .PHONY: docker-compose-down
 docker-compose-down: ## Run docker-compose down to bring down services listed in the compose file
 	# NOTE: [See NOTE in docker-compose rule about .env file]
 	docker-compose --project-directory . --file ${docker_compose_file} down ${args}
-
-.PHONY: docker-build-spark
-docker-build-spark: ## Run docker build to build a base container image for spark, hadoop, and python installed
-	# NOTE: [See NOTE in above docker-compose rule about .env file]
-	echo "docker build --tag spark-base --build-arg PROJECT_LOG_DIR=${PROJECT_LOG_DIR} ${args} --file ${dockerfile_for_spark} $$(dirname ${dockerfile_for_spark})"
-	docker build --tag spark-base --build-arg PROJECT_LOG_DIR=${PROJECT_LOG_DIR} ${args} --file ${dockerfile_for_spark} $$(dirname ${dockerfile_for_spark})
 
 .PHONY: docker-compose-build
 docker-compose-build: ## Ensure ALL services in the docker-compose.yaml file have an image built for them according to their build: key

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,11 @@ docker-compose-run: ## Use docker-compose run <args> to run one or more Docker C
 	# NOTE: [See NOTE in docker-compose rule about .env file]
 	docker-compose --project-directory . --file ${docker_compose_file} run ${args}
 
+.PHONY: docker-compose-run-spark
+docker-compose-run-spark: ## Use docker-compose run <args> to run one or more Docker Compose services with options with the spark profile
+	# NOTE: [See NOTE in docker-compose rule about .env file]
+	docker-compose --profile spark --project-directory . --file ${docker_compose_file} run ${args}
+
 .PHONY: docker-compose-down
 docker-compose-down: ## Run docker-compose down to bring down services listed in the compose file
 	# NOTE: [See NOTE in docker-compose rule about .env file]

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,12 @@ docker-compose-down: ## Run docker-compose down to bring down services listed in
 	# NOTE: [See NOTE in docker-compose rule about .env file]
 	docker-compose --project-directory . --file ${docker_compose_file} down ${args}
 
+.PHONY: docker-build-spark
+docker-build-spark: ## Run docker build to build a base container image for spark, hadoop, and python installed
+	# NOTE: [See NOTE in above docker-compose rule about .env file]
+	echo "docker build --tag spark-base --build-arg PROJECT_LOG_DIR=${PROJECT_LOG_DIR} ${args} --file ${dockerfile_for_spark} $$(dirname ${dockerfile_for_spark})"
+	docker build --tag spark-base --build-arg PROJECT_LOG_DIR=${PROJECT_LOG_DIR} ${args} --file ${dockerfile_for_spark} $$(dirname ${dockerfile_for_spark})
+
 .PHONY: docker-compose-build
 docker-compose-build: ## Ensure ALL services in the docker-compose.yaml file have an image built for them according to their build: key
 	# NOTE: This *may* creates a compose-specific image name IF an image: YAML key does not specify the image name to be used as

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,14 +199,14 @@ services:
         source: ${MINIO_DATA_DIR:-../data/s3}
         target: /data
     ports:
-      - ${MINIO_PORT:-9000}:9000
-      - ${MINIO_CONSOLE_PORT:-9001}:9001
+      - ${MINIO_PORT:-10001}:10001
+      - ${MINIO_CONSOLE_PORT:-10002}:10002
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-usaspending}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-usaspender}
-    command: server --address ":9000" --console-address ":9001" /data
+    command: server --address ":10001" --console-address ":10002" /data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://${MINIO_HOST:-localhost}:${MINIO_PORT:-9000}/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://${MINIO_HOST:-localhost}:${MINIO_PORT:-10001}/minio/health/live"]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
**Description:**
Sets default minio ports in docker-compose file to 10001 and 10002 to match local config and template env. 
Adds ${profiles} to `docker-compose-run` make target to allow profiles to be passed in.


**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. N/A Necessary PR reviewers:
    - [x] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-284](https://federal-spending-transparency.atlassian.net/browse/PIPE-284):
    - [x] Link to this Pull-Request
  
**Area for explaining above N/A when needed:**
```
```
