### PR TITLE
[Bug Fix] Adds filter for attisdropped to Swap Commands column verification query

### DIFF
--- a/usaspending_api/etl/management/commands/swap_in_new_table.py
+++ b/usaspending_api/etl/management/commands/swap_in_new_table.py
@@ -409,6 +409,7 @@ class Command(BaseCommand):
             FROM pg_attribute
             INNER JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
             WHERE pg_class.relname = '{self.temp_table_name}' AND pg_attribute.attnum > 0
+            AND pg_attribute.attisdropped = FALSE
             ORDER BY pg_attribute.attname
         """
         )
@@ -419,6 +420,7 @@ class Command(BaseCommand):
             FROM pg_attribute
             INNER JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
             WHERE pg_class.relname = '{self.curr_table_name}' AND pg_attribute.attnum > 0
+            AND pg_attribute.attisdropped = FALSE
             ORDER BY pg_attribute.attname
         """
         )


### PR DESCRIPTION
**Description:**
The `swap_in_new_table.py` command is currently failing to swap the `recipient_profile` table with it's temporary counterpart. This is because a query used to determine whether the columns match between temp and live tables is returning an extra record, representing a column that was dropped on `recipient_profile`. This PR adds a filter to the query to prevent dropped columns from being returned 

**Technical details:**

From: https://www.postgresql.org/docs/current/catalog-pg-attribute.html
```
attisdropped bool

This column has been dropped and is no longer valid. 
A dropped column is still physically present in the table,
but is ignored by the parser and so cannot be accessed via SQL.
```

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
