### PR TITLE
[HOTFIX] [DEV-9073] Fetch unique broker recipients by UEI

### DIFF
--- a/usaspending_api/broker/management/sql/restock_duns.sql
+++ b/usaspending_api/broker/management/sql/restock_duns.sql
@@ -25,7 +25,7 @@ CREATE TABLE raw.temporary_restock_duns AS (
   FROM
     dblink ('broker_server', '(
       SELECT
-        DISTINCT ON (sam_recipient.awardee_or_recipient_uniqu)
+        DISTINCT ON (sam_recipient.uei)
         sam_recipient.awardee_or_recipient_uniqu,
         sam_recipient.legal_business_name,
         sam_recipient.dba_name,
@@ -48,7 +48,7 @@ CREATE TABLE raw.temporary_restock_duns AS (
       FROM
         sam_recipient
       ORDER BY
-        sam_recipient.awardee_or_recipient_uniqu,
+        sam_recipient.uei,
         sam_recipient.activation_date DESC NULLS LAST)') AS broker_duns
           (
             awardee_or_recipient_uniqu text,


### PR DESCRIPTION
**Description:**
Recipients in broker that came from SAM after Apr 2021 that have a UEI and `NULL` for DUNS number are ignored by the broker -> usaspending `sam_recipient` data integration

**Technical details:**
Need to be grouping by `UEI` and not DUNS number (`awardee_or_recipient_uniqu`)
See Jira ticket for in depth discussion: [DEV-9073](https://federal-spending-transparency.atlassian.net/browse/DEV-9073)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [NA] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [NA] Matview impact assessment completed
5. [NA] Frontend impact assessment completed
6. [x] Data validation completed
7. [NA] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9073](https://federal-spending-transparency.atlassian.net/browse/DEV-9073):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
