### PR TITLE
[DEV-9403] Update total_outlays calculation for /v2/awards/{id} endpoint

### DIFF
--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -8,7 +8,6 @@ from model_bakery import baker
 
 @pytest.fixture
 def awards_and_transactions(db):
-
     # DUNS
     duns = {"awardee_or_recipient_uniqu": "123", "legal_business_name": "Sams Club"}
 
@@ -978,7 +977,6 @@ def test_award_last_updated_endpoint(client, update_awards):
 
 
 def test_award_endpoint_generated_id(client, awards_and_transactions):
-
     resp = client.get("/api/v2/awards/ASST_AGG_1830212.0481163_3620/")
     assert resp.status_code == status.HTTP_200_OK
     assert json.loads(resp.content.decode("utf-8")) == expected_response_asst
@@ -997,7 +995,6 @@ def test_award_endpoint_generated_id(client, awards_and_transactions):
 
 
 def test_award_endpoint_parent_award(client, awards_and_transactions):
-
     dsws1 = baker.make("submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2020-01-01")
     baker.make("submissions.SubmissionAttributes", toptier_code="ABC", submission_window=dsws1)
     baker.make("submissions.SubmissionAttributes", toptier_code="002", submission_window=dsws1)
@@ -1024,7 +1021,6 @@ def test_award_endpoint_parent_award(client, awards_and_transactions):
 
 
 def test_award_endpoint_parent_award_no_submissions(client, awards_and_transactions):
-
     # Test contract award with parent
     resp = client.get("/api/v2/awards/7/")
     assert resp.status_code == status.HTTP_200_OK
@@ -1049,7 +1045,6 @@ def test_award_endpoint_parent_award_no_submissions(client, awards_and_transacti
 
 
 def test_award_multiple_cfdas(client, awards_and_transactions):
-
     resp = client.get("/api/v2/awards/3/")
     assert resp.status_code == status.HTTP_200_OK
     assert json.loads(resp.content.decode("utf-8"))["cfda_info"] == [
@@ -1328,12 +1323,49 @@ def test_outlay_calculations(client, awards_and_transactions):
         disaster_emergency_fund=defc,
         submission_id=4,
     )
+    baker.make(
+        "awards.FinancialAccountsByAwards",
+        award_id=2,
+        gross_outlay_amount_by_award_cpe=None,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=None,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=None,
+        submission_id=4,
+    )
+    baker.make(
+        "awards.FinancialAccountsByAwards",
+        award_id=3,
+        gross_outlay_amount_by_award_cpe=20,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=20,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=20,
+        disaster_emergency_fund=defc,
+        submission_id=4,
+    )
+    baker.make(
+        "awards.FinancialAccountsByAwards",
+        award_id=3,
+        gross_outlay_amount_by_award_cpe=30,
+        ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe=30,
+        ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe=30,
+        submission_id=4,
+    )
+
     resp = client.get("/api/v2/awards/1/")
     assert resp.status_code == status.HTTP_200_OK
     assert json.loads(resp.content.decode("utf-8"))["account_obligations_by_defc"] == [{"code": "L", "amount": 10.0}]
     assert json.loads(resp.content.decode("utf-8"))["account_outlays_by_defc"] == [{"code": "L", "amount": 7.0}]
     assert json.loads(resp.content.decode("utf-8"))["total_account_obligation"] == 10.0
     assert json.loads(resp.content.decode("utf-8"))["total_account_outlay"] == 7.0
+    assert json.loads(resp.content.decode("utf-8"))["total_outlay"] == 7.0
+
+    # Test Award 2 returns NULL (None) and not 0
+    resp = client.get("/api/v2/awards/2/")
+    assert resp.status_code == status.HTTP_200_OK
+    assert json.loads(resp.content.decode("utf-8"))["total_outlay"] is None
+
+    # Test that Award 3's amounts are all summed together
+    resp = client.get("/api/v2/awards/3/")
+    assert resp.status_code == status.HTTP_200_OK
+    assert json.loads(resp.content.decode("utf-8"))["total_outlay"] == 150
 
 
 expected_response_asst = {

--- a/usaspending_api/awards/tests/test_awards_v2.py
+++ b/usaspending_api/awards/tests/test_awards_v2.py
@@ -1,9 +1,9 @@
 import datetime
-import pytest
 import json
 
-from rest_framework import status
+import pytest
 from model_bakery import baker
+from rest_framework import status
 
 
 @pytest.fixture

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -646,7 +646,12 @@ def fetch_total_outlays(award_id: int) -> dict:
             as last_period_total_outlay
         FROM
             financial_accounts_by_awards faba
-        WHERE {award_id_sql}
+        INNER JOIN submission_attributes sa
+            ON faba.submission_id = sa.submission_id
+        WHERE
+            {award_id_sql}
+            AND
+            sa.is_final_balances_for_fy = TRUE
         GROUP BY faba.award_id
     )
     SELECT sum(CASE WHEN sa.is_final_balances_for_fy = TRUE THEN (

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -637,27 +637,36 @@ def fetch_account_details_award(award_id: int) -> dict:
 def fetch_total_outlays(award_id: int) -> dict:
     sql = """
     with date_signed_outlay_amounts (award_id, last_period_total_outlay) as (
-        SELECT faba. award_id, COALESCE(sum(COALESCE(faba.gross_outlay_amount_by_award_cpe,0)
-            + COALESCE(faba.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe, 0)
-            + COALESCE(faba.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe, 0)), 0) as last_period_total_outlay
+        SELECT
+            faba.award_id,
+            COALESCE(
+                sum(COALESCE(faba.gross_outlay_amount_by_award_cpe,0)
+                + COALESCE(faba.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe, 0)
+                + COALESCE(faba.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe, 0)), 0)
+            as last_period_total_outlay
         FROM
             financial_accounts_by_awards faba
-        INNER JOIN submission_attributes sa
-            ON faba.submission_id = sa.submission_id
-        INNER JOIN vw_awards a
-            ON faba.award_id = a.id
-        INNER JOIN vw_transaction_normalized tn ON tn.id = a.earliest_transaction_id
-        WHERE sa.is_final_balances_for_fy AND sa.reporting_fiscal_year = tn.fiscal_year AND {award_id_sql}
+        WHERE {award_id_sql}
         GROUP BY faba.award_id
     )
-    SELECT sum(CASE WHEN sa.is_final_balances_for_fy = TRUE THEN (COALESCE(faba.gross_outlay_amount_by_award_cpe,0)
-            + COALESCE(faba.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe, 0)
-            + COALESCE(faba.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe, 0)) END) AS total_outlay
+    SELECT sum(CASE WHEN sa.is_final_balances_for_fy = TRUE THEN (
+        COALESCE(faba.gross_outlay_amount_by_award_cpe,0)
+        + COALESCE(faba.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe, 0)
+        + COALESCE(faba.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe, 0)
+    ) END) AS total_outlay
     FROM
         financial_accounts_by_awards faba
     INNER JOIN submission_attributes sa
         ON faba.submission_id = sa.submission_id
-    INNER JOIN date_signed_outlay_amounts o ON faba.award_id = o.award_id AND o.last_period_total_outlay != 0;
+    INNER JOIN date_signed_outlay_amounts o ON faba.award_id = o.award_id
+    WHERE
+        o.last_period_total_outlay != 0
+        AND
+        (
+            faba.gross_outlay_amount_by_award_cpe IS NOT NULL
+            AND
+            faba.gross_outlay_amount_by_award_cpe != 0
+        );
     """
     results = execute_sql_to_ordered_dictionary(sql.format(award_id_sql=f"faba.award_id = {award_id}"))
     if len(results) > 0:

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -646,7 +646,6 @@ def fetch_total_outlays(award_id: int) -> dict:
             ON faba.submission_id = sa.submission_id
         INNER JOIN vw_awards a
             ON faba.award_id = a.id
-            AND a.date_signed >= '2019-10-01'
         INNER JOIN vw_transaction_normalized tn ON tn.id = a.earliest_transaction_id
         WHERE sa.is_final_balances_for_fy AND sa.reporting_fiscal_year = tn.fiscal_year AND {award_id_sql}
         GROUP BY faba.award_id


### PR DESCRIPTION
**Description:**
Updated the logic for calculating the `total_outlay` value, on the /v2/awards/{id} endpoint, to include all outlay amounts including COVID and IIJA outlays. Also removed any date filtering. The endpoint also returns `null` if there are no outlays, instead of `0`.

**Technical details:**
Updated the logic for calculating the `total_outlay` value, on the /v2/awards/{id} endpoint, to include all outlay amounts including COVID and IIJA outlays. Also removed any date filtering. The endpoint also returns `null` if there are no outlays, instead of `0`.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [ ] Necessary PR reviewers:
    - [ ] Backend
3. [x] Data validation completed
4. [x] Jira Ticket [DEV-9403](https://federal-spending-transparency.atlassian.net/browse/DEV-9403):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
