### PR TITLE
[PIPE-289] Removes contype clause from read_constraints template

### DIFF
--- a/usaspending_api/config/envs/qat.py
+++ b/usaspending_api/config/envs/qat.py
@@ -24,13 +24,6 @@ class QATConfig(DefaultConfig):
     ENV_CODE: ClassVar[str] = "qat"
 
     # ==== [AWS] ====
-    # In local dev env, default to NOT using AWS.
-    # - For S3, MinIO will be used, and the AWS Endpoints defaulted below  will be used by MinIO to connect to "S3"
-    #   locally.
-    # - If you want to connect to AWS from your local dev env setup, for S3 as the backing object store of data,
-    #   set this to True, and change the AWS endpoints/region to that of the targeted AWS account
-    # - Then you MUST set your AWS creds (access/secret/token) by way of setting AWS_PROFILE env var (e.g. in your
-    #   .env file)
     AWS_PROFILE: str = None
     AWS_REGION = ""
     SPARK_S3_BUCKET = "dti-da-usaspending-spark-qat"

--- a/usaspending_api/etl/management/commands/copy_table_metadata.py
+++ b/usaspending_api/etl/management/commands/copy_table_metadata.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("script")
 # since that script uses relative imports which do not work well with the rest of the repo code
 TEMPLATE = {
     "read_indexes": "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = '{}' AND tablename = '{}';",
-    "read_constraints": "select conname, pg_get_constraintdef(oid) from pg_constraint where contype IN ('p', 'f') and conrelid = '{}'::regclass;",
+    "read_constraints": "select conname, pg_get_constraintdef(oid) from pg_constraint where conrelid = '{}'::regclass;",
 }
 
 


### PR DESCRIPTION
**Description:**
A unique constraint is not being copied in `copy_table_metadata.py` because constraints are currently limited to foreign and primary keys. This is causing the next pipeline command, `swap_in_new_table.py` to fail (mismatched constraints between live and temp tables).

This PR removes the clause of the `read_constraints` template that limits constraints to foreign and primary keys.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-289](https://federal-spending-transparency.atlassian.net/browse/PIPE-289):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
