### PR TITLE
PIPE-493; Change nullValue arg to emptyValue in spark csv write options

### DIFF
--- a/usaspending_api/common/etl/spark.py
+++ b/usaspending_api/common/etl/spark.py
@@ -610,7 +610,7 @@ def write_csv_file(
     ).csv(
         path=parts_dir,
         header=False,
-        nullValue="",  # "" creates the output of ,,, for null values. Using None defaults to an output of ,"","",""
+        emptyValue="",  # "" creates the output of ,,, for null values to match behavior of previous Postgres job
         escape='"',  # " is used to escape the 'quote' character setting (which defaults to "). Escaped quote = ""
         ignoreLeadingWhiteSpace=False,  # must set for CSV write, as it defaults to true
         ignoreTrailingWhiteSpace=False,  # must set for CSV write, as it defaults to true


### PR DESCRIPTION
**Description:**
The PostgresSQL queries were converted to SparkSQL for the Covid-19 download job. There were a few differences between the download files from before and after the changes.

**Technical details:**
Small adjustments were made to the SparkSQL queries and the settings were adjusted for how to write null data to a csv file when using spark.

**Requirements for PR merge:**

1. N/A - Unit & integration tests updated
2. N/A - API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. N/A - Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. [x] Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [x] Jira Tickets - [PIPE-493](https://federal-spending-transparency.atlassian.net/browse/PIPE-493),  [PIPE-498](https://federal-spending-transparency.atlassian.net/browse/PIPE-498),  [PIPE-499](https://federal-spending-transparency.atlassian.net/browse/PIPE-499), [PIPE-500](https://federal-spending-transparency.atlassian.net/browse/PIPE-500), [PIPE-501](https://federal-spending-transparency.atlassian.net/browse/PIPE-501), [PIPE-502](https://federal-spending-transparency.atlassian.net/browse/PIPE-502):
    - [x] Link to this Pull-Request
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. No established pattern for testing SQL, so no unit tests were added for this work.
2. API Contract was not changed as part of this work, therefore it does not need any updates.
4. Matview was not impacted by any of these changes.
5. Frontend was not impacted by any of these changes.
7. No operational changes need to be done as part of this PR.
```
