### PR TITLE
[DEV-10089] Remaining endpoints implement time period filter decorator pattern

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -185,15 +185,15 @@ def get_download_sources(json_request: dict, download_job: DownloadJob = None, o
             # Use correct date range columns for advanced search
             # (Will not change anything for keyword search since "time_period" is not provided))
             filters = deepcopy(json_request["filters"])
-            if (download_type == "elasticsearch_awards" or download_type == "awards") and json_request["filters"].get(
-                "time_period"
-            ) is not None:
-                for time_period in filters["time_period"]:
-                    time_period["gte_date_type"] = time_period.get("date_type", "action_date")
-                    time_period["lte_date_type"] = time_period.get("date_type", "date_signed")
+
             if json_request["filters"].get("time_period") is not None and download_type == "sub_awards":
                 for time_period in filters["time_period"]:
                     # sub awards do not support `new_awards_only` date type
+                    #   the reason we need this check is because downloads are
+                    #   sometimes a mix between prime awards and subawards
+                    #   and share the same filters. In the cases where the
+                    #   download requests `new_awards_only` we only want to apply this
+                    #   date type to the prime award summaries
                     if time_period.get("date_type") == NEW_AWARDS_ONLY_KEYWORD:
                         del time_period["date_type"]
                     if time_period.get("date_type") == "date_signed":


### PR DESCRIPTION
**Description:**
In DEV-9834 we implemented a decorator pattern for the Time Period filter object in requests. We’ve updated most places in our code to work with a concrete class of this decorator pattern. However, there are still some places in our code that do not use these classes and instead manipulate the time period dictionary directly. The purpose of this story is to implement this pattern for the remaining time periods.

**Technical details:**
A side effect of this PR is that it actually fixes a bug that wasn't known in the awards download. Turns out because this last time period filter wasn't update to the new pattern, the awards download didn't support `new_awards_only`. Now it does.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10089](https://federal-spending-transparency.atlassian.net/browse/DEV-10089):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
