### PR TITLE
[DEV-9531] Update API contract fields for Congressional districts

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -108,12 +108,7 @@ Returns the number of transactions that would be included in a download request 
         + `last_modified_date`
 
 ## LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)
 
 ## AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
@@ -218,12 +218,7 @@ List of table columns
         + `date_signed`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
@@ -97,12 +97,7 @@ This endpoint takes award filters, and returns the number of awards in each awar
         + `date_signed`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
@@ -56,7 +56,7 @@ This endpoint takes award filters, and returns the number of awards in each awar
         + `foreign`
 + `place_of_performance_locations` (optional, array[LocationObject], fixed-type)
 + `agencies` (optional, array[AgencyObject], fixed-type)
-+ `recipient_search_text`: `[Hampton`, `Roads`] (optional, array[string])
++ `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
     + Text searched across a recipient’s name, UEI, and DUNS
 + `recipient_scope` (optional, enum[string])
     + Members

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category.md
@@ -127,12 +127,7 @@ This endpoint returns a list of the top results of specific categories sorted by
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country` (required, string)
-+ `state` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
@@ -149,12 +149,7 @@ This endpoint returns a list of the top results of Awarding Agencies sorted by t
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_subagency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_subagency.md
@@ -146,12 +146,7 @@ This endpoint returns a list of the top results of Awarding Subagencies sorted b
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/cfda.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/cfda.md
@@ -146,12 +146,7 @@ This endpoint returns a list of the top results of CFDA sorted by the total amou
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/country.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/country.md
@@ -148,12 +148,7 @@ This endpoint returns a list of the top results of Countries sorted by the total
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/county.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/county.md
@@ -147,12 +147,7 @@ This endpoint returns a list of the top results of Counties sorted by the total 
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/district.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/district.md
@@ -147,12 +147,7 @@ This endpoint returns a list of the top results of Congressional Districts sorte
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/federal_account.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/federal_account.md
@@ -148,12 +148,7 @@ This endpoint returns a list of the top results of Federal Accounts sorted by th
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_agency.md
@@ -146,12 +146,7 @@ This endpoint returns a list of the top results of Funding Agencies sorted by th
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_subagency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_subagency.md
@@ -146,12 +146,7 @@ This endpoint returns a list of the top results of Funding Subagencies sorted by
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/naics.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/naics.md
@@ -146,12 +146,7 @@ This endpoint returns a list of the top results of NAICS sorted by the total amo
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/object_class.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/object_class.md
@@ -152,12 +152,7 @@ This endpoint returns a list of the top results of Object Classes sorted by the 
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/program_activity.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/program_activity.md
@@ -166,12 +166,7 @@ This endpoint returns a list of the top results of Program Activity sorted by th
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md
@@ -146,12 +146,7 @@ This endpoint returns a list of the top results of PSC sorted by the total amoun
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient.md
@@ -147,12 +147,7 @@ This endpoint returns a list of the top results of Recipients sorted by the tota
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient_duns.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient_duns.md
@@ -149,12 +149,7 @@ This endpoint returns a list of the top results of Recipient DUNS sorted by the 
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/state_territory.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/state_territory.md
@@ -147,12 +147,7 @@ This endpoint returns a list of the top results of State Territories sorted by t
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/tas.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/tas.md
@@ -166,12 +166,7 @@ This endpoint returns a list of the top results of Treasury Account Symbol sorte
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
@@ -144,12 +144,7 @@ This endpoint takes award filters, and returns aggregated obligation amounts in 
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
@@ -50,4 +50,4 @@ Returns the counts of transaction records which match the keyword grouped by awa
 # Data Structures
 
 ## AdvancedFilterObject (object)
-+ `keywords`: [[`lockheed`]] (required, array[string], fixed-type)
++ `keywords`: [`lockheed`] (required, array[string], fixed-type)

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_over_time.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_over_time.md
@@ -113,12 +113,7 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
         + `last_modified_date`
 
 ### LocationObject (object)
-+ `country`: `USA` (required, string)
-+ `state`: `VA` (optional, string)
-+ `county` (optional, string)
-+ `city` (optional, string)
-+ `district` (optional, string)
-+ `zip` (optional, string)
+These fields are defined in the [StandardLocationObject](../../../../search_filters.md#standard-location-object)
 
 ### AgencyObject (object)
 + `type` (required, enum[string])

--- a/usaspending_api/api_contracts/search_filters.md
+++ b/usaspending_api/api_contracts/search_filters.md
@@ -84,13 +84,21 @@ A city in a state:
 }
 ```
 
-
-A US congressional district:
+Original US congressional district:
 ```
 {
     "country": "USA",
     "state": "VA",
-    "district": "11"
+    "district_original": "11"
+}
+```
+
+Current US congressional district:
+```
+{
+    "country": "USA",
+    "state": "VA",
+    "district_current": "11"
 }
 ```
 
@@ -113,9 +121,12 @@ Keys in a location object include:
     * If `county` is provided, a `district` value *must never* be provided.
 * **city** - string city name
     * If no `state` is provided, this will return results for all cities in any state with the provided name
-* **district** - a 2 character code indicating the congressional district
-    * If `district` is provided, a `state` must always be provided as well.
-    * If `district` is provided, a `county` *must never* be provided.
+* **district_original** - a 2 character code indicating the original congressional district, before redistricting
+    * If `district_original` is provided, a `state` must always be provided as well.
+    * If `district_original` is provided, a `county` *must never* be provided.
+* **district_current** - a 2 character code indicating the current congressional district, after redistricting
+    * If `district_current` is provided, a `state` must always be provided as well.
+    * If `district_current` is provided, a `county` *must never* be provided.
 * **zip** - a 5 digit string indicating the postal area to search within.
 
 

--- a/usaspending_api/api_contracts/search_filters.md
+++ b/usaspending_api/api_contracts/search_filters.md
@@ -67,12 +67,38 @@ A US county:
 }
 ```
 
+All US cities with a given name:
+```
+{
+    "country": "USA",
+    "city": "Portland"
+}
+```
+
+A city in a state:
+```
+{
+    "country": "USA",
+    "state": "OR",
+    "city": "Portland"
+}
+```
+
+
 A US congressional district:
 ```
 {
     "country": "USA",
     "state": "VA",
     "district": "11"
+}
+```
+
+A ZIP code:
+```
+{
+    "country": "USA",
+    "zip": "60661"
 }
 ```
 
@@ -85,9 +111,12 @@ Keys in a location object include:
 * **county** - a 3 digit FIPS code indicating the county
     * If `county` is provided, a `state` must always be provided as well.
     * If `county` is provided, a `district` value *must never* be provided.
+* **city** - string city name
+    * If no `state` is provided, this will return results for all cities in any state with the provided name
 * **district** - a 2 character code indicating the congressional district
     * If `district` is provided, a `state` must always be provided as well.
     * If `district` is provided, a `county` *must never* be provided.
+* **zip** - a 5 digit string indicating the postal area to search within.
 
 
 ## Keyword Search


### PR DESCRIPTION
**Description:**
Update API contracts that reference congressional districts to include a second district-related field to support the congressional district changes. The existing `district` field was renamed to `district_original` and a new field named `district_current` was added to the contracts.

**Technical details:**
Renamed the existing `district` field of the `Standard Location Object` in search_filters.md to `district_original` and added a `district_current` field to the object.

**Requirements for PR merge:**

1. [x] API documentation updated
2. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
3. [x] Jira Ticket [DEV-9531](https://federal-spending-transparency.atlassian.net/browse/DEV-9531):
    - [x] Link to this Pull-Request