### PR TITLE
[DEV-8603] Download date fix

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -182,12 +182,13 @@ def get_download_sources(json_request: dict, download_job: DownloadJob = None, o
 
             # Use correct date range columns for advanced search
             # (Will not change anything for keyword search since "time_period" is not provided))
-            if download_type == "elasticsearch_awards" or download_type == "awards":
+            if (download_type == "elasticsearch_awards" or download_type == "awards") and json_request["filters"].get(
+                "time_period"
+            ) is not None:
                 filters = deepcopy(json_request["filters"])
-                if filters.get("time_period") is not None:
-                    for time_period in filters["time_period"]:
-                        time_period["gte_date_type"] = time_period.get("date_type", "action_date")
-                        time_period["lte_date_type"] = time_period.get("date_type", "date_signed")
+                for time_period in filters["time_period"]:
+                    time_period["gte_date_type"] = time_period.get("date_type", "action_date")
+                    time_period["lte_date_type"] = time_period.get("date_type", "date_signed")
             else:
                 filters = add_date_range_comparison_types(
                     json_request["filters"],

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -181,12 +181,11 @@ def get_download_sources(json_request: dict, download_job: DownloadJob = None, o
 
             # Use correct date range columns for advanced search
             # (Will not change anything for keyword search since "time_period" is not provided))
-            filters = add_date_range_comparison_types(
-                json_request["filters"],
-                is_subaward=download_type != "awards",
-                gte_date_type="action_date",
-                lte_date_type="date_signed",
-            )
+            filters = json_request["filters"]
+            if not download_type != "awards" and filters.get("time_period") is not None:
+                for time_period in filters["time_period"]:
+                    time_period["gte_date_type"] = time_period.get("date_type", "action_date")
+                    time_period["lte_date_type"] = time_period.get("date_type", "date_signed")
             if download_type == "elasticsearch_awards" or download_type == "elasticsearch_transactions":
                 queryset = filter_function(filters, download_job=download_job)
             else:


### PR DESCRIPTION
**Description:**
Fixes a bug with the download/awards endpoint where the `date_type` field was not being applied correctly. Also fixes bug that was causing subaward downloads to fail

**Technical details:**
The subaward bug was due to the fact that the subaward data does not contain any form of `date_signed` for subawards,  so the subaward download will ignore the `date_signed` type and default to using `action_date`.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-8603](https://federal-spending-transparency.atlassian.net/browse/DEV-8603):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
