### PR TITLE
[DEV-9941] Updates `spending_by_award` with "new_awards_only" `date_type`

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
@@ -207,17 +207,15 @@ List of table columns
     + Example: Providing the `Z` DEF code and setting the subaward parameter to `True` will only return results where the `sub_action_date` is on or after `11/15/2021` since this is the enactment date of the public law associated with disaster code `Z`.
 
 ### TimePeriodObject (object)
-+ `start_date`: `2017-10-01` (required, string)
-    Currently limited to an earliest date of `2007-10-01` (FY2008).  For data going back to `2000-10-01` (FY2001), use either the Custom Award Download
-    feature on the website or one of our `download` or `bulk_download` API endpoints.
-+ `end_date`: `2018-09-30` (required, string)
-    Currently limited to an earliest date of `2007-10-01` (FY2008).  For data going back to `2000-10-01` (FY2001), use either the Custom Award Download
-    feature on the website or one of our `download` or `bulk_download` API endpoints.
-+ `date_type` (optional, enum[string])
-    + Members
-        + `action_date`
-        + `last_modified_date`
-        + `date_signed`
+This TimePeriodObject can fall into different categories based on the request.
++ if `subawards` true
+
+    See the Subaward Search category defined in [SubawardSearchTimePeriodObject](../../../search_filters.md#subaward-search-time-period-object)
+
++ otherwise
+
+    See the Award Search category defined in [AwardSearchTimePeriodObject](../../../search_filters.md#award-search-time-period-object)
+
 
 ### LocationObject (object)
 These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)

--- a/usaspending_api/api_contracts/search_filters.md
+++ b/usaspending_api/api_contracts/search_filters.md
@@ -191,11 +191,12 @@ Request parameter description:
 + `end_date`: (required)
     See [Time Period](#time-period)
 + `date_type`: (optional)
+    If `date_type` is set to one of the following members then that member is used to compare to both the `start_date` and `end_date` input.
     + Members
         + `action_date`
-            This date type value is the default type compared to the `start_date`.
+            This date type value is the default type compared to the `start_date` when a value isn't set for `date_type` in the request. Typically, `action_date` represents the date of the latest transaction associated with the award.
         + `date_signed`
-            This date type value is the default type compared to the `end_date`.
+            This date type value is the default type compared to the `end_date` when a value isn't set for `date_type` in the request. Typically, `date_signed` represents the date of the base transaction associated with the award.
         + `last_modified_date`
         + `new_awards_only`
             Indicates when the results should reflect new awards only. You should expect only

--- a/usaspending_api/api_contracts/search_filters.md
+++ b/usaspending_api/api_contracts/search_filters.md
@@ -177,6 +177,30 @@ Request parameter description:
 * `date_type`:  (enum[string])
     Check specific time period objects for date_type's members, defaults, and descriptions.
 
+## Award Search Time Period Object
+
+**Description:**
+See [Time Period](#time-period)
+
+**Examples**
+See [Time Period](#time-period)
+
+Request parameter description:
++ `start_date`: (required)
+    See [Time Period](#time-period)
++ `end_date`: (required)
+    See [Time Period](#time-period)
++ `date_type`: (optional)
+    + Members
+        + `action_date`
+            This date type value is the default type compared to the `start_date`.
+        + `date_signed`
+            This date type value is the default type compared to the `end_date`.
+        + `last_modified_date`
+        + `new_awards_only`
+            Indicates when the results should reflect new awards only. You should expect only
+            awards whose base transaction date falls within the time period bounds specified to be returned.
+
 ## Transaction Search Time Period Object
 
 **Description:**

--- a/usaspending_api/search/filters/time_period/decorators.py
+++ b/usaspending_api/search/filters/time_period/decorators.py
@@ -46,7 +46,7 @@ class NewAwardsOnlyTimePeriod(AbstractTimePeriod):
                 {"award_date_signed": {"gte": self.start_date()}},
             ],
             _QueryType.AWARDS: [
-                {"date_signed": {"lte": self.start_date()}},
+                {"date_signed": {"gte": self.start_date()}},
             ],
         }
 

--- a/usaspending_api/search/filters/time_period/query_types.py
+++ b/usaspending_api/search/filters/time_period/query_types.py
@@ -58,3 +58,52 @@ class TransactionSearchTimePeriod(AbstractTimePeriod):
         if ret_date_type in self._date_type_transaction_search_map:
             ret_date_type = self._date_type_transaction_search_map[ret_date_type]
         return ret_date_type
+
+
+class AwardSearchTimePeriod(AbstractTimePeriod):
+    """A time period implementation that's designed to suit the time period filters
+    on award search.
+
+    This concrete implementation supports the filter [AwardSearchTimePeriodObject](#usaspending_api/api_contracts/search_filters.md#award-search-time-period-object).
+    """
+
+    def __init__(self, default_start_date: str, default_end_date: str):
+        """Constructor to create AwardSearchTimePeriod object.
+
+        Args:
+            default_start_date: This is the start date value to use when start date is not present in the filter value.
+                See start date in [AwardSearchTimePeriodObject](#usaspending_api/api_contracts/search_filters.md#award-search-time-period-object)
+                for definition.
+            default_end_date: This is the end date value to use when end date is not present in the filter value.
+                See end date in [AwardSearchTimePeriodObject](#usaspending_api/api_contracts/search_filters.md#award-search-time-period-object)
+                for definition.
+        """
+        self._default_start_date = default_start_date
+        self._default_end_date = default_end_date
+        self._filter_value = {}
+
+    @property
+    def filter_value(self):
+        return self._filter_value
+
+    @filter_value.setter
+    def filter_value(self, filter_value):
+        self._filter_value = filter_value
+
+    def start_date(self):
+        return self._filter_value.get("start_date") or self._default_start_date
+
+    def end_date(self):
+        return self._filter_value.get("end_date") or self._default_end_date
+
+    def gte_date_type(self):
+        return self._filter_value.get("date_type", "action_date")
+
+    def lte_date_type(self):
+        return self._filter_value.get("date_type", "date_signed")
+
+    def gte_date_range(self):
+        return [{f"{self.gte_date_type()}": {"gte": self.start_date()}}]
+
+    def lte_date_range(self):
+        return [{f"{self.lte_date_type()}": {"lte": self.end_date()}}]

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -1604,8 +1604,8 @@ def test_date_range_with_new_awards_only(
 
     request_for_2015 = {
         "subawards": True,
-        "fields": ["Award ID"],
-        "sort": "Award ID",
+        "fields": ["Sub-Award ID"],
+        "sort": "Sub-Award ID",
         "limit": 50,
         "page": 1,
         "filters": {

--- a/usaspending_api/search/tests/unit/test_time_period.py
+++ b/usaspending_api/search/tests/unit/test_time_period.py
@@ -170,7 +170,6 @@ def test_new_awards_only_award_search_time_period():
     assert search_obj_decorator.gte_date_type() == expected_gte_date_type
     assert search_obj_decorator.lte_date_type() == expected_lte_date_type
 
-    # Repeating all tests with new_awards_only true
     time_period_filter = {"date_type": "new_awards_only", "start_date": "2020-10-01", "end_date": "2021-09-30"}
     search_obj_decorator.filter_value = time_period_filter
     expected_start_date = "2020-10-01"

--- a/usaspending_api/search/tests/unit/test_time_period.py
+++ b/usaspending_api/search/tests/unit/test_time_period.py
@@ -1,4 +1,4 @@
-from usaspending_api.search.filters.time_period.query_types import TransactionSearchTimePeriod
+from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod, TransactionSearchTimePeriod
 from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyTimePeriod
 from usaspending_api.search.filters.elasticsearch.filter import _QueryType
 
@@ -38,14 +38,14 @@ def test_transaction_search_time_period():
     expected_gte_date_type = "award_date_signed"
     expected_lte_date_type = "award_date_signed"
     assert transaction_search.gte_date_type() == expected_gte_date_type
-    assert transaction_search.gte_date_type() == expected_lte_date_type
+    assert transaction_search.lte_date_type() == expected_lte_date_type
 
     time_period_filter = {"start_date": "2020-10-01", "end_date": "2021-09-30"}
     transaction_search.filter_value = time_period_filter
     expected_gte_date_type = "action_date"
     expected_lte_date_type = "action_date"
     assert transaction_search.gte_date_type() == expected_gte_date_type
-    assert transaction_search.gte_date_type() == expected_lte_date_type
+    assert transaction_search.lte_date_type() == expected_lte_date_type
 
     # Repeating all tests with new_awards_only true
     time_period_filter = {"date_type": "new_awards_only", "start_date": "2020-10-01", "end_date": "2021-09-30"}
@@ -64,7 +64,7 @@ def test_transaction_search_time_period():
     expected_gte_date_type = "new_awards_only"
     expected_lte_date_type = "new_awards_only"
     assert transaction_search.gte_date_type() == expected_gte_date_type
-    assert transaction_search.gte_date_type() == expected_lte_date_type
+    assert transaction_search.lte_date_type() == expected_lte_date_type
 
 
 def test_new_awards_only_transaction_search_time_period():
@@ -106,14 +106,14 @@ def test_new_awards_only_transaction_search_time_period():
     expected_gte_date_type = "award_date_signed"
     expected_lte_date_type = "award_date_signed"
     assert transaction_search_decorator.gte_date_type() == expected_gte_date_type
-    assert transaction_search_decorator.gte_date_type() == expected_lte_date_type
+    assert transaction_search_decorator.lte_date_type() == expected_lte_date_type
 
     time_period_filter = {"start_date": "2020-10-01", "end_date": "2021-09-30"}
     transaction_search_decorator.filter_value = time_period_filter
     expected_gte_date_type = "action_date"
     expected_lte_date_type = "action_date"
     assert transaction_search_decorator.gte_date_type() == expected_gte_date_type
-    assert transaction_search_decorator.gte_date_type() == expected_lte_date_type
+    assert transaction_search_decorator.lte_date_type() == expected_lte_date_type
 
     # Repeating all tests with new_awards_only true
     time_period_filter = {"date_type": "new_awards_only", "start_date": "2020-10-01", "end_date": "2021-09-30"}
@@ -124,3 +124,62 @@ def test_new_awards_only_transaction_search_time_period():
     assert transaction_search_decorator.start_date() == expected_start_date
     assert transaction_search_decorator.end_date() == expected_end_date
     assert transaction_search_decorator._new_awards_only() == expected_new_awards_only
+
+
+def test_new_awards_only_award_search_time_period():
+    default_start_date = "1111-11-11"
+    default_end_date = "9999-99-99"
+    search_obj = AwardSearchTimePeriod(default_start_date=default_start_date, default_end_date=default_end_date)
+    search_obj_decorator = NewAwardsOnlyTimePeriod(time_period_obj=search_obj, query_type=_QueryType.AWARDS)
+
+    # Testing for correct output of start and end date
+    time_period_filter = {"start_date": "2020-10-01", "end_date": "2021-09-30"}
+    search_obj_decorator.filter_value = time_period_filter
+    expected_start_date = "2020-10-01"
+    expected_end_date = "2021-09-30"
+    expected_new_awards_only = False
+    assert search_obj_decorator.start_date() == expected_start_date
+    assert search_obj_decorator.end_date() == expected_end_date
+    assert search_obj_decorator._new_awards_only() == expected_new_awards_only
+
+    time_period_filter = {"end_date": "2021-09-30"}
+    search_obj_decorator.filter_value = time_period_filter
+    assert search_obj_decorator.start_date() == default_start_date
+
+    time_period_filter = {"start_date": "2020-10-01"}
+    search_obj_decorator.filter_value = time_period_filter
+    assert search_obj_decorator.end_date() == default_end_date
+
+    time_period_filter = {}
+    search_obj_decorator.filter_value = time_period_filter
+    assert search_obj_decorator.end_date() == default_end_date
+    assert search_obj_decorator.start_date() == default_start_date
+
+    # Testing for correct output of date type
+    time_period_filter = {"date_type": "date_signed", "start_date": "2020-10-01", "end_date": "2021-09-30"}
+    search_obj_decorator.filter_value = time_period_filter
+    expected_gte_date_type = "date_signed"
+    expected_lte_date_type = "date_signed"
+    assert search_obj_decorator.gte_date_type() == expected_gte_date_type
+    assert search_obj_decorator.lte_date_type() == expected_lte_date_type
+
+    time_period_filter = {"start_date": "2020-10-01", "end_date": "2021-09-30"}
+    search_obj_decorator.filter_value = time_period_filter
+    expected_gte_date_type = "action_date"
+    expected_lte_date_type = "date_signed"
+    assert search_obj_decorator.gte_date_type() == expected_gte_date_type
+    assert search_obj_decorator.lte_date_type() == expected_lte_date_type
+
+    # Repeating all tests with new_awards_only true
+    time_period_filter = {"date_type": "new_awards_only", "start_date": "2020-10-01", "end_date": "2021-09-30"}
+    search_obj_decorator.filter_value = time_period_filter
+    expected_start_date = "2020-10-01"
+    expected_end_date = "2021-09-30"
+    expected_gte_date_type_range = [{"date_signed": {"gte": f"{expected_start_date}"}}]
+    expected_lte_date_type_range = [{"date_signed": {"lte": f"{expected_end_date}"}}]
+    expected_new_awards_only = True
+    assert search_obj_decorator.start_date() == expected_start_date
+    assert search_obj_decorator.end_date() == expected_end_date
+    assert search_obj_decorator.gte_date_range() == expected_gte_date_type_range
+    assert search_obj_decorator.lte_date_range() == expected_lte_date_type_range
+    assert search_obj_decorator._new_awards_only() == expected_new_awards_only


### PR DESCRIPTION
**Description:**
Currently, requests to the `spending_by_award` endpoint can request new awards only by including a time period filter with `date_type = date_signed`. However, other endpoints (namely those that are transaction based) only return new awards only when a time period filter has `date_type = new_awards_only`. Even though new awards only is supported in both the transaction based endpoints and the `spending_by_award`, we’d like to make a consistent way to retrieve new awards only between all endpoints. Consistency is the purpose of this PR.

**Technical details:**
Additionally, this PR updates another award based endpoint that returns a count of new awards to leverage the new "new_awards_only" `date_type` member.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-9941](https://federal-spending-transparency.atlassian.net/browse/DEV-9941):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
4. The nature of this work does not impact materialized views
5. The nature of this work does not require frontend impact assessments
7. No operation tickets needed.
