### PR TITLE
[DEV-9214] Update API document

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/federal_accounts/account_number.md
+++ b/usaspending_api/api_contracts/contracts/v2/federal_accounts/account_number.md
@@ -26,9 +26,9 @@ This endpoint returns the agency identifier, account code, title, and database i
         + `parent_agency_name`: Department of State (required, string)
         + `bureau_name`: Interest on the Public Debt (required, string)
         + `bureau_slug`: interest-on-the-public-debt (required, string)
-        + `total_obligated_amount`: `-31604.5` (required, number) - Sum of all child Treasury Account `obligated_amount` values
-        + `total_gross_outlay_amount`: 7643425.94 (required, number) - Sum of all child Treasury Account `gross_outlay_amount` values
-        + `total_budgetary_resources`: 54653496.23 (required, number) - Sum of all child Treasury Account `budgetary_resources_amount` values
+        + `total_obligated_amount`: `-31604.5` (optional, number) - Sum of all child Treasury Account `obligated_amount` values or `null` if there are no child Treasury Accounts.
+        + `total_gross_outlay_amount`: 7643425.94 (optional, number) - Sum of all child Treasury Account `gross_outlay_amount` values or `null` if there are no child Treasury Accounts.
+        + `total_budgetary_resources`: 54653496.23 (optional, number) - Sum of all child Treasury Account `budgetary_resources_amount` values or `null` if there are no child Treasury Accounts.
         + `children` (required, array[TreasuryAccount], fixed-type) - List of applicable Treasury Accounts for the given Federal Account and fiscal year. Otherwise, it will be an empty array.
 
     + Body


### PR DESCRIPTION
Update the API contract to mark the **total_obligated_amount**, **total_gross_outlay_amount**, and **total_budgetary_resources** attributes as optional instead of required.

**Description:**
These attributes can be `null` if there are no applicable child Treasury Accounts for the given Federal Account in the given Fiscal Year.

**Requirements for PR merge:**

1. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [x] Backend
2. [x] Jira Ticket [DEV-9214](https://federal-spending-transparency.atlassian.net/browse/DEV-9214):
    - [x] Link to this Pull-Request
