### PR TITLE
[PIPE-289] Drop Unique Award ID Constraint in Award Search

### DIFF
--- a/usaspending_api/search/migrations/0008_awardsearch_table.py
+++ b/usaspending_api/search/migrations/0008_awardsearch_table.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 import django.db.models.deletion
 import django.db.models.expressions
 
-additional_sql = [
-    'ALTER TABLE rpt.award_search DROP COLUMN id',
-    'CREATE UNIQUE INDEX as_idx_award_id ON rpt.award_search(award_id)'
-]
 
 class Migration(migrations.Migration):
 
@@ -119,7 +115,7 @@ class Migration(migrations.Migration):
         # Trick Django into believing this is a foreign primary key for purposes of using the ORM,
         # but avoid the headache that comes with foreign keys and the primary key constraint
         migrations.RunSQL(
-            sql=";".join(additional_sql),
+            sql='ALTER TABLE rpt.award_search DROP COLUMN id; CREATE UNIQUE INDEX as_idx_award_id ON rpt.award_search(award_id);',
             reverse_sql="",
             state_operations=[
                 migrations.AlterField(

--- a/usaspending_api/search/migrations/0008_awardsearch_table.py
+++ b/usaspending_api/search/migrations/0008_awardsearch_table.py
@@ -5,6 +5,10 @@ from django.db import migrations, models
 import django.db.models.deletion
 import django.db.models.expressions
 
+additional_sql = [
+    'ALTER TABLE rpt.award_search DROP COLUMN id',
+    'CREATE UNIQUE INDEX as_idx_award_id ON rpt.award_search(award_id)'
+]
 
 class Migration(migrations.Migration):
 
@@ -18,7 +22,7 @@ class Migration(migrations.Migration):
             name='AwardSearch',
             fields=[
                 ('treasury_account_identifiers', django.contrib.postgres.fields.ArrayField(base_field=models.IntegerField(), default=list, null=True, size=None)),
-                ('award', models.BigIntegerField(unique=True, serialize=False, db_column="award_id")),
+                ('award', models.BigIntegerField(serialize=False, db_column="award_id")),
                 ('category', models.TextField(null=True)),
                 ('type', models.TextField(null=True)),
                 ('type_description', models.TextField(null=True)),
@@ -115,7 +119,7 @@ class Migration(migrations.Migration):
         # Trick Django into believing this is a foreign primary key for purposes of using the ORM,
         # but avoid the headache that comes with foreign keys and the primary key constraint
         migrations.RunSQL(
-            sql="ALTER TABLE rpt.award_search DROP COLUMN id",
+            sql=";".join(additional_sql),
             reverse_sql="",
             state_operations=[
                 migrations.AlterField(


### PR DESCRIPTION
**Description:**
Simply drops the unique constraint on `award_id` in `rpt.award_search`

**Technical details:**
Note: this unique index is not managed by the model. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-289](https://federal-spending-transparency.atlassian.net/browse/PIPE-289):
    - [ ] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
