### PR TITLE
[HOTFIX] Use Django extra() to join ES downloads to download_job_lookup

### DIFF
--- a/usaspending_api/download/helpers/elasticsearch_download_functions.py
+++ b/usaspending_api/download/helpers/elasticsearch_download_functions.py
@@ -138,12 +138,13 @@ class AwardsElasticsearchDownload(_ElasticsearchDownload):
     def query(cls, filters: dict, download_job: DownloadJob) -> QuerySet:
         base_queryset = DBAwardSearch.objects.all()
         cls._populate_download_lookups(filters, download_job)
-        queryset = base_queryset.filter(
-            Exists(
-                DownloadJobLookup.objects.filter(
-                    lookup_id=OuterRef("award_id"), download_job_id=download_job.download_job_id
-                )
-            )
+        queryset = base_queryset.extra(
+            tables=["download_job_lookup"],
+            where=[
+                '"download_job_lookup"."download_job_id" = %s '
+                'AND "download_job_lookup"."lookup_id" = "award_search"."award_id"'
+            ],
+            params=[download_job.download_job_id],
         )
 
         return queryset
@@ -158,12 +159,13 @@ class TransactionsElasticsearchDownload(_ElasticsearchDownload):
     def query(cls, filters: dict, download_job: DownloadJob) -> QuerySet:
         base_queryset = DBTransactionSearch.objects.all()
         cls._populate_download_lookups(filters, download_job)
-        queryset = base_queryset.filter(
-            Exists(
-                DownloadJobLookup.objects.filter(
-                    lookup_id=OuterRef("transaction_id"), download_job_id=download_job.download_job_id
-                )
-            )
+        queryset = base_queryset.extra(
+            tables=["download_job_lookup"],
+            where=[
+                '"download_job_lookup"."download_job_id" = %s '
+                'AND "download_job_lookup"."lookup_id" = "transaction_search"."transaction_id"'
+            ],
+            params=[download_job.download_job_id],
         )
 
         return queryset

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -392,31 +392,31 @@ LOGGING = {
     },
     "handlers": {
         "server": {
-            "level": "INFO",
+            "level": "DEBUG",
             "class": "logging.handlers.WatchedFileHandler",
             "filename": str(APP_DIR / "logs" / "server.log"),
             "formatter": "user_readable",
         },
         "console_file": {
-            "level": "INFO",
+            "level": "DEBUG",
             "class": "logging.handlers.WatchedFileHandler",
             "filename": str(APP_DIR / "logs" / "console.log"),
             "formatter": "specifics",
         },
-        "console": {"level": "INFO", "class": "logging.StreamHandler", "formatter": "simpletime"},
-        "script": {"level": "INFO", "class": "logging.StreamHandler", "formatter": "detailed"},
+        "console": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "simpletime"},
+        "script": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "detailed"},
     },
     "loggers": {
         # The root logger; i.e. "all modules"
         "": {"handlers": ["console", "console_file"], "level": "WARNING", "propagate": False},
         # The "root" logger for all usaspending_api modules
-        "usaspending_api": {"handlers": ["console", "console_file"], "level": "INFO", "propagate": False},
+        "usaspending_api": {"handlers": ["console", "console_file"], "level": "DEBUG", "propagate": False},
         # Logger for Django API requests via middleware. See logging.py
-        "server": {"handlers": ["server"], "level": "INFO", "propagate": False},
+        "server": {"handlers": ["server"], "level": "DEBUG", "propagate": False},
         # Catch-all logger (over)used for non-Django-API commands that output to the console
-        "console": {"handlers": ["console", "console_file"], "level": "INFO", "propagate": False},
+        "console": {"handlers": ["console", "console_file"], "level": "DEBUG", "propagate": False},
         # More-verbose logger for ETL scripts
-        "script": {"handlers": ["script"], "level": "INFO", "propagate": False},
+        "script": {"handlers": ["script"], "level": "DEBUG", "propagate": False},
         # Logger used to specifically record exceptions
         "exceptions": {"handlers": ["console", "console_file"], "level": "ERROR", "propagate": False},
     },


### PR DESCRIPTION
**Description:**
Using Django `extra()` to 'join' using WHERE on download_job_lookup rather than the slower EXISTS queries

Comes up with a query like:
```
FROM "transaction_search"
    LEFT OUTER JOIN "award_search" ON ("transaction_search"."award_id" = "award_search"."award_id"),
"download_job_lookup"
WHERE (("download_job_lookup"."download_job_id" = 7156455
        AND "download_job_lookup"."lookup_id" = "transaction_search"."transaction_id")
    AND "transaction_search"."is_fpds")
LIMIT 500000
```

Instead of
```
FROM "transaction_search"
    LEFT OUTER JOIN "award_search" ON ("transaction_search"."award_id" = "award_search"."award_id")
WHERE (EXISTS (
        SELECT
            (1) AS "a"
        FROM
            "download_job_lookup" U0
        WHERE (U0."download_job_id" = 7156454
            AND U0."lookup_id" = "transaction_search"."transaction_id")
    LIMIT 1)
AND "transaction_search"."is_fpds")
LIMIT 500000
```

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
