### PR TITLE
[DEV-10017] Add support for CD code 90 [hotfix][staging]

### DIFF
--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -511,15 +511,6 @@ def awards_and_transactions(db):
     # References Population Congressional District
     baker.make(
         "references.PopCongressionalDistrict",
-        id=1,
-        state_code="45",
-        state_name="South Carolina",
-        state_abbreviation="SC",
-        congressional_district="90",
-        latest_population=1,
-    )
-    baker.make(
-        "references.PopCongressionalDistrict",
         id=2,
         state_code="45",
         state_name="South Carolina",

--- a/usaspending_api/search/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_geography.py
@@ -1,6 +1,6 @@
 import json
-import pytest
 
+import pytest
 from rest_framework import status
 
 from usaspending_api.common.helpers.generic_helper import get_time_period_message
@@ -479,6 +479,13 @@ def _test_correct_response_for_place_of_performance_district_without_geo_filters
         "geo_layer": "district",
         "results": [
             {
+                "aggregated_amount": 500000.0,
+                "display_name": None,
+                "per_capita": None,
+                "population": None,
+                "shape_code": ""
+            },
+            {
                 "aggregated_amount": 50005.0,
                 "display_name": "SC-10",
                 "per_capita": 5000.5,
@@ -491,13 +498,6 @@ def _test_correct_response_for_place_of_performance_district_without_geo_filters
                 "per_capita": 0.5,
                 "population": 100,
                 "shape_code": "4550",
-            },
-            {
-                "aggregated_amount": 500000.0,
-                "display_name": "SC-90",
-                "per_capita": 500000.0,
-                "population": 1,
-                "shape_code": "4590",
             },
             {
                 "aggregated_amount": 5500.0,
@@ -620,6 +620,13 @@ def _test_correct_response_for_recipient_location_district_without_geo_filters(c
         "geo_layer": "district",
         "results": [
             {
+                "aggregated_amount": 50.0,
+                "display_name": None,
+                "per_capita": None,
+                "population": None,
+                "shape_code": "",
+            },
+            {
                 "aggregated_amount": 5000000.0,
                 "display_name": "SC-10",
                 "per_capita": 500000.0,
@@ -632,13 +639,6 @@ def _test_correct_response_for_recipient_location_district_without_geo_filters(c
                 "per_capita": 5005.0,
                 "population": 100,
                 "shape_code": "4550",
-            },
-            {
-                "aggregated_amount": 50.0,
-                "display_name": "SC-90",
-                "per_capita": 50.0,
-                "population": 1,
-                "shape_code": "4590",
             },
             {
                 "aggregated_amount": 55000.0,

--- a/usaspending_api/search/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_geography.py
@@ -483,7 +483,7 @@ def _test_correct_response_for_place_of_performance_district_without_geo_filters
                 "display_name": None,
                 "per_capita": None,
                 "population": None,
-                "shape_code": ""
+                "shape_code": "",
             },
             {
                 "aggregated_amount": 50005.0,

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -1,21 +1,23 @@
 from abc import ABCMeta
+from collections import Counter
 from decimal import Decimal
-from django.db.models import QuerySet, F, TextField
-from django.db.models.functions import Concat
 from enum import Enum
-from typing import List
+from typing import Dict, List
 
+from django.db.models import F, QuerySet, TextField
+from django.db.models.functions import Concat
+
+from usaspending_api.recipient.models import StateData
 from usaspending_api.references.abbreviations import code_to_state, fips_to_code
+from usaspending_api.references.models import PopCongressionalDistrict, PopCounty, RefCountryCode
 from usaspending_api.search.helpers.spending_by_category_helpers import (
     fetch_country_name_from_code,
     fetch_state_name_from_code,
 )
 from usaspending_api.search.v2.views.spending_by_category_views.spending_by_category import (
-    Category,
     AbstractSpendingByCategoryViewSet,
+    Category,
 )
-from usaspending_api.references.models import RefCountryCode, PopCounty, PopCongressionalDistrict
-from usaspending_api.recipient.models import StateData
 
 
 class LocationType(Enum):
@@ -23,6 +25,47 @@ class LocationType(Enum):
     STATE_TERRITORY = "state"
     COUNTY = "county"
     CONGRESSIONAL_DISTRICT = "congressional"
+
+
+def _combine_dicts_by_keys(dicts, keys, sum_key) -> List[Dict]:
+    """Combine all dictionaries in a list that have the same values for the given field(s)
+
+    Args:
+        dicts (list[dict]): List of dictionaries that may contain duplicate values.
+        keys (list[str]): List of keys to check the values of in each dictionary.
+            If ALL of the values for these keys are the same between dictionaries, then they
+            will be combined into one dictionary.
+        sum_key (str): A key within the duplicate dictionaries that will be summed together.
+
+    Returns:
+        List[Dict]: List of dictionaries, after combining and summing any duplicate dictionaries
+
+    Example:
+        [
+            {'id': None, 'code': '01', 'name': 'ID-01', 'amount': Decimal('74338979.79')},
+            {'id': None, 'code': '02', 'name': 'ID-02', 'amount': Decimal('32381356.49')},
+            {'id': None, 'code': None, 'name': None, 'amount': Decimal('6952030.82')},
+            {'id': None, 'code': None, 'name': None, 'amount': Decimal('645582')},
+            {'id': None, 'code': None, 'name': None, 'amount': Decimal('4324')}
+        ]
+
+        becomes this after combing the last 3 dictionaries because the `code` and `name` keys are the same:
+        [
+            {'id': None, 'code': '01', 'name': 'ID-01', 'amount': Decimal('74338979.79')},
+            {'id': None, 'code': '02', 'name': 'ID-02', 'amount': Decimal('32381356.49')},
+            {'id': None, 'code': None, 'name': None, 'amount': Decimal('7601936.82')},
+        ]
+    """
+    combined_dicts = {}
+
+    for d in dicts:
+        key = tuple(d[key] for key in keys)
+        if key not in combined_dicts:
+            combined_dicts[key] = d.copy()
+        else:
+            combined_dicts[key][sum_key] += d[sum_key]
+
+    return list(combined_dicts.values())
 
 
 class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMeta):
@@ -67,13 +110,25 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
                 .values("shape_code", "name", "code")
             )
         elif self.location_type == LocationType.CONGRESSIONAL_DISTRICT:
+            # Get all `shape_code`, `state_code`, and `congressional_district` values for the given state
             location_info_query = (
                 PopCongressionalDistrict.objects.annotate(
                     shape_code=Concat(F("state_code"), F("congressional_district"), output_field=TextField())
                 )
-                .filter(shape_code__in=code_list)
+                .filter(state_code__in={sc[:2] for sc in code_list})
                 .values("shape_code", "state_code", "congressional_district")
             )
+
+            # Add the `90` congressional code to the list of valid codes, if the given state has more
+            #   than 1 congressional district
+            counts = Counter([state["state_code"] for state in location_info_query.all()])
+            for state_code, occurrences in counts.items():
+                if occurrences > 1:
+                    current_location_info[f"{state_code}90"] = {
+                        "state_code": state_code,
+                        "congressional_district": "90",
+                    }
+
             # can't do the distict transformation in the queryset, see below
         for location_info in location_info_query.all():
             shape_code = location_info.pop("shape_code")
@@ -103,6 +158,12 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
                     "amount": int(bucket.get("sum_field", {"value": 0})["value"]) / Decimal("100"),
                 }
             )
+
+        # Combine all dicts in the `results` list that have the same values for
+        #   `code` and `name`. Sum their `amount` values together.
+        if self.location_type == LocationType.CONGRESSIONAL_DISTRICT:
+            results = _combine_dicts_by_keys(results, ["code", "name"], "amount")
+
         return results
 
     def query_django_for_subawards(self, base_queryset: QuerySet) -> List[dict]:

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_locations.py
@@ -159,8 +159,9 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
                 }
             )
 
-        # Combine all dicts in the `results` list that have the same values for
-        #   `code` and `name`. Sum their `amount` values together.
+        # Combine all dicts in the `results` list that have the same values for `code` and `name`and sum their `amount`
+        # values together. These fields can be `None` if they don't match an entry in the ref_population_cong_district
+        # table.
         if self.location_type == LocationType.CONGRESSIONAL_DISTRICT:
             results = _combine_dicts_by_keys(results, ["code", "name"], "amount")
 
@@ -194,8 +195,8 @@ class AbstractLocationViewSet(AbstractSpendingByCategoryViewSet, metaclass=ABCMe
             django_values = ["sub_place_of_perform_country_co", "sub_place_of_perform_state_code"]
             annotations = {"code": F("sub_place_of_perform_state_code")}
         else:
-            django_values = [f"sub_place_of_perform_country_co"]
-            annotations = {"code": F(f"sub_place_of_perform_country_co")}
+            django_values = ["sub_place_of_perform_country_co"]
+            annotations = {"code": F("sub_place_of_perform_country_co")}
 
         queryset = self.common_db_query(base_queryset, django_filters, django_values).annotate(**annotations)
         lower_limit = self.pagination.lower_limit


### PR DESCRIPTION
**Description:**
Add support for congressional district values of `90`. Add a function for combining multiple dictionaries in a list that have the same `code` and `name` value and sum their `amount` field values together into one dictionary.

**Technical details:**
Since the congressional district value of `90` is not in the database for any U.S. state, the transactions associated with this congressional code had the congressional district value (`90`) replaced with `None`. There is now a check to see if the amount of congressional districts for the given state is greater than 1. If this is true, then `90` is added to the list of valid congressional districts for that state and will no longer be replaced with `None`.

Added a function that checks all of the dictionaries in the provided list to see if certain keys have the same values. If they do, then these dictionaries are combined into one dictionary and their `amount` keys are summed together.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Data validation completed
6. [x] Jira Ticket [DEV-10017](https://federal-spending-transparency.atlassian.net/browse/DEV-10017):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
