### PR TITLE
Fix over-indentation in for-loop

### DIFF
--- a/usaspending_api/agency/v2/views/sub_agency.py
+++ b/usaspending_api/agency/v2/views/sub_agency.py
@@ -66,8 +66,8 @@ class SubAgencyList(PaginationMixin, AgencyBase):
         office_codes = []
         for bucket in buckets:
             office_codes.extend([child.get("key") for child in bucket.get("offices").get("buckets")])
-            # remove any potential dups
-            office_codes = set(list(office_codes))
+        # remove any potential dups
+        office_codes = set(list(office_codes))
 
         # Get the current recipient info
         current_office_info = {}


### PR DESCRIPTION
**Description:**
Moved line that converts a `list` to a `set` outside of the `for` loop.

**Technical details:**
List was being converted to a set within a loop that was then trying to call the `.extend()` method on the set. I moved the `set()` call to be outside of the loop.

**Requirements for PR merge:**

1. [ ] Necessary PR reviewers:
    - [ ] Backend
2. Jira Ticket [DEV-9400](https://federal-spending-transparency.atlassian.net/browse/DEV-9400):
    - [x] Link to this Pull-Request
