### PR TITLE
[DEV-9974] Retry Data Dictionary Download 

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -47,10 +47,6 @@ EXCEL_ROW_LIMIT = 1000000
 WAIT_FOR_PROCESS_SLEEP = 5
 JOB_TYPE = "USAspendingDownloader"
 
-# Data Dictionary retry settings
-DATA_DICTIONARY_DOWNLOAD_RETRY_COUNT = 3
-DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN = 5
-
 logger = logging.getLogger(__name__)
 
 
@@ -743,7 +739,7 @@ def add_data_dictionary_to_zip(working_dir, zip_file_path):
     data_dictionary_file_path = os.path.join(working_dir, data_dictionary_file_name)
     data_dictionary_url = settings.DATA_DICTIONARY_DOWNLOAD_URL
 
-    max_attempts = DATA_DICTIONARY_DOWNLOAD_RETRY_COUNT
+    max_attempts = settings.DATA_DICTIONARY_DOWNLOAD_RETRY_COUNT
 
     # We are currently receiving timeouts when trying to retrieve the data dictionary during
     # the nightly pipeline. Adding retry logic here until those timeouts are resolved
@@ -753,7 +749,7 @@ def add_data_dictionary_to_zip(working_dir, zip_file_path):
             break
         except (HTTPError, RemoteDisconnected):
             if attempt < max_attempts - 1:
-                time.sleep(DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN)
+                time.sleep(settings.DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN)
                 continue
             else:
                 raise

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -19,6 +19,7 @@ from ddtrace import tracer
 from ddtrace.ext import SpanTypes
 from django.conf import settings
 from http.client import RemoteDisconnected
+from urllib.error import HTTPError
 
 from usaspending_api.download.models.download_job_lookup import DownloadJobLookup
 from usaspending_api.search.filters.time_period.decorators import NEW_AWARDS_ONLY_KEYWORD
@@ -746,7 +747,7 @@ def add_data_dictionary_to_zip(working_dir, zip_file_path):
         try:
             RetrieveFileFromUri(data_dictionary_url).copy(data_dictionary_file_path)
             break
-        except RemoteDisconnected:
+        except (HTTPError, RemoteDisconnected):
             if attempt < max_attempts - 1:
                 time.sleep(delay_between_attempts)
                 continue

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -739,16 +739,16 @@ def add_data_dictionary_to_zip(working_dir, zip_file_path):
     data_dictionary_file_path = os.path.join(working_dir, data_dictionary_file_name)
     data_dictionary_url = settings.DATA_DICTIONARY_DOWNLOAD_URL
 
-    max_attempts = settings.DATA_DICTIONARY_DOWNLOAD_RETRY_COUNT
+    retry_count = settings.DATA_DICTIONARY_DOWNLOAD_RETRY_COUNT
 
     # We are currently receiving timeouts when trying to retrieve the data dictionary during
     # the nightly pipeline. Adding retry logic here until those timeouts are resolved
-    for attempt in range(max_attempts):
+    for attempt in range(retry_count + 1):
         try:
             RetrieveFileFromUri(data_dictionary_url).copy(data_dictionary_file_path)
             break
         except (HTTPError, RemoteDisconnected):
-            if attempt < max_attempts - 1:
+            if attempt < retry_count:
                 time.sleep(settings.DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN)
                 continue
             else:

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -20,6 +20,10 @@ MAX_DOWNLOAD_LIMIT = 500000
 # Timeout limit for streaming downloads
 DOWNLOAD_TIMEOUT_MIN_LIMIT = 10
 
+# Data Dictionary retry settings
+DATA_DICTIONARY_DOWNLOAD_RETRY_COUNT = 3
+DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN = 5
+
 # Default timeout for SQL statements in Django
 DEFAULT_DB_TIMEOUT_IN_SECONDS = int(os.environ.get("DEFAULT_DB_TIMEOUT_IN_SECONDS", 0))
 DOWNLOAD_DB_TIMEOUT_IN_HOURS = 4


### PR DESCRIPTION
**Description:**
Several Nightly Pipelines have failed during the Covid Download generation step. These failures were caused by timeouts when trying to download the latest version of the Data Dictionary to include in the Download Zip file. 

Example failed pipeline logs:

```
[2023-06-11T18:31:56.498Z]   File "/usr/local/lib/python3.7/urllib/request.py", line 649, in http_error_default
[2023-06-11T18:31:56.498Z]     raise HTTPError(req.full_url, code, msg, hdrs, fp)
[2023-06-11T18:31:56.498Z] urllib.error.HTTPError: HTTP Error 504: Gateway Time-out
```

```
[2023-06-10T23:23:39.429Z]   File "/usr/local/lib/python3.7/http/client.py", line 265, in _read_status
[2023-06-10T23:23:39.429Z]     raise RemoteDisconnected("Remote end closed connection without"
[2023-06-10T23:23:39.429Z] http.client.RemoteDisconnected: Remote end closed connection without response
```

**Technical details:**
This PR adds retry logic to the method in the download code that downloads the data dictionary and adds it to the zip `add_data_dictionary_to_zip(working_dir, zip_file_path)`.

I decided against adding retry logic directly to the `RetrieveFileFromUri` class that is used generally to download files. 

I have set a retry count of 3 and a time between retries of 5 seconds. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations <OPTIONAL>
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-9974](https://federal-spending-transparency.atlassian.net/browse/DEV-9974):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
