### PR TITLE
[DEV-9733] Adds additional logging for downloads

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -718,6 +718,7 @@ def strip_file_extension(file_name):
 
 
 def fail_download(download_job, exception, message):
+    write_to_log(message=message, is_error=True, download_job=download_job)
     stack_trace = "".join(
         traceback.format_exception(etype=type(exception), value=exception, tb=exception.__traceback__)
     )

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -144,7 +144,7 @@ def _handle_queue_error(exc):
             download_job_id = int(exc.queue_message.body)
         log_job_message(
             logger=logger,
-            message=f"{type(exc).__name__} caught. Attempting to fail the DownloadJob",
+            message=f"{type(exc).__name__} caught. Attempting to fail the DownloadJob with id = {download_job_id}",
             job_type=JOB_TYPE,
             job_id=download_job_id,
             is_exception=True,
@@ -152,14 +152,25 @@ def _handle_queue_error(exc):
         if download_job_id:
             stack_trace = "".join(traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__))
             status = "failed"
-            _update_download_job_status(download_job_id, status, stack_trace)
-            log_job_message(
-                logger=logger,
-                message=f"Marked DownloadJob with id = {download_job_id} as {status}",
-                job_type=JOB_TYPE,
-                job_id=download_job_id,
-                is_exception=True,
-            )
+            try:
+                _update_download_job_status(download_job_id, status, stack_trace)
+                log_job_message(
+                    logger=logger,
+                    message=f"Marked DownloadJob with id = {download_job_id} as {status}",
+                    job_type=JOB_TYPE,
+                    job_id=download_job_id,
+                    is_exception=True,
+                )
+            except Exception as e:
+                log_job_message(
+                    logger=logger,
+                    message=f"Unable to mark DownloadJob with id = {download_job_id} as {status}",
+                    job_type=JOB_TYPE,
+                    job_id=download_job_id,
+                    is_exception=True,
+                )
+                raise e
+
     except:  # noqa
         pass
     raise exc


### PR DESCRIPTION
**Description:**
Adds some logging around downloads that are being marked as failed. 

**Technical details:**
- Simply logs the same message being stored in the db in the `fail_download()` method of `download_generation`. 
- Adds exception handling to the SQS step attempting to fail the job

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9733](https://federal-spending-transparency.atlassian.net/browse/DEV-9733):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
