### PR TITLE
[PIPE-347] reset es deletes load date at delta transaction loader initial_run

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
             self.no_initial_copy = options["no_initial_copy"]
 
             # Capture minimum last load date of the source tables to update the "last_load_date" after completion
-            next_last_load = get_earliest_load_date("source_procurement_transaction", "source_assistance_transaction")
+            next_last_load = get_earliest_load_date(["source_procurement_transaction", "source_assistance_transaction"])
             if not next_last_load:
                 next_last_load = datetime.utcfromtimestamp(0)
 


### PR DESCRIPTION
**Description:**
Make sure that the `es_deletes` load date is also reset when the new delta load dates are _initially_ set

**Technical details:**
- Set at the `initial_run` of the transaction delta tables **only**

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
