### PR TITLE
[DEV-8905] Adjust award_description download field

### DIFF
--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -612,7 +612,7 @@ def test_download_awards_with_foreign_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 593
+    assert resp.json()["total_columns"] == 595
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())

--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -635,7 +635,7 @@ def test_download_awards_with_foreign_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 593
+    assert resp.json()["total_columns"] == 595
 
 
 @pytest.mark.django_db

--- a/usaspending_api/bulk_download/tests/test_download.py
+++ b/usaspending_api/bulk_download/tests/test_download.py
@@ -451,7 +451,7 @@ def test_download_awards_with_all_award_types(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 9
-    assert resp.json()["total_columns"] == 593
+    assert resp.json()["total_columns"] == 595
 
 
 def test_download_awards_with_all_prime_awards(client, award_data):
@@ -473,7 +473,7 @@ def test_download_awards_with_all_prime_awards(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 6
-    assert resp.json()["total_columns"] == 384
+    assert resp.json()["total_columns"] == 386
 
 
 def test_download_awards_with_some_prime_awards(client, award_data):
@@ -495,7 +495,7 @@ def test_download_awards_with_some_prime_awards(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 3
-    assert resp.json()["total_columns"] == 284
+    assert resp.json()["total_columns"] == 285
 
 
 def test_download_awards_with_all_sub_awards(client, award_data):
@@ -564,7 +564,7 @@ def test_download_awards_with_domestic_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 593
+    assert resp.json()["total_columns"] == 595
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())
@@ -587,7 +587,7 @@ def test_download_awards_with_domestic_scope(client, award_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 593
+    assert resp.json()["total_columns"] == 595
 
 
 def test_download_awards_with_foreign_scope(client, award_data):

--- a/usaspending_api/download/tests/integration/test_populate_monthly_delta_files.py
+++ b/usaspending_api/download/tests/integration/test_populate_monthly_delta_files.py
@@ -387,6 +387,7 @@ def test_specific_agency(monthly_download_delta_data, monkeypatch):
         "",
         "",
         "",
+        "",
         f"{HOST}/award/CONT_AWD_1_0_0/" if "localhost" in HOST else f"https://{HOST}/award/CONT_AWD_1_0_0/",
         "",
     ]

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -154,7 +154,7 @@ query_paths = {
                 ("type_of_idc", "latest_transaction__contract_data__type_of_idc_description"),
                 ("type_of_contract_pricing_code", "latest_transaction__contract_data__type_of_contract_pricing"),
                 ("type_of_contract_pricing", "latest_transaction__contract_data__type_of_contract_pric_desc"),
-                ("award_description", "description"),
+                ("prime_award_base_transaction_description", "description"),
                 ("solicitation_identifier", "latest_transaction__contract_data__solicitation_identifier"),
                 ("number_of_actions", "latest_transaction__contract_data__number_of_actions"),
                 (
@@ -724,7 +724,7 @@ query_paths = {
                 ("funding_opportunity_goals_text", "latest_transaction__assistance_data__funding_opportunity_goals"),
                 ("assistance_type_code", "latest_transaction__assistance_data__assistance_type"),
                 ("assistance_type_description", "latest_transaction__assistance_data__assistance_type_desc"),
-                ("award_description", "description"),
+                ("prime_award_base_transaction_description", "description"),
                 (
                     "business_funds_indicator_code",
                     "latest_transaction__assistance_data__business_funds_indicator",
@@ -854,7 +854,8 @@ query_paths = {
                 ("type_of_idc", "transaction__contract_data__type_of_idc_description"),
                 ("type_of_contract_pricing_code", "transaction__contract_data__type_of_contract_pricing"),
                 ("type_of_contract_pricing", "transaction__contract_data__type_of_contract_pric_desc"),
-                ("award_description", "transaction__contract_data__award_description"),
+                ("transaction_description", "transaction__contract_data__award_description"),
+                ("prime_award_base_transaction_description", "transaction__award__description"),
                 ("action_type_code", "transaction__action_type"),
                 ("action_type", "transaction__action_type_description"),
                 ("solicitation_identifier", "transaction__contract_data__solicitation_identifier"),
@@ -1234,7 +1235,8 @@ query_paths = {
                 ("funding_opportunity_goals_text", "transaction__assistance_data__funding_opportunity_goals"),
                 ("assistance_type_code", "transaction__assistance_data__assistance_type"),
                 ("assistance_type_description", "transaction__assistance_data__assistance_type_desc"),
-                ("award_description", "transaction__assistance_data__award_description"),
+                ("transaction_description", "transaction__assistance_data__award_description"),
+                ("prime_award_base_transaction_description", "transaction__award__description"),
                 ("business_funds_indicator_code", "transaction__assistance_data__business_funds_indicator"),
                 ("business_funds_indicator_description", "transaction__assistance_data__business_funds_ind_desc"),
                 ("business_types_code", "transaction__assistance_data__business_types"),
@@ -1339,7 +1341,7 @@ query_paths = {
                     "prime_award_primary_place_of_performance_country_name",
                     "broker_subaward__place_of_perform_country_na",
                 ),
-                ("prime_award_description", "broker_subaward__award_description"),
+                ("prime_award_base_transaction_description", "broker_subaward__award_description"),
                 ("prime_award_project_title", "broker_subaward__program_title"),
                 ("prime_award_naics_code", "broker_subaward__naics"),
                 ("prime_award_naics_description", "broker_subaward__naics_description"),
@@ -1491,7 +1493,7 @@ query_paths = {
                     "prime_award_primary_place_of_performance_country_name",
                     "broker_subaward__place_of_perform_country_na",
                 ),
-                ("prime_award_description", "broker_subaward__award_description"),
+                ("prime_award_base_transaction_description", "broker_subaward__award_description"),
                 ("prime_award_cfda_numbers_and_titles", None),  # Annotation is used to create this column
                 ("subaward_type", "broker_subaward__subaward_type"),
                 ("subaward_fsrs_report_id", "broker_subaward__internal_id"),
@@ -2026,7 +2028,7 @@ query_paths = {
                 ("award_type", "award_type"),  # Column is annotated in account_download.py
                 ("idv_type_code", "award__latest_transaction__contract_data__idv_type"),
                 ("idv_type", "award__latest_transaction__contract_data__idv_type_description"),
-                ("award_description", "award__description"),
+                ("prime_award_base_transaction_description", "award__description"),
                 ("awarding_agency_code", "awarding_agency_code"),  # Column is annotated in account_download.py
                 ("awarding_agency_name", "awarding_agency_name"),  # Column is annotated in account_download.py
                 ("awarding_subagency_code", "awarding_subagency_code"),  # Column is annotated in account_download.py
@@ -2142,7 +2144,7 @@ query_paths = {
                 ("award_type", "award_type"),  # Column is annotated in account_download.py
                 ("idv_type_code", "award__latest_transaction__contract_data__idv_type"),
                 ("idv_type", "award__latest_transaction__contract_data__idv_type_description"),
-                ("award_description", "award__description"),
+                ("prime_award_base_transaction_description", "award__description"),
                 ("awarding_agency_code", "awarding_agency_code"),  # Column is annotated in account_download.py
                 ("awarding_agency_name", "awarding_agency_name"),  # Column is annotated in account_download.py
                 ("awarding_subagency_code", "awarding_subagency_code"),  # Column is annotated in account_download.py


### PR DESCRIPTION
**Description:**
Changes the names of `award_description` in several download files to `prime_award_base_transaction_description` or `transaction_description` and updates Glossary/Data Dictionary.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-8905](https://federal-spending-transparency.atlassian.net/browse/DEV-8905):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
