### PR TITLE
[FIX] Pin previous version of `drf-api-tracking` to fix failing app installs

### DIFF
--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -13,7 +13,7 @@ Django==3.2.*
 django_cte==1.2.*
 djangorestframework==3.13.*
 docutils==0.15.2
-drf-api-tracking==1.8.*
+drf-api-tracking==1.8.0
 drf-extensions==0.7.*
 elasticsearch-dsl==7.1.0
 elasticsearch==7.1.0


### PR DESCRIPTION
We have been experiencing the same issue described in this bug for the `drf-api-tracking` Python library. The suggested fix is to pin to version `1.8.0` instead of using the latest version `1.8.2`

https://github.com/lingster/drf-api-tracking/issues/92