### PR TITLE
[DEV-9043] Fixing the CFDA filter to account for whitespace in regex

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -375,7 +375,7 @@ class _ProgramNumbers(_Filter):
         for v in filter_values:
             if query_type == _QueryType.AWARDS:
                 escaped_program_number = v.replace(".", "\\.")
-                r = f""".*\\"cfda_number\\": \\"{escaped_program_number}\\".*"""
+                r = f""".*\\"cfda_number\\"\\s*:\\s*\\"{escaped_program_number}\\".*"""
                 programs_numbers_query.append(ES_Q("regexp", cfdas=r))
             else:
                 programs_numbers_query.append(ES_Q("match", cfda_number=v))

--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -375,7 +375,7 @@ class _ProgramNumbers(_Filter):
         for v in filter_values:
             if query_type == _QueryType.AWARDS:
                 escaped_program_number = v.replace(".", "\\.")
-                r = f""".*\\"cfda_number\\"\\s*:\\s*\\"{escaped_program_number}\\".*"""
+                r = f""".*\\"cfda_number\\" *: *\\"{escaped_program_number}\\".*"""
                 programs_numbers_query.append(ES_Q("regexp", cfdas=r))
             else:
                 programs_numbers_query.append(ES_Q("match", cfda_number=v))


### PR DESCRIPTION
**Description:**
Change to account for whitespace in CFDA filter.

**Technical details:**
With the move to Spark the JSON formatted values have a white space difference. After a look around the codebase this doesn't appear to be affecting anything else, but in this particular case is causing the regex to not find any / limited matches. 

Unit / integration tests were not updated for this case because they populated using the award and transaction search views. There are tech debt ticket(s) to determine the best path forward for tests.

This change will support old and new records in Elasticsearch without the need to re-index.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9043](https://federal-spending-transparency.atlassian.net/browse/DEV-9043):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
