### PR TITLE
[DEV-10149] Removes Unnecessary Award Updates from Postgres C to D Linkage Code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
 before_install:
   # Postgresql-13 requires manual installation
   - sudo apt-get install -y wget
-  - sudo sh -c "wget -O - http://package.perforce.com/apt/ubuntu/dists/bionic/Release.gpg | apt-key add -"
+  - sudo wget -qO - https://package.perforce.com/perforce.pubkey | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install -y lsb-release gnupg2 iproute2
   - wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
 before_install:
   # Postgresql-13 requires manual installation
   - sudo apt-get install -y wget
-  - sudo sh -c "wget -O - http://package.perforce.com/apt/ubuntu/dists/bionic/Release.gpg | apt-key add -
+  - sudo sh -c "wget -O - http://package.perforce.com/apt/ubuntu/dists/bionic/Release.gpg | apt-key add -"
   - sudo apt-get update
   - sudo apt-get install -y lsb-release gnupg2 iproute2
   - wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
 before_install:
   # Postgresql-13 requires manual installation
   - sudo apt-get install -y wget
-  - sudo wget -qO - https://package.perforce.com/perforce.pubkey | gpg --dearmor | tee /usr/share/keyrings/perforce.gpg
+  - sudo wget -qO - https://package.perforce.com/perforce.pubkey | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install -y lsb-release gnupg2 iproute2
   - wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,10 @@ env:
 
 before_install:
   # Postgresql-13 requires manual installation
+  - sudo apt-get install -y wget
+  - sudo sh -c "wget -O - http://package.perforce.com/apt/ubuntu/dists/bionic/Release.gpg | apt-key add -
   - sudo apt-get update
-  - sudo apt-get install -y wget lsb-release gnupg2 iproute2
+  - sudo apt-get install -y lsb-release gnupg2 iproute2
   - wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -
   - echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
 before_install:
   # Postgresql-13 requires manual installation
   - sudo apt-get install -y wget
-  - sudo wget -qO - https://package.perforce.com/perforce.pubkey | sudo apt-key add -
+  - sudo wget -qO - https://package.perforce.com/perforce.pubkey | gpg --dearmor | tee /usr/share/keyrings/perforce.gpg
   - sudo apt-get update
   - sudo apt-get install -y lsb-release gnupg2 iproute2
   - wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -

--- a/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_fain.sql
+++ b/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_fain.sql
@@ -1,41 +1,29 @@
 -- When only FAIN is populated in File C, update File C assistance records to
 -- link to a corresponding award if there is a single exact match based on FAIN.
-WITH update_cte AS (
-    UPDATE financial_accounts_by_awards AS faba
-    SET
-        award_id = (
-            SELECT
-                award_id
-            FROM
-                {file_d_table} AS aw
-            WHERE
-                UPPER(aw.fain) = UPPER(faba.fain)
-        )
-    WHERE
-        faba.financial_accounts_by_awards_id = ANY(
-            SELECT
-                faba_sub.financial_accounts_by_awards_id
-            FROM
-                financial_accounts_by_awards AS faba_sub
-            WHERE
-                faba_sub.fain IS NOT NULL
-                AND faba_sub.uri IS NULL
-                AND faba_sub.award_id IS NULL
-                AND (
-                    SELECT COUNT(*)
-                    FROM {file_d_table} AS aw_sub
-                    WHERE UPPER(aw_sub.fain) = UPPER(faba_sub.fain)
-                ) = 1
-                {submission_id_clause}
-        )
-    RETURNING award_id
-)
-UPDATE
-    {file_d_table} a
+UPDATE financial_accounts_by_awards AS faba
 SET
-    update_date = NOW()
-FROM
-    update_cte
+    award_id = (
+        SELECT
+            award_id
+        FROM
+            {file_d_table} AS aw
+        WHERE
+            UPPER(aw.fain) = UPPER(faba.fain)
+    )
 WHERE
-    a.award_id = update_cte.award_id
-;
+    faba.financial_accounts_by_awards_id = ANY(
+        SELECT
+            faba_sub.financial_accounts_by_awards_id
+        FROM
+            financial_accounts_by_awards AS faba_sub
+        WHERE
+            faba_sub.fain IS NOT NULL
+            AND faba_sub.uri IS NULL
+            AND faba_sub.award_id IS NULL
+            AND (
+                SELECT COUNT(*)
+                FROM {file_d_table} AS aw_sub
+                WHERE UPPER(aw_sub.fain) = UPPER(faba_sub.fain)
+            ) = 1
+            {submission_id_clause}
+    );

--- a/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_fain_and_uri.sql
+++ b/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_fain_and_uri.sql
@@ -1,87 +1,64 @@
 -- When both FAIN and URI are populated in File C, update File C assistance
 -- records to link to a corresponding award if there is an single exact match
 -- based on FAIN
-WITH update_cte AS (
-    UPDATE financial_accounts_by_awards AS faba
-    SET
-        award_id = (
-            SELECT
-                id
-            FROM
-                vw_awards AS aw
-            WHERE
-                UPPER(aw.fain) = UPPER(faba.fain)
-        )
-    WHERE
-        faba.financial_accounts_by_awards_id = ANY(
-            SELECT
-                faba_sub.financial_accounts_by_awards_id
-            FROM
-                financial_accounts_by_awards AS faba_sub
-            WHERE
-                faba_sub.fain IS NOT NULL
-                AND faba_sub.uri IS NOT NULL
-                AND faba_sub.award_id IS NULL
-                AND (
-                    SELECT COUNT(*)
-                    FROM vw_awards AS aw_sub
-                    WHERE
-                        UPPER(aw_sub.fain) = UPPER(faba_sub.fain)
-                ) = 1
-                {submission_id_clause}
-        )
-    RETURNING award_id
-)
-UPDATE
-    {file_d_table} a
+UPDATE financial_accounts_by_awards AS faba
 SET
-    update_date = NOW()
-FROM
-    update_cte
+    award_id = (
+        SELECT
+            id
+        FROM
+            vw_awards AS aw
+        WHERE
+            UPPER(aw.fain) = UPPER(faba.fain)
+    )
 WHERE
-    a.award_id = update_cte.award_id
-;
+    faba.financial_accounts_by_awards_id = ANY(
+        SELECT
+            faba_sub.financial_accounts_by_awards_id
+        FROM
+            financial_accounts_by_awards AS faba_sub
+        WHERE
+            faba_sub.fain IS NOT NULL
+            AND faba_sub.uri IS NOT NULL
+            AND faba_sub.award_id IS NULL
+            AND (
+                SELECT COUNT(*)
+                FROM vw_awards AS aw_sub
+                WHERE
+                    UPPER(aw_sub.fain) = UPPER(faba_sub.fain)
+            ) = 1
+            {submission_id_clause}
+    );
+
 
 -- When both FAIN and URI are populated in File C, update File C assistance
 -- records to link to a corresponding award if there is an single exact match
 -- based on URI
-WITH update_cte AS (
-    UPDATE financial_accounts_by_awards AS faba
-    SET
-        award_id = (
-            SELECT
-                award_id
-            FROM
-                {file_d_table} AS aw
-            WHERE
-                UPPER(aw.uri) = UPPER(faba.uri)
-        )
-    WHERE
-        faba.financial_accounts_by_awards_id = ANY(
-            SELECT
-                faba_sub.financial_accounts_by_awards_id
-            FROM
-                financial_accounts_by_awards AS faba_sub
-            WHERE
-                faba_sub.fain IS NOT NULL
-                AND faba_sub.uri IS NOT NULL
-                AND faba_sub.award_id IS NULL
-                AND (
-                    SELECT COUNT(*)
-                    FROM {file_d_table} AS aw_sub
-                    WHERE
-                        UPPER(aw_sub.uri) = UPPER(faba_sub.uri)
-                ) = 1
-                {submission_id_clause}
-            )
-        RETURNING award_id
-    )
-UPDATE
-    {file_d_table} a
+UPDATE financial_accounts_by_awards AS faba
 SET
-    update_date = NOW()
-FROM
-    update_cte
+    award_id = (
+        SELECT
+            award_id
+        FROM
+            {file_d_table} AS aw
+        WHERE
+            UPPER(aw.uri) = UPPER(faba.uri)
+    )
 WHERE
-    a.award_id = update_cte.award_id
-;
+    faba.financial_accounts_by_awards_id = ANY(
+        SELECT
+            faba_sub.financial_accounts_by_awards_id
+        FROM
+            financial_accounts_by_awards AS faba_sub
+        WHERE
+            faba_sub.fain IS NOT NULL
+            AND faba_sub.uri IS NOT NULL
+            AND faba_sub.award_id IS NULL
+            AND (
+                SELECT COUNT(*)
+                FROM {file_d_table} AS aw_sub
+                WHERE
+                    UPPER(aw_sub.uri) = UPPER(faba_sub.uri)
+            ) = 1
+            {submission_id_clause}
+        );

--- a/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_piid.sql
+++ b/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_piid.sql
@@ -1,89 +1,65 @@
 -- When PIID and Parent PIID are populated, update File C contract records to
 --  link to a corresponding award if there is a single exact match based on PIID
 --  and Parent PIID
-WITH update_cte AS (
-    UPDATE financial_accounts_by_awards AS faba
-    SET
-        award_id = (
-            SELECT
-                award_id
-            FROM
-                {file_d_table} AS aw
-            WHERE
-                UPPER(aw.piid) = UPPER(faba.piid)
-                AND UPPER(aw.parent_award_piid) = UPPER(faba.parent_award_id)
-        )
-    WHERE
-        faba.financial_accounts_by_awards_id = ANY(
-            SELECT
-                faba_sub.financial_accounts_by_awards_id
-            FROM
-                financial_accounts_by_awards AS faba_sub
-            WHERE
-                faba_sub.piid IS NOT NULL
-                AND faba_sub.award_id IS NULL
-                AND faba_sub.parent_award_id IS NOT NULL
-                AND (
-                    SELECT COUNT(*)
-                    FROM {file_d_table} AS aw_sub
-                    WHERE
-                        UPPER(aw_sub.piid) = UPPER(faba_sub.piid)
-                        AND UPPER(aw_sub.parent_award_piid) = UPPER(faba_sub.parent_award_id)
-                ) = 1
-                {submission_id_clause}
-        )
-    RETURNING award_id
-)
-UPDATE
-    {file_d_table} a
+UPDATE financial_accounts_by_awards AS faba
 SET
-    update_date = NOW()
-FROM
-    update_cte
+    award_id = (
+        SELECT
+            award_id
+        FROM
+            {file_d_table} AS aw
+        WHERE
+            UPPER(aw.piid) = UPPER(faba.piid)
+            AND UPPER(aw.parent_award_piid) = UPPER(faba.parent_award_id)
+    )
 WHERE
-    a.award_id = update_cte.award_id
-;
+    faba.financial_accounts_by_awards_id = ANY(
+        SELECT
+            faba_sub.financial_accounts_by_awards_id
+        FROM
+            financial_accounts_by_awards AS faba_sub
+        WHERE
+            faba_sub.piid IS NOT NULL
+            AND faba_sub.award_id IS NULL
+            AND faba_sub.parent_award_id IS NOT NULL
+            AND (
+                SELECT COUNT(*)
+                FROM {file_d_table} AS aw_sub
+                WHERE
+                    UPPER(aw_sub.piid) = UPPER(faba_sub.piid)
+                    AND UPPER(aw_sub.parent_award_piid) = UPPER(faba_sub.parent_award_id)
+            ) = 1
+            {submission_id_clause}
+    );
 
 -- When PIID is populated and Parent PIID is NULL, update File C contract
 --  records to link to a corresponding award if there is a single exact match
 -- based on PIID
-WITH update_cte AS (
-    UPDATE financial_accounts_by_awards AS faba
-    SET
-        award_id = (
-            SELECT
-                award_id
-            FROM
-                {file_d_table} AS aw
-            WHERE
-                UPPER(aw.piid) = UPPER(faba.piid)
-        )
-    WHERE
-        faba.financial_accounts_by_awards_id = ANY(
-            SELECT
-                faba_sub.financial_accounts_by_awards_id
-            FROM
-                financial_accounts_by_awards AS faba_sub
-            WHERE
-                faba_sub.piid IS NOT NULL
-                AND faba_sub.award_id IS NULL
-                AND faba_sub.parent_award_id IS NULL
-                AND (
-                    SELECT COUNT(*)
-                    FROM {file_d_table} AS aw_sub
-                    WHERE
-                        UPPER(aw_sub.piid) = UPPER(faba_sub.piid)
-                ) = 1
-                {submission_id_clause}
-        )
-    RETURNING award_id
-)
-UPDATE
-    {file_d_table} a
+UPDATE financial_accounts_by_awards AS faba
 SET
-    update_date = NOW()
-FROM
-    update_cte
+    award_id = (
+        SELECT
+            award_id
+        FROM
+            {file_d_table} AS aw
+        WHERE
+            UPPER(aw.piid) = UPPER(faba.piid)
+    )
 WHERE
-    a.award_id = update_cte.award_id
-;
+    faba.financial_accounts_by_awards_id = ANY(
+        SELECT
+            faba_sub.financial_accounts_by_awards_id
+        FROM
+            financial_accounts_by_awards AS faba_sub
+        WHERE
+            faba_sub.piid IS NOT NULL
+            AND faba_sub.award_id IS NULL
+            AND faba_sub.parent_award_id IS NULL
+            AND (
+                SELECT COUNT(*)
+                FROM {file_d_table} AS aw_sub
+                WHERE
+                    UPPER(aw_sub.piid) = UPPER(faba_sub.piid)
+            ) = 1
+            {submission_id_clause}
+    );

--- a/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_uri.sql
+++ b/usaspending_api/etl/management/sql/c_file_linkage/update_file_c_linkages_uri.sql
@@ -1,41 +1,29 @@
 -- When only URI is populated in File C, update File C assistance records to
 -- link to a corresponding award if there is a single exact match based on URI.
-WITH update_cte as (
-    UPDATE financial_accounts_by_awards AS faba
-    SET
-        award_id = (
-            SELECT
-                award_id
-            FROM
-                {file_d_table} AS aw
-            WHERE
-                UPPER(aw.uri) = UPPER(faba.uri)
-        )
-    WHERE
-        faba.financial_accounts_by_awards_id = ANY(
-            SELECT
-                faba_sub.financial_accounts_by_awards_id
-            FROM
-                financial_accounts_by_awards AS faba_sub
-            WHERE
-                faba_sub.uri IS NOT NULL
-                AND faba_sub.fain IS NULL
-                AND faba_sub.award_id IS NULL
-                AND (
-                    SELECT COUNT(*)
-                    FROM {file_d_table} AS aw_sub
-                    WHERE UPPER(aw_sub.uri) = UPPER(faba_sub.uri)
-                ) = 1
-                {submission_id_clause}
-        )
-    RETURNING award_id
-)
-UPDATE
-    {file_d_table} a
+UPDATE financial_accounts_by_awards AS faba
 SET
-    update_date = NOW()
-FROM
-    update_cte
+    award_id = (
+        SELECT
+            award_id
+        FROM
+            {file_d_table} AS aw
+        WHERE
+            UPPER(aw.uri) = UPPER(faba.uri)
+    )
 WHERE
-    a.award_id = update_cte.award_id
-;
+    faba.financial_accounts_by_awards_id = ANY(
+        SELECT
+            faba_sub.financial_accounts_by_awards_id
+        FROM
+            financial_accounts_by_awards AS faba_sub
+        WHERE
+            faba_sub.uri IS NOT NULL
+            AND faba_sub.fain IS NULL
+            AND faba_sub.award_id IS NULL
+            AND (
+                SELECT COUNT(*)
+                FROM {file_d_table} AS aw_sub
+                WHERE UPPER(aw_sub.uri) = UPPER(faba_sub.uri)
+            ) = 1
+            {submission_id_clause}
+    );

--- a/usaspending_api/submissions/management/commands/rm_submission.py
+++ b/usaspending_api/submissions/management/commands/rm_submission.py
@@ -39,10 +39,6 @@ class Command(BaseCommand):
         except ObjectDoesNotExist:
             raise RuntimeError(f"Broker submission ID {submission_id} does not exist")
 
-        # Mark associated Accounts as updated, so they will be reloaded in ES nightly load
-        AwardSearch.objects.filter(
-            award_id__in=FinancialAccountsByAwards.objects.filter(submission_id=submission_id).values("award_id")
-        ).update(update_date=datetime.now(timezone.utc))
         deleted_stats = submission.delete()
 
         models = {


### PR DESCRIPTION
**Description:**
In order for an Award record to be updated in Elasticsearch in the nightly pipeline, it’s `update_date` must be later than the last time Elasticsearch indexer ran. Consequently several places in the codebase update the `update_date` field on the `award_search` table such as the DAB Submission Loader.

In the post-Phase-3 version of the pipeline, the Elasticsearch indexer runs using Delta data instead of Postgres data, so any changes to the Postgres copy of `award_search` don’t have any impact on the Elasticsearch Indexer. 

We still have a few steps related to loading submissions that update the Postgres `award_search` table’s `update_date` field. This can be a lengthy operation that can cause significant slowdowns in the nightly pipeline, especially when a large submission is either created or deleted.

**Technical details:**

Two places were updated in the code base to account for this:
Removed code from the `rm_submission` command that touches `award_search` records associated with a submission being removed. 

Removed code from the Postgres File C to D linkage queries that updates award_search records after a new submission is loaded. These are the SQL files that were updated. It looks messy in Github, but I essentially removed the outer query from each query block and left the code that was previously in each CTE as the main query. 


**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. N/A - API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10149](https://federal-spending-transparency.atlassian.net/browse/DEV-10149):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
