### PR TITLE
[PIPE-474] Modify initial_run code in Delta loader to handle orphaned transactions & awards

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -995,6 +995,7 @@ class Command(BaseCommand):
         Procedure to create & set up transaction_id_lookup and award_id_lookup tables and create other tables in
         int database that will be populated by subsequent calls.
         """
+
         @contextmanager
         def prepare_temp_tables():
             # Since the table to track the orphaned transactions is only needed for this function, just using a
@@ -1155,7 +1156,7 @@ class Command(BaseCommand):
                         award_id LONG NOT NULL
                     )
                     USING DELTA
-                    LOCATION 
+                    LOCATION
                         's3a://{self.spark_s3_bucket}/{delta_lake_s3_path}/{destination_database}/{destination_table}'
                 """
             )
@@ -1202,7 +1203,7 @@ class Command(BaseCommand):
                         generated_unique_award_id STRING NOT NULL
                     )
                     USING DELTA
-                    LOCATION 
+                    LOCATION
                         's3a://{self.spark_s3_bucket}/{delta_lake_s3_path}/{destination_database}/{destination_table}'
                 """
             )
@@ -1269,7 +1270,7 @@ class Command(BaseCommand):
                                     -- Again, want to exclude orphaned transactions, as they will not be copied into the
                                     -- int schema.
                                     WHERE ucase(pfabs.afa_generated_unique) NOT IN (
-                                        SELECT 
+                                        SELECT
                                             transaction_unique_id FROM temp.orphaned_transaction_info WHERE NOT is_fpds
                                     )
                                 )

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -1069,7 +1069,7 @@ class Command(BaseCommand):
                 """
                     INSERT OVERWRITE temp.orphaned_transaction_info
                         SELECT tn.id AS transaction_id, tn.transaction_unique_id, tn.is_fpds, tn.unique_award_key
-                        FROM raw.transaction_normalized AS tn 
+                        FROM raw.transaction_normalized AS tn
                         LEFT JOIN raw.detached_award_procurement AS dap ON (
                             tn.transaction_unique_id = ucase(dap.detached_award_proc_unique)
                         )
@@ -1232,7 +1232,7 @@ class Command(BaseCommand):
                                     raw.awards AS aw INNER JOIN raw.detached_award_procurement AS dap ON (
                                         aw.generated_unique_award_id = ucase(dap.unique_award_key)
                                     )
-                                -- Again, want to exclude orphaned transactions, as they will not be copied into the 
+                                -- Again, want to exclude orphaned transactions, as they will not be copied into the
                                 -- int schema.
                                 WHERE ucase(dap.detached_award_proc_unique) NOT IN (
                                     SELECT transaction_unique_id FROM temp.orphaned_transaction_info WHERE is_fpds
@@ -1251,7 +1251,7 @@ class Command(BaseCommand):
                                     raw.awards AS aw INNER JOIN raw.published_fabs AS pfabs ON (
                                         aw.generated_unique_award_id = ucase(pfabs.unique_award_key)
                                     )
-                                -- Again, want to exclude orphaned transactions, as they will not be copied into the 
+                                -- Again, want to exclude orphaned transactions, as they will not be copied into the
                                 -- int schema.
                                 WHERE ucase(pfabs.afa_generated_unique) NOT IN (
                                     SELECT transaction_unique_id FROM temp.orphaned_transaction_info WHERE NOT is_fpds
@@ -1318,9 +1318,9 @@ class Command(BaseCommand):
                 TRANSACTION_FABS_COLUMNS,
                 TRANSACTION_FPDS_COLUMNS,
                 list(TRANSACTION_NORMALIZED_COLUMNS),
-                list(AWARDS_COLUMNS)
+                list(AWARDS_COLUMNS),
             ),
-            ("transaction_id", "transaction_id", "id", "id")
+            ("transaction_id", "transaction_id", "id", "id"),
         ):
             call_command(
                 "create_delta_table",

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -1002,7 +1002,7 @@ class Command(BaseCommand):
         set_last_load_date = True
 
         self.logger.info(f"Creating database {destination_database}, if not already existing.")
-        self.spark.sql(f"CREATE DATABASE IF NOT EXISTS {destination_database};")
+        self.spark.sql(f"CREATE DATABASE IF NOT EXISTS {destination_database}")
 
         self.logger.info(f"Creating {destination_table} table")
         self.spark.sql(
@@ -1016,6 +1016,35 @@ class Command(BaseCommand):
                 )
                 USING DELTA
                 LOCATION 's3a://{self.spark_s3_bucket}/{delta_lake_s3_path}/{destination_database}/{destination_table}'
+            """
+        )
+
+        # Although there SHOULDN'T be any "orphaned" transactions (transactions that are missing records
+        #   in one of the source tables) by the time this code is ultimately run in production, putting in
+        #   code to avoid copying orphaned transactions to the int tables, just in case.
+        # Due to the size of the dataset, need to keep information about the orphaned transactions in a table.
+        #   If we tried to insert the data directly into a SQL statement, it can break the Spark driver.
+        #   However, since the table is only needed for this function, just using a managed table in the temp schema.
+        self.spark.sql(f"CREATE DATABASE IF NOT EXISTS temp")
+        self.spark.sql(
+            """
+                CREATE OR REPLACE TABLE temp.orphaned_transaction_info (
+                    transaction_id        LONG NOT NULL,
+                    transaction_unique_id STRING NOT NULL,
+                    is_fpds               BOOLEAN NOT NULL,
+                    unique_award_key      STRING NOT NULL
+                )
+                USING DELTA
+            """
+        )
+
+        # We actually need another temporary table to handle orphaned awards
+        self.spark.sql(
+            """
+                CREATE OR REPLACE TABLE temp.orphaned_award_info (
+                    award_id LONG NOT NULL
+                )
+                USING DELTA
             """
         )
 
@@ -1035,8 +1064,25 @@ class Command(BaseCommand):
                 # Don't try to handle anything else
                 raise e
         else:
-            # Insert existing transactions into the lookup table
+            # First, find orphaned transactions
+            self.spark.sql(
+                """
+                    INSERT OVERWRITE temp.orphaned_transaction_info
+                        SELECT tn.id AS transaction_id, tn.transaction_unique_id, tn.is_fpds, tn.unique_award_key
+                        FROM raw.transaction_normalized AS tn 
+                        LEFT JOIN raw.detached_award_procurement AS dap ON (
+                            tn.transaction_unique_id = ucase(dap.detached_award_proc_unique)
+                        )
+                        LEFT JOIN raw.published_fabs AS pfabs ON (
+                            tn.transaction_unique_id = ucase(pfabs.afa_generated_unique)
+                        )
+                        WHERE dap.detached_award_proc_unique IS NULL AND pfabs.afa_generated_unique IS NULL
+                """
+            )
+
+            # Insert existing non-orphaned transactions into the lookup table
             self.logger.info("Populating transaction_id_lookup table from raw.transaction_normalized")
+
             # Note that the transaction loader code will convert string fields to upper case, so we have to match
             # on the upper-cased versions of the strings.
             self.spark.sql(
@@ -1049,6 +1095,8 @@ class Command(BaseCommand):
                     FROM raw.transaction_normalized AS tn INNER JOIN raw.detached_award_procurement AS dap ON (
                         tn.transaction_unique_id = ucase(dap.detached_award_proc_unique)
                     )
+                    -- Want to exclude orphaned transactions, as they will not be copied into the int schema.
+                    WHERE tn.id NOT IN (SELECT transaction_id FROM temp.orphaned_transaction_info WHERE is_fpds)
                     UNION ALL
                     SELECT
                         tn.id AS transaction_id,
@@ -1057,6 +1105,8 @@ class Command(BaseCommand):
                     FROM raw.transaction_normalized AS tn INNER JOIN raw.published_fabs AS pfabs ON (
                         tn.transaction_unique_id = ucase(pfabs.afa_generated_unique)
                     )
+                    -- Want to exclude orphaned transactions, as they will not be copied into the int schema.
+                    WHERE tn.id NOT IN (SELECT transaction_id FROM temp.orphaned_transaction_info WHERE NOT is_fpds)
                 """
             )
 
@@ -1081,6 +1131,21 @@ class Command(BaseCommand):
             update_last_load_date(destination_table, next_last_load)
             # es_deletes should remain in lockstep with transaction load dates, so if they are reset, it should be reset
             update_last_load_date("es_deletes", next_last_load)
+
+        # Need a table to keep track of awards in which some, but not all, transactions are deleted.
+        destination_table = "award_ids_delete_modified"
+
+        self.logger.info(f"Creating {destination_table} table")
+        self.spark.sql(
+            f"""
+                CREATE OR REPLACE TABLE {destination_database}.{destination_table} (
+                    award_id LONG NOT NULL
+                )
+                USING DELTA
+                LOCATION 's3a://{self.spark_s3_bucket}/{delta_lake_s3_path}/{destination_database}/{destination_table}'
+            """
+        )
+        # Nothing to add to this table yet.
 
         # award_id_lookup
         destination_table = "award_id_lookup"
@@ -1119,11 +1184,7 @@ class Command(BaseCommand):
                     -- the correct rows for deleting so that it can be run in parallel with the transaction_id_lookup
                     -- ETL level
                     is_fpds BOOLEAN NOT NULL,
-                    -- transaction_unique_id *shouldn't* be NULL in the query used to populate this table.
-                    -- However, at least in qat, there are awards that don't actually match any transactions,
-                    -- and we want all awards to be listed in this table, so, for now, at least, leaving off
-                    -- the NOT NULL constraint from transaction_unique_id
-                    transaction_unique_id STRING,
+                    transaction_unique_id STRING NOT NULL,
                     generated_unique_award_id STRING NOT NULL
                 )
                 USING DELTA
@@ -1145,47 +1206,86 @@ class Command(BaseCommand):
                 # Don't try to handle anything else
                 raise e
         else:
-            # Insert existing transactions and their corresponding award_ids into the lookup table
+            # Insert existing non-orphaned transactions and their corresponding award_ids into the lookup table
             self.logger.info("Populating award_id_lookup table from raw.awards")
+
             # Once again we have to match on the upper-cased versions of the strings from published_fabs
             # and detached_award_procurement.
             self.spark.sql(
                 f"""
-                INSERT OVERWRITE {destination_database}.{destination_table}
-                    SELECT
-                        existing_awards.id AS award_id,
-                        existing_awards.is_fpds,
-                        existing_awards.transaction_unique_id,
-                        existing_awards.generated_unique_award_id
-                    FROM (
-                        (
-                            SELECT
-                                aw.id,
-                                TRUE AS is_fpds,
-                                -- The transaction loader code will convert this to upper case, so use that
-                                -- version here.
-                                ucase(dap.detached_award_proc_unique) AS transaction_unique_id,
-                                aw.generated_unique_award_id
-                            FROM
-                                raw.awards AS aw INNER JOIN raw.detached_award_procurement AS dap ON (
-                                    aw.generated_unique_award_id = ucase(dap.unique_award_key)
+                    INSERT OVERWRITE {destination_database}.{destination_table}
+                        SELECT
+                            existing_awards.id AS award_id,
+                            existing_awards.is_fpds,
+                            existing_awards.transaction_unique_id,
+                            existing_awards.generated_unique_award_id
+                        FROM (
+                            (
+                                SELECT
+                                    aw.id,
+                                    TRUE AS is_fpds,
+                                    -- The transaction loader code will convert this to upper case, so use that
+                                    -- version here.
+                                    ucase(dap.detached_award_proc_unique) AS transaction_unique_id,
+                                    aw.generated_unique_award_id
+                                FROM
+                                    raw.awards AS aw INNER JOIN raw.detached_award_procurement AS dap ON (
+                                        aw.generated_unique_award_id = ucase(dap.unique_award_key)
+                                    )
+                                -- Again, want to exclude orphaned transactions, as they will not be copied into the 
+                                -- int schema.
+                                WHERE ucase(dap.detached_award_proc_unique) NOT IN (
+                                    SELECT transaction_unique_id FROM temp.orphaned_transaction_info WHERE is_fpds
                                 )
-                        )
-                        UNION ALL
-                        (
-                            SELECT
-                                aw.id,
-                                FALSE AS is_fpds,
-                                -- The transaction loader code will convert this to upper case, so use that
-                                -- version here.
-                                ucase(pfabs.afa_generated_unique) AS transaction_unique_id,
-                                aw.generated_unique_award_id
-                            FROM
-                                raw.awards AS aw INNER JOIN raw.published_fabs AS pfabs ON (
-                                    aw.generated_unique_award_id = ucase(pfabs.unique_award_key)
+                            )
+                            UNION ALL
+                            (
+                                SELECT
+                                    aw.id,
+                                    FALSE AS is_fpds,
+                                    -- The transaction loader code will convert this to upper case, so use that
+                                    -- version here.
+                                    ucase(pfabs.afa_generated_unique) AS transaction_unique_id,
+                                    aw.generated_unique_award_id
+                                FROM
+                                    raw.awards AS aw INNER JOIN raw.published_fabs AS pfabs ON (
+                                        aw.generated_unique_award_id = ucase(pfabs.unique_award_key)
+                                    )
+                                -- Again, want to exclude orphaned transactions, as they will not be copied into the 
+                                -- int schema.
+                                WHERE ucase(pfabs.afa_generated_unique) NOT IN (
+                                    SELECT transaction_unique_id FROM temp.orphaned_transaction_info WHERE NOT is_fpds
                                 )
+                            )
+                        ) AS existing_awards
+                """
+            )
+
+            # Any award that has a transaction inserted into award_id_lookup table that also has an orphaned
+            # transaction is an award that will have to be updated the first time this command is called with the
+            # awards ETL level, so add those awards to the award_ids_delete_modified table.
+            self.logger.info("Updating award_ids_delete_modified table")
+            self.spark.sql(
+                """
+                    INSERT INTO int.award_ids_delete_modified
+                        SELECT DISTINCT(award_id)
+                        FROM int.award_id_lookup
+                        WHERE transaction_unique_id IN (
+                            SELECT transaction_unique_id FROM temp.orphaned_transaction_info
                         )
-                    ) AS existing_awards
+                """
+            )
+
+            # Awards that have orphaned transactions, but that *aren't* in the award_ids_delete_modified table are
+            # orphaned awards (those with no remaining transactions), so put those into the orphaned_award_info table.
+            self.spark.sql(
+                """
+                    INSERT INTO temp.orphaned_award_info
+                        SELECT DISTINCT(aidlu.award_id)
+                        FROM temp.orphaned_transaction_info AS oti INNER JOIN int.award_id_lookup AS aidlu ON (
+                            oti.transaction_unique_id = aidlu.transaction_unique_id
+                        )
+                        WHERE aidlu.award_id NOT IN (SELECT * FROM int.award_ids_delete_modified)
                 """
             )
 
@@ -1211,30 +1311,17 @@ class Command(BaseCommand):
             # es_deletes should remain in lockstep with transaction load dates, so if they are reset, it should be reset
             update_last_load_date("es_deletes", next_last_load)
 
-        # Need a table to keep track of awards in which some, but not all, transactions are deleted.
-        destination_table = "award_ids_delete_modified"
-
-        self.logger.info(f"Creating {destination_table} table")
-        self.spark.sql(
-            f"""
-                CREATE OR REPLACE TABLE {destination_database}.{destination_table} (
-                    award_id LONG NOT NULL
-                )
-                USING DELTA
-                LOCATION 's3a://{self.spark_s3_bucket}/{delta_lake_s3_path}/{destination_database}/{destination_table}'
-            """
-        )
-
-        # Nothing to add to this table here.
-
         # Create other tables in 'int' database
-        self.logger.info("Creating tables in new database location")
-        table_to_col_names_dict = {}
-        table_to_col_names_dict["transaction_fabs"] = TRANSACTION_FABS_COLUMNS
-        table_to_col_names_dict["transaction_fpds"] = TRANSACTION_FPDS_COLUMNS
-        table_to_col_names_dict["transaction_normalized"] = list(TRANSACTION_NORMALIZED_COLUMNS)
-        table_to_col_names_dict["awards"] = list(AWARDS_COLUMNS)
-        for destination_table, col_names in table_to_col_names_dict.items():
+        for destination_table, col_names, orphaned_record_key in zip(
+            ("transaction_fabs", "transaction_fpds", "transaction_normalized", "awards"),
+            (
+                TRANSACTION_FABS_COLUMNS,
+                TRANSACTION_FPDS_COLUMNS,
+                list(TRANSACTION_NORMALIZED_COLUMNS),
+                list(AWARDS_COLUMNS)
+            ),
+            ("transaction_id", "transaction_id", "id", "id")
+        ):
             call_command(
                 "create_delta_table",
                 "--destination-table",
@@ -1260,11 +1347,24 @@ class Command(BaseCommand):
                         # Don't try to handle anything else
                         raise e
                 else:
+                    # Handle exclusion of orphaned records
+                    if destination_table != "awards":
+                        orphan_str = f"""
+                            WHERE {orphaned_record_key} NOT IN (
+                                SELECT transaction_id FROM temp.orphaned_transaction_info
+                            )
+                        """
+                    else:
+                        orphan_str = (
+                            f"WHERE {orphaned_record_key} NOT IN (SELECT award_id FROM temp.orphaned_award_info)"
+                        )
+
                     # Handle the possibility that the order of columns is different between the raw and int tables.
                     self.spark.sql(
                         f"""
                         INSERT OVERWRITE {destination_database}.{destination_table} ({", ".join(col_names)})
                             SELECT {", ".join(col_names)} FROM raw.{destination_table}
+                            {orphan_str}
                         """
                     )
 
@@ -1276,3 +1376,6 @@ class Command(BaseCommand):
                         # es_deletes should remain in lockstep with transaction load dates, so if they are reset,
                         # it should be reset
                         update_last_load_date("es_deletes", next_last_load)
+
+        self.spark.sql("DROP TABLE temp.orphaned_transaction_info")
+        self.spark.sql("DROP TABLE temp.orphaned_award_info")

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -356,7 +356,7 @@ class Command(BaseCommand):
                 )
                 WHERE rank = 1
             ),
-            transaction_latest as (
+            transaction_latest AS (
                 SELECT * FROM (
                     SELECT
                         -- General update columns (id at top, rest alphabetically by alias/name)
@@ -464,8 +464,9 @@ class Command(BaseCommand):
                                           if col_name not in set_subquery_ignored_columns])}
             FROM transaction_latest AS latest
             INNER JOIN transaction_earliest AS earliest ON latest.id = earliest.id
-            INNER JOIN transaction_ec AS ec ON latest.id = ec.id
             INNER JOIN transaction_totals AS totals on latest.id = totals.id
+            -- Not every award will have a record in transaction_ec, so need to do a LEFT JOIN on it.
+            LEFT JOIN transaction_ec AS ec ON latest.id = ec.id
         """
 
         # On set, create_date will not be changed and update_date will be set below.  The subaward columns will not


### PR DESCRIPTION
**Description:**
This PR addresses the issue of "orphaned" transactions (records in the `transaction_fabs|fpds|normalized` tables that have no associated records in the source (`raw.detached_award_procurement` or `raw.published_fabs`) tables, and any awards that are impacted by orphaned transactions.

Due to timing of reviews, etc, this PR also fixes an issue with the `awards` ETL level.

**Technical details:**
During the `initial_run` ETL level of the `load_transactions_in_delta` command, this code first identifies any orphaned transactions in the `raw.transaction_normalized` table.  It then prevents those transactions from being added to the `int.transaction_id_lookup` or `id.award_id_lookup` tables, and prevents them from being copied from the `raw` to `int` versions of the `transaction_fabs|fpds|normalized` tables.  It also identifies any awards that have some orphaned transactions associated with them and marks them for modification during the next run of the `awards` ETL level.  Lastly, it finds any awards that are themselves orphaned (lacking any transactions) once the orphaned transactions have been excluded, and it excludes them from being copied from the `raw.awards` table to the `int.awards` table.

NOTE: All of the current tests for `load_transactions_to_delta` pass with these changes, but no new unit tests have been added to test out this functionality yet.

For the `awards` ETL level, needed to change an `INNER JOIN` to a `LEFT JOIN` to handle a sparse CTE. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [PIPE-474](https://federal-spending-transparency.atlassian.net/browse/PIPE-474):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
