### PR TITLE
Set autovacuum_enabled=FALSE for new tables

### DIFF
--- a/usaspending_api/etl/management/commands/load_table_from_delta.py
+++ b/usaspending_api/etl/management/commands/load_table_from_delta.py
@@ -183,13 +183,13 @@ class Command(BaseCommand):
                     create_temp_sql = f"""
                         CREATE TABLE {temp_table} (
                             LIKE {postgres_table} INCLUDING DEFAULTS INCLUDING IDENTITY
-                        )
+                        ) WITH (autovacuum_enabled=FALSE)
                     """
                 else:
                     create_temp_sql = f"""
                         CREATE TABLE {temp_table} (
                             {", ".join([f'{key} {val}' for key, val in postgres_cols.items()])}
-                        )
+                        ) WITH (autovacuum_enabled=FALSE)
                     """
                 with db.connection.cursor() as cursor:
                     logger.info(f"Creating {temp_table}")


### PR DESCRIPTION
**Description:**
Change the `autovacuum` setting for the new tables created via `load_tables_from_delta`.

**Technical details:**
In Postgres autovacuum on a table is used to help manage dead tuples that accumulate from UPDATE and DELETE statements. In the case of any table created via `load_tables_from_delta` there should never be any sort of UPDATE or DELETE since these are copied over from Databricks and put into place. That means that any resources spent on `autovacuum` is essentially a waste / going to block other queries for no reason.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
