### PR TITLE
[PIPE-279,PIPE-280] Allow override of Delta db and table names

### DIFF
--- a/usaspending_api/common/helpers/spark_helpers.py
+++ b/usaspending_api/common/helpers/spark_helpers.py
@@ -57,14 +57,14 @@ RDS_REF_TABLES = [
 
 
 def get_active_spark_context() -> SparkContext:
-    """Returns the active spark context if there is one and it's not stopped, otherwise returns None"""
+    """Returns the active ``SparkContext`` if there is one and it's not stopped, otherwise returns None"""
     if is_spark_context_stopped():
         return None
     return SparkContext._active_spark_context
 
 
-def get_active_spark_session() -> SparkContext:
-    """Returns the active spark context if there is one and it's not stopped, otherwise returns None"""
+def get_active_spark_session() -> SparkSession:
+    """Returns the active ``SparkSession`` if there is one and it's not stopped, otherwise returns None"""
     if is_spark_context_stopped():
         return None
     return SparkSession.getActiveSession()

--- a/usaspending_api/etl/management/commands/create_delta_table.py
+++ b/usaspending_api/etl/management/commands/create_delta_table.py
@@ -184,8 +184,8 @@ class Command(BaseCommand):
         spark_s3_bucket = options["spark_s3_bucket"]
 
         table_spec = TABLE_SPEC[destination_table]
-        destination_database = options.get("alt_db", table_spec["destination_database"])
-        destination_table_name = options.get("alt_name", destination_table)
+        destination_database = options["alt_db"] or table_spec["destination_database"]
+        destination_table_name = options["alt_name"] or destination_table
 
         # Set the database that will be interacted with for all Delta Lake table Spark-based activity
         logger.info(f"Using Spark Database: {destination_database}")

--- a/usaspending_api/etl/management/commands/load_table_to_delta.py
+++ b/usaspending_api/etl/management/commands/load_table_to_delta.py
@@ -73,12 +73,12 @@ class Command(BaseCommand):
         destination_table = options["destination_table"]
 
         table_spec = TABLE_SPEC[destination_table]
-        destination_database = options.get("alt_db", table_spec["destination_database"])
+        destination_database = options["alt_db"] or table_spec["destination_database"]
+        destination_table_name = options["alt_name"] or destination_table
         source_table = table_spec["source_table"]
         partition_column = table_spec["partition_column"]
         partition_column_type = table_spec["partition_column_type"]
         custom_schema = table_spec["custom_schema"]
-        destination_table_name = options.get("alt_name", destination_table)
 
         # Set the database that will be interacted with for all Delta Lake table Spark-based activity
         logger.info(f"Using Spark Database: {destination_database}")


### PR DESCRIPTION
**Description:**
When running the create and load django mgmt commands for delta tables, use `--alt-db` or `--alt-name` to allow overriding the name of the db and table used.

**Technical details:**
- Still needs the `--destination-table`, as that is what is used to look up the default metadata from the `TABLE_SPEC` for the delta table
- If not provided, will use defaults
- Can use one or both
- Unit tests updated to exercise this functionality and existing create/load tests pass

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [x] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [x] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-279](https://federal-spending-transparency.atlassian.net/browse/PIPE-279), [PIPE-280](https://federal-spending-transparency.atlassian.net/browse/PIPE-280):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
