### PR TITLE
[DEV-7066]; Removes 'Non-Award Spending' from `api/v2/spending` endpoint

### DIFF
--- a/usaspending_api/api_docs/markdown/landing_page.md
+++ b/usaspending_api/api_docs/markdown/landing_page.md
@@ -13,7 +13,7 @@ The USASpending API is in V2. V1 endpoints are currently Deprecated.
 
 The USAspending API (Application Programming Interface) allows the public to access comprehensive U.S. government spending data.
 
-The data include spending on _awards_ (_e.g._, who received federal contracts or grants, geographic breakdowns, agency breakdowns, and much more). The data also include account-level, non-award spending such as federal employee compensation. You can learn more about the data and the federal law that requires it to be publicly accessible (the DATA Act) at http://fedspendingtransparency.github.io.
+The data include spending on _awards_ (_e.g._, who received federal contracts or grants, geographic breakdowns, agency breakdowns, and much more). The data also include account-level such as federal employee compensation. You can learn more about the data and the federal law that requires it to be publicly accessible (the DATA Act) at http://fedspendingtransparency.github.io.
 
 ## Getting Started <a name="getting-started"></a>
 

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -1075,9 +1075,9 @@ def test_unreported_file_c(client):
     response = resp.json()
     response2 = resp2.json()
     expected_results = {
-        "total": -15,
-        "agencies": ["random_recipient_name_2", "Non-Award Spending", "random_recipient_name_1"],
-        "amounts": [-3, -3, -9],
+        "total": -12,
+        "agencies": ["random_recipient_name_2", "random_recipient_name_1"],
+        "amounts": [-3, -9],
     }
 
     actual_results = {
@@ -1086,4 +1086,7 @@ def test_unreported_file_c(client):
         "amounts": [entry["amount"] for entry in response["results"]],
     }
     assert expected_results == actual_results
+    # "Non-Award Spending" was removed as requested by DEV-7066
+    # This assertion is to ensure its not unintentionally added back
+    assert "Non-Award Spending" not in actual_results
     assert response["total"] == response2["total"]

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -1079,7 +1079,7 @@ def test_unreported_file_c(client):
         "agencies": ["random_recipient_name_2", "random_recipient_name_1"],
         "amounts": [-3, -9],
     }
-    print(response2)
+
     actual_results = {
         "total": response["total"],
         "agencies": [entry["name"] for entry in response["results"]],
@@ -1091,6 +1091,8 @@ def test_unreported_file_c(client):
     assert "Non-Award Spending" not in actual_results
     # After removing "Non-Award Spending" from recipient aggregation
     # we don't expect object_class and recipient to total to the same number
+    # The sum of amounts on the breakdown by recipient will still equal
+    # the sum of the awards for that recipient
     assert response["total"] != response2["total"]
     assert response["total"] == -12
     assert response2["total"] == -15

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -1087,7 +1087,7 @@ def test_unreported_file_c(client):
     }
     assert expected_results == actual_results
     # "Non-Award Spending" was removed as requested by DEV-7066
-    # This assertion is to ensure its not unintentionally added back
+    # This assertion is to ensure it's not unintentionally added back
     assert "Non-Award Spending" not in actual_results
     # After removing "Non-Award Spending" from recipient aggregation
     # we don't expect object_class and recipient to total to the same number

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -1079,7 +1079,7 @@ def test_unreported_file_c(client):
         "agencies": ["random_recipient_name_2", "random_recipient_name_1"],
         "amounts": [-3, -9],
     }
-
+    print(response2)
     actual_results = {
         "total": response["total"],
         "agencies": [entry["name"] for entry in response["results"]],
@@ -1089,4 +1089,8 @@ def test_unreported_file_c(client):
     # "Non-Award Spending" was removed as requested by DEV-7066
     # This assertion is to ensure its not unintentionally added back
     assert "Non-Award Spending" not in actual_results
-    assert response["total"] == response2["total"]
+    # After removing "Non-Award Spending" from recipient aggregation
+    # we don't expect object_class and recipient to total to the same number
+    assert response["total"] != response2["total"]
+    assert response["total"] == -12
+    assert response2["total"] == -15

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -1087,12 +1087,12 @@ def test_unreported_file_c(client):
     }
     assert expected_results == actual_results
     # "Non-Award Spending" was removed as requested by DEV-7066
-    # This assertion is to ensure it's not unintentionally added back
+    #   This assertion is to ensure it's not unintentionally added back
     assert "Non-Award Spending" not in actual_results
     # After removing "Non-Award Spending" from recipient aggregation
-    # we don't expect object_class and recipient to total to the same number
+    #   we don't expect object_class and recipient to total to the same number.
     # The sum of amounts on the breakdown by recipient will still equal
-    # the sum of the awards for that recipient
+    #   the sum of the awards for that recipient
     assert response["total"] != response2["total"]
     assert response["total"] == -12
     assert response2["total"] == -15

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -10,7 +10,6 @@ from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
 
 UNREPORTED_DATA_NAME = "Unreported Data"
-UNREPORTED_FILE_C_NAME = "Non-Award Spending"
 VALID_UNREPORTED_DATA_TYPES = ["agency", "budget_function", "object_class"]
 VALID_UNREPORTED_FILTERS = ["fy", "quarter", "period"]
 
@@ -192,12 +191,12 @@ def type_filter(_type, filters, limit=None):
         # we need to get the File B data for the same set of filters, so we re-run the spending_filter but without setting the _type to any of the alt keys.
         alt_set2, queryset2 = spending_filter(alt_set, queryset, filters, "")
         expected_total = queryset2.aggregate(total=Sum("amount"))["total"]
-        unreported_obj = {"id": None, "code": None, "type": _type, "name": UNREPORTED_FILE_C_NAME, "amount": None}
-        if not (actual_total is None or expected_total is None):
-            unreported_obj["amount"] = expected_total - actual_total
-            result_set.append(unreported_obj)
-            actual_total = expected_total
-            result_set.sort(key=lambda k: k["amount"], reverse=True)
+        # unreported_obj = {"id": None, "code": None, "type": _type, "name": UNREPORTED_FILE_C_NAME, "amount": None}
+        # if not (actual_total is None or expected_total is None):
+        #     unreported_obj["amount"] = expected_total - actual_total
+        #     result_set.append(unreported_obj)
+        #     actual_total = expected_total
+        result_set.sort(key=lambda k: k["amount"], reverse=True)
 
         result_set = result_set[:limit] if _type == "award" else result_set
 

--- a/usaspending_api/spending_explorer/v2/filters/type_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/type_filter.py
@@ -191,11 +191,7 @@ def type_filter(_type, filters, limit=None):
         # we need to get the File B data for the same set of filters, so we re-run the spending_filter but without setting the _type to any of the alt keys.
         alt_set2, queryset2 = spending_filter(alt_set, queryset, filters, "")
         expected_total = queryset2.aggregate(total=Sum("amount"))["total"]
-        # unreported_obj = {"id": None, "code": None, "type": _type, "name": UNREPORTED_FILE_C_NAME, "amount": None}
-        # if not (actual_total is None or expected_total is None):
-        #     unreported_obj["amount"] = expected_total - actual_total
-        #     result_set.append(unreported_obj)
-        #     actual_total = expected_total
+
         result_set.sort(key=lambda k: k["amount"], reverse=True)
 
         result_set = result_set[:limit] if _type == "award" else result_set


### PR DESCRIPTION
**Description:**
Spending explorer is currently adding an extra section to the breakdown of a Recipient by Awards called “Non-Award Spending”. This amount represents the difference between calculated File B spending and File C spending. Because this amount skews the results of the breakdown by award, causing totals not to roll up to the amount from the previous drill down (see screenshot), we have decided to remove this section from the breakdown by recipient. 

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-7066](https://federal-spending-transparency.atlassian.net/browse/DEV-7066):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download) (N/A)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
7. No operation tickets needed
8b. The changes introduced under this PR are unlikely to negatively impact performance
