### PR TITLE
[PIPE-466] Usage of INT FABA 

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -56,7 +56,7 @@ class DeltaLakeElasticsearchIndexerController(AbstractElasticsearchIndexerContro
         elif self.config["load_type"] == "award":
             identifier_replacements["award_search"] = "rpt.award_search"
         elif self.config["load_type"] == "covid19-faba":
-            identifier_replacements["financial_accounts_by_awards"] = "raw.financial_accounts_by_awards"
+            identifier_replacements["financial_accounts_by_awards"] = "int.financial_accounts_by_awards"
             identifier_replacements["vw_awards"] = "int.awards"
         else:
             raise ValueError(

--- a/usaspending_api/etl/management/commands/update_covid_awards_in_delta.py
+++ b/usaspending_api/etl/management/commands/update_covid_awards_in_delta.py
@@ -14,7 +14,7 @@ UPDATE_AWARDS_SQL = """
     SELECT
         DISTINCT award_id
     FROM
-        raw.financial_accounts_by_awards faba
+        int.financial_accounts_by_awards faba
     INNER JOIN global_temp.submission_attributes sa ON
         faba.submission_id = sa.submission_id
     INNER JOIN global_temp.dabs_submission_window_schedule dabs ON

--- a/usaspending_api/search/delta_models/award_search.py
+++ b/usaspending_api/search/delta_models/award_search.py
@@ -460,7 +460,7 @@ LEFT OUTER JOIN (
                 END), 0) AS outlay,
             COALESCE(sum(faba.transaction_obligated_amount), 0) AS obligation
         FROM
-            raw.financial_accounts_by_awards AS faba
+            int.financial_accounts_by_awards AS faba
         INNER JOIN
             global_temp.disaster_emergency_fund_code AS defc ON (faba.disaster_emergency_fund_code = defc.code AND defc.group_name = 'covid_19')
         INNER JOIN
@@ -512,7 +512,7 @@ LEFT OUTER JOIN (
     COLLECT_SET(taa.treasury_account_identifier) AS treasury_account_identifiers
   FROM
     global_temp.treasury_appropriation_account taa
-  INNER JOIN raw.financial_accounts_by_awards faba ON (taa.treasury_account_identifier = faba.treasury_account_id)
+  INNER JOIN int.financial_accounts_by_awards faba ON (taa.treasury_account_identifier = faba.treasury_account_id)
   INNER JOIN global_temp.federal_account fa ON (taa.federal_account_id = fa.id)
   INNER JOIN global_temp.toptier_agency agency ON (fa.parent_toptier_agency_id = agency.toptier_agency_id)
   WHERE

--- a/usaspending_api/search/delta_models/subaward_search.py
+++ b/usaspending_api/search/delta_models/subaward_search.py
@@ -243,7 +243,7 @@ subaward_search_load_sql_string = fr"""
         FROM
             global_temp.treasury_appropriation_account AS taa
         INNER JOIN
-            raw.financial_accounts_by_awards AS faba
+            int.financial_accounts_by_awards AS faba
                 ON taa.treasury_account_identifier = faba.treasury_account_id
         WHERE
             faba.award_id IS NOT NULL

--- a/usaspending_api/transactions/delta_models/transaction_search.py
+++ b/usaspending_api/transactions/delta_models/transaction_search.py
@@ -1026,7 +1026,7 @@ transaction_search_load_sql_string = fr"""
                 ),
                 TRUE
             ) AS tas_components
-        FROM raw.financial_accounts_by_awards AS faba
+        FROM int.financial_accounts_by_awards AS faba
         INNER JOIN global_temp.treasury_appropriation_account AS taa ON taa.treasury_account_identifier = faba.treasury_account_id
         INNER JOIN global_temp.federal_account AS fa ON fa.id = taa.federal_account_id
         INNER JOIN global_temp.toptier_agency agency ON (fa.parent_toptier_agency_id = agency.toptier_agency_id)


### PR DESCRIPTION
**Descriptions**

Updates a few downstream jobs to use the `int` version of the `financial_accounts_by_awards` table:
- Subaward Search
- Transaction Search
- Award Search
- Touch Covid Awards