### PR TITLE
[DEV-9171] Subaward Download piid/fain, not award_id

### DIFF
--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1266,7 +1266,7 @@ query_paths = {
         "d1": OrderedDict(
             [
                 ("prime_award_unique_key", "unique_award_key"),
-                ("prime_award_piid", "award_piid_fain"),
+                ("prime_award_piid", "piid"),
                 ("prime_award_parent_piid", "parent_award_id"),
                 ("prime_award_amount", "award_amount"),
                 ("prime_award_disaster_emergency_fund_codes", None),  # Annotation is used to create this column
@@ -1422,7 +1422,7 @@ query_paths = {
         "d2": OrderedDict(
             [
                 ("prime_award_unique_key", "unique_award_key"),
-                ("prime_award_fain", "award_piid_fain"),
+                ("prime_award_fain", "fain"),
                 ("prime_award_amount", "award_amount"),
                 ("prime_award_disaster_emergency_fund_codes", None),  # Annotation is used to create this column
                 (

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1266,7 +1266,7 @@ query_paths = {
         "d1": OrderedDict(
             [
                 ("prime_award_unique_key", "unique_award_key"),
-                ("prime_award_piid", "award_id"),
+                ("prime_award_piid", "award_piid_fain"),
                 ("prime_award_parent_piid", "parent_award_id"),
                 ("prime_award_amount", "award_amount"),
                 ("prime_award_disaster_emergency_fund_codes", None),  # Annotation is used to create this column
@@ -1422,7 +1422,7 @@ query_paths = {
         "d2": OrderedDict(
             [
                 ("prime_award_unique_key", "unique_award_key"),
-                ("prime_award_fain", "award_id"),
+                ("prime_award_fain", "award_piid_fain"),
                 ("prime_award_amount", "award_amount"),
                 ("prime_award_disaster_emergency_fund_codes", None),  # Annotation is used to create this column
                 (


### PR DESCRIPTION
**Description:**
Subaward download piid/fain columns should have piid/fain, not award_id

**Technical details:**
N/A

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9171](https://federal-spending-transparency.atlassian.net/browse/DEV-9171):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
