### PR TITLE
AwardSeach Congressional District Download Hotfix

### DIFF
--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -34,8 +34,8 @@ def geocode_filter_subaward_locations(scope: str, values: list) -> Q:
     """
     or_queryset = Q()
 
-    # Yes, these are mostly the same, but congressional is different
-    # and I'd rather have them all laid out here versus burying a extra couple lines for congressional
+    # Yes, these are mostly the same, but congressional_code is different
+    # and I'd rather have them all laid out here versus burying a extra couple lines for congressional_code
     location_mappings = {
         "country_code": {"sub_legal_entity": "country_code", "sub_place_of_perform": "country_co"},
         "zip5": {"sub_legal_entity": "zip5", "sub_place_of_perform": "zip5"},


### PR DESCRIPTION
**Description:**
Fixes a typo that is causing the Award Search downloads to break when filtering by congressional district.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9212](https://federal-spending-transparency.atlassian.net/browse/DEV-9212):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
