### PR TITLE
[PIPE-289] Adds schema to call to make_read_indexes()

### DIFF
--- a/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
+++ b/usaspending_api/database_scripts/matview_generator/chunked_matview_sql_generator.py
@@ -158,7 +158,7 @@ def create_componentized_files(sql_json):
     sql_strings = make_matview_empty(matview_name, GLOBAL_ARGS.chunk_count)
     write_sql_file(sql_strings, filename_base + "__empty")
 
-    sql_strings = make_read_indexes(matview_name)
+    sql_strings = make_read_indexes(f"{table_schema}.{matview_name}")
     write_sql_file(sql_strings, filename_base + "__indexes")
 
     sql_strings = make_read_constraints(matview_name)


### PR DESCRIPTION
**Description:**
The `make_read_indexes(table_name)` method in `chunked_sql_matview_generator.py` is expecting the schema to be included in the `table_name` parameter in the following format `<schema>.<table>`, otherwise the schema defaults to public. 

**Technical details:**
The `chunked_sql_matview_generator.py` script is already reading the schema from the source json file, but it wasn't being used in the `make_read_indexes(table_name)` call. This PR adds the schema to the `table_name` string.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-289](https://federal-spending-transparency.atlassian.net/browse/PIPE-289):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
