### PR TITLE
Fix: Updating `update_award_lookup_ids()` for existing awards

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -986,7 +986,7 @@ class Command(BaseCommand):
             INSERT INTO int.award_id_lookup
             SELECT
                 COALESCE(
-                    all_new_awards.existing_award_id, 
+                    all_new_awards.existing_award_id,
                     {previous_max_id} + DENSE_RANK(all_new_awards.unique_award_key) OVER (
                         ORDER BY all_new_awards.unique_award_key
                     )
@@ -1003,7 +1003,7 @@ class Command(BaseCommand):
                         ucase(dap.unique_award_key) AS unique_award_key,
                         award_aidlu.award_id AS existing_award_id
                     FROM
-                         dap_filtered AS dap 
+                         dap_filtered AS dap
                     LEFT JOIN aidlu_fpds AS trans_aidlu ON (
                             ucase(dap.detached_award_proc_unique) = trans_aidlu.transaction_unique_id
                          )

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -971,14 +971,25 @@ class Command(BaseCommand):
                 SELECT * FROM int.award_id_lookup
                 WHERE is_fpds = TRUE
             ),
+            aidlu_fpds_map AS (
+                SELECT award_id, generated_unique_award_id FROM aidlu_fpds
+                GROUP BY award_id, generated_unique_award_id
+            ),
             aidlu_fabs AS (
                 SELECT * FROM int.award_id_lookup
                 WHERE is_fpds = FALSE
+            ),
+            aidlu_fabs_map AS (
+                SELECT award_id, generated_unique_award_id FROM aidlu_fabs
+                GROUP BY award_id, generated_unique_award_id
             )
             INSERT INTO int.award_id_lookup
             SELECT
-                {previous_max_id} + DENSE_RANK(all_new_awards.unique_award_key) OVER (
-                    ORDER BY all_new_awards.unique_award_key
+                COALESCE(
+                    all_new_awards.existing_award_id, 
+                    {previous_max_id} + DENSE_RANK(all_new_awards.unique_award_key) OVER (
+                        ORDER BY all_new_awards.unique_award_key
+                    )
                 ) AS award_id,
                 all_new_awards.is_fpds,
                 all_new_awards.transaction_unique_id,
@@ -989,12 +1000,17 @@ class Command(BaseCommand):
                         TRUE AS is_fpds,
                         -- The transaction loader code will convert these to upper case, so use those versions here.
                         ucase(dap.detached_award_proc_unique) AS transaction_unique_id,
-                        ucase(dap.unique_award_key) AS unique_award_key
+                        ucase(dap.unique_award_key) AS unique_award_key,
+                        award_aidlu.award_id AS existing_award_id
                     FROM
-                         dap_filtered AS dap LEFT JOIN aidlu_fpds AS aidlu ON (
-                            ucase(dap.detached_award_proc_unique) = aidlu.transaction_unique_id
+                         dap_filtered AS dap 
+                    LEFT JOIN aidlu_fpds AS trans_aidlu ON (
+                            ucase(dap.detached_award_proc_unique) = trans_aidlu.transaction_unique_id
                          )
-                    WHERE aidlu.transaction_unique_id IS NULL
+                    LEFT JOIN aidlu_fpds_map AS award_aidlu ON (
+                            ucase(dap.unique_award_key) = award_aidlu.generated_unique_award_id
+                         )
+                    WHERE trans_aidlu.transaction_unique_id IS NULL
                 )
                 UNION ALL
                 (
@@ -1002,12 +1018,17 @@ class Command(BaseCommand):
                         FALSE AS is_fpds,
                         -- The transaction loader code will convert these to upper case, so use those versions here.
                         ucase(pfabs.afa_generated_unique) AS transaction_unique_id,
-                        ucase(pfabs.unique_award_key) AS unique_award_key
+                        ucase(pfabs.unique_award_key) AS unique_award_key,
+                        award_aidlu.award_id AS existing_award_id
                     FROM
-                        pfabs_filtered AS pfabs LEFT JOIN aidlu_fabs AS aidlu ON (
-                            ucase(pfabs.afa_generated_unique) = aidlu.transaction_unique_id
+                        pfabs_filtered AS pfabs
+                    LEFT JOIN aidlu_fabs AS trans_aidlu ON (
+                            ucase(pfabs.afa_generated_unique) = trans_aidlu.transaction_unique_id
                          )
-                    WHERE aidlu.transaction_unique_id IS NULL
+                    LEFT JOIN aidlu_fpds_map AS award_aidlu ON (
+                            ucase(pfabs.unique_award_key) = award_aidlu.generated_unique_award_id
+                         )
+                    WHERE trans_aidlu.transaction_unique_id IS NULL
                 )
             ) AS all_new_awards
         """


### PR DESCRIPTION
This function adds new transaction/award mappings to `award_id_lookup` for incoming transactions. The problem is that it creates new `award_id`s *even if the new transaction points to an existing award*. This updates the new records to reuse the existing `award_id` for already existing awards.