### PR TITLE
[PIPE-236] Fix covid sql award id ref in subaward files

### DIFF
--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_contracts.sql
@@ -144,7 +144,7 @@ INNER JOIN (
             0
         ) != 0
         OR COALESCE(SUM(faba.transaction_obligated_amount), 0) != 0
-) DEFC ON (DEFC.award_id = awards.id)
+) DEFC ON (DEFC.award_id = awards.award_id)
 WHERE (
     "subaward_search"."prime_award_group" IN ('procurement')
     AND "subaward_search"."sub_action_date" >= '2020-04-01'

--- a/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
+++ b/usaspending_api/disaster/management/sql/disaster_covid19_file_f_grants.sql
@@ -141,7 +141,7 @@ INNER JOIN (
             0
         ) != 0
         OR COALESCE(SUM(faba.transaction_obligated_amount), 0) != 0
-) DEFC ON (DEFC.award_id = awards.id)
+) DEFC ON (DEFC.award_id = awards.award_id)
 WHERE (
     "subaward_search"."prime_award_group" IN ('grant')
     AND "subaward_search"."sub_action_date" >= '2020-04-01'


### PR DESCRIPTION
**Description:**
Subaward File F SQL for COVID Download has wrong PK reference

**Technical details:**
Find and replace left `award.id` when it should reference `award_id` of `award_search` on the join.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
