### PR TITLE
[DEV-9609] `is_aws()` missing exception

### DIFF
--- a/usaspending_api/common/helpers/aws_helpers.py
+++ b/usaspending_api/common/helpers/aws_helpers.py
@@ -1,5 +1,6 @@
 from urllib.request import urlopen
 from urllib.error import URLError
+import socket
 
 
 def is_aws():
@@ -8,7 +9,7 @@ def is_aws():
     meta = "http://169.254.169.254/latest/meta-data/"
     try:
         result = urlopen(meta, timeout=2).status == 200
-    except (ConnectionError, TimeoutError, URLError):
+    except (ConnectionError, TimeoutError, URLError, socket.timeout):
         return result
     return result
 


### PR DESCRIPTION
**Description:**
Updates AWS function to indicate that the environment is not AWS if a socket timeout is caught.


**Technical details:**
Depending on a developer's host machine configurations, a `socket.timeout` exception could be raised when checking if the environment is AWS. The code base before this PR did not account for such a case.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed (N/A)
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-9609](https://federal-spending-transparency.atlassian.net/browse/DEV-9609):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)  (N/A)
    - [x] Before / After data comparison  (N/A)

**Area for explaining above N/A when needed:**
1. This PR fixes an issue that caused existing unit and intergation tests to fail, no new functionality introduced.
2. Nothing needs to be documented
4. Matview not impacted
5. Does not impact frontend
6. Does not change data, no validation needed
7. No operation tickets needed
8b. Nature of the change does not impact performance
8c. No performance evaluation done, nothing to compare
```
```
