### PR TITLE
[DEV-9162] HOTFIX - new_awards_over_time recipient hash fix

### DIFF
--- a/usaspending_api/etl/es_award_template.json
+++ b/usaspending_api/etl/es_award_template.json
@@ -125,10 +125,10 @@
           }
         },
         "recipient_hash": {
-          "type": "text",
+          "type": "keyword",
           "fields": {
-            "keyword": {
-              "type": "keyword"
+            "hash": {
+              "type": "murmur3"
             }
           }
         },


### PR DESCRIPTION
**Description:**
Re-defines the `recipient_hash` field in the awards Elasticsearch index from `text` type with a `keyword` field to being a `keyword` type.

**Technical details:**
Will require a re-index of the awards index

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-9162](https://federal-spending-transparency.atlassian.net/browse/DEV-9262):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
