### PR TITLE
[PIPE-353] More concurrent CSV writers for load_table_from_delta

### DIFF
--- a/usaspending_api/config/envs/default.py
+++ b/usaspending_api/config/envs/default.py
@@ -313,7 +313,7 @@ class DefaultConfig(BaseSettings):
     # number of partitions to split/group batches of CSV files into, which need to be written via COPY to PG
     # This multiplier will be multiplied against the max_parallel_workers value of the target database. It can be a
     # fraction less than 1.0. The final value will be the greater of that or ``SPARK_CSV_WRITE_TO_PG_MIN_PARTITIONS``
-    SPARK_CSV_WRITE_TO_PG_PARALLEL_WORKER_MULTIPLIER: float = 0.5
+    SPARK_CSV_WRITE_TO_PG_PARALLEL_WORKER_MULTIPLIER: float = 1.0
 
     # Spark is connecting JDBC to Elasticsearch here and this config calibrates the throughput from one to the other,
     # and have to accommodate limitations on either side of the pipe.


### PR DESCRIPTION
**Description:**
Scaling up how many write connections are open when pushing CSV data from delta tables back down to Postgres

**Technical details:**
With our approach to scaling up the aurora writer instance, it looks like we can handle more concurrent writers. That and the transaction_search parallel write seems to lag fairly far behind award search, so less concurrency is happening among writing the two tables.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
