### PR TITLE
[PIPE-474]  raw fabs to tx norm date parsing fixes

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -22,6 +22,7 @@ from usaspending_api.broker.helpers.last_load_date import (
     get_last_load_date,
     update_last_load_date,
 )
+from usaspending_api.common.data_classes import TransactionColumn
 from usaspending_api.common.etl.spark import create_ref_temp_views
 from usaspending_api.common.helpers.spark_helpers import (
     get_active_spark_session,
@@ -513,67 +514,73 @@ class Command(BaseCommand):
         self.spark.sql("DELETE FROM int.award_ids_delete_modified")
 
     def source_subquery_sql(self, transaction_type=None):
-        def handle_column(col, bronze_table_name):
-            # Require a separator for mmddYYYY, but not for YYYYmmdd, or there is no way to tell them apart
-            #   from just regexp, and only YYYYmmdd has been seen without a separator.
-            # Each of these regexps allows for an optional timestamp portion, separated from the date by some character,
-            #   and the timestamp allows for an optional UTC offset.  In any case, the timestamp is ignored, though.
-            regexp_mmddYYYY = (
-                r"(\\d{2})(?<sep>[-/])(\\d{2})(\\k<sep>)(\\d{4})(.\\d{2}:\\d{2}:\\d{2}([+-]\\d{2}:\\d{2})?)?"
-            )
-            regexp_YYYYmmdd = (
-                r"(\\d{4})(?<sep>[-/]?)(\\d{2})(\\k<sep>)(\\d{2})(.\\d{2}:\\d{2}:\\d{2}([+-]\\d{2}:\\d{2})?)?"
-            )
 
+        # When handling date-parsing, require a separator for mmddYYYY, but not for YYYYmmdd, or there is no way to
+        # tell them apart from just regexp, and only YYYYmmdd has been seen without a separator.
+        # Each of these regexps allows for an optional timestamp portion, separated from the date by some character,
+        #   and the timestamp allows for an optional UTC offset.  In any case, the timestamp is ignored, though.
+        regexp_mmddYYYY = r"(\\d{2})(?<sep>[-/])(\\d{2})(\\k<sep>)(\\d{4})(.\\d{2}:\\d{2}:\\d{2}([+-]\\d{2}:\\d{2})?)?"
+        regexp_YYYYmmdd = r"(\\d{4})(?<sep>[-/]?)(\\d{2})(\\k<sep>)(\\d{2})(.\\d{2}:\\d{2}:\\d{2}([+-]\\d{2}:\\d{2})?)?"
+
+        def build_date_format_sql(
+            col: TransactionColumn, is_casted_to_date: bool = True, is_result_aliased: bool = True
+        ) -> str:
+            """Builder function to wrap a column in date-parsing logic.
+
+            It will either parse it in mmddYYYY format with - or / as a required separated, or in YYYYmmdd format
+            with or without either of - or / as a separtor.
+            Args:
+                is_casted_to_date (bool): if true, the parsed result will be cast to DATE to provide a DATE datatype,
+                    otherwise it remains a STRING in YYYY-mm-dd format
+                is_result_aliased (bool) if true, aliases the parsing result with the given ``col``'s ``dest_name``
+            """
+            mmddYYYY_fmt = f"""
+                (regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 5)
+                || '-' ||
+                regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 1)
+                || '-' ||
+                regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 3))
+            """
+            YYYYmmdd_fmt = f"""
+                (regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 1)
+                || '-' ||
+                regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 3)
+                || '-' ||
+                regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 5))
+            """
+            if is_casted_to_date:
+                mmddYYYY_fmt = f"CAST({mmddYYYY_fmt}" f"AS DATE)"
+                YYYYmmdd_fmt = f"CAST({YYYYmmdd_fmt}" f"AS DATE)"
+            sql_snippet = f"""
+                CASE WHEN regexp({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}')
+                          THEN {mmddYYYY_fmt}
+                     ELSE {YYYYmmdd_fmt}
+                END{' AS ' + col.dest_name if is_result_aliased else ''}
+            """
+            return sql_snippet
+
+        def handle_column(col, bronze_table_name, is_result_aliased=True):
             if col.handling == "cast":
-                retval = f"CAST({bronze_table_name}.{col.source} AS {col.delta_type}) AS {col.dest_name}"
+                retval = f"CAST({bronze_table_name}.{col.source} AS {col.delta_type}){' AS ' + col.dest_name if is_result_aliased else ''}"
             elif col.handling == "literal":
                 # Use col.source directly as the value
-                retval = f"{col.source} AS {col.dest_name}"
+                retval = f"{col.source}{' AS ' + col.dest_name if is_result_aliased else ''}"
             elif col.handling == "parse_string_datetime_to_date":
                 # These are string fields that actually hold DATES/TIMESTAMPS and need to be cast as dates.
                 # However, they may not be properly parsed when calling CAST(... AS DATE).
-                retval = f"""
-                    CASE WHEN regexp({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}')
-                              THEN CAST((regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 5)
-                                         || '-' ||
-                                         regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 1)
-                                         || '-' ||
-                                         regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 3))
-                                        AS DATE)
-                         ELSE CAST((regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 1)
-                                    || '-' ||
-                                    regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 3)
-                                    || '-' ||
-                                    regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 5))
-                                   AS DATE)
-                    END AS {col.dest_name}
-                """
+                retval = build_date_format_sql(col, is_casted_to_date=True, is_result_aliased=is_result_aliased)
             elif col.handling == "string_datetime_remove_timestamp":
                 # These are string fields that actually hold DATES/TIMESTAMPS, but need the non-DATE part discarded,
                 # even though they remain as strings
-                retval = f"""
-                    CASE WHEN regexp({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}')
-                              THEN (regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 5)
-                                    || '-' ||
-                                    regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 1)
-                                    || '-' ||
-                                    regexp_extract({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}', 3))
-                         ELSE (regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 1)
-                               || '-' ||
-                               regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 3)
-                               || '-' ||
-                               regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 5))
-                    END AS {col.dest_name}
-                """
+                retval = build_date_format_sql(col, is_casted_to_date=False, is_result_aliased=is_result_aliased)
             elif col.delta_type.upper() == "STRING":
                 # Capitalize all string values
-                retval = f"ucase({bronze_table_name}.{col.source}) AS {col.dest_name}"
+                retval = f"ucase({bronze_table_name}.{col.source}){' AS ' + col.dest_name if is_result_aliased else ''}"
             elif col.delta_type.upper() == "BOOLEAN" and not col.handling == "leave_null":
                 # Unless specified, convert any nulls to false for boolean columns
-                retval = f"COALESCE({bronze_table_name}.{col.source}, FALSE) AS {col.dest_name}"
+                retval = f"COALESCE({bronze_table_name}.{col.source}, FALSE){' AS ' + col.dest_name if is_result_aliased else ''}"
             else:
-                retval = f"{bronze_table_name}.{col.source} AS {col.dest_name}"
+                retval = f"{bronze_table_name}.{col.source}{' AS ' + col.dest_name if is_result_aliased else ''}"
 
             return retval
 
@@ -595,12 +602,19 @@ class Command(BaseCommand):
             return select_cols
 
         def select_columns_transaction_normalized(bronze_table_name):
+            action_date_col = next(
+                filter(
+                    lambda c: c.dest_name == "action_date" and c.source == "action_date",
+                    FABS_TO_NORMALIZED_COLUMN_INFO if transaction_type == "fabs" else DAP_TO_NORMALIZED_COLUMN_INFO,
+                )
+            )
+            parse_action_date_sql_snippet = handle_column(action_date_col, bronze_table_name, is_result_aliased=False)
             select_cols = [
                 "award_id_lookup.award_id",
                 "awarding_agency.id AS awarding_agency_id",
-                f"""CASE WHEN month(to_date({bronze_table_name}.action_date)) > 9
-                             THEN year(to_date({bronze_table_name}.action_date)) + 1
-                         ELSE year(to_date({bronze_table_name}.action_date))
+                f"""CASE WHEN month({parse_action_date_sql_snippet}) > 9
+                             THEN year({parse_action_date_sql_snippet}) + 1
+                         ELSE year({parse_action_date_sql_snippet})
                     END AS fiscal_year""",
                 "funding_agency.id AS funding_agency_id",
             ]

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -549,8 +549,12 @@ class Command(BaseCommand):
                 regexp_extract({bronze_table_name}.{col.source}, '{regexp_YYYYmmdd}', 5))
             """
             if is_casted_to_date:
-                mmddYYYY_fmt = f"CAST({mmddYYYY_fmt}" f"AS DATE)"
-                YYYYmmdd_fmt = f"CAST({YYYYmmdd_fmt}" f"AS DATE)"
+                mmddYYYY_fmt = f"""CAST({mmddYYYY_fmt}
+                            AS DATE)
+                """
+                YYYYmmdd_fmt = f"""CAST({YYYYmmdd_fmt}
+                            AS DATE)
+                """
             sql_snippet = f"""
                 CASE WHEN regexp({bronze_table_name}.{col.source}, '{regexp_mmddYYYY}')
                           THEN {mmddYYYY_fmt}

--- a/usaspending_api/transactions/delta_models/transaction_fabs.py
+++ b/usaspending_api/transactions/delta_models/transaction_fabs.py
@@ -129,6 +129,7 @@ transaction_fabs_sql_string = rf"""
 
 # Mapping from raw.published_fabs to int.transaction_normalized columns, where a simple mapping exists
 FABS_TO_NORMALIZED_COLUMN_INFO = [
+    # action_date seen as: mm/dd/YYYY, YYYYmmdd, YYYY-mm-dd, so need special parsing
     TransactionColumn("action_date", "action_date", "DATE", "parse_string_datetime_to_date"),
     TransactionColumn("action_type", "action_type", "STRING"),
     TransactionColumn("action_type_description", "action_type_description", "STRING"),
@@ -142,8 +143,13 @@ FABS_TO_NORMALIZED_COLUMN_INFO = [
     TransactionColumn("modification_number", "award_modification_amendme", "STRING"),
     TransactionColumn("non_federal_funding_amount", "non_federal_funding_amount", "NUMERIC(23,2)"),
     TransactionColumn("original_loan_subsidy_cost", "original_loan_subsidy_cost", "NUMERIC(23,2)"),
-    TransactionColumn("period_of_performance_current_end_date", "period_of_performance_curr", "DATE", "cast"),
-    TransactionColumn("period_of_performance_start_date", "period_of_performance_star", "DATE", "cast"),
+    # period_of_performance_* fields seen as: mm/dd/YYYY as well as YYYYmmdd, so need special parsing
+    TransactionColumn(
+        "period_of_performance_current_end_date", "period_of_performance_curr", "DATE", "parse_string_datetime_to_date"
+    ),
+    TransactionColumn(
+        "period_of_performance_start_date", "period_of_performance_star", "DATE", "parse_string_datetime_to_date"
+    ),
     TransactionColumn("transaction_unique_id", "afa_generated_unique", "STRING"),
     TransactionColumn("type", "assistance_type", "STRING"),
     TransactionColumn("type_description", "assistance_type_desc", "STRING"),

--- a/usaspending_api/transactions/delta_models/transaction_fpds.py
+++ b/usaspending_api/transactions/delta_models/transaction_fpds.py
@@ -363,6 +363,7 @@ DAP_TO_NORMALIZED_COLUMN_INFO = [
     TransactionColumn("modification_number", "award_modification_amendme", "STRING"),
     TransactionColumn("non_federal_funding_amount", "NULL", "NUMERIC(23, 2)", "literal"),
     TransactionColumn("original_loan_subsidy_cost", "NULL", "NUMERIC(23, 2)", "literal"),
+    # All period_of_performance_* fields seen as: YYYY-MM-DD 00:00:00, so cast works
     TransactionColumn("period_of_performance_current_end_date", "period_of_performance_curr", "DATE", "cast"),
     TransactionColumn("period_of_performance_start_date", "period_of_performance_star", "DATE", "cast"),
     TransactionColumn("transaction_unique_id", "detached_award_proc_unique", "STRING"),

--- a/usaspending_api/transactions/delta_models/transaction_fpds.py
+++ b/usaspending_api/transactions/delta_models/transaction_fpds.py
@@ -364,8 +364,13 @@ DAP_TO_NORMALIZED_COLUMN_INFO = [
     TransactionColumn("non_federal_funding_amount", "NULL", "NUMERIC(23, 2)", "literal"),
     TransactionColumn("original_loan_subsidy_cost", "NULL", "NUMERIC(23, 2)", "literal"),
     # All period_of_performance_* fields seen as: YYYY-MM-DD 00:00:00, so cast works
-    TransactionColumn("period_of_performance_current_end_date", "period_of_performance_curr", "DATE", "cast"),
-    TransactionColumn("period_of_performance_start_date", "period_of_performance_star", "DATE", "cast"),
+    # BUT it's still just a string and could morph, so defensively smart-date-parsing the string
+    TransactionColumn(
+        "period_of_performance_current_end_date", "period_of_performance_curr", "DATE", "parse_string_datetime_to_date"
+    ),
+    TransactionColumn(
+        "period_of_performance_start_date", "period_of_performance_star", "DATE", "parse_string_datetime_to_date"
+    ),
     TransactionColumn("transaction_unique_id", "detached_award_proc_unique", "STRING"),
     TransactionColumn("unique_award_key", "unique_award_key", "STRING"),
     TransactionColumn("usaspending_unique_transaction_id", "NULL", "STRING", "literal"),


### PR DESCRIPTION
**Description:**
Adding further date-parsing handling of the published_fabs to transaction_normalized mappings for action_date and the two period of performance columns, since raw fabs records see string dates in a variety of formats"

**Technical details:**
- the `raw.published_fabs.action_date` column was being used in its raw form to derive the fiscal year, and needed to be parsed into a date first
- the `raw.published_fabs.period_of_performance_curr|star` columns were being casted to date, but that will now work with strings in the format of `mm/dd/YYYY`, which this raw table has

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
