### PR TITLE
[DEV-10183] Update search/spending_by_geography endpoint to support domestic and foreign countries

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
@@ -34,7 +34,7 @@ This endpoint takes award filters, and returns aggregated obligation amounts in 
                 + `district`
                 + `country`
         + `geo_layer_filters` (optional, array[string])
-            List of U.S. state codes, U.S. county codes, U.S. Congressional districts, or ISO 3166-1 alpha-3 country codes to show results for. If you are searching for a foreign country, you **must** include either the `place_of_performance_scope` or `recipient_scope` filter and set it to `foreign`
+            List of U.S. state codes, U.S. county codes, U.S. Congressional districts, or ISO 3166-1 alpha-3 country codes to show results for.
 
     + Body
 
@@ -103,7 +103,7 @@ This endpoint takes award filters, and returns aggregated obligation amounts in 
 + `time_period` (optional, array[TimePeriodObject], fixed-type)
 + `place_of_performance_scope` (optional, enum[string])
     + Members
-        + `domestic`
+        + `domestic` (default for `geo_layer` members: `state`, `county`, `district`)
         + `foreign`
 + `place_of_performance_locations` (optional, array[LocationObject], fixed-type)
 + `agencies` (optional, array[AgencyObject], fixed-type)
@@ -111,7 +111,7 @@ This endpoint takes award filters, and returns aggregated obligation amounts in 
     + Text searched across a recipient’s name, UEI, and DUNS
 + `recipient_scope` (optional, enum[string])
     + Members
-        + `domestic`
+        + `domestic` (default for `geo_layer` members: `state`, `county`, `district`)
         + `foreign`
 + `recipient_locations` (optional, array[LocationObject], fixed-type)
 + `recipient_type_names`: [`category_business`, `sole_proprietorship`] (optional, array[string])

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_geography.md
@@ -102,16 +102,20 @@ This endpoint takes award filters, and returns aggregated obligation amounts in 
 + `keywords` : [`transport`] (optional, array[string])
 + `time_period` (optional, array[TimePeriodObject], fixed-type)
 + `place_of_performance_scope` (optional, enum[string])
+    + The **default** value below only applies to `geo_layer` values of `county`, `district` and `state`.
+    + Default: `domestic`
     + Members
-        + `domestic` (default for `geo_layer` members: `state`, `county`, `district`)
+        + `domestic`
         + `foreign`
 + `place_of_performance_locations` (optional, array[LocationObject], fixed-type)
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
     + Text searched across a recipient’s name, UEI, and DUNS
 + `recipient_scope` (optional, enum[string])
+    + The **default** value below only applies to `geo_layer` values of `county`, `district` and `state`.
+    + Default: `domestic`
     + Members
-        + `domestic` (default for `geo_layer` members: `state`, `county`, `district`)
+        + `domestic`
         + `foreign`
 + `recipient_locations` (optional, array[LocationObject], fixed-type)
 + `recipient_type_names`: [`category_business`, `sole_proprietorship`] (optional, array[string])

--- a/usaspending_api/search/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_geography.py
@@ -385,7 +385,7 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
                 "per_capita": None,
                 "population": None,
                 "shape_code": "USA",
-            }
+            },
         ],
         "messages": [get_time_period_message()],
     }
@@ -394,7 +394,6 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
     resp_json = resp.json()
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
-
 
     # Subawards
 
@@ -761,7 +760,6 @@ def _test_correct_response_for_recipient_location_country_with_geo_filters(clien
     resp_json = resp.json()
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
-
 
     # Subawards
 
@@ -1153,7 +1151,7 @@ def _test_correct_response_for_place_of_perforance_country_without_geo_filters(c
                 "per_capita": None,
                 "population": None,
                 "shape_code": "USA",
-            }
+            },
         ],
         "messages": [get_time_period_message()],
     }
@@ -1162,7 +1160,6 @@ def _test_correct_response_for_place_of_perforance_country_without_geo_filters(c
     resp_json = resp.json()
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
-
 
     # Subawards
 
@@ -1449,11 +1446,11 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
         "geo_layer": "country",
         "results": [
             {
-                'aggregated_amount': 5.0,
-                'display_name': 'Canada',
-                'per_capita': None,
-                'population': None,
-                'shape_code': 'CAN'
+                "aggregated_amount": 5.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
             },
             {
                 "aggregated_amount": 5000000.0,
@@ -1527,11 +1524,11 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
         "geo_layer": "country",
         "results": [
             {
-                'aggregated_amount': 5.0,
-                'display_name': 'Canada',
-                'per_capita': None,
-                'population': None,
-                'shape_code': 'CAN'
+                "aggregated_amount": 5.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
             },
             {
                 "aggregated_amount": 5000000.0,
@@ -1555,7 +1552,6 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
     resp_json = resp.json()
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
-
 
     # Subawards
 

--- a/usaspending_api/search/tests/integration/test_spending_by_geography.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_geography.py
@@ -277,6 +277,9 @@ def _test_correct_response_for_place_of_performance_state_with_geo_filters(clien
 
 def _test_correct_response_for_place_of_perforance_country_with_geo_filters(client):
     # Prime awards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `place_of_performance_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -284,7 +287,7 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
             {
                 "scope": "place_of_performance",
                 "geo_layer": "country",
-                "geo_layer_filters": ["CAN"],
+                "geo_layer_filters": ["CAN", "USA"],
                 "filters": {
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
                     "place_of_performance_scope": "foreign",
@@ -312,7 +315,91 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
 
+    # Get only domestic results
+    # (CAN results should be excluded since `place_of_performance_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "geo_layer_filters": ["CAN", "USA"],
+                "filters": {
+                    "place_of_performance_scope": "domestic",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5555555.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            }
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign results
+    # (USA and CAN should both be in the results since `place_of_performance_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "geo_layer_filters": ["CAN", "USA"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            },
+            {
+                "aggregated_amount": 5555555.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            }
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
     # Subawards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `place_of_performance_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -321,7 +408,83 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
                 "scope": "place_of_performance",
                 "geo_layer": "country",
                 "subawards": True,
-                "geo_layer_filters": ["CAN"],
+                "geo_layer_filters": ["CAN", "USA"],
+                "filters": {
+                    "place_of_performance_scope": "foreign",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 12345.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get only domestic results
+    # (CAN results should be excluded since `place_of_performance_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "subawards": True,
+                "geo_layer_filters": ["CAN", "USA"],
+                "filters": {
+                    "place_of_performance_scope": "domestic",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 733231.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign results
+    # (USA and CAN should both be in the results since `place_of_performance_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "subawards": True,
+                "geo_layer_filters": ["CAN", "USA"],
                 "filters": {
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
                 },
@@ -338,6 +501,13 @@ def _test_correct_response_for_place_of_perforance_country_with_geo_filters(clie
                 "per_capita": None,
                 "population": None,
                 "shape_code": "CAN",
+            },
+            {
+                "aggregated_amount": 733231.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
             },
         ],
         "messages": [get_time_period_message()],
@@ -474,6 +644,9 @@ def _test_correct_response_for_recipient_location_state_with_geo_filters(client)
 
 def _test_correct_response_for_recipient_location_country_with_geo_filters(client):
     # Prime awards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `recipient_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -481,7 +654,7 @@ def _test_correct_response_for_recipient_location_country_with_geo_filters(clien
             {
                 "scope": "recipient_location",
                 "geo_layer": "country",
-                "geo_layer_filters": ["JPN"],
+                "geo_layer_filters": ["JPN", "USA"],
                 "filters": {
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
                     "recipient_scope": "foreign",
@@ -509,7 +682,91 @@ def _test_correct_response_for_recipient_location_country_with_geo_filters(clien
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
 
+    # Get only domestic results
+    # (JPN results should be excluded since `recipient_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "geo_layer_filters": ["JPN", "USA"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "recipient_scope": "domestic",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5555550.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign country results
+    # (USA and JPN should both be in the results since `recipient_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "geo_layer_filters": ["JPN", "USA"],
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+            {
+                "aggregated_amount": 5555550.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
     # Subawards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `recipient_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -518,9 +775,10 @@ def _test_correct_response_for_recipient_location_country_with_geo_filters(clien
                 "scope": "recipient_location",
                 "geo_layer": "country",
                 "subawards": True,
-                "geo_layer_filters": ["JPN"],
+                "geo_layer_filters": ["JPN", "USA"],
                 "filters": {
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                    "recipient_scope": "foreign",
                 },
             }
         ),
@@ -535,6 +793,88 @@ def _test_correct_response_for_recipient_location_country_with_geo_filters(clien
                 "per_capita": None,
                 "population": None,
                 "shape_code": "JPN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get only domestic results
+    # (JPN results should be excluded since `recipient_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "geo_layer_filters": ["JPN", "USA"],
+                "subawards": True,
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "recipient_scope": "domestic",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 66666.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign country results
+    # (USA and JPN should both be in the results since `recipient_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "geo_layer_filters": ["JPN", "USA"],
+                "subawards": True,
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 678910.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+            {
+                "aggregated_amount": 66666.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
             },
         ],
         "messages": [get_time_period_message()],
@@ -709,7 +1049,8 @@ def _test_correct_response_for_place_of_performance_state_without_geo_filters(cl
 
 
 def _test_correct_response_for_place_of_perforance_country_without_geo_filters(client):
-    # Prime awards
+    # Get only foreign country results
+    # (USA results should be excluded since `place_of_performance_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -718,7 +1059,78 @@ def _test_correct_response_for_place_of_perforance_country_without_geo_filters(c
                 "scope": "place_of_performance",
                 "geo_layer": "country",
                 "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
                     "place_of_performance_scope": "foreign",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get only domestic results
+    # (CAN results should be excluded since `place_of_performance_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "filters": {
+                    "place_of_performance_scope": "domestic",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5555555.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            }
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign results
+    # (USA and CAN should both be in the results since `place_of_performance_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "filters": {
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
                 },
             }
@@ -734,6 +1146,13 @@ def _test_correct_response_for_place_of_perforance_country_without_geo_filters(c
                 "per_capita": None,
                 "population": None,
                 "shape_code": "CAN",
+            },
+            {
+                "aggregated_amount": 5555555.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
             }
         ],
         "messages": [get_time_period_message()],
@@ -744,7 +1163,85 @@ def _test_correct_response_for_place_of_perforance_country_without_geo_filters(c
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
 
+
     # Subawards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `place_of_performance_scope` is set to "foreign")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "subawards": True,
+                "filters": {
+                    "place_of_performance_scope": "foreign",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 12345.0,
+                "display_name": "Canada",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "CAN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get only domestic results
+    # (CAN results should be excluded since `place_of_performance_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "place_of_performance",
+                "geo_layer": "country",
+                "subawards": True,
+                "filters": {
+                    "place_of_performance_scope": "domestic",
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "place_of_performance",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 733231.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign results
+    # (USA and CAN should both be in the results since `place_of_performance_scope` is excluded)
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -930,6 +1427,9 @@ def _test_correct_response_for_recipient_location_state_without_geo_filters(clie
 
 def _test_correct_response_for_recipient_location_country_without_geo_filters(client):
     # Prime awards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `recipient_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -938,8 +1438,8 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
                 "scope": "recipient_location",
                 "geo_layer": "country",
                 "filters": {
-                    "recipient_scope": "foreign",
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "recipient_scope": "foreign",
                 },
             }
         ),
@@ -949,11 +1449,11 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
         "geo_layer": "country",
         "results": [
             {
-                "aggregated_amount": 5.0,
-                "display_name": "Canada",
-                "per_capita": None,
-                "population": None,
-                "shape_code": "CAN",
+                'aggregated_amount': 5.0,
+                'display_name': 'Canada',
+                'per_capita': None,
+                'population': None,
+                'shape_code': 'CAN'
             },
             {
                 "aggregated_amount": 5000000.0,
@@ -971,7 +1471,96 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
     resp_json["results"].sort(key=_get_shape_code_for_sort)
     assert resp_json == expected_response
 
+    # Get only domestic results
+    # (CAN and JPN results should be excluded since `recipient_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "recipient_scope": "domestic",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 5555550.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign country results
+    # (USA, CAN and JPN should all be in the results since `recipient_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                'aggregated_amount': 5.0,
+                'display_name': 'Canada',
+                'per_capita': None,
+                'population': None,
+                'shape_code': 'CAN'
+            },
+            {
+                "aggregated_amount": 5000000.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+            {
+                "aggregated_amount": 5555550.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+
     # Subawards
+
+    # Get only foreign country results
+    # (USA results should be excluded since `recipient_scope` is set to "foreign")
     resp = client.post(
         "/api/v2/search/spending_by_geography",
         content_type="application/json",
@@ -982,6 +1571,80 @@ def _test_correct_response_for_recipient_location_country_without_geo_filters(cl
                 "subawards": True,
                 "filters": {
                     "time_period": [{"start_date": "2018-10-01", "end_date": "2022-09-30"}],
+                    "recipient_scope": "foreign",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 678910.0,
+                "display_name": "Japan",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "JPN",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get only domestic results
+    # (JPN results should be excluded since `recipient_scope` is set to "domestic")
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "subawards": True,
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
+                    "recipient_scope": "domestic",
+                },
+            }
+        ),
+    )
+    expected_response = {
+        "scope": "recipient_location",
+        "geo_layer": "country",
+        "results": [
+            {
+                "aggregated_amount": 66666.0,
+                "display_name": "United States",
+                "per_capita": None,
+                "population": None,
+                "shape_code": "USA",
+            },
+        ],
+        "messages": [get_time_period_message()],
+    }
+    assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
+
+    resp_json = resp.json()
+    resp_json["results"].sort(key=_get_shape_code_for_sort)
+    assert resp_json == expected_response
+
+    # Get both domestic and foreign country results
+    # (USA and JPN should both be in the results since `recipient_scope` is excluded)
+    resp = client.post(
+        "/api/v2/search/spending_by_geography",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "scope": "recipient_location",
+                "geo_layer": "country",
+                "subawards": True,
+                "filters": {
+                    "time_period": [{"start_date": "2018-10-01", "end_date": "2020-09-30"}],
                 },
             }
         ),

--- a/usaspending_api/search/v2/views/spending_by_geography.py
+++ b/usaspending_api/search/v2/views/spending_by_geography.py
@@ -178,8 +178,15 @@ class SpendingByGeographyVisualizationViewSet(APIView):
             else:
                 scope_filter_name = "recipient_scope"
 
-            # Only search for values within USA, but don't overwrite a user's search
-            if scope_filter_name not in self.filters:
+            # If searching for COUNTY, DISTRICT, or STATE then only search for values within
+            #   USA, but don't overwrite a user's search.
+            # DO add `recipient_scope` or `place_of_performance_scope` if it wasn't already included.
+
+            # If searching for COUNTRY and no scope was provided, then return results for all
+            #   countries provided in the `geo_layer_filters` list.
+            # DO NOT add `recipient_scope` or `place_of_performance_scope` to the filters, if it
+            #   wasn't already included.
+            if scope_filter_name not in self.filters and self.geo_layer != GeoLayer.COUNTRY:
                 self.filters[scope_filter_name] = "domestic"
 
             self.obligation_column = "generated_pragmatic_obligation"


### PR DESCRIPTION
**Description:**
Update the `search/spending_by_geography` endpoint to allow for requests that include USA and non-USA country codes in the same request.

**Technical details:**
Previously, either `place_of_performance_scope` or `recipient_scope` (depending on the `scope` value) were being added to requests if it wasn't already present and defaulting to a value of `domestic`. This meant that only USA results would be returned, even if non-USA country codes were included in the `geo_layer_filters` filter. Previously there was no way to get both domestic and foreign country results in the same request because you could only do one of the following:

1. Add either `place_of_performance_scope` or `recipient_scope` and set it to `domestic`. This filters out any non-USA results.
2. Add either `place_of_performance_scope` or `recipient_scope` and set it to `foreign`. This filters out any USA results.
3. Exclude either `place_of_performance_scope` or `recipient_scope` in the request. The code would add this filter back and set it to `domestic`. This would filter out any non-USA results.

After this update, if you search for countries and do **not** include either `place_of_performance_scope` or `recipient_scope` then we no longer add it to the filters and just return results for every country code listed in `geo_layer_filters`. Requests for counties, states, and districts **will still** have these filters added since they only apply to the USA.


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
5. [x] API documentation updated
6. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
7. [x] Data validation completed
8. [ ] Jira Ticket [DEV-10183](https://federal-spending-transparency.atlassian.net/browse/DEV-10183):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
