### PR TITLE
[PIPE-10] pyspark as dev dependency only

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,9 @@
 #     - Variables defined here will override variables of the same name in default or env-specific
 #       config data classes (e.g. DefaultConfig in default.py and/or LocalConfig local.py)
 ########################################################################################################################
+# ==== [Python] ====
+PYTHON_VERSION=3.7.13
+
 # ==== [App] ====
 # MATVIEW_SQL_DIR has to be inside of the project (check the docker-compose file)
 MATVIEW_SQL_DIR=matview_sql

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.xml
 # pip files
 *\.egg-info/
 pip-selfcheck.json
+build/
 
 # for a project-local (rather than home-dir based) virtual environment directory
 \.venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
 install:
   # setuptools is pinned to version 60.8.2 due to an error occurring with built-in version
   - travis_retry pip install setuptools==60.8.2
-  - travis_retry pip install -r requirements/requirements.txt
+  - travis_retry pip install .[dev]
   - travis_retry pip install coveralls
   # Checkout dependent broker code used to spin up a broker integration test db. Put it in its own folder alongside this repo's code
   - echo "Using ${BROKER_REPO_BRANCH} branch from ${BROKER_REPO_URL}"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 #### Variables used in this Makefile.
 #### Uppercased are environment vars, or make-specific vars. All others should be lower-snake-case
 ENV_CODE ?= lcl  # default ENV_CODE to lcl if not set
-python_version := 3.7.13
+PYTHON_VERSION ?= 3.7.13  # default version if not set in .env or an env var
 venv_name := usaspending-api
 docker_compose_file := docker-compose.yml
 dockerfile_for_spark := Dockerfile.spark
@@ -51,15 +51,15 @@ printvars: ## Print the Environment variables present in calls to make, plus var
 
 .python-version: ## Attempt to setup python using pyenv
 	@if ! command -v pyenv &> /dev/null; then \
-		echo "WARNING: pyenv could not be found. Install pyenv to get a virtual env running with the compatible python version: ${python_version}. Will fallback to using system python3."; \
+		echo "WARNING: pyenv could not be found. Install pyenv to get a virtual env running with the compatible python version: ${PYTHON_VERSION}. Will fallback to using system python3."; \
 	else \
 	  	set -x; \
-	  	echo "pyenv setting python version to ${python_version}"; \
-  		pyenv install -s ${python_version}; \
-  		pyenv local ${python_version}; \
+	  	echo "pyenv setting python version to ${PYTHON_VERSION}"; \
+  		pyenv install -s ${PYTHON_VERSION}; \
+  		pyenv local ${PYTHON_VERSION}; \
   		python3 -V; \
-  		if [ "$$(python3 -V)" != "Python ${python_version}" ]; then \
-  			echo "ERROR: pyenv was not able to set local python version to ${python_version}"; \
+  		if [ "$$(python3 -V)" != "Python ${PYTHON_VERSION}" ]; then \
+  			echo "ERROR: pyenv was not able to set local python version to ${PYTHON_VERSION}"; \
   			exit 1; \
   		fi; \
 	fi;

--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -30,7 +30,6 @@ psutil==5.6.*
 psycopg2-binary==2.8.*
 py-gfm==0.1.4
 pydantic[dotenv]==1.9.0
-pyspark==3.2.1
 python-json-logger==0.1.9
 requests==2.25.*
 retrying==1.3.3

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,6 +6,7 @@ flake8==3.8.4
 mock==3.0.5
 model-bakery==1.5.*
 pre-commit==1.20.0
+pyspark==3.2.1
 pytest-cov==2.10.1
 pytest-django==4.2.0
 pytest==6.2.*

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,1 @@
 -r requirements-app.txt
--r requirements-dev.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ addopts=--cov=usaspending_api
 [flake8]
 select=C,E,F,W,B,B950
 ignore=E501,W503,E203,F541
-exclude=.venv,usaspending_api/*/migrations/*
+exclude=.venv,build,usaspending_api.egg-info,usaspending_api/*/migrations/*
 max-line-length=120
 
 [coverage:run]


### PR DESCRIPTION
**Description:**
Only pip install pyspark when in local dev or a CI build.

**Technical details:**
- The web app does not need pyspark
- The bulk download does not need pyspark
- `usaspending-backend` docker container doesn't need it
- And spark platforms we run on will already have pyspark

NOTE: Is based on `mod/pipe-191-include-all-static-files-on-install` from #3495 

Testing:
- It passes CI and all unit/integration tests, after Travis was changed to use `pip install .[dev]`
- Ran the `load_table_from_delta` in spark platform and it succeeded without error. i.e. it uses the baked-in Spark that's already there (we don't need to supply it via a pip installed `pyspark`).

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [x] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-10](https://federal-spending-transparency.atlassian.net/browse/PIPE-10):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
