### PR TITLE
[DEV-10128] Add countries to search/spending_by_geography endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
@@ -32,7 +32,9 @@ This endpoint takes award filters, and returns aggregated obligation amounts in 
                 + `state`
                 + `county`
                 + `district`
+                + `country`
         + `geo_layer_filters` (optional, array[string])
+            List of U.S. state codes, U.S. county codes, U.S. Congressional districts, or ISO 3166-1 alpha-3 country codes to show results for. If you are searching for a foreign country, you **must** include either the `place_of_performance_scope` or `recipient_scope` filter and set it to `foreign`
 
     + Body
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -73,6 +73,7 @@ def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[di
         "recipient_location_congressional_agg_key": funcs.recipient_location_congressional_agg_key,
         "recipient_location_congressional_cur_agg_key": funcs.recipient_location_congressional_cur_agg_key,
         "recipient_location_county_agg_key": funcs.recipient_location_county_agg_key,
+        "recipient_location_country_agg_key": lambda x: x["recipient_location_country_code"],
     }
     drop_fields = [
         "pop_state_name",

--- a/usaspending_api/etl/es_transaction_template.json
+++ b/usaspending_api/etl/es_transaction_template.json
@@ -4,17 +4,29 @@
     "index.max_result_window": null,
     "index.refresh_interval": -1,
     "index": {
-      "number_of_shards" : 5,
-      "number_of_replicas" : 0,
-      "sort.field" : ["federal_action_obligation.keyword", "action_date"],
-      "sort.order" : ["desc", "desc"],
-      "sort.missing": ["_last", "_last"]
+      "number_of_shards": 5,
+      "number_of_replicas": 0,
+      "sort.field": [
+        "federal_action_obligation.keyword",
+        "action_date"
+      ],
+      "sort.order": [
+        "desc",
+        "desc"
+      ],
+      "sort.missing": [
+        "_last",
+        "_last"
+      ]
     },
     "analysis": {
       "analyzer": {
         "stemmer_analyzer": {
-            "tokenizer": "standard",
-            "filter": ["lowercase", "singular_stemmer"]
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "singular_stemmer"
+          ]
         }
       },
       "filter": {
@@ -506,12 +518,12 @@
           }
         }
       },
-	  "pop_county_fips": {
-		"type": "keyword"
-	  },
-	  "pop_state_fips": {
-		"type": "keyword"
-	  },
+      "pop_county_fips": {
+        "type": "keyword"
+      },
+      "pop_state_fips": {
+        "type": "keyword"
+      },
       "recipient_location_country_code": {
         "type": "keyword"
       },
@@ -580,12 +592,21 @@
           }
         }
       },
-	  "recipient_location_state_fips": {
-		"type": "keyword"
-	  },
-	  "recipient_location_county_fips": {
-		"type": "keyword"
-	  },
+      "recipient_location_country_agg_key": {
+        "type": "keyword",
+        "eager_global_ordinals": true,
+        "fields": {
+          "hash": {
+            "type": "murmur3"
+          }
+        }
+      },
+      "recipient_location_state_fips": {
+        "type": "keyword"
+      },
+      "recipient_location_county_fips": {
+        "type": "keyword"
+      },
       "tas_paths": {
         "type": "keyword"
       },
@@ -605,7 +626,7 @@
         "type": "keyword"
       },
       "disaster_emergency_fund_codes": {
-          "type": "keyword"
+        "type": "keyword"
       },
       "recipient_uei": {
         "type": "text",

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -513,7 +513,6 @@ def awards_and_transactions(db):
         sub_action_date="2020-01-07",
     )
 
-
     # References State Data
     baker.make("recipient.StateData", id="45-2020", fips="45", code="SC", name="South Carolina")
     baker.make("recipient.StateData", id="53-2020", fips="53", code="WA", name="Washington")

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -1,5 +1,5 @@
-from model_bakery import baker
 import pytest
+from model_bakery import baker
 
 
 @pytest.fixture
@@ -127,6 +127,7 @@ def awards_and_transactions(db):
     baker.make("search.AwardSearch", award_id=5, latest_transaction_id=50, action_date="2020-01-01")
     baker.make("search.AwardSearch", award_id=6, latest_transaction_id=60, action_date="2020-01-01")
     baker.make("search.AwardSearch", award_id=7, latest_transaction_id=70, action_date="2020-01-01")
+    baker.make("search.AwardSearch", award_id=8, latest_transaction_id=80, action_date="2020-01-01")
 
     baker.make("awards.FinancialAccountsByAwards", pk=1, award_id=1, treasury_account_id=1)
     baker.make("accounts.TreasuryAppropriationAccount", pk=1, federal_account_id=1)
@@ -465,14 +466,62 @@ def awards_and_transactions(db):
         parent_uei=None,
         federal_accounts=[],
     )
+    baker.make(
+        "search.TransactionSearch",
+        transaction_id=80,
+        award_id=7,
+        federal_action_obligation=5000000,
+        generated_pragmatic_obligation=5000000,
+        action_date="2020-01-07",
+        fiscal_action_date="2020-04-07",
+        is_fpds=True,
+        pop_country_code="USA",
+        pop_country_name="UNITED STATES",
+        recipient_location_country_code="JPN",
+        recipient_location_country_name="JAPAN",
+        recipient_name="MULTIPLE RECIPIENTS",
+        recipient_name_raw="MULTIPLE RECIPIENTS",
+        recipient_hash="64af1cb7-993c-b64b-1c58-f5289af014c0",
+    )
+
+    # Subawards
+    baker.make(
+        "search.SubawardSearch",
+        broker_subaward_id=1,
+        award_id=7,
+        subaward_amount=12345,
+        sub_place_of_perform_country_co="CAN",
+        sub_legal_entity_country_code="USA",
+        sub_action_date="2020-01-07",
+    )
+    baker.make(
+        "search.SubawardSearch",
+        broker_subaward_id=2,
+        award_id=8,
+        subaward_amount=678910,
+        sub_place_of_perform_country_co="USA",
+        sub_legal_entity_country_code="JPN",
+        sub_action_date="2020-01-07",
+    )
+    baker.make(
+        "search.SubawardSearch",
+        broker_subaward_id=3,
+        award_id=1,
+        subaward_amount=54321,
+        sub_place_of_perform_country_co="USA",
+        sub_legal_entity_country_code="USA",
+        sub_action_date="2020-01-07",
+    )
+
 
     # References State Data
     baker.make("recipient.StateData", id="45-2020", fips="45", code="SC", name="South Carolina")
     baker.make("recipient.StateData", id="53-2020", fips="53", code="WA", name="Washington")
 
-    # References Country
-    baker.make("references.RefCountryCode", country_code="CAN", country_name="CANADA")
+    # Ref Country Code
     baker.make("references.RefCountryCode", country_code="USA", country_name="UNITED STATES")
+    baker.make("references.RefCountryCode", country_code="CAN", country_name="CANADA")
+    baker.make("references.RefCountryCode", country_code="JPN", country_name="JAPAN")
 
     # References Population County
     baker.make(
@@ -680,7 +729,3 @@ def awards_and_transactions(db):
     # NAICS
     baker.make("references.NAICS", code="111110", description="NAICS 1")
     baker.make("references.NAICS", code="222220", description="NAICS 2")
-
-    # Ref Country Code
-    baker.make("references.RefCountryCode", country_code="USA", country_name="UNITED STATES")
-    baker.make("references.RefCountryCode", country_code="CAN", country_name="CANADA")

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_country.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_country.py
@@ -36,8 +36,8 @@ def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, 
         "limit": 10,
         "page_metadata": {"page": 1, "next": None, "previous": None, "hasNext": False, "hasPrevious": False},
         "results": [
+            {"amount": 5555555.0, "code": "USA", "id": None, "name": "UNITED STATES"},
             {"amount": 5000000.0, "code": "CAN", "id": None, "name": "CANADA"},
-            {"amount": 555555.0, "code": "USA", "id": None, "name": "UNITED STATES"},
         ],
         "messages": [get_time_period_message()],
     }

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_recipient.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_recipient.py
@@ -237,6 +237,12 @@ def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, 
                 "amount": 5000000.0,
                 "code": "Recipient not provided",
                 "name": "MULTIPLE RECIPIENTS",
+                "recipient_id": None
+            },
+            {
+                "amount": 5000000.0,
+                "code": "Recipient not provided",
+                "name": "MULTIPLE RECIPIENTS",
                 "recipient_id": "64af1cb7-993c-b64b-1c58-f5289af014c0-R",
             },
             {

--- a/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_recipient.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/test_spending_by_recipient.py
@@ -237,7 +237,7 @@ def test_correct_response(client, monkeypatch, elasticsearch_transaction_index, 
                 "amount": 5000000.0,
                 "code": "Recipient not provided",
                 "name": "MULTIPLE RECIPIENTS",
-                "recipient_id": None
+                "recipient_id": None,
             },
             {
                 "amount": 5000000.0,

--- a/usaspending_api/search/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_geography.py
@@ -148,9 +148,11 @@ def test_correct_response_with_geo_filters(
         _test_correct_response_for_place_of_performance_county_with_geo_filters,
         _test_correct_response_for_place_of_performance_district_with_geo_filters,
         _test_correct_response_for_place_of_performance_state_with_geo_filters,
+        _test_correct_response_for_place_of_perforance_country_with_geo_filters,
         _test_correct_response_for_recipient_location_county_with_geo_filters,
         _test_correct_response_for_recipient_location_district_with_geo_filters,
         _test_correct_response_for_recipient_location_state_with_geo_filters,
+        _test_correct_response_for_recipient_location_country_with_geo_filters,
     ]
 
     for test in test_cases:
@@ -262,6 +264,81 @@ def _test_correct_response_for_place_of_performance_state_with_geo_filters(clien
                 "per_capita": 550.06,
                 "population": 1000,
                 "shape_code": "SC",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
+def _test_correct_response_for_place_of_perforance_country_with_geo_filters(client):
+    # Prime awards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "geo_layer_filters": ["CAN"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "place_of_performance_scope": "foreign",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
+    # Subawards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "subawards": True,
+                "geo_layer_filters": ["CAN"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 12345.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
             },
         ],
         "messages": [get_time_period_message()],
@@ -396,6 +473,81 @@ def _test_correct_response_for_recipient_location_state_with_geo_filters(client)
     assert resp_json == expected_response
 
 
+def _test_correct_response_for_recipient_location_country_with_geo_filters(client):
+    # Prime awards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "geo_layer_filters": ["JPN"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "recipient_scope": "foreign",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
+    # Subawards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "subawards": True,
+                "geo_layer_filters": ["JPN"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 678910.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
 def test_correct_response_without_geo_filters(
     client, monkeypatch, elasticsearch_transaction_index, awards_and_transactions
 ):
@@ -406,9 +558,11 @@ def test_correct_response_without_geo_filters(
         _test_correct_response_for_place_of_performance_county_without_geo_filters,
         _test_correct_response_for_place_of_performance_district_without_geo_filters,
         _test_correct_response_for_place_of_performance_state_without_geo_filters,
+        _test_correct_response_for_place_of_perforance_country_without_geo_filters,
         _test_correct_response_for_recipient_location_county_without_geo_filters,
         _test_correct_response_for_recipient_location_district_without_geo_filters,
         _test_correct_response_for_recipient_location_state_without_geo_filters,
+        _test_correct_response_for_recipient_location_country_without_geo_filters,
     ]
 
     for test in test_cases:
@@ -556,6 +710,86 @@ def _test_correct_response_for_place_of_performance_state_without_geo_filters(cl
     assert resp_json == expected_response
 
 
+def _test_correct_response_for_place_of_perforance_country_without_geo_filters(client):
+    # Prime awards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "filters": {
+                    "place_of_performance_scope": "foreign",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            }
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
+    # Subawards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "subawards": True,
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 12345.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            },
+            {
+                "aggregated_amount": 733231.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
 def _test_correct_response_for_recipient_location_county_without_geo_filters(client):
     resp = client.post(
         "/api/v2/search/spending_by_geography",
@@ -686,6 +920,93 @@ def _test_correct_response_for_recipient_location_state_without_geo_filters(clie
                 "per_capita": 5.5,
                 "population": 10000,
                 "shape_code": "WA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
+def _test_correct_response_for_recipient_location_country_without_geo_filters(client):
+    # Prime awards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "filters": {
+                    "recipient_scope": "foreign",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN"
+            },
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            }
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
+    # Subawards
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "subawards": True,
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 678910.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+            {
+                "aggregated_amount": 66666.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
             },
         ],
         "messages": [get_time_period_message()],

--- a/usaspending_api/search/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_geography.py
@@ -312,7 +312,6 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
 
-
     # Subawards
     resp = client.post(
         "/api/v2/search/spending_by_geography",
@@ -509,7 +508,6 @@ def _test_correct_response_for_recipient_location_country_with_geo_filters(clien
     resp_json = resp.json()
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
-
 
     # Subawards
     resp = client.post(
@@ -746,7 +744,6 @@ def _test_correct_response_for_place_of_perforance_country_without_geo_filters(c
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
 
-
     # Subawards
     resp = client.post(
         "/api/v2/search/spending_by_geography",
@@ -956,7 +953,7 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
                 "display_name": "Canada",
                 "per_capita": None,
                 "population": None,
-                "shape_code": "CAN"
+                "shape_code": "CAN",
             },
             {
                 "aggregated_amount": 5000000.0,
@@ -964,7 +961,7 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
                 "per_capita": None,
                 "population": None,
                 "shape_code": "JPN",
-            }
+            },
         ],
         "messages": [get_time_period_message()],
     }
@@ -973,7 +970,6 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
     resp_json = resp.json()
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
-
 
     # Subawards
     resp = client.post(

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -420,11 +420,11 @@ class SpendingByGeographyVisualizationViewSet(APIView):
             ref_countries = RefCountryCode.objects.filter(country_code__in=self.geo_layer_filters).values(
                 "country_code", "country_name"
             )
-            ref_countries = {country["country_code"]: country["country_name"] for country in ref_countries}
         # If no specific countries were provided, then get all subawards grouped by country
         else:
             ref_countries = RefCountryCode.objects.all().values("country_code", "country_name")
-            ref_countries = {country["country_code"]: country["country_name"] for country in ref_countries}
+
+        ref_countries = {country["country_code"]: country["country_name"] for country in ref_countries}
         # Sum the `subaward_amount` columns and exclude any subawards with $0 amounts
         country_queryset = country_queryset.annotate(transaction_amount=Sum("subaward_amount")).exclude(
             transaction_amount=0

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -424,7 +424,8 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         else:
             ref_countries = RefCountryCode.objects.all().values("country_code", "country_name")
             ref_countries = {country["country_code"]: country["country_name"] for country in ref_countries}
-        country_queryset = country_queryset.annotate(transaction_amount=Sum("subaward_amount")).filter(transaction_amount__gt=0)
+        # Sum the `subaward_amount` columns and exclude any subawards with $0 amounts
+        country_queryset = country_queryset.annotate(transaction_amount=Sum("subaward_amount")).exclude(transaction_amount=0)
 
         results = []
         for x in country_queryset:

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -223,11 +223,10 @@ class SpendingByGeographyVisualizationViewSet(APIView):
             # Only state scope will add its own state code
             # State codes are consistent in database i.e. AL, AK
             fields_list.append(self.loc_lookup)
-
-            return self.state_results(kwargs, fields_list, self.loc_lookup)
+            results = self.state_results(kwargs, fields_list, self.loc_lookup)
 
         elif self.geo_layer == GeoLayer.COUNTRY:
-            return self.country_results(self.loc_lookup)
+            results = self.country_results(self.loc_lookup)
 
         else:
             # County and district scope will need to select multiple fields
@@ -248,15 +247,15 @@ class SpendingByGeographyVisualizationViewSet(APIView):
                 geo_queryset = self.county_district_queryset_subawards(
                     kwargs, fields_list, self.loc_lookup, state_lookup, self.scope_field_name
                 )
-
-                return self.county_results(state_lookup, county_name_lookup, geo_queryset)
+                results = self.county_results(state_lookup, county_name_lookup, geo_queryset)
 
             else:
                 geo_queryset = self.county_district_queryset_subawards(
                     kwargs, fields_list, self.loc_lookup, state_lookup, self.scope_field_name
                 )
+                results = self.district_results(state_lookup, geo_queryset)
 
-                return self.district_results(state_lookup, geo_queryset)
+        return results
 
     def state_results(self, filter_args: Dict[str, str], lookup_fields: List[str], loc_lookup: str) -> List[dict]:
         # Adding additional state filters if specified

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -407,7 +407,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         """Find subaward results for countries
 
         Args:
-            loc_lookup (String): Name of the field on the SubawardSearch model to use to find subawards. 
+            loc_lookup (String): Name of the field on the SubawardSearch model to use to find subawards.
 
         Returns:
             List[dict]: List of subaward results by country
@@ -418,14 +418,18 @@ class SpendingByGeographyVisualizationViewSet(APIView):
         if self.geo_layer_filters:
             country_queryset = country_queryset.filter(**{f"{loc_lookup}__in": self.geo_layer_filters})
 
-            ref_countries = RefCountryCode.objects.filter(country_code__in=self.geo_layer_filters).values("country_code", "country_name")
+            ref_countries = RefCountryCode.objects.filter(country_code__in=self.geo_layer_filters).values(
+                "country_code", "country_name"
+            )
             ref_countries = {country["country_code"]: country["country_name"] for country in ref_countries}
         # If no specific countries were provided, then get all subawards grouped by country
         else:
             ref_countries = RefCountryCode.objects.all().values("country_code", "country_name")
             ref_countries = {country["country_code"]: country["country_name"] for country in ref_countries}
         # Sum the `subaward_amount` columns and exclude any subawards with $0 amounts
-        country_queryset = country_queryset.annotate(transaction_amount=Sum("subaward_amount")).exclude(transaction_amount=0)
+        country_queryset = country_queryset.annotate(transaction_amount=Sum("subaward_amount")).exclude(
+            transaction_amount=0
+        )
 
         results = []
         for x in country_queryset:
@@ -448,7 +452,7 @@ class SpendingByGeographyVisualizationViewSet(APIView):
             )
 
         # Sort the results by `shape_code` value
-        results = sorted(results, key=lambda x: x['shape_code'])
+        results = sorted(results, key=lambda x: x["shape_code"])
 
         return results
 

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -447,6 +447,9 @@ class SpendingByGeographyVisualizationViewSet(APIView):
                 }
             )
 
+        # Sort the results by `shape_code` value
+        results = sorted(results, key=lambda x: x['shape_code'])
+
         return results
 
     def build_elasticsearch_search_with_aggregation(self, filter_query: ES_Q) -> Optional[TransactionSearch]:


### PR DESCRIPTION
**Description:**
Add a new `geo_layer` filter value of `country` that returns award and subaward spending by country.

**Technical details:**
* Update the Transactions ES index to add a `recipient_location_country_agg_key` field.
* Updated the `search/spending_by_geography` endpoint to use the `recipient_location_country_agg_key` or `pop_country_agg_key` to group ES transactions by country and return that amount for any/all countries included in the request.
* Updated the `search/spending_by_geography` endpoint to query SubawardSearch for all subawards where `sub_place_of_perform_country_co` or `sub_legal_entity_country_code` contains the country code included in the API request.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-10128):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
```
