### PR TITLE
[DEV-9941] Updates `spending_by_award_count` with "new_awards_only" `date_type`

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
@@ -84,17 +84,15 @@ This endpoint takes award filters, and returns the number of awards in each awar
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward parameter is set to `True`, the query will only return results that have a sub_action_date on or after the enactment date of the public law associated with that disaster code.
 
 ### TimePeriodObject (object)
-+ `start_date`: `2017-10-01` (required, string)
-    Currently limited to an earliest date of `2007-10-01` (FY2008).  For data going back to `2000-10-01` (FY2001), use either the Custom Award Download
-    feature on the website or one of our `download` or `bulk_download` API endpoints.
-+ `end_date`: `2018-09-30` (required, string)
-    Currently limited to an earliest date of `2007-10-01` (FY2008).  For data going back to `2000-10-01` (FY2001), use either the Custom Award Download
-    feature on the website or one of our `download` or `bulk_download` API endpoints.
-+ `date_type` (optional, enum[string])
-    + Members
-        + `action_date`
-        + `last_modified_date`
-        + `date_signed`
+This TimePeriodObject can fall into different categories based on the request.
++ if `subawards` true
+
+    See the Subaward Search category defined in [SubawardSearchTimePeriodObject](../../../search_filters.md#subaward-search-time-period-object)
+
++ otherwise
+
+    See the Award Search category defined in [AwardSearchTimePeriodObject](../../../search_filters.md#award-search-time-period-object)
+
 
 ### LocationObject (object)
 These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)

--- a/usaspending_api/search/tests/unit/test_spending_by_award_count.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_award_count.py
@@ -232,13 +232,13 @@ def test_spending_by_award_count_new_awards_only(client, monkeypatch, elasticsea
         "subawards": False,
         "filters": {
             "time_period": [
-                {"date_type": "new_awards_only", "start_date": "2012-09-09", "end_date": "2012-09-13"},
+                {"date_type": "new_awards_only", "start_date": "2012-09-09", "end_date": "2012-09-11"},
             ]
         },
     }
 
     expected_response = {
-        "results": {"contracts": 0, "idvs": 0, "loans": 1, "direct_payments": 0, "grants": 0, "other": 0},
+        "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 1, "other": 0},
         "messages": [get_time_period_message()],
     }
 
@@ -254,13 +254,13 @@ def test_spending_by_award_count_new_awards_only(client, monkeypatch, elasticsea
         "subawards": False,
         "filters": {
             "time_period": [
-                {"date_type": "new_awards_only", "start_date": "2012-09-09", "end_date": "2012-09-10"},
+                {"date_type": "new_awards_only", "start_date": "2012-09-09", "end_date": "2012-09-09"},
             ]
         },
     }
 
     expected_response = {
-        "results": {"contracts": 0, "idvs": 0, "loans": 0, "direct_payments": 0, "grants": 0, "other": 0},
+        "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 0, "other": 0},
         "messages": [get_time_period_message()],
     }
 

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -19,6 +19,9 @@ from usaspending_api.common.query_with_filters import QueryWithFilters
 from usaspending_api.common.validator.award_filter import AWARD_FILTER_NO_RECIPIENT_ID
 from usaspending_api.common.validator.pagination import PAGINATION
 from usaspending_api.common.validator.tinyshield import TinyShield
+from usaspending_api.search.filters.elasticsearch.filter import _QueryType
+from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyTimePeriod
+from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod
 
 logger = logging.getLogger(__name__)
 
@@ -59,11 +62,6 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         filters = json_request.get("filters", None)
         if filters is None:
             raise InvalidParameterException("Missing required request parameters: 'filters'")
-
-        if not subawards and filters.get("time_period") is not None:
-            for time_period in filters["time_period"]:
-                time_period["gte_date_type"] = time_period.get("date_type", "action_date")
-                time_period["lte_date_type"] = time_period.get("date_type", "date_signed")
 
         if "award_type_codes" in filters and "no intersection" in filters["award_type_codes"]:
             # "Special case": there will never be results when the website provides this value
@@ -109,7 +107,15 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         return results
 
     def query_elasticsearch_for_prime_awards(self, filters) -> list:
-        filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters)
+        filter_options = {}
+        time_period_obj = AwardSearchTimePeriod(
+            default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
+        )
+        new_awards_only_decorator = NewAwardsOnlyTimePeriod(
+            time_period_obj=time_period_obj, query_type=_QueryType.AWARDS
+        )
+        filter_options["time_period_obj"] = new_awards_only_decorator
+        filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
         s = AwardSearch().filter(filter_query)
 
         s.aggs.bucket(


### PR DESCRIPTION
**Description:**
Currently, requests to the `spending_by_award` endpoint can use a `date_type` member called "new_awards_only". Our API exposes a similar endpoint `spending_by_award_count`. In order for this endpoint to return a correct count it also needs to support the `date_type` member.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL>
    - [x] Operations <OPTIONAL>
    - [x] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-9941](https://federal-spending-transparency.atlassian.net/browse/DEV-9941):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
4. The nature of this work does not impact materialized views
5. The nature of this work does not require frontend impact assessments
7. No operation tickets needed.
