### PR TITLE
[PIPE-408] Rename inherited partition indexes and shrink swap transaction boundaries

### DIFF
--- a/usaspending_api/etl/management/commands/load_table_from_delta.py
+++ b/usaspending_api/etl/management/commands/load_table_from_delta.py
@@ -215,13 +215,6 @@ class Command(BaseCommand):
             cursor.execute(temp_dest_table_exists_sql)
             temp_dest_table_exists = cursor.fetchone()[0]
 
-        self.logger.warn(
-            f"!!!!!!!!\n!!!!!!!!\n\ttemp_dest_table_exists = {temp_dest_table_exists}\n!!!!!!!!\n!!!!!!!!\n"
-        )
-        self.logger.warn(f"!!!!!!!!\n!!!!!!!!\n\trecreate = {recreate}\n!!!!!!!!\n!!!!!!!!\n")
-        if temp_dest_table_exists:
-            self.logger.warn(f"----ENTERED HERE BECAUSE temp_dest_table_exists EVALUATED TO TRUTHY----")
-
         # If it does, and we're recreating it, drop it first
         if temp_dest_table_exists and recreate:
             self.logger.info(f"{temp_table} exists and recreate argument provided. Dropping first.")

--- a/usaspending_api/etl/management/commands/swap_in_new_table.py
+++ b/usaspending_api/etl/management/commands/swap_in_new_table.py
@@ -3,6 +3,7 @@ import logging
 import re
 
 from datetime import datetime
+from pprint import pformat
 from typing import List, OrderedDict, Optional
 from django.core.management import BaseCommand
 from django.db import connection, ProgrammingError, transaction
@@ -179,8 +180,9 @@ class Command(BaseCommand):
             self.analyze_temp_table(cursor)
             self.grant_privs_on_temp_table(cursor)
 
-            # Do the swap via renames
-            self.swap_table_view_sql(cursor)
+            # Do the swaps via renames
+            self.swap_dependent_views(cursor)
+            self.swap_table(cursor)
 
             if not options["keep_old_data"]:
                 self.drop_old_views(cursor)
@@ -281,39 +283,50 @@ class Command(BaseCommand):
         if rename_sql:
             cursor.execute("\n".join(rename_sql))
 
+    def swap_dependent_views(self, cursor):
+        sql_view_template = "ALTER {mv_s}VIEW {old_view_schema}.{old_view_name} RENAME TO {new_view_name};"
+        for dep_view in self.dep_views:
+            # Coordinate the schema move and view renames in 1 atomic operation
+            # But don't have the transaction span more than 1 view at a time to avoid any potential deadlocks with
+            # ongoing queries
+            with transaction.atomic():
+                mv_s = "MATERIALIZED " if dep_view["is_matview"] else ""
+                view_rename_sql = [
+                    # 1. move temp suffixed view to the target schema
+                    f"ALTER {mv_s}VIEW {self.temp_schema_name}.{dep_view['dep_view_name']}{self.source_suffix} "
+                    f"SET SCHEMA {dep_view['dep_view_schema']};",
+                    # 2. rename active view in target schema to have old suffix
+                    sql_view_template.format(
+                        mv_s=mv_s,
+                        old_view_schema=dep_view['dep_view_schema'],
+                        old_view_name=dep_view['dep_view_name'],
+                        new_view_name=f"{dep_view['dep_view_name']}{self.old_suffix}",
+                    ),
+                    # 3. rename temp view (now moved into target schema) to active name
+                    sql_view_template.format(
+                        mv_s=mv_s,
+                        old_view_schema=dep_view['dep_view_schema'],
+                        old_view_name=f"{dep_view['dep_view_name']}{self.source_suffix}",
+                        new_view_name=dep_view["dep_view_name"],
+                    ),
+                ]
+                logger.info(f"Running view swap SQL in an atomic transaction:\n{pformat(view_rename_sql)}")
+                cursor.execute("\n".join(view_rename_sql))
+
     @transaction.atomic
-    def swap_table_view_sql(self, cursor):
-        logger.info("Renaming the new and old tables and views")
+    def swap_table(self, cursor):
+        logger.info("Renaming the new and old table")
         sql_table_template = "ALTER TABLE {old_table_name} RENAME TO {new_table_name};"
 
-        rename_sql = [
+        table_rename_sql = [
             f"ALTER TABLE {self.temp_table_name} SET SCHEMA {self.curr_schema_name};",
             sql_table_template.format(
                 old_table_name=self.curr_table_name, new_table_name=f"{self.curr_table_name}{self.old_suffix}"
             ),
             sql_table_template.format(old_table_name=self.temp_table_name, new_table_name=f"{self.curr_table_name}"),
         ]
-
-        sql_view_template = "ALTER {mv_s}VIEW {old_view_name} RENAME TO {new_view_name};"
-        for dep_view in self.dep_views:
-            mv_s = "MATERIALIZED " if dep_view["is_matview"] else ""
-            rename_sql.extend(
-                [
-                    sql_view_template.format(
-                        mv_s=mv_s,
-                        old_view_name=dep_view["dep_view_fullname"],
-                        new_view_name=f"{dep_view['dep_view_name']}{self.old_suffix}",
-                    ),
-                    f"ALTER {mv_s}VIEW {self.temp_schema_name}.{dep_view['dep_view_name']}{self.source_suffix} "
-                    f"SET SCHEMA {dep_view['dep_view_schema']};",
-                    sql_view_template.format(
-                        mv_s=mv_s,
-                        old_view_name=f"{dep_view['dep_view_fullname']}{self.source_suffix}",
-                        new_view_name=dep_view["dep_view_name"],
-                    ),
-                ]
-            )
-        cursor.execute("\n".join(rename_sql))
+        logger.info(f"Running table swap SQL in an atomic transaction:\n{pformat(table_rename_sql)}")
+        cursor.execute("\n".join(table_rename_sql))
 
     def drop_old_table_sql(self, cursor):
         self.drop_old_table_metadata(cursor)

--- a/usaspending_api/etl/management/commands/swap_in_new_table.py
+++ b/usaspending_api/etl/management/commands/swap_in_new_table.py
@@ -298,14 +298,14 @@ class Command(BaseCommand):
                     # 2. rename active view in target schema to have old suffix
                     sql_view_template.format(
                         mv_s=mv_s,
-                        old_view_schema=dep_view['dep_view_schema'],
-                        old_view_name=dep_view['dep_view_name'],
+                        old_view_schema=dep_view["dep_view_schema"],
+                        old_view_name=dep_view["dep_view_name"],
                         new_view_name=f"{dep_view['dep_view_name']}{self.old_suffix}",
                     ),
                     # 3. rename temp view (now moved into target schema) to active name
                     sql_view_template.format(
                         mv_s=mv_s,
-                        old_view_schema=dep_view['dep_view_schema'],
+                        old_view_schema=dep_view["dep_view_schema"],
                         old_view_name=f"{dep_view['dep_view_name']}{self.source_suffix}",
                         new_view_name=dep_view["dep_view_name"],
                     ),

--- a/usaspending_api/search/migrations/0027_transaction_search_guaid_idx.py
+++ b/usaspending_api/search/migrations/0027_transaction_search_guaid_idx.py
@@ -10,12 +10,34 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveIndex(
-            model_name='transactionsearch',
-            name='ts_idx_award_key_pre2008',
-        ),
-        migrations.AddIndex(
-            model_name='transactionsearch',
-            index=models.Index(fields=['generated_unique_award_id'], name='ts_idx_award_key'),
+        migrations.RunSQL(
+            sql="""
+                DROP INDEX ts_idx_award_key_pre2008;
+                CREATE INDEX ts_idx_award_key ON rpt.transaction_search(generated_unique_award_id text_ops);
+                -- Must rename the auto-named inherited indexes on child partitions of this parent partitioned table, 
+                -- so that they follow the naming convention of the parent, and copy_table_metadata command will 
+                -- continue to work
+                ALTER INDEX rpt.transaction_search_fabs_generated_unique_award_id_idx RENAME TO ts_idx_award_key_fabs;
+                ALTER INDEX rpt.transaction_search_fpds_generated_unique_award_id_idx RENAME TO ts_idx_award_key_fpds;
+            """,
+            reverse_sql="""
+                DROP INDEX ts_idx_award_key;
+                CREATE INDEX ts_idx_award_key_pre2008 ON rpt.transaction_search(generated_unique_award_id text_ops) WHERE action_date < '2007-10-01'::date;
+                -- Must rename the auto-named inherited indexes on child partitions of this parent partitioned table, 
+                -- so that they follow the naming convention of the parent, and copy_table_metadata command will 
+                -- continue to work
+                ALTER INDEX IF EXISTS rpt.transaction_search_fabs_generated_unique_award_id_idx RENAME TO ts_idx_award_key_pre2008_fabs;
+                ALTER INDEX IF EXISTS rpt.transaction_search_fpds_generated_unique_award_id_idx RENAME TO ts_idx_award_key_pre2008_fpds;
+            """,
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name='transactionsearch',
+                    name='ts_idx_award_key_pre2008',
+                ),
+                migrations.AddIndex(
+                    model_name='transactionsearch',
+                    index=models.Index(fields=['generated_unique_award_id'], name='ts_idx_award_key'),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
**Description:**
1. Keeping inherited indexes named according to convention during migrations
2. Shrinking boundaries around table+view renames during swap to avoid deadlocks

**Technical details:**
1. `copy_table_metadata` does not work if child/inherited indexes are not named the same as parent indexes except for the partition suffix. So migrations (for now) need to rename the auto-named inherited indexes.
2. Deadlocks have occurred if a table rename is happening in the same transaction as the dependent view renames that direct queries to the view
    - The suspicion is that queries can eek in by way of the view, which has not yet been locked for rename, that direct the query to the table, which is already locked for rename, and then the view cannot be locked due to this deadlock scenario
    - So make each rename operation atomic all on its own. Atomic transactions will cover 1) moving to target schema, 2) renaming active to old, 3) renaming temp to active ... but only for 1 table or view at a time, not the whole bunch.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
4. [ ] API documentation updated
5. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
6. [ ] Matview impact assessment completed
7. [ ] Frontend impact assessment completed
8. [ ] Data validation completed
9. [ ] Appropriate Operations ticket(s) created
10. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
