### PR TITLE
Include pre-2000 data to award and transaction search

### DIFF
--- a/usaspending_api/search/delta_models/award_search.py
+++ b/usaspending_api/search/delta_models/award_search.py
@@ -532,8 +532,5 @@ WHERE
         )
     )
     -- Make sure that we also pick up the current state of Pre2008 matview
-    OR (
-        latest_transaction.action_date >= '2000-10-01'
-        AND latest_transaction.action_date < '2007-10-01'
-    )
+    OR latest_transaction.action_date < '2007-10-01'
 """

--- a/usaspending_api/transactions/delta_models/transaction_search.py
+++ b/usaspending_api/transactions/delta_models/transaction_search.py
@@ -1033,6 +1033,4 @@ transaction_search_load_sql_string = fr"""
         WHERE faba.award_id IS NOT NULL
         GROUP BY faba.award_id
     ) FED_AND_TRES_ACCT ON (FED_AND_TRES_ACCT.award_id = transaction_normalized.award_id)
-    WHERE
-        transaction_normalized.action_date >= '2000-10-01'
 """

--- a/usaspending_api/transactions/delta_models/transaction_search.py
+++ b/usaspending_api/transactions/delta_models/transaction_search.py
@@ -1032,7 +1032,7 @@ transaction_search_load_sql_string = fr"""
         INNER JOIN global_temp.toptier_agency agency ON (fa.parent_toptier_agency_id = agency.toptier_agency_id)
         WHERE faba.award_id IS NOT NULL
         GROUP BY faba.award_id
-    ) FED_AND_TRES_ACCT ON (FED_AND_TRES_ACCT.award_id = transaction_normalized.award_id)\
+    ) FED_AND_TRES_ACCT ON (FED_AND_TRES_ACCT.award_id = transaction_normalized.award_id)
     WHERE
         TRUE
 """

--- a/usaspending_api/transactions/delta_models/transaction_search.py
+++ b/usaspending_api/transactions/delta_models/transaction_search.py
@@ -1032,5 +1032,7 @@ transaction_search_load_sql_string = fr"""
         INNER JOIN global_temp.toptier_agency agency ON (fa.parent_toptier_agency_id = agency.toptier_agency_id)
         WHERE faba.award_id IS NOT NULL
         GROUP BY faba.award_id
-    ) FED_AND_TRES_ACCT ON (FED_AND_TRES_ACCT.award_id = transaction_normalized.award_id)
+    ) FED_AND_TRES_ACCT ON (FED_AND_TRES_ACCT.award_id = transaction_normalized.award_id)\
+    WHERE
+        TRUE
 """

--- a/usaspending_api/transactions/delta_models/transaction_search.py
+++ b/usaspending_api/transactions/delta_models/transaction_search.py
@@ -1033,6 +1033,4 @@ transaction_search_load_sql_string = fr"""
         WHERE faba.award_id IS NOT NULL
         GROUP BY faba.award_id
     ) FED_AND_TRES_ACCT ON (FED_AND_TRES_ACCT.award_id = transaction_normalized.award_id)
-    WHERE
-        TRUE
 """


### PR DESCRIPTION
Including pre-2000 data in awards and transactions to not lose data in the gold view transition and to work with the migrations.