### PR TITLE
[PIPE-236] Drop Foreign Key Constraints in Awards View Migration

### DIFF
--- a/usaspending_api/awards/migrations/0098_auto_20221215_2029.py
+++ b/usaspending_api/awards/migrations/0098_auto_20221215_2029.py
@@ -18,15 +18,29 @@ class Migration(migrations.Migration):
             name='award',
             options={'managed': False},
         ),
-        migrations.AlterField(
-            model_name='financialaccountsbyawards',
-            name='award',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='financial_set', to='search.awardsearch'),
+        migrations.RunSQL(
+            sql="ALTER TABLE financial_accounts_by_awards DROP CONSTRAINT financial_accounts_by_awards_award_id_eb90a5fa_fk_awards_id",
+            reverse_sql="",
+            state_operations=[
+                migrations.AlterField(
+                    model_name='financialaccountsbyawards',
+                    name='award',
+                    field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE,
+                                            related_name='financial_set', to='search.awardsearch'),
+                ),
+            ]
         ),
-        migrations.AlterField(
-            model_name='parentaward',
-            name='award',
-            field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, serialize=False, to='search.awardsearch'),
+        migrations.RunSQL(
+            sql="ALTER TABLE rpt.parent_award DROP CONSTRAINT parent_award_award_id_97f76a63_fk_awards_id",
+            reverse_sql="",
+            state_operations=[
+                migrations.AlterField(
+                    model_name='parentaward',
+                    name='award',
+                    field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True,
+                                               serialize=False, to='search.awardsearch'),
+                ),
+            ]
         ),
         migrations.RunSQL(
             sql=vw_awards_sql,

--- a/usaspending_api/awards/migrations/0098_auto_20221215_2029.py
+++ b/usaspending_api/awards/migrations/0098_auto_20221215_2029.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                     name='award',
                     field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE,
                                             related_name='financial_set', to='search.awardsearch'),
-                ),
+                )
             ]
         ),
         migrations.RunSQL(
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                     name='award',
                     field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True,
                                                serialize=False, to='search.awardsearch'),
-                ),
+                )
             ]
         ),
         migrations.RunSQL(


### PR DESCRIPTION
**Description:**
Updates the vw_award migration to secretly drop the foreign key contraints related to faba and parent_awards.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/PIPE-236):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
