### PR TITLE
[DEV-9887] Use Major Object Class Name

### DIFF
--- a/usaspending_api/agency/tests/integration/test_agency_tas_object_class.py
+++ b/usaspending_api/agency/tests/integration/test_agency_tas_object_class.py
@@ -122,27 +122,19 @@ def test_tas_object_class_success(client, monkeypatch, agency_account_data, help
             "next": None,
             "page": 1,
             "previous": None,
-            "total": 3,
+            "total": 1,
         },
         "results": [
             {
-                "gross_outlay_amount": 100000.0,
-                "name": "supplies",
-                "obligated_amount": 100.0,
-                "children": [{"gross_outlay_amount": 100000.0, "name": "NAME 3", "obligated_amount": 100.0}],
-            },
-            {
-                "gross_outlay_amount": 1000000.0,
-                "name": "hvac",
-                "obligated_amount": 10.0,
-                "children": [{"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0}],
-            },
-            {
-                "gross_outlay_amount": 10000000.0,
-                "name": "equipment",
-                "obligated_amount": 1.0,
-                "children": [{"gross_outlay_amount": 10000000.0, "name": "NAME 1", "obligated_amount": 1.0}],
-            },
+                "gross_outlay_amount": 11100000.0,
+                "name": "Other",
+                "obligated_amount": 111.0,
+                "children": [
+                    {"gross_outlay_amount": 100000.0, "name": "NAME 3", "obligated_amount": 100.0},
+                    {"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0},
+                    {"gross_outlay_amount": 10000000.0, "name": "NAME 1", "obligated_amount": 1.0},
+                ],
+            }
         ],
     }
 
@@ -191,7 +183,7 @@ def test_tas_object_class_multiple_pa_per_oc(client, monkeypatch, tas_mulitple_p
         "results": [
             {
                 "gross_outlay_amount": 11000000.0,
-                "name": "equipment",
+                "name": "Other",
                 "obligated_amount": 11.0,
                 "children": [
                     {"gross_outlay_amount": 1000000.0, "name": "NAME 2", "obligated_amount": 10.0},
@@ -227,7 +219,7 @@ def test_tas_object_class_multiple_submission_years(client, agency_account_data)
         "results": [
             {
                 "gross_outlay_amount": 10000.0,
-                "name": "interest",
+                "name": "Other",
                 "obligated_amount": 1000.0,
                 "children": [{"gross_outlay_amount": 10000.0, "name": "NAME 4", "obligated_amount": 1000.0}],
             }

--- a/usaspending_api/agency/tests/integration/test_agency_tas_program_activity.py
+++ b/usaspending_api/agency/tests/integration/test_agency_tas_program_activity.py
@@ -195,17 +195,17 @@ def test_tas_program_activity_multiple_object_classes(client, tas_mulitple_oc_pe
         "results": [
             {
                 "name": "NAME 4",
-                "gross_outlay_amount": 11000.0,
-                "obligated_amount": 11000.0,
+                "gross_outlay_amount": 111000.0,
+                "obligated_amount": 11100.0,
                 "children": [
                     {
-                        "gross_outlay_amount": 1000.0,
+                        "gross_outlay_amount": 101000.0,
                         "name": "Other",
-                        "obligated_amount": 10000.0,
+                        "obligated_amount": 10100.0,
                     },
                     {
                         "gross_outlay_amount": 10000.0,
-                        "name": "Other",
+                        "name": "Other2",
                         "obligated_amount": 1000.0,
                     },
                 ],
@@ -293,7 +293,10 @@ def tas_mulitple_oc_per_tas():
         oc, major_object_class=10, major_object_class_name="Other", object_class=120, object_class_name="supplies"
     )
     oc2 = baker.make(
-        oc, major_object_class=10, major_object_class_name="Other", object_class=130, object_class_name="interest"
+        oc, major_object_class=10, major_object_class_name="Other2", object_class=130, object_class_name="interest"
+    )
+    oc3 = baker.make(
+        oc, major_object_class=10, major_object_class_name="Other", object_class=120, object_class_name="supplies"
     )
 
     fabpaoc = "financial_activities.FinancialAccountsByProgramActivityObjectClass"
@@ -314,4 +317,13 @@ def tas_mulitple_oc_per_tas():
         object_class=oc1,
         obligations_incurred_by_program_object_class_cpe=10000,
         gross_outlay_amount_by_program_object_class_cpe=1000,
+    )
+    baker.make(
+        fabpaoc,
+        treasury_account=tas1,
+        submission=sub1,
+        program_activity=pa1,
+        object_class=oc3,
+        obligations_incurred_by_program_object_class_cpe=100,
+        gross_outlay_amount_by_program_object_class_cpe=100000,
     )

--- a/usaspending_api/agency/tests/integration/test_agency_tas_program_activity.py
+++ b/usaspending_api/agency/tests/integration/test_agency_tas_program_activity.py
@@ -31,7 +31,7 @@ def test_tas_program_activity_success(client, monkeypatch, agency_account_data, 
                 "obligated_amount": 100.0,
                 "children": [
                     {
-                        "name": "supplies",
+                        "name": "Other",
                         "gross_outlay_amount": 100000.0,
                         "obligated_amount": 100.0,
                     }
@@ -43,7 +43,7 @@ def test_tas_program_activity_success(client, monkeypatch, agency_account_data, 
                 "obligated_amount": 10.0,
                 "children": [
                     {
-                        "name": "hvac",
+                        "name": "Other",
                         "gross_outlay_amount": 1000000.0,
                         "obligated_amount": 10.0,
                     }
@@ -55,7 +55,7 @@ def test_tas_program_activity_success(client, monkeypatch, agency_account_data, 
                 "obligated_amount": 1.0,
                 "children": [
                     {
-                        "name": "equipment",
+                        "name": "Other",
                         "gross_outlay_amount": 10000000.0,
                         "obligated_amount": 1.0,
                     }
@@ -116,7 +116,7 @@ def test_tas_multiple_program_activity_belonging_one_object_class(
                 "children": [
                     {
                         "gross_outlay_amount": 1000000.0,
-                        "name": "equipment",
+                        "name": "Other",
                         "obligated_amount": 10.0,
                     }
                 ],
@@ -128,7 +128,7 @@ def test_tas_multiple_program_activity_belonging_one_object_class(
                 "children": [
                     {
                         "gross_outlay_amount": 10000000.0,
-                        "name": "equipment",
+                        "name": "Other",
                         "obligated_amount": 1.0,
                     }
                 ],
@@ -164,7 +164,7 @@ def test_tas_program_activity_multiple_submission_years(client, agency_account_d
                 "gross_outlay_amount": 10000.0,
                 "name": "NAME 4",
                 "obligated_amount": 1000.0,
-                "children": [{"gross_outlay_amount": 10000.0, "name": "interest", "obligated_amount": 1000.0}],
+                "children": [{"gross_outlay_amount": 10000.0, "name": "Other", "obligated_amount": 1000.0}],
             }
         ],
     }
@@ -200,12 +200,12 @@ def test_tas_program_activity_multiple_object_classes(client, tas_mulitple_oc_pe
                 "children": [
                     {
                         "gross_outlay_amount": 1000.0,
-                        "name": "supplies",
+                        "name": "Other",
                         "obligated_amount": 10000.0,
                     },
                     {
                         "gross_outlay_amount": 10000.0,
-                        "name": "interest",
+                        "name": "Other",
                         "obligated_amount": 1000.0,
                     },
                 ],

--- a/usaspending_api/agency/v2/views/tas_object_class_list.py
+++ b/usaspending_api/agency/v2/views/tas_object_class_list.py
@@ -83,6 +83,7 @@ class TASObjectClassList(PaginationMixin, AgencyBase):
             filters.append(Q(object_class_name__icontains=self.filter))
         queryset_results = (
             ObjectClass.objects.filter(*filters)
+            .values("major_object_class_name")
             .annotate(
                 name=F("major_object_class_name"),
                 obligated_amount=Sum(
@@ -93,7 +94,6 @@ class TASObjectClassList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
-            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 
@@ -121,6 +121,7 @@ class TASObjectClassList(PaginationMixin, AgencyBase):
         ]
         queryset_results = (
             RefProgramActivity.objects.filter(*filters)
+            .values("program_activity_name")
             .annotate(
                 name=F("program_activity_name"),
                 obligated_amount=Sum(
@@ -131,7 +132,6 @@ class TASObjectClassList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
-            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 

--- a/usaspending_api/agency/v2/views/tas_object_class_list.py
+++ b/usaspending_api/agency/v2/views/tas_object_class_list.py
@@ -94,6 +94,7 @@ class TASObjectClassList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
+            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 
@@ -132,6 +133,7 @@ class TASObjectClassList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
+            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 

--- a/usaspending_api/agency/v2/views/tas_program_activity_list.py
+++ b/usaspending_api/agency/v2/views/tas_program_activity_list.py
@@ -82,6 +82,7 @@ class TASProgramActivityList(PaginationMixin, AgencyBase):
             filters.append(Q(program_activity_name__icontains=self.filter))
         queryset_results = (
             RefProgramActivity.objects.filter(*filters)
+            .values("program_activity_name")
             .annotate(
                 name=F("program_activity_name"),
                 obligated_amount=Sum(
@@ -92,7 +93,6 @@ class TASProgramActivityList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
-            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 
@@ -121,6 +121,7 @@ class TASProgramActivityList(PaginationMixin, AgencyBase):
         ]
         queryset_results = (
             ObjectClass.objects.filter(*filters)
+            .values("major_object_class_name")
             .annotate(
                 name=F("major_object_class_name"),
                 obligated_amount=Sum(
@@ -131,7 +132,6 @@ class TASProgramActivityList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
-            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 

--- a/usaspending_api/agency/v2/views/tas_program_activity_list.py
+++ b/usaspending_api/agency/v2/views/tas_program_activity_list.py
@@ -93,6 +93,7 @@ class TASProgramActivityList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
+            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 
@@ -132,6 +133,7 @@ class TASProgramActivityList(PaginationMixin, AgencyBase):
                 ),
             )
             .order_by(f"{'-' if self.pagination.sort_order == 'desc' else ''}{self.pagination.sort_key}")
+            .values("name", "obligated_amount", "gross_outlay_amount")
         )
         return queryset_results
 


### PR DESCRIPTION
**Description & Technical details:**
When aggregating obligations and outlays for object class, we need to use major object class name. This was a miss when this work was originally developed. Additionally, there are multiple ids per major object class name so now we need to remove id from the aggregation otherwise we'll have multiple groups with the same name.
