### PR TITLE
[DEV-9816] Don't COALESCE Country Name in One Case

### DIFF
--- a/usaspending_api/transactions/delta_models/transaction_fabs.py
+++ b/usaspending_api/transactions/delta_models/transaction_fabs.py
@@ -62,7 +62,7 @@ TRANSACTION_FABS_COLUMN_INFO = [
         "STRING",
         scalar_transformation="CASE \
             WHEN {input} = 'USA' THEN 'UNITED STATES' \
-            WHEN COALESCE({input}, '') = '' AND legal_entity_country_code in ('UNITED STATES', 'USA') THEN 'UNITED STATES' \
+            WHEN COALESCE({input}, '') = '' AND legal_entity_country_code = 'UNITED STATES' THEN 'UNITED STATES' \
             ELSE {input} \
             END",
     ),
@@ -107,7 +107,7 @@ TRANSACTION_FABS_COLUMN_INFO = [
         "STRING",
         scalar_transformation="CASE \
             WHEN {input} = 'USA' THEN 'UNITED STATES' \
-            WHEN COALESCE({input}, '') = '' AND place_of_perform_country_c in ('UNITED STATES', 'USA') THEN 'UNITED STATES' \
+            WHEN COALESCE({input}, '') = '' AND place_of_perform_country_c = 'UNITED STATES' THEN 'UNITED STATES' \
             ELSE {input} \
             END",
     ),

--- a/usaspending_api/transactions/delta_models/transaction_fpds.py
+++ b/usaspending_api/transactions/delta_models/transaction_fpds.py
@@ -154,8 +154,9 @@ TRANSACTION_FPDS_COLUMN_INFO = [
         "legal_entity_country_name",
         "legal_entity_country_name",
         "STRING",
-        scalar_transformation="CASE {input} \
-            WHEN 'USA' THEN 'UNITED STATES' \
+        scalar_transformation="CASE \
+            WHEN {input} = 'USA' THEN 'UNITED STATES' \
+            WHEN COALESCE({input}, '') = '' AND legal_entity_country_code = 'UNITED STATES' THEN 'UNITED STATES' \
             ELSE {input} \
             END",
     ),
@@ -237,8 +238,9 @@ TRANSACTION_FPDS_COLUMN_INFO = [
         "place_of_perform_country_n",
         "place_of_perform_country_n",
         "STRING",
-        scalar_transformation="CASE {input} \
-            WHEN 'USA' THEN 'UNITED STATES' \
+        scalar_transformation="CASE \
+            WHEN {input} = 'USA' THEN 'UNITED STATES' \
+            WHEN COALESCE({input}, '') = '' AND place_of_perform_country_c = 'UNITED STATES' THEN 'UNITED STATES' \
             ELSE {input} \
             END",
     ),


### PR DESCRIPTION
**Description:**
The purpose of this PR is to fix a bug found during testing of DEV-9816. The bug was caused by coalescing country name to UNITED STATES anytime it was blank and the country code was USA. We only want to coalesce country name to UNITED STATES when the code is UNITED STATES. This transformation was also missing in the FPDS transaction load. This PR adds it there.

