### PR TITLE
[DEV-9958] Federal Account Balance not Collapsing Properly in Download

### DIFF
--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -382,6 +382,7 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
         "USSGL483200_undeliv_orders_oblig_transferred_prepaid_advanced",
         "gross_outlay_amount",
         "adjustments_to_unobligated_balance_brought_forward_cpe",
+        "gross_outlay_amount_FYB_to_period_end",
     ]
 
     # Group by all columns within the file that can't be summed
@@ -403,7 +404,7 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
     summed_cols["gross_outlay_amount_FYB_to_period_end"] = Sum(
         generate_gross_outlay_amount_derived_field(account_type, closed_submission_queryset)
     )
-    summed_cols["adjustments_to_unobligated_balance_brought_forward_cpe"] = Sum(
+    summed_cols["adjustments_to_unobligated_balance_brought_forward_cpe"] = F(
         "adjustments_to_unobligated_balance_brought_forward_cpe"
     )
     queryset = queryset.annotate(**summed_cols)
@@ -433,10 +434,6 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
     queryset = queryset.values(*grouped_cols)
 
     # Sum all summable fields again at new grain
-    # These columns are dynamic so Django cannot "SUM" them again
-    summed_cols["adjustments_to_unobligated_balance_brought_forward_cpe"] = F(
-        "adjustments_to_unobligated_balance_brought_forward_cpe"
-    )
     queryset = queryset.annotate(**summed_cols)
 
     # Concatenate the remaining columns to transform the data

--- a/usaspending_api/accounts/v2/filters/account_download.py
+++ b/usaspending_api/accounts/v2/filters/account_download.py
@@ -320,12 +320,6 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
         "submission_period": get_fyp_or_q_notation("submission"),
         "last_modified_date"
         + NAMING_CONFLICT_DISCRIMINATOR: Cast(Max("submission__published_date"), output_field=DateField()),
-        "gross_outlay_amount": Sum(
-            generate_gross_outlay_amount_derived_field(account_type, closed_submission_queryset)
-        ),
-        "gross_outlay_amount_FYB_to_period_end": Sum(
-            generate_gross_outlay_amount_derived_field(account_type, closed_submission_queryset)
-        ),
     }
 
     if account_type != "account_balances":
@@ -386,6 +380,8 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
         "USSGL483100_undelivered_orders_obligations_transferred_unpaid",
         "USSGL493100_delivered_orders_obligations_transferred_unpaid",
         "USSGL483200_undeliv_orders_oblig_transferred_prepaid_advanced",
+        "gross_outlay_amount",
+        "adjustments_to_unobligated_balance_brought_forward_cpe",
     ]
 
     # Group by all columns within the file that can't be summed
@@ -400,8 +396,59 @@ def generate_federal_account_query(queryset, account_type, tas_id, filters):
         for val in values_dict["federal_account"]
         if val in all_summed_cols
     }
+    # These columns require a more complex aggregation than others
+    summed_cols["gross_outlay_amount"] = Sum(
+        generate_gross_outlay_amount_derived_field(account_type, closed_submission_queryset)
+    )
+    summed_cols["gross_outlay_amount_FYB_to_period_end"] = Sum(
+        generate_gross_outlay_amount_derived_field(account_type, closed_submission_queryset)
+    )
+    summed_cols["adjustments_to_unobligated_balance_brought_forward_cpe"] = Sum(
+        "adjustments_to_unobligated_balance_brought_forward_cpe"
+    )
+    queryset = queryset.annotate(**summed_cols)
 
-    return queryset.annotate(**summed_cols)
+    if account_type != "account_balances":
+        # If the file is not File A we are done
+        return queryset
+
+    # For File A, we expect one row per unique pair of federal_account_symbol and submission_period
+
+    # List of the columns that may be concatenated in File A
+    all_concat_cols = [
+        "owning_agency_name",
+        "reporting_agency_name",
+        "federal_account_name",
+        "agency_identifier_name",
+        "budget_function",
+        "budget_subfunction",
+    ]
+
+    # Perform a "GROUP BY" again to transform the data into the grain we expect
+    grouped_cols = [
+        fed_acct_values_dict[val]
+        for val in fed_acct_values_dict
+        if val not in all_summed_cols and val not in all_concat_cols
+    ]
+    queryset = queryset.values(*grouped_cols)
+
+    # Sum all summable fields again at new grain
+    # These columns are dynamic so Django cannot "SUM" them again
+    summed_cols["adjustments_to_unobligated_balance_brought_forward_cpe"] = F(
+        "adjustments_to_unobligated_balance_brought_forward_cpe"
+    )
+    queryset = queryset.annotate(**summed_cols)
+
+    # Concatenate the remaining columns to transform the data
+    # into the grain we expect
+    concatenated_cols = {
+        val: StringAggWithDefault(values_dict["treasury_account"].get(val, None), ";", distinct=True)
+        for val in values_dict["federal_account"]
+        if val in all_concat_cols
+    }
+    queryset = queryset.annotate(**concatenated_cols)
+
+    return queryset
 
 
 def award_financial_derivations(derived_fields):


### PR DESCRIPTION
**Description:**
This PR corrects the federal account behavior in account downloads. The endpoint impacted by this PR is `/api/v2/download/accounts/` with "account_level" = "federal_account". The records in this download will now be unique per pair of federal_account_symbol and submission_period values. The other columns are aggregated accordingly to get the result set down to this grain.

**Technical details:**
This work leverages the existing pattern of annotations in the `account_download.py` module.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-9958](https://federal-spending-transparency.atlassian.net/browse/DEV-9958):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
7. No operation tickets needed
