### PR TITLE
[PIPE-380] Defer partition drop on swap

### DIFF
--- a/usaspending_api/etl/management/commands/swap_in_new_table.py
+++ b/usaspending_api/etl/management/commands/swap_in_new_table.py
@@ -426,7 +426,12 @@ class Command(BaseCommand):
         for val in temp_indexes:
             tindexname = re.sub(rf"{self.source_suffix}$", self.dest_suffix, val["indexname"], count=1)
             tindexdef = re.sub(
-                rf"(.*?){self.source_suffix}(\s+|$)", rf"\g<1>{self.dest_suffix}\g<2>", val["indexdef"], flags=re.I
+                # Name ending in source suffix, that may be quoted (due to special chars like $), that are followed
+                # by whitespace or the end of the line
+                rf"(.*?){self.source_suffix}(\"?\s+|\"?$)",
+                rf"\g<1>{self.dest_suffix}\g<2>",
+                val["indexdef"],
+                flags=re.I,
             )
             if self.is_temp_table_partitioned:
                 tindexdef = re.sub("ON ONLY", "ON", tindexdef, flags=re.I)


### PR DESCRIPTION
**Description:**
During swap of a partitioned table, skip dropping partitions, and wait til parent table is dropped which will remove them

**Technical details:**
If a targeted table to swap-out is a partition of a parent partitioned table,  it will not be dropped after its swap takes palce. Swapped-out partitions are not deleted after the swap due to the risk of their live parent partitioned table still receiving traffic while having one of its partitions deleted. If the parent partitioned table is also being swapped, then the partition will be deleted when the parent is deleted. Otherwise delete swapped/old partitions need to be deleted manually.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
