### PR TITLE
[DEV-9901] Update spending_by_award endpoint to support recipient names ending in periods

### DIFF
--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -1,6 +1,6 @@
 import pytest
-
 from model_bakery import baker
+
 from usaspending_api.references.models.ref_program_activity import RefProgramActivity
 from usaspending_api.search.models import AwardSearch
 
@@ -182,6 +182,44 @@ def spending_by_award_test_data():
         total_covid_outlay=0,
         total_covid_obligation=0,
         covid_spending_by_defc=[{"defc": "Q", "outlay": 0, "obligation": 0}],
+    )
+
+    # Awards only used for testing their `recipient_name` values
+    baker.make(
+        "search.AwardSearch",
+        award_id=997,
+        type="A",
+        category="contract",
+        date_signed="2019-01-01",
+        action_date="2019-01-01",
+        fain="fain997",
+        display_award_id="award997",
+        generated_unique_award_id="ASST_NON_TESTING_997",
+        recipient_name="ACME INC",
+    )
+    baker.make(
+        "search.AwardSearch",
+        award_id=998,
+        type="A",
+        category="contract",
+        date_signed="2019-01-01",
+        action_date="2019-01-01",
+        fain="fain998",
+        display_award_id="award998",
+        generated_unique_award_id="ASST_NON_TESTING_998",
+        recipient_name="ACME INC.",
+    )
+    baker.make(
+        "search.AwardSearch",
+        award_id=999,
+        type="A",
+        category="contract",
+        date_signed="2019-01-01",
+        action_date="2019-01-01",
+        fain="fain999",
+        display_award_id="award999",
+        generated_unique_award_id="ASST_NON_TESTING_999",
+        recipient_name="ACME INC.XYZ",
     )
 
     # Toptier Agency

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -1521,9 +1521,12 @@ def test_search_after(client, monkeypatch, spending_by_award_test_data, elastics
         {"internal_id": 2, "Award ID": "abc222", "generated_internal_id": "CONT_AWD_TESTING_2"},
         {"internal_id": 3, "Award ID": "abc333", "generated_internal_id": "CONT_AWD_TESTING_3"},
         {"internal_id": 5, "Award ID": "abcdef123", "generated_internal_id": "CONT_AWD_TESTING_5"},
+        {"internal_id": 997, "Award ID": "award997", "generated_internal_id": "ASST_NON_TESTING_997"},
+        {"internal_id": 998, "Award ID": "award998", "generated_internal_id": "ASST_NON_TESTING_998"},
+        {"internal_id": 999, "Award ID": "award999", "generated_internal_id": "ASST_NON_TESTING_999"},
     ]
     assert resp.status_code == status.HTTP_200_OK
-    assert len(resp.json().get("results")) == 3
+    assert len(resp.json().get("results")) == len(expected_result)
     assert resp.json().get("results") == expected_result, "Award Type Code filter does not match expected result"
 
 


### PR DESCRIPTION
**Description:**
Update the Award Search Elasticsearch query to allow for searching by recipient names that end in a period. Previously searching for ACME INC would match `ACME INC` and `ACME INC.`, but searching for ACME INC. would not returns results for `ACME INC.`

**Technical details:**
If the `recipient_search_text` value ends in a period then add a `regexp` query to return any recipient names that match the given text that end in a `.` or have a `.` after the `recipient_search_text` value followed by 0 or more characters. As an example, searching for `ACME INC.` will now return results for:
* `ACME INC.`  (ends with a period, exact match for the given search text)
* `ACME INC.Q`  (has a period followed by 1 character)
* `ACME INC.XYZ`  (has a period followed by multiple characters)

Regex: `\\..*`
Matches a literal period character (`\\.`) followed by any sequence of characters, including an empty string (`.*`).

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Data validation completed
5. [x] Jira Ticket [DEV-9901](https://federal-spending-transparency.atlassian.net/browse/DEV-9901):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
