### PR TITLE
[PIPE-474] Handle additional data discrepancies

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -1440,9 +1440,9 @@ class Command(BaseCommand):
                 # As for transaction_id_seq, make sure to get the maximum award id from the raw table in case there are
                 # records in raw.awards that don't correspond to any records in either of the source tables.
                 # This way, new award_ids won't repeat the ids of any of those "orphaned" award records.
-                max_id = self.spark.sql(
-                    f"SELECT MAX(award_id) AS max_id FROM raw.transaction_normalized"
-                ).collect()[0]["max_id"]
+                max_id = self.spark.sql(f"SELECT MAX(award_id) AS max_id FROM raw.transaction_normalized").collect()[0][
+                    "max_id"
+                ]
 
             if max_id is None:
                 # Can't set a Postgres sequence to 0, so set to 1 in this case.  If this happens, the award IDs

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -1384,16 +1384,16 @@ class Command(BaseCommand):
                                         -- versions here.
                                         ucase(dap.detached_award_proc_unique) AS transaction_unique_id,
                                         ucase(dap.unique_award_key) AS generated_unique_award_id
-                                    FROM raw.transaction_normalized AS tn 
+                                    FROM raw.transaction_normalized AS tn
                                     INNER JOIN raw.detached_award_procurement AS dap ON (
                                         tn.transaction_unique_id = ucase(dap.detached_award_proc_unique)
                                     )
                                     /* Again, want to exclude orphaned transactions, as they will not be copied into the
                                        int schema.  We have to be careful and only exclude transactions based on their
-                                       transaction_id, though!  There shouldn't be, but there can be multiple 
+                                       transaction_id, though!  There shouldn't be, but there can be multiple
                                        transactions with the same transaction_unique_id in raw.transaction_normalized!
-                                       We only want to exclude those that don't have matching records in 
-                                       raw.transaction_fabs|fpds.                                                  */ 
+                                       We only want to exclude those that don't have matching records in
+                                       raw.transaction_fabs|fpds.                                                  */
                                     WHERE tn.id NOT IN (
                                         SELECT transaction_id FROM temp.orphaned_transaction_info WHERE is_fpds
                                     )
@@ -1407,7 +1407,7 @@ class Command(BaseCommand):
                                         -- versions here.
                                         ucase(pfabs.afa_generated_unique) AS transaction_unique_id,
                                         ucase(pfabs.unique_award_key) AS generated_unique_award_id
-                                    FROM raw.transaction_normalized AS tn 
+                                    FROM raw.transaction_normalized AS tn
                                     INNER JOIN raw.published_fabs AS pfabs ON (
                                         tn.transaction_unique_id = ucase(pfabs.afa_generated_unique)
                                     )

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -444,7 +444,7 @@ class InitialRunWithPostgresLoader:
     expected_initial_transaction_fpds = [
         {
             **procure,
-            "action_date": procure["action_date"],
+            "action_date": dateutil.parser.parse(procure["action_date"]).date().isoformat(),
             "detached_award_proc_unique": procure["detached_award_proc_unique"].upper(),
             "transaction_id": procure["detached_award_procurement_id"] + len(initial_assists),
             "unique_award_key": procure["unique_award_key"].upper(),
@@ -758,7 +758,7 @@ class TestInitialRunNoPostgresLoader:
     initial_transaction_fpds = [
         {
             **procure,
-            "action_date": procure["action_date"],
+            "action_date": dateutil.parser.parse(procure["action_date"]).date().isoformat(),
             "detached_award_proc_unique": procure["detached_award_proc_unique"].upper(),
             "transaction_id": procure["detached_award_procurement_id"] * 2,
             "unique_award_key": procure["unique_award_key"].upper(),
@@ -767,14 +767,14 @@ class TestInitialRunNoPostgresLoader:
     ] + [
         {
             **initial_procures[3],
-            "action_date": initial_procures[3]["action_date"],
+            "action_date": dateutil.parser.parse(initial_procures[3]["action_date"]).date().isoformat(),
             "detached_award_proc_unique": initial_procures[3]["detached_award_proc_unique"].upper(),
             "transaction_id": 9,
             "unique_award_key": initial_procures[3]["unique_award_key"].upper(),
         },
         {
             **initial_procures[4],
-            "action_date": initial_procures[4]["action_date"],
+            "action_date": dateutil.parser.parse(initial_procures[4]["action_date"]).date().isoformat(),
             "detached_award_proc_unique": initial_procures[4]["detached_award_proc_unique"].upper(),
             "transaction_id": 10,
             "unique_award_key": initial_procures[4]["unique_award_key"].upper(),
@@ -1639,9 +1639,7 @@ class TransactionFabsFpdsCore:
         expected_transaction_fabs_fpds_append.update(
             {
                 "transaction_id": self.new_transaction_id,
-                "action_date": insert_update_datetime.date().isoformat()
-                if self.etl_level == "transaction_fabs"
-                else insert_update_datetime.isoformat(),
+                "action_date": insert_update_datetime.date().isoformat(),
                 "created_at": insert_update_datetime,
                 "updated_at": insert_update_datetime,
             }

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -1411,10 +1411,7 @@ class TransactionFabsFpdsCore:
         assert equal_datasets(expected_transaction_fabs_fpds, delta_data, "")
 
     def unexpected_paths_test_core(
-        self,
-        load_other_raw_tables,
-        expected_initial_transaction_id_lookup,
-        expected_initial_award_id_lookup
+        self, load_other_raw_tables, expected_initial_transaction_id_lookup, expected_initial_award_id_lookup
     ):
         # 1. Call load_transactions_in_delta with etl-level of initial_run first, making sure to load
         # raw.transaction_normalized along with the source tables, but don't copy the raw tables to int.
@@ -1527,7 +1524,7 @@ class TransactionFabsFpdsCore:
                 )
             ],
             TestInitialRunNoPostgresLoader.expected_initial_transaction_id_lookup,
-            TestInitialRunNoPostgresLoader.expected_initial_award_id_lookup
+            TestInitialRunNoPostgresLoader.expected_initial_award_id_lookup,
         )
 
     def happy_paths_test_core(

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -1414,6 +1414,7 @@ class TransactionFabsFpdsCore:
         self,
         load_other_raw_tables,
         expected_initial_transaction_id_lookup,
+        expected_initial_award_id_lookup
     ):
         # 1. Call load_transactions_in_delta with etl-level of initial_run first, making sure to load
         # raw.transaction_normalized along with the source tables, but don't copy the raw tables to int.
@@ -1427,7 +1428,7 @@ class TransactionFabsFpdsCore:
         # the initial data.
         kwargs = {
             "expected_last_load_transaction_id_lookup": initial_source_table_load_datetime,
-            "expected_last_load_award_id_lookup": BEGINNING_OF_TIME,
+            "expected_last_load_award_id_lookup": initial_source_table_load_datetime,
             "expected_last_load_transaction_normalized": BEGINNING_OF_TIME,
             "expected_last_load_transaction_fabs": BEGINNING_OF_TIME,
             "expected_last_load_transaction_fpds": BEGINNING_OF_TIME,
@@ -1436,7 +1437,7 @@ class TransactionFabsFpdsCore:
         TestInitialRun.verify(
             self.spark,
             expected_initial_transaction_id_lookup,
-            [],
+            expected_initial_award_id_lookup,
             0,
             len(self.expected_initial_transaction_fabs),
             len(self.expected_initial_transaction_fpds),
@@ -1491,7 +1492,7 @@ class TransactionFabsFpdsCore:
         TestInitialRun.verify(
             self.spark,
             expected_initial_transaction_id_lookup,
-            [],
+            expected_initial_award_id_lookup,
             0,
             len(self.expected_initial_transaction_fabs),
             len(self.expected_initial_transaction_fpds),
@@ -1526,6 +1527,7 @@ class TransactionFabsFpdsCore:
                 )
             ],
             TestInitialRunNoPostgresLoader.expected_initial_transaction_id_lookup,
+            TestInitialRunNoPostgresLoader.expected_initial_award_id_lookup
         )
 
     def happy_paths_test_core(

--- a/usaspending_api/transactions/delta_models/transaction_fpds.py
+++ b/usaspending_api/transactions/delta_models/transaction_fpds.py
@@ -3,7 +3,7 @@ from usaspending_api.common.data_classes import TransactionColumn
 TRANSACTION_FPDS_COLUMN_INFO = [
     TransactionColumn("a_76_fair_act_action", "a_76_fair_act_action", "STRING"),
     TransactionColumn("a_76_fair_act_action_desc", "a_76_fair_act_action_desc", "STRING"),
-    TransactionColumn("action_date", "action_date", "STRING"),
+    TransactionColumn("action_date", "action_date", "STRING", "string_datetime_remove_timestamp"),
     TransactionColumn("action_type", "action_type", "STRING"),
     TransactionColumn("action_type_description", "action_type_description", "STRING"),
     TransactionColumn("agency_id", "agency_id", "STRING"),
@@ -124,7 +124,7 @@ TRANSACTION_FPDS_COLUMN_INFO = [
     TransactionColumn("information_technology_com", "information_technology_com", "STRING"),
     TransactionColumn("inherently_government_desc", "inherently_government_desc", "STRING"),
     TransactionColumn("inherently_government_func", "inherently_government_func", "STRING"),
-    TransactionColumn("initial_report_date", "initial_report_date", "STRING"),
+    TransactionColumn("initial_report_date", "initial_report_date", "STRING", "string_datetime_remove_timestamp"),
     TransactionColumn("inter_municipal_local_gove", "inter_municipal_local_gove", "BOOLEAN"),
     TransactionColumn("interagency_contract_desc", "interagency_contract_desc", "STRING"),
     TransactionColumn("interagency_contracting_au", "interagency_contracting_au", "STRING"),
@@ -186,7 +186,9 @@ TRANSACTION_FPDS_COLUMN_INFO = [
     TransactionColumn("officer_4_name", "high_comp_officer4_full_na", "STRING"),
     TransactionColumn("officer_5_amount", "high_comp_officer5_amount", "NUMERIC(23,2)", "cast"),
     TransactionColumn("officer_5_name", "high_comp_officer5_full_na", "STRING"),
-    TransactionColumn("ordering_period_end_date", "ordering_period_end_date", "STRING"),
+    TransactionColumn(
+        "ordering_period_end_date", "ordering_period_end_date", "STRING", "string_datetime_remove_timestamp"
+    ),
     TransactionColumn("organizational_type", "organizational_type", "STRING"),
     TransactionColumn("other_minority_owned_busin", "other_minority_owned_busin", "BOOLEAN"),
     TransactionColumn("other_not_for_profit_organ", "other_not_for_profit_organ", "BOOLEAN"),


### PR DESCRIPTION
**Description:**
Continuing to update delta transaction loader code to match any additional differences with the Postgres transaction loader behavior.

**Technical details:**
Changes:
1. In `initial_run`, change the way the `int.award_id_lookup` table is populated and how orphaned transactions are excluded from this table.
2. In last PR, mistakenly allowed several fields to pass unaltered from `raw.detached_award_procurement` to `int.transaction_fpds`.  Revert this change and the changes to the tests.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
3. [ ] API documentation updated
4. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
5. [ ] Matview impact assessment completed
6. [ ] Frontend impact assessment completed
7. [ ] Data validation completed
8. [ ] Appropriate Operations ticket(s) created
9. [ ] Jira Ticket [PIPE-474](https://federal-spending-transparency.atlassian.net/browse/PIPE-474):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
