### PR TITLE
[PIPE-408] Fixing copy-paste error on funding_agency_id index rename

### DIFF
--- a/usaspending_api/search/migrations/0028_transaction_search_agency_indexes.py
+++ b/usaspending_api/search/migrations/0028_transaction_search_agency_indexes.py
@@ -20,8 +20,8 @@ class Migration(migrations.Migration):
                 ALTER INDEX rpt.transaction_search_fpds_awarding_agency_id_idx RENAME TO ts_idx_awarding_agency_id_fpds;
                 CREATE INDEX ts_idx_funding_agency_id ON rpt.transaction_search(funding_agency_id int4_ops);
                 -- (Same comment as above)
-                ALTER INDEX rpt.transaction_search_fabs_funding_agency_id_idx RENAME TO ts_idx_awarding_funding_id_fabs;
-                ALTER INDEX rpt.transaction_search_fpds_funding_agency_id_idx RENAME TO ts_idx_awarding_funding_id_fpds;
+                ALTER INDEX rpt.transaction_search_fabs_funding_agency_id_idx RENAME TO ts_idx_funding_agency_id_fabs;
+                ALTER INDEX rpt.transaction_search_fpds_funding_agency_id_idx RENAME TO ts_idx_funding_agency_id_fpds;
             """,
             reverse_sql="""
                 DROP INDEX ts_idx_funding_agency_id;


### PR DESCRIPTION
**Description:**
Index name on the partitions got the wrong name due to copy-paste error. Fixing that. 

**Technical details:**
Should have contained `funding_ageny_id` in the name.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
