### PR TITLE
Update postgresql version and add liblzma headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ WORKDIR /dockermount
 
 RUN yum -y update && yum clean all
 # sqlite-devel added as prerequisite for coverage python lib, used by pytest-cov plugin
-RUN yum -y install wget gcc openssl-devel bzip2-devel libffi libffi-devel zlib-devel sqlite-devel
+RUN yum -y install wget gcc openssl-devel bzip2-devel libffi libffi-devel zlib-devel sqlite-devel xz-devel
 RUN yum -y groupinstall "Development Tools"
 
-##### Install PostgreSQL 10 client (psql)
+##### Install PostgreSQL 13 client (psql)
 RUN yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN yum -y install postgresql10
+RUN yum -y install postgresql13
 
 ##### Building python 3.7
 WORKDIR /usr/src


### PR DESCRIPTION
**Description:**
Updated Dockerfile to add liblzma headers package and to install a newer version of the PostgreSQL client.

**Technical details:**
Added the `xz-devel` package so that Python can build with LZMA compression supported and remove the following warning when launching Python inside a container:

> UserWarning: Could not import the lzma module. Your installed Python is incomplete. Attempting to use lzma compression will result in a RuntimeError.

Updated `postgresql10` to `postgresql13` since the version 10 client is no longer available through **pgdg-redhat-repo-latest.noarch.rpm**.

**Requirements for PR merge:**

1. [ ] Necessary PR reviewers:
    - [x] Backend
    - [x] Ops