### PR TITLE
[DEV-10278] Fix Error when Sorting by Start Date with Loans

### DIFF
--- a/usaspending_api/common/helpers/api_helper.py
+++ b/usaspending_api/common/helpers/api_helper.py
@@ -83,30 +83,44 @@ def raise_if_sort_key_not_valid(sort_key, field_list, award_type_codes, is_subaw
 
     Raise API exception if sort key is not present
     """
-    msg_prefix = ""
-    if is_subaward:
-        msg_prefix = "Sub-"
-        field_external_name_list = list(contract_subaward_mapping.keys()) + list(grant_subaward_mapping.keys())
-    else:
-        if set(award_type_codes) <= set(contract_type_mapping):
-            msg_prefix = "Contract "
-            field_external_name_list = list(contracts_mapping.keys())
-        elif set(award_type_codes) <= set(loan_type_mapping):
-            msg_prefix = "Loan "
-            field_external_name_list = list(loan_mapping.keys())
-        elif set(award_type_codes) <= set(idv_type_mapping):
-            msg_prefix = "IDVs "
-            field_external_name_list = list(idv_mapping.keys())
-        elif set(award_type_codes) <= set(non_loan_assistance_type_mapping):
-            msg_prefix = "Non-Loan Assistance "
-            field_external_name_list = list(non_loan_assist_mapping.keys())
+    award_type, field_external_name_list = get_award_type_and_mapping_values(award_type_codes, is_subaward)
 
     if sort_key not in field_external_name_list:
         raise InvalidParameterException(
-            "Sort value '{}' not found in {}Award mappings: {}".format(sort_key, msg_prefix, field_external_name_list)
+            "Sort value '{}' not found in {} mappings: {}".format(sort_key, award_type, field_external_name_list)
         )
 
     if sort_key not in field_list:
         raise InvalidParameterException(
             "Sort value '{}' not found in requested fields: {}".format(sort_key, field_list)
         )
+
+
+def get_award_type_and_mapping_values(award_type_codes: list, is_subaward: bool):
+    """Returns a tuple including the type of award and the award mapping values based on the
+    input provided.
+
+    If the input doesn't match any award type mappings:
+        Raise an exception JSON response.
+    """
+    if is_subaward:
+        award_type = "Sub-Award"
+        award_type_mapping_values = list(contract_subaward_mapping.keys()) + list(grant_subaward_mapping.keys())
+    elif set(award_type_codes) <= set(contract_type_mapping):
+        award_type = "Contract Award"
+        award_type_mapping_values = list(contracts_mapping.keys())
+    elif set(award_type_codes) <= set(loan_type_mapping):
+        award_type = "Loan Award"
+        award_type_mapping_values = list(loan_mapping.keys())
+    elif set(award_type_codes) <= set(idv_type_mapping):
+        award_type = "IDV Award"
+        award_type_mapping_values = list(idv_mapping.keys())
+    elif set(award_type_codes) <= set(non_loan_assistance_type_mapping):
+        award_type = "Non-Loan Assistance Award"
+        award_type_mapping_values = list(non_loan_assist_mapping.keys())
+    else:
+        raise InvalidParameterException(
+            "Award type codes '{}' did not match any award mappings.".format(award_type_codes)
+        )
+
+    return award_type, award_type_mapping_values

--- a/usaspending_api/common/helpers/api_helper.py
+++ b/usaspending_api/common/helpers/api_helper.py
@@ -1,4 +1,5 @@
 import json
+from typing import List, Tuple
 from usaspending_api.common.exceptions import UnprocessableEntityException, InvalidParameterException
 from usaspending_api.awards.v2.lookups.lookups import (
     assistance_type_mapping,
@@ -96,12 +97,18 @@ def raise_if_sort_key_not_valid(sort_key, field_list, award_type_codes, is_subaw
         )
 
 
-def get_award_type_and_mapping_values(award_type_codes: list, is_subaward: bool):
-    """Returns a tuple including the type of award and the award mapping values based on the
-    input provided.
+def get_award_type_and_mapping_values(award_type_codes: List[str], is_subaward: bool) -> Tuple[str, List[str]]:
+    """Returns a tuple including the type of award and the award mapping values based on the input provided.
+    If the input doesn't match any award type mappings then it will raise an exception JSON response.
 
-    If the input doesn't match any award type mappings:
-        Raise an exception JSON response.
+    Args:
+        award_type_codes: List of award type codes
+        is_subaward: Boolean based on if its a subaward
+
+    Returns:
+        A tuple of two items
+            - First element is a string that describes the award type
+            - Second element is a list of strings that are the values from the corresponding award mapping
     """
     if is_subaward:
         award_type = "Sub-Award"

--- a/usaspending_api/search/tests/unit/test_spending_by_award.py
+++ b/usaspending_api/search/tests/unit/test_spending_by_award.py
@@ -59,16 +59,40 @@ def test_raise_if_award_types_not_valid_subset():
 
 
 def test_raise_if_sort_key_not_valid():
-    example_award_fields = [
+    example_contract_award_codes = ["A", "B"]
+    example_idv_award_codes = ["IDV_A", "IDV_B"]
+    example_loan_award_codes = ["07", "08"]
+    example_non_loan_assist_award_codes = ["09"]
+
+    example_base_award_fields = [
         "Award ID",
         "Recipient Name",
+        "Awarding Agency",
+        "Awarding Sub Agency",
+    ]
+
+    example_contract_award_fields = [
         "Start Date",
         "End Date",
         "Award Amount",
-        "Awarding Agency",
-        "Awarding Sub Agency",
         "Contract Award Type",
-    ]
+    ] + example_base_award_fields
+
+    example_idv_award_fields = [
+        "Start Date",
+        "End Date",
+        "Award Amount",
+        "Last Date to Order",
+    ] + example_base_award_fields
+
+    example_loan_award_fields = ["Issued Date", "Loan Value"] + example_base_award_fields
+
+    example_non_loan_assist_award_fields = [
+        "Start Date",
+        "End Date",
+        "Award Amount",
+        "Award Type",
+    ] + example_base_award_fields
 
     example_subaward_fields = [
         "Sub-Award ID",
@@ -81,35 +105,135 @@ def test_raise_if_sort_key_not_valid():
         "Sub-Award Type",
     ]
 
-    assert raise_if_sort_key_not_valid(sort_key="Award ID", field_list=example_award_fields, is_subaward=False) is None
-    assert raise_if_sort_key_not_valid(sort_key="End Date", field_list=example_award_fields, is_subaward=False) is None
     assert (
-        raise_if_sort_key_not_valid(sort_key="Awarding Agency", field_list=example_subaward_fields, is_subaward=True)
+        raise_if_sort_key_not_valid(
+            sort_key="Award ID",
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
         is None
     )
     assert (
-        raise_if_sort_key_not_valid(sort_key="Sub-Award ID", field_list=example_subaward_fields, is_subaward=True)
+        raise_if_sort_key_not_valid(
+            sort_key="End Date",
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
+        is None
+    )
+    assert (
+        raise_if_sort_key_not_valid(
+            sort_key="Awarding Agency",
+            field_list=example_subaward_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=True,
+        )
+        is None
+    )
+    assert (
+        raise_if_sort_key_not_valid(
+            sort_key="Sub-Award ID",
+            field_list=example_subaward_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=True,
+        )
+        is None
+    )
+    assert (
+        raise_if_sort_key_not_valid(
+            sort_key="Last Date to Order",
+            field_list=example_idv_award_fields,
+            award_type_codes=example_idv_award_codes,
+            is_subaward=False,
+        )
+        is None
+    )
+    assert (
+        raise_if_sort_key_not_valid(
+            sort_key="Issued Date",
+            field_list=example_loan_award_fields,
+            award_type_codes=example_loan_award_codes,
+            is_subaward=False,
+        )
+        is None
+    )
+    assert (
+        raise_if_sort_key_not_valid(
+            sort_key="Award Type",
+            field_list=example_non_loan_assist_award_fields,
+            award_type_codes=example_non_loan_assist_award_codes,
+            is_subaward=False,
+        )
         is None
     )
 
     with pytest.raises(InvalidParameterException):
         # Valid mapping, but missing from the field list
-        raise_if_sort_key_not_valid(sort_key="Description", field_list=example_award_fields, is_subaward=False)
+        raise_if_sort_key_not_valid(
+            sort_key="Description",
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
 
     with pytest.raises(InvalidParameterException):
-        raise_if_sort_key_not_valid(sort_key="Bad Key", field_list=example_award_fields, is_subaward=False)
+        raise_if_sort_key_not_valid(
+            sort_key="Bad Key",
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
 
     with pytest.raises(InvalidParameterException):
-        raise_if_sort_key_not_valid(sort_key="", field_list=example_award_fields, is_subaward=False)
+        raise_if_sort_key_not_valid(
+            sort_key="",
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
 
     with pytest.raises(InvalidParameterException):
-        raise_if_sort_key_not_valid(sort_key=None, field_list=example_award_fields, is_subaward=False)
+        raise_if_sort_key_not_valid(
+            sort_key=None,
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
 
     with pytest.raises(InvalidParameterException):
-        raise_if_sort_key_not_valid(sort_key="Bad Key", field_list=example_subaward_fields, is_subaward=True)
+        raise_if_sort_key_not_valid(
+            sort_key="Bad Key",
+            field_list=example_subaward_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=True,
+        )
 
     with pytest.raises(InvalidParameterException):
-        raise_if_sort_key_not_valid(sort_key="Description", field_list=example_subaward_fields, is_subaward=True)
+        raise_if_sort_key_not_valid(
+            sort_key="Description",
+            field_list=example_subaward_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=True,
+        )
+
+    # Check that it won't allow a sort key that isn't in a specific award mapping
+    with pytest.raises(InvalidParameterException):
+        raise_if_sort_key_not_valid(
+            sort_key="Issued Date",
+            field_list=example_contract_award_fields,
+            award_type_codes=example_contract_award_codes,
+            is_subaward=False,
+        )
+
+    with pytest.raises(InvalidParameterException):
+        raise_if_sort_key_not_valid(
+            sort_key="Start Date",
+            field_list=example_loan_award_fields,
+            award_type_codes=example_loan_award_codes,
+            is_subaward=False,
+        )
 
 
 def test_get_queryset():

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -111,7 +111,9 @@ class SpendingByAwardVisualizationViewSet(APIView):
             return Response(self.populate_response(results=[], has_next=False))
 
         raise_if_award_types_not_valid_subset(self.filters["award_type_codes"], self.is_subaward)
-        raise_if_sort_key_not_valid(self.pagination["sort_key"], self.fields, self.is_subaward)
+        raise_if_sort_key_not_valid(
+            self.pagination["sort_key"], self.fields, self.filters["award_type_codes"], self.is_subaward
+        )
 
         if self.is_subaward:
             raw_response = self.create_response_for_subawards(self.construct_queryset())


### PR DESCRIPTION
**Description:**
An uncaught error was thrown when an API user would try to search for loan awards and sort them by `Start Date`. This is because loan awards have an `Issued Date`, and not a `Start Date`. More filtering was added when the API request is received to not allow this invalid sort value to be processed.

**Technical details:**
The request verification previously was allowing sort values that appeared in any of the award mappings, although some types of awards don't have the same mappings. This is what allowed the `Start Date` to not be rejected and then cause an error later on when the application was trying to sort the results on a column that doesn't exist. I changed the sort value verification to be more granular and only allow values that correspond with the award type being requested.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. N/A - Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. N/A - Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-10278](https://federal-spending-transparency.atlassian.net/jira/software/c/projects/DEV/boards/25?selectedIssue=DEV-10278):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)

**Area for explaining above N/A when needed:**
```
4. Matview was not impacted by any of these changes.
5. Frontend was not impacted by any of these changes
6. None of the current changes would affect the data
7. No operational changes need to be done as part of this PR.
```
