### PR TITLE
Updating the order of columns for the TS population query

### DIFF
--- a/usaspending_api/transactions/delta_models/transaction_search.py
+++ b/usaspending_api/transactions/delta_models/transaction_search.py
@@ -64,10 +64,10 @@ TRANSACTION_SEARCH_COLUMNS = {
     "federal_action_obligation": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": False},
     "original_loan_subsidy_cost": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": False},
     "face_value_loan_guarantee": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": False},
+    "indirect_federal_sharing": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": True},
     "funding_amount": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": True},
     "total_funding_amount": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": True},
     "non_federal_funding_amount": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": True},
-    "indirect_federal_sharing": {"delta": "NUMERIC(23,2)", "postgres": "NUMERIC(23,2)", "gold": True},
     # Recipient
     "recipient_hash": {"delta": "STRING", "postgres": "TEXT", "gold": False},
     "recipient_levels": {"delta": "ARRAY<STRING>", "postgres": "TEXT[]", "gold": False},


### PR DESCRIPTION
**Description:**
Correcting the order of the indirect-federal-sharing column in TS in DBR such that when it's running the loading query `INSERT OVERWRITE rpt.transaction_search (**the cols in a specific order**) SELECT (**the cols needing to match the specific order**) FROM ...`

**Technical details:**
N/A

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
