### PR TITLE
[DEV-9929] Use set comprehension instead of list comprehension

### DIFF
--- a/usaspending_api/search/filters/postgres/defc.py
+++ b/usaspending_api/search/filters/postgres/defc.py
@@ -66,7 +66,7 @@ class DefCodes:
 
             results = cursor.fetchall()
 
-        results = [result[0] for result in results]
+        results = {result[0] for result in results}
         q = Q(broker_subaward_id__in=results)
 
         return q

--- a/usaspending_api/search/filters/postgres/defc.py
+++ b/usaspending_api/search/filters/postgres/defc.py
@@ -66,6 +66,10 @@ class DefCodes:
 
             results = cursor.fetchall()
 
+        # The above SQL will return 1 result (row) for each DEF code it's associated with IF that DEF code
+        #   is also in the API request ({def_codes}). This means the same `broker_subaward_id` can be returned
+        #   multiple times because each row matches a different DEF code from the API request, using a set
+        #   removes these duplicate `broker_subaward_id` values.
         results = {result[0] for result in results}
         q = Q(broker_subaward_id__in=results)
 


### PR DESCRIPTION
**Description:**
Remove duplicate Subaward IDs in the case where the same Subaward is associated with multiple disaster codes that are included in the API request. A Subaward ID should only be returned once, even if it's associated with multiple DEF codes in the request.

**Technical details:**
Use a set instead of a list to remove duplicate Subaward IDs from the subquery.

**Requirements for PR merge:**

1. [ ] Necessary PR reviewers:
    - [ ] Backend
2. [x] Data validation completed
3. [x] Jira Ticket [DEV-9929](https://federal-spending-transparency.atlassian.net/browse/DEV-9929):
    - [x] Link to this Pull-Request

