### PR TITLE
[DEV-9269] Subaward Spending Over Time Hotfix

### DIFF
--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -95,7 +95,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             queryset = queryset.annotate(quarter=FiscalQuarter("sub_action_date"))
             month_quarter_cols.append("quarter")
 
-        first_values = ["prime_fy"] + month_quarter_cols
+        first_values = ["sub_fiscal_year"] + month_quarter_cols
         second_values = ["aggregated_amount"] + month_quarter_cols
         second_values_dict = {"fy": F("sub_fiscal_year")}
         order_by_cols = ["fy"] + month_quarter_cols


### PR DESCRIPTION
**Description:**
The subaward spending over time query discreetly groups by `prime_fy` which skews the counts. This replaces it with `sub_fiscal_year` appropriately.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9269](https://federal-spending-transparency.atlassian.net/browse/DEV-9269):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
