### PR TITLE
[OPS-2361] Implement delta for uwsgi max lifetime restart

### DIFF
--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -40,5 +40,5 @@ cheaper-rss-limit-hard = 7730941133
 # Configuration to limit the lifespan of a worker to mitigate the
 #  risk of memory leaks in the application or dependencies
 max-requests = 1000
-max-requests-delta = 1
 max-worker-lifetime = 104400
+max-worker-lifetime-delta = 200

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -41,4 +41,4 @@ cheaper-rss-limit-hard = 7730941133
 #  risk of memory leaks in the application or dependencies
 max-requests = 1000
 max-worker-lifetime = 104400
-max-worker-lifetime-delta = 200
+max-worker-lifetime-delta = 20


### PR DESCRIPTION
**Description:**
We are periodically seeing instances in prod get replaced by the load balancer due to failing health checks on random intervals that sometimes round to 29 hours.
Uwsgi workers are currently set to restart after a lifetime of 29 hours. This causes all of the workers to go down at the same time if their lifetime is the same. This addresses the issue by implementing a delta to spread the restart times out.
Also removing an unsupported value for the max-requests-delta.

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [OPS-2361](https://federal-spending-transparency.atlassian.net/browse/OPS-2361):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
