### PR TITLE
[DEV-9705] Restores download limit of 4 hours

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -22,9 +22,7 @@ DOWNLOAD_TIMEOUT_MIN_LIMIT = 10
 
 # Default timeout for SQL statements in Django
 DEFAULT_DB_TIMEOUT_IN_SECONDS = int(os.environ.get("DEFAULT_DB_TIMEOUT_IN_SECONDS", 0))
-# Temporarily increase this limit to 6 hours
-# TODO - Change this back to 4 hours
-DOWNLOAD_DB_TIMEOUT_IN_HOURS = 6
+DOWNLOAD_DB_TIMEOUT_IN_HOURS = 4
 CONNECTION_MAX_SECONDS = 10
 
 # Default type for when a Primary Key is not specified


### PR DESCRIPTION
**Description:**
Download time limit (in hours) was increased to 6 temporarily to support a GAO audit. This PR restores the time limit to 4 hours. 

