### PR TITLE
Possible SSRF in code. No fix suggested.

### DIFF
--- a/usaspending_api/common/experimental_api_flags.py
+++ b/usaspending_api/common/experimental_api_flags.py
@@ -46,30 +46,10 @@ def mirror_request_to_elasticsearch(request: Union[HttpRequest, Request]):
     # without disrupting the primary request
     try:
         if request.method == "GET":
-            """
-            ***************** Warning *****************
-            Possible Server-Side Request Forgery (SSRF) attack!
-            Path:
-            	File: experimental_api_flags.py, Line: 35
-            		url = request.build_absolute_uri()
-            		Variable url is assigned a tainted value from an external source.
-            	File: experimental_api_flags.py, Line: 49
-            		requests.get(url, data, headers=headers, timeout=0.01)
-            		Tainted information is used in a sink.
-            """
+            # Possible Server-Side Request Forgery (SSRF) attack!
             requests.get(url, data, headers=headers, timeout=0.01)
         elif request.method == "POST":
-            """
-            ***************** Warning *****************
-            Possible Server-Side Request Forgery (SSRF) attack!
-            Path:
-            	File: experimental_api_flags.py, Line: 35
-            		url = request.build_absolute_uri()
-            		Variable url is assigned a tainted value from an external source.
-            	File: experimental_api_flags.py, Line: 51
-            		requests.post(url, data, headers=headers, timeout=0.01)
-            		Tainted information is used in a sink.
-            """
+            # Possible Server-Side Request Forgery (SSRF) attack!
             requests.post(url, data, headers=headers, timeout=0.01)
         else:
             pass

--- a/usaspending_api/common/experimental_api_flags.py
+++ b/usaspending_api/common/experimental_api_flags.py
@@ -46,7 +46,7 @@ def mirror_request_to_elasticsearch(request: Union[HttpRequest, Request]):
     # without disrupting the primary request
     try:
         if request.method == "GET":
-            '''
+            """
             ***************** Warning *****************
             Possible Server-Side Request Forgery (SSRF) attack!
             Path:
@@ -56,10 +56,10 @@ def mirror_request_to_elasticsearch(request: Union[HttpRequest, Request]):
             	File: experimental_api_flags.py, Line: 49
             		requests.get(url, data, headers=headers, timeout=0.01)
             		Tainted information is used in a sink.
-            '''
+            """
             requests.get(url, data, headers=headers, timeout=0.01)
         elif request.method == "POST":
-            '''
+            """
             ***************** Warning *****************
             Possible Server-Side Request Forgery (SSRF) attack!
             Path:
@@ -69,7 +69,7 @@ def mirror_request_to_elasticsearch(request: Union[HttpRequest, Request]):
             	File: experimental_api_flags.py, Line: 51
             		requests.post(url, data, headers=headers, timeout=0.01)
             		Tainted information is used in a sink.
-            '''
+            """
             requests.post(url, data, headers=headers, timeout=0.01)
         else:
             pass

--- a/usaspending_api/common/experimental_api_flags.py
+++ b/usaspending_api/common/experimental_api_flags.py
@@ -46,8 +46,30 @@ def mirror_request_to_elasticsearch(request: Union[HttpRequest, Request]):
     # without disrupting the primary request
     try:
         if request.method == "GET":
+            '''
+            ***************** Warning *****************
+            Possible Server-Side Request Forgery (SSRF) attack!
+            Path:
+            	File: experimental_api_flags.py, Line: 35
+            		url = request.build_absolute_uri()
+            		Variable url is assigned a tainted value from an external source.
+            	File: experimental_api_flags.py, Line: 49
+            		requests.get(url, data, headers=headers, timeout=0.01)
+            		Tainted information is used in a sink.
+            '''
             requests.get(url, data, headers=headers, timeout=0.01)
         elif request.method == "POST":
+            '''
+            ***************** Warning *****************
+            Possible Server-Side Request Forgery (SSRF) attack!
+            Path:
+            	File: experimental_api_flags.py, Line: 35
+            		url = request.build_absolute_uri()
+            		Variable url is assigned a tainted value from an external source.
+            	File: experimental_api_flags.py, Line: 51
+            		requests.post(url, data, headers=headers, timeout=0.01)
+            		Tainted information is used in a sink.
+            '''
             requests.post(url, data, headers=headers, timeout=0.01)
         else:
             pass


### PR DESCRIPTION
In file: experimental_api_flags.py, there is a method call that fetches a remote resource based on a URL that may come from user-provided, untrusted data. This may allow an attacker to send a crafted request to an unexpected destination. 

The untrusted data in both cases originate from the same source. In experimental_api_flags.py file, line 35, we have

    url = request.build_absolute_uri()

Here variable url is assigned a tainted value from an external source. This is then used in an HTTP method call.

We suggested proper sanitization before user-provided data can be used to fetch remote resources. The actual fix is domain specific; so an actual fix is not provided.