### PR TITLE
[FIX] Fixes for local unit test issues with newer versions of django

### DIFF
--- a/usaspending_api/idvs/tests/test_awards_idvs_accounts_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_accounts_v2.py
@@ -9,6 +9,10 @@ FEDERAL_ACCOUNT_ENDPOINT = "/api/v2/idvs/accounts/"
 
 
 class IDVAccountsTestCase(TestCase):
+    # Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
+    # See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases
+    databases = "__all__"
+
     @classmethod
     def setUp(cls):
         create_idv_test_data()

--- a/usaspending_api/idvs/tests/test_awards_idvs_activity_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_activity_v2.py
@@ -11,6 +11,10 @@ ENDPOINT = "/api/v2/idvs/activity/"
 
 
 class IDVAwardsTestCase(TestCase):
+    # Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
+    # See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         create_idv_test_data()

--- a/usaspending_api/idvs/tests/test_awards_idvs_amounts_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_amounts_v2.py
@@ -34,6 +34,10 @@ EXPECTED_GOOD_OUTPUT = {
 
 
 class IDVAmountsTestCase(TestCase):
+    # Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
+    # See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         baker.make("search.AwardSearch", award_id=1)

--- a/usaspending_api/idvs/tests/test_awards_idvs_awards_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_awards_v2.py
@@ -13,6 +13,10 @@ ENDPOINT = "/api/v2/idvs/awards/"
 
 
 class IDVAwardsTestCase(TestCase):
+    # Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
+    # See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         create_idv_test_data()

--- a/usaspending_api/idvs/tests/test_awards_idvs_funding_v2.py
+++ b/usaspending_api/idvs/tests/test_awards_idvs_funding_v2.py
@@ -10,6 +10,10 @@ DETAIL_ENDPOINT = "/api/v2/idvs/funding/"
 
 
 class IDVFundingTestCase(TestCase):
+    # Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
+    # See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         create_idv_test_data()

--- a/usaspending_api/idvs/tests/test_federal_account_count.py
+++ b/usaspending_api/idvs/tests/test_federal_account_count.py
@@ -5,6 +5,10 @@ from model_bakery import baker
 
 
 class IDVFundingTestCase(TestCase):
+    # Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
+    # See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         create_idv_test_data()

--- a/usaspending_api/tests/conftest_spark.py
+++ b/usaspending_api/tests/conftest_spark.py
@@ -139,6 +139,7 @@ def spark(tmp_path_factory) -> SparkSession:
     extra_conf = {
         # This is the default, but being explicit
         "spark.master": "local[*]",
+        "spark.driver.host": "127.0.0.1",  # if not set fails in local envs, trying to use network IP instead
         # Client deploy mode is the default, but being explicit.
         # Means the driver node is the place where the SparkSession is instantiated (and/or where spark-submit
         # process is started from, even if started under the hood of a Py4J JavaGateway). With a "standalone" (not

--- a/usaspending_api/urls.py
+++ b/usaspending_api/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, re_path
     2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, re_path
+from usaspending_api import settings
 from usaspending_api import views as views
 from usaspending_api.common.views import MarkdownView
 


### PR DESCRIPTION
**Description:**
Fixes some minor local unit test errors that likely came in with django upgrade.

**Technical details:**
1. When DEBUG=True, seems the django debug toolbar urls throws issues unless we import our settings from the designated DJANGO_SETTINGS_MODULE (`usaspending_api.settings`)
2. Need to set this so that data for TestCase (and inheritors like SimpleTestCase) flush these DBs at tear-down
    - See: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.SimpleTestCase.databases

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
4. [ ] API documentation updated
5. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
6. [ ] Matview impact assessment completed
7. [ ] Frontend impact assessment completed
8. [ ] Data validation completed
9. [ ] Appropriate Operations ticket(s) created
10. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
