### PR TITLE
[DEV-9929] Update Subaward DEFC date filter

### DIFF
--- a/usaspending_api/awards/tests/unit/test_subaward_filter.py
+++ b/usaspending_api/awards/tests/unit/test_subaward_filter.py
@@ -1,10 +1,54 @@
 import pytest
 from model_bakery import baker
+
 from usaspending_api.awards.v2.filters.sub_award import subaward_filter
 
 
 @pytest.fixture
 def subaward_data(db):
+    # Non-COVID-19 & non-IIJA disaster code
+    baker.make(
+        "references.DisasterEmergencyFundCode",
+        code="A",
+        public_law="PUBLIC LAW FOR CODE A",
+        earliest_public_law_enactment_date=None,
+    )
+
+    # COVID-19 disaster code
+    baker.make(
+        "references.DisasterEmergencyFundCode",
+        code="L",
+        public_law="PUBLIC LAW FOR CODE L",
+        earliest_public_law_enactment_date="2020-03-06",
+    )
+
+    # IIJA disaster code
+    baker.make(
+        "references.DisasterEmergencyFundCode",
+        code="Z",
+        public_law="PUBLIC LAW FOR CODE Z",
+        earliest_public_law_enactment_date="2021-11-15",
+    )
+
+    award_search1 = baker.make(
+        "search.AwardSearch",
+        award_id=111,
+        generated_unique_award_id="UNIQUE_AWARD_ID_1",
+        disaster_emergency_fund_codes=["A"],
+    )
+    award_search2 = baker.make(
+        "search.AwardSearch",
+        award_id=222,
+        generated_unique_award_id="UNIQUE_AWARD_ID_2",
+        disaster_emergency_fund_codes=["A", "L"],
+    )
+    award_search3 = baker.make(
+        "search.AwardSearch",
+        award_id=333,
+        generated_unique_award_id="UNIQUE_AWARD_ID_3",
+        disaster_emergency_fund_codes=["Z"],
+    )
+
     baker.make(
         "search.SubawardSearch",
         broker_subaward_id=1,
@@ -12,8 +56,9 @@ def subaward_data(db):
         sub_ultimate_parent_unique_ide="111111110",
         sub_awardee_or_recipient_uei="AAAAAAAAAAAA",
         sub_ultimate_parent_uei="AAAAAAAAAAA0",
+        award=award_search1,
+        sub_action_date="2018-01-01",
     )
-
     baker.make(
         "search.SubawardSearch",
         broker_subaward_id=2,
@@ -21,8 +66,9 @@ def subaward_data(db):
         sub_ultimate_parent_unique_ide="222222220",
         sub_awardee_or_recipient_uei="BBBBBBBBBBBB",
         sub_ultimate_parent_uei="BBBBBBBBBBB0",
+        award=award_search2,
+        sub_action_date="2020-04-01",
     )
-
     baker.make(
         "search.SubawardSearch",
         broker_subaward_id=3,
@@ -30,6 +76,18 @@ def subaward_data(db):
         sub_ultimate_parent_unique_ide="333333330",
         sub_awardee_or_recipient_uei="CCCCCCCCCCCC",
         sub_ultimate_parent_uei="CCCCCCCCCCC0",
+        award=award_search3,
+        sub_action_date="2022-01-01",
+    )
+    baker.make(
+        "search.SubawardSearch",
+        broker_subaward_id=4,
+        sub_awardee_or_recipient_uniqu="444444444",
+        sub_ultimate_parent_unique_ide="444444440",
+        sub_awardee_or_recipient_uei="CCCCCCCCCCCC",
+        sub_ultimate_parent_uei="CCCCCCCCCCC0",
+        award=award_search3,
+        sub_action_date="2020-01-01",
     )
 
 
@@ -49,3 +107,43 @@ def test_keyword_filter_uei_lowercase(subaward_data):
     filters = {"keywords": ["aaaaaaaaaaaa", "bbbbbbbbbbb0", "ccc"]}
     results = subaward_filter(filters).all()
     assert len(results) == 2
+
+
+def test_defc_filter(subaward_data):
+    """Test that only the correct subawards are returned when a disaster code
+    is provided.
+    """
+
+    # Test DEF code `A` which doesn't have an enactment date
+    filters = {"def_codes": ["A"]}
+    results = subaward_filter(filters).all()
+    assert len(results) == 2
+
+    # Test DEF code `Z`
+    # Subaward 4 should not be returned because it's `sub_action_date`
+    #   is prior to the enactment date of DEF code `Z`
+    filters = {"def_codes": ["Z"]}
+    results = subaward_filter(filters).all()
+    assert len(results) == 1
+
+    filters = {"def_codes": ["L"]}
+    results = subaward_filter(filters).all()
+    assert len(results) == 1
+
+    filters = {"def_codes": ["L", "Z"]}
+    results = subaward_filter(filters).all()
+    assert len(results) == 2
+
+
+def test_defc_and_date_filters(subaward_data):
+    """Test the combination of the `def_codes` and `time_period` filters"""
+
+    # No subawards should be returned, because even though Subaward 4 falls into this `time_period`
+    #   it's `sub_action_date` is prior to when DEF code `Z` went into effect and therefore filtered out
+    filters = {"def_codes": ["Z"], "time_period": [{"start_date": "2019-01-01", "end_date": "2021-12-01"}]}
+    results = subaward_filter(filters).all()
+    assert len(results) == 0
+
+    filters = {"def_codes": ["A", "L", "Z"], "time_period": [{"start_date": "2018-01-01", "end_date": "2023-01-01"}]}
+    results = subaward_filter(filters).all()
+    assert len(results) == 3

--- a/usaspending_api/awards/v2/filters/sub_award.py
+++ b/usaspending_api/awards/v2/filters/sub_award.py
@@ -7,7 +7,7 @@ from usaspending_api.awards.models import TransactionNormalized
 from usaspending_api.awards.v2.filters.filter_helpers import combine_date_range_queryset, total_obligation_queryset
 from usaspending_api.awards.v2.filters.location_filter_geocode import ALL_FOREIGN_COUNTRIES, create_nested_object
 from usaspending_api.common.exceptions import InvalidParameterException
-from usaspending_api.references.models import PSC, DisasterEmergencyFundCode
+from usaspending_api.references.models import PSC
 from usaspending_api.search.filters.postgres.defc import DefCodes
 from usaspending_api.search.filters.postgres.psc import PSCCodes
 from usaspending_api.search.filters.postgres.tas import TasCodes, TreasuryAccounts
@@ -335,24 +335,6 @@ def subaward_filter(filters, for_downloads=False):
             queryset = queryset.filter(TreasuryAccounts.build_tas_codes_filter(queryset, value))
 
         elif key == "def_codes":
-            def_codes_with_enactment_dates = DisasterEmergencyFundCode.objects.exclude(
-                earliest_public_law_enactment_date__isnull=True
-            ).values_list("code", "earliest_public_law_enactment_date")
-            def_codes_with_enactment_dates = dict(def_codes_with_enactment_dates)
-
             queryset = queryset.filter(DefCodes.build_def_codes_filter(value))
-
-            if any(code in def_codes_with_enactment_dates.keys() for code in value):
-                # Get the earliest enactment date of all public laws that apply to the
-                #   provided def codes
-                earliest_applicable_enactment_date = min(
-                    [
-                        def_codes_with_enactment_dates[defc]
-                        for defc in value
-                        if defc in def_codes_with_enactment_dates.keys()
-                    ]
-                )
-
-                queryset = queryset.filter(sub_action_date__gte=earliest_applicable_enactment_date)
 
     return queryset

--- a/usaspending_api/download/tests/integration/test_download_disaster.py
+++ b/usaspending_api/download/tests/integration/test_download_disaster.py
@@ -45,6 +45,7 @@ def awards_and_transactions():
         total_loan_value=3,
         generated_unique_award_id="ASST_NEW_1",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["L"],
     )
     award2 = baker.make(
         "search.AwardSearch",
@@ -53,6 +54,7 @@ def awards_and_transactions():
         total_loan_value=30,
         generated_unique_award_id="ASST_NEW_2",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["M"],
     )
     award3 = baker.make(
         "search.AwardSearch",
@@ -61,6 +63,7 @@ def awards_and_transactions():
         total_loan_value=300,
         generated_unique_award_id="ASST_NEW_3",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["N"],
     )
     award4 = baker.make(
         "search.AwardSearch",
@@ -69,6 +72,7 @@ def awards_and_transactions():
         total_loan_value=0,
         generated_unique_award_id="CONT_NEW_1",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["L", "M"],
     )
     award5 = baker.make(
         "search.AwardSearch",
@@ -77,6 +81,7 @@ def awards_and_transactions():
         total_loan_value=0,
         generated_unique_award_id="CONT_NEW_2",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["M", "N"],
     )
     award6 = baker.make(
         "search.AwardSearch",
@@ -85,6 +90,7 @@ def awards_and_transactions():
         total_loan_value=0,
         generated_unique_award_id="CONT_NEW_3",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["L", "N"],
     )
     award7 = baker.make(
         "search.AwardSearch",
@@ -93,7 +99,17 @@ def awards_and_transactions():
         total_loan_value=0,
         generated_unique_award_id="CONT_NEW_4",
         action_date="2020-01-01",
+        disaster_emergency_fund_codes=["L", "M", "N"],
     )
+
+    # Subawards
+    baker.make("search.SubawardSearch", broker_subaward_id=1, award=award1, sub_action_date="2023-01-01")
+    baker.make("search.SubawardSearch", broker_subaward_id=2, award=award2, sub_action_date="2023-01-01")
+    baker.make("search.SubawardSearch", broker_subaward_id=3, award=award3, sub_action_date="2023-01-01")
+    baker.make("search.SubawardSearch", broker_subaward_id=4, award=award4, sub_action_date="2023-01-01")
+    baker.make("search.SubawardSearch", broker_subaward_id=5, award=award5, sub_action_date="2023-01-01")
+    baker.make("search.SubawardSearch", broker_subaward_id=6, award=award6, sub_action_date="2023-01-01")
+    baker.make("search.SubawardSearch", broker_subaward_id=7, award=award7, sub_action_date="2023-01-01")
 
     # Disaster Emergency Fund Code
     defc1 = baker.make(

--- a/usaspending_api/search/filters/postgres/defc.py
+++ b/usaspending_api/search/filters/postgres/defc.py
@@ -10,6 +10,18 @@ class DefCodes:
         """Build a SQL filter to only include Subawards that are associated with any
         DEF codes included in the API request.
 
+        Which subawards should be returned currently is currently
+        decided by:
+
+            1. JOINing the award_search table to the subaward_search table on the
+                `award_id` fields WHERE there is any overlap between the disaster
+                code(s) provided in the request and the award_search row's
+                `disaster_emergency_fund_codes` array.
+            2. We then SELECT the `broker_subaward_id` WHERE the UNNESTed disaster
+                code equals one of the disaster codes provided in the API request
+                and WHERE the subaward's `sub_action_date` is on or after the
+                disaster code's `earliest_public_law_enactment_date`
+
         Args:
             filter_values (List[str]): List of DEF codes to use in filtering. These come
                 from the API request.

--- a/usaspending_api/search/filters/postgres/defc.py
+++ b/usaspending_api/search/filters/postgres/defc.py
@@ -1,6 +1,5 @@
+from django.db import connection
 from django.db.models import Q
-
-from usaspending_api.awards.models import FinancialAccountsByAwards
 
 
 class DefCodes:
@@ -20,9 +19,42 @@ class DefCodes:
             provided DEF code filter(s).
         """
 
-        subquery = FinancialAccountsByAwards.objects.filter(disaster_emergency_fund__in=filter_values).values(
-            "award__award_id"
-        )
-        q = Q(award_id__in=subquery)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                with unnested_sub as (
+                    select
+                        ss.broker_subaward_id,
+                        ss.award_id,
+                        unnest(aws.disaster_emergency_fund_codes) as "singular_defc",
+                        ss.sub_action_date
+                    from
+                        rpt.subaward_search as ss
+                    join rpt.award_search as aws
+                        on ss.award_id = aws.award_id
+                    where
+                         array[{def_codes}] && aws.disaster_emergency_fund_codes
+                    )
+                    select
+                        us.broker_subaward_id
+                    from
+                        unnested_sub as us
+                    join disaster_emergency_fund_code as defc
+                        on defc.code = us.singular_defc
+                    where
+                        us.singular_defc in ({def_codes})
+                        and (
+                            defc.earliest_public_law_enactment_date is null
+                            or defc.earliest_public_law_enactment_date <= sub_action_date
+                        );
+                """.format(
+                    def_codes=",".join([f"'{code}'" for code in filter_values])
+                )
+            )
+
+            results = cursor.fetchall()
+
+        results = [result[0] for result in results]
+        q = Q(broker_subaward_id__in=results)
 
         return q


### PR DESCRIPTION
**Description:**
Update the existing date filter that is used when searching for Subawards associated with a DEFC.

**Technical details:**
The current logic picks the earliest `earliest_public_law_enactment_date` of all DEF codes in the request and compares the Subaward's `sub_action_date` to that value. This is inaccurate because the same enactment date is applied to all Subaward results and extra Subawards can be returned for DEF codes with an enactment date later than the earliest enactment date.

The updated logic will only return Subawards, that are associated with a DEFC, where the `sub_action_date` is on/after the DEFC's `earliest_public_law_enactment_date`.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [ ] Necessary PR reviewers:
    - [ ] Backend
3. [x] Frontend impact assessment completed
4. [x] Data validation completed
5. [x] Jira Ticket [DEV-9929](https://federal-spending-transparency.atlassian.net/browse/DEV-9929):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
