### PR TITLE
[PIPE-10, DEV-2564] Fix .env file location in DefaultConfig.Config

### DIFF
--- a/usaspending_api/config/envs/default.py
+++ b/usaspending_api/config/envs/default.py
@@ -23,7 +23,9 @@ from pydantic import (
 from pydantic.fields import ModelField
 
 _PROJECT_NAME = "usaspending-api"
-_PROJECT_ROOT_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
+# WARNING: This is relative to THIS file's location. If it is moved/refactored, this needs to be confirmed to point
+# to the project root dir (i.e. usaspending-api/)
+_PROJECT_ROOT_DIR = pathlib.Path(__file__).parent.parent.parent.parent.resolve()
 _SRC_ROOT_DIR = _PROJECT_ROOT_DIR / _PROJECT_NAME.replace("-", "_")
 
 


### PR DESCRIPTION
**Description:**
Adding project root dir module constants to default.py broke the relative path location of .env, and wasn't reading in .env values. Fixing the path

**Technical details:**
The path was looking one directory down into `usaspending_api`. Pulled it up one directory, which fixes the path resolution. 
Also added a bunch more tests to verify this.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [NA] Frontend <OPTIONAL>
    - [NA] Operations <OPTIONAL>
    - [NA] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [NA] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-10](https://federal-spending-transparency.atlassian.net/browse/PIPE-10), [DEV-2564](https://federal-spending-transparency.atlassian.net/browse/DEV-2564):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
