### PR TITLE
[PIPE-509] Reduce Calls to load-transactions-in-delta Django Command

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -210,6 +210,7 @@ class Command(BaseCommand):
         """
         Return a list of the award ids corresponding to the transaction_unique_ids that are about to be deleted.
         """
+        table_exists = self.spark._jsparkSession.catalog().tableExists(f"int.award_id_lookup")
         sql = f"""
             WITH txns_to_delete AS (
                 {self.award_id_lookup_delete_subquery}
@@ -225,10 +226,15 @@ class Command(BaseCommand):
         #       returned by a SELECT subquery inside the 'IN').  Thus, this code should return a dataframe directly,
         #       create a temporary view from the dataframe in award_id_lookup_post_delete, and use that temporary
         #       view to either do a subquery in the 'IN' clause or to JOIN against.
-        possibly_modified_award_ids = [str(row["award_id"]) for row in self.spark.sql(sql).collect()]
+        if table_exists:
+            possibly_modified_award_ids = [str(row["award_id"]) for row in self.spark.sql(sql).collect()]
+        else:
+            raise Exception(f"Table: int.{self.etl_level} does not exist.")
+
         return possibly_modified_award_ids
 
     def delete_records_sql(self):
+        table_exists = self.spark._jsparkSession.catalog().tableExists(f"int.{self.etl_level}")
         if self.etl_level == "transaction_id_lookup":
             id_col = "transaction_id"
             subquery = """
@@ -287,15 +293,18 @@ class Command(BaseCommand):
                 WHERE awards.id IS NOT NULL AND award_id_lookup.award_id IS NULL
             """
 
-        sql = f"""
-            MERGE INTO int.{self.etl_level}
-            USING (
-                {subquery}
-            ) AS deleted_records
-            ON {self.etl_level}.{id_col} = deleted_records.id_to_remove
-            WHEN MATCHED
-            THEN DELETE
-        """
+        if table_exists:
+            sql = f"""
+                MERGE INTO int.{self.etl_level}
+                USING (
+                    {subquery}
+                ) AS deleted_records
+                ON {self.etl_level}.{id_col} = deleted_records.id_to_remove
+                WHEN MATCHED
+                THEN DELETE
+            """
+        else:
+            raise Exception(f"Table: int.{self.etl_level} does not exist.")
 
         return sql
 

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -1131,18 +1131,6 @@ class TestTransactionIdLookup:
         TestInitialRun.initial_run(
             s3_data_bucket, load_source_tables=False, load_other_raw_tables=load_other_raw_tables, initial_copy=False
         )
-        call_command("load_transactions_in_delta", "--etl-level", "transaction_id_lookup")
-
-        # With no deletes or inserts yet, the transaction_id_lookup table should be the same as after the initial run.
-        # Also, the last load dates for the id lookup tables should match the load dates of the source tables.
-        kwargs = {
-            "expected_last_load_transaction_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
-            "expected_last_load_award_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
-            "expected_last_load_transaction_normalized": _BEGINNING_OF_TIME,
-            "expected_last_load_transaction_fabs": _BEGINNING_OF_TIME,
-            "expected_last_load_transaction_fpds": _BEGINNING_OF_TIME,
-        }
-        TestInitialRun.verify(spark, expected_initial_transaction_id_lookup, expected_initial_award_id_lookup, **kwargs)
 
         # 1. Test deleting the transaction(s) with the last transaction ID(s) from the appropriate raw table,
         # followed by a call to load_transaction_in_delta with etl-level of transaction_id_lookup
@@ -1442,7 +1430,7 @@ class TestAwardIdLookup:
         TestInitialRun.initial_run(
             s3_data_bucket, load_source_tables=False, load_other_raw_tables=load_other_raw_tables, initial_copy=False
         )
-        
+
         # 1. Test deleting the transactions with the last award ID from the appropriate raw table,
         # followed by a call to load_transaction_in_delta with etl-level of award_id_lookup
         # 2. Test for a single inserted transaction, and another call to load_transaction_in_delta with etl-level of

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -881,7 +881,7 @@ class TestTransactionIdLookup:
         # First, load the source tables to Delta.
         _load_tables_to_delta(s3_unittest_data_bucket)
 
-        # 2. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
+        # 1. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
         # initial_run, then transaction_id_lookup.  However, call initial_run with blank raw.transaction_normalized
         # and raw.awards tables.
 
@@ -1096,7 +1096,7 @@ class TestAwardIdLookup:
         # First, load the source tables to Delta
         _load_tables_to_delta(s3_unittest_data_bucket)
 
-        # 2. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
+        # 1. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
         # initial_run, then award_id_lookup.  However, call initial_run with blank raw.transaction_normalized
         # and raw.awards tables.
 
@@ -1324,7 +1324,7 @@ class _TransactionFabsFpdsCore:
         # First, load the source tables to Delta
         _load_tables_to_delta(self.s3_data_bucket)
 
-        # 2. Call load_transactions_in_delta with etl-level of initial_run first, but without first loading
+        # 1. Call load_transactions_in_delta with etl-level of initial_run first, but without first loading
         # raw.transaction_normalized or raw.awards.  Then immediately call load_transactions_in_delta with
         # etl-level of transaction_f[ab|pd]s.
         TestInitialRun.initial_run(self.s3_data_bucket)
@@ -1343,7 +1343,7 @@ class _TransactionFabsFpdsCore:
         kwargs[f"expected_last_load_{self.etl_level}"] = _INITIAL_SOURCE_TABLE_LOAD_DATETIME
         TestInitialRun.verify(self.spark, [], [], **kwargs)
 
-        # 3. With raw.transaction_normalized and raw.awards still not created, call load_transactions_in_delta
+        # 2. With raw.transaction_normalized and raw.awards still not created, call load_transactions_in_delta
         # with etl-level of transaction_id_lookup, and then again with etl-level of transaction_f[ab|pd]s.
 
         # Since the call to load_transactions_in_delta with etl-level of transaction_f[ab|pd]s above succeeded, we first

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -878,14 +878,8 @@ class TestTransactionIdLookup:
     def test_unexpected_paths(
         self, spark, s3_unittest_data_bucket, hive_unittest_metastore_db, _populate_initial_source_tables_pg
     ):
-        # 1. Test calling load_transactions_in_delta with etl-level of transaction_id_lookup without first
-        # calling calling load_transactions_in_delta with etl-level of initial_run
-
         # First, load the source tables to Delta.
         _load_tables_to_delta(s3_unittest_data_bucket)
-
-        with raises(pyspark.sql.utils.AnalysisException, match="Table or view not found: int.transaction_id_lookup"):
-            call_command("load_transactions_in_delta", "--etl-level", "transaction_id_lookup")
 
         # 2. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
         # initial_run, then transaction_id_lookup.  However, call initial_run with blank raw.transaction_normalized
@@ -1099,14 +1093,8 @@ class TestAwardIdLookup:
     def test_unexpected_paths(
         self, spark, s3_unittest_data_bucket, hive_unittest_metastore_db, _populate_initial_source_tables_pg
     ):
-        # 1. Test calling load_transactions_in_delta with etl-level of award_id_lookup without first
-        # calling load_transactions_in_delta with etl-level of initial_run
-
         # First, load the source tables to Delta
         _load_tables_to_delta(s3_unittest_data_bucket)
-
-        with raises(pyspark.sql.utils.AnalysisException, match="Table or view not found: int.award_id_lookup"):
-            call_command("load_transactions_in_delta", "--etl-level", "award_id_lookup")
 
         # 2. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
         # initial_run, then award_id_lookup.  However, call initial_run with blank raw.transaction_normalized
@@ -1335,11 +1323,6 @@ class _TransactionFabsFpdsCore:
     def unexpected_paths_source_tables_only_test_core(self):
         # First, load the source tables to Delta
         _load_tables_to_delta(self.s3_data_bucket)
-
-        # 1. Test calling load_transactions_in_delta with etl-level of transaction_f[ab|pd]s before calling with
-        # etl-level of initial_run.
-        with raises(pyspark.sql.utils.AnalysisException, match=f"Table or view not found: int.{self.etl_level}"):
-            call_command("load_transactions_in_delta", "--etl-level", self.etl_level)
 
         # 2. Call load_transactions_in_delta with etl-level of initial_run first, but without first loading
         # raw.transaction_normalized or raw.awards.  Then immediately call load_transactions_in_delta with

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -931,16 +931,15 @@ class TestTransactionIdLookup:
         expected_initial_award_id_lookup,
         expected_transaction_id_lookup_pops,
     ):
+        # Call load_transactions_in_delta with the etl-level set to the proper sequencing of initial_run
+        # Since these tests only care about the condition of the transaction_id_lookup table after various
+        # operations, only load the essential tables to Delta, and don't copy the raw transaction tables to int.
+        TestInitialRun.initial_run(s3_data_bucket, load_other_raw_tables=load_other_raw_tables, initial_copy=False)
 
         # 1. Test deleting the transaction(s) with the last transaction ID(s) from the appropriate raw table,
         # followed by a call to load_transaction_in_delta with etl-level of transaction_id_lookup
         # 2. Test for a single inserted transaction, and another call to load_transaction_in_delta with etl-level of
         # transaction_id_lookup.
-
-        # Call load_transactions_in_delta with the etl-level set to the proper sequencing of initial_run
-        # Since these tests only care about the condition of the transaction_id_lookup table after various
-        # operations, only load the essential tables to Delta, and don't copy the raw transaction tables to int.
-        TestInitialRun.initial_run(s3_data_bucket, load_other_raw_tables=load_other_raw_tables, initial_copy=False)
 
         spark.sql(
             """
@@ -1153,63 +1152,22 @@ class TestAwardIdLookup:
         expected_award_id_lookup_pops,
         partially_deleted_award_id,
     ):
-        # 1. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
-        # initial_run, then award_id_lookup
-
+        # Call load_transactions_in_delta with the etl-level set to the proper sequencing of initial_run, then award_id_lookup
         # Since these tests only care about the condition of the award_id_lookup table after various
         # operations, only load the essential tables to Delta, and don't copy the raw transaction tables to int.
         TestInitialRun.initial_run(s3_data_bucket, load_other_raw_tables=load_other_raw_tables, initial_copy=False)
-        call_command("load_transactions_in_delta", "--etl-level", "award_id_lookup")
 
-        # With no deletes or inserts, the award_id_lookup table should be the same as after the initial run.
-        # Also, the last load dates for the id lookup tables should match the load dates of the source tables.
-        kwargs = {
-            "expected_last_load_transaction_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
-            "expected_last_load_award_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
-            "expected_last_load_transaction_normalized": _BEGINNING_OF_TIME,
-            "expected_last_load_transaction_fabs": _BEGINNING_OF_TIME,
-            "expected_last_load_transaction_fpds": _BEGINNING_OF_TIME,
-        }
-        TestInitialRun.verify(spark, expected_initial_transaction_id_lookup, expected_initial_award_id_lookup, **kwargs)
-
-        # 2. Test deleting the transactions with the last award ID from the appropriate raw table,
+        # 1. Test deleting the transactions with the last award ID from the appropriate raw table,
         # followed by a call to load_transaction_in_delta with etl-level of award_id_lookup
+        # 2. Test for a single inserted transaction, and another call to load_transaction_in_delta with etl-level of
+        # award_id_lookup.
+
         spark.sql(
             """
             DELETE FROM raw.detached_award_procurement
             WHERE detached_award_procurement_id = 4 OR detached_award_procurement_id = 5
         """
         )
-        call_command("load_transactions_in_delta", "--etl-level", "award_id_lookup")
-
-        # Verify award_id_lookup table
-        query = "SELECT * FROM int.award_id_lookup ORDER BY award_id, transaction_unique_id"
-        delta_data = [row.asDict() for row in spark.sql(query).collect()]
-
-        expected_award_id_lookup = deepcopy(expected_initial_award_id_lookup)
-        expected_award_id_lookup.pop()
-        expected_award_id_lookup.pop()
-        assert equal_datasets(expected_award_id_lookup, delta_data, "")
-
-        # Make sure award_id_seq hasn't gone backwards
-        with connection.cursor() as cursor:
-            cursor.execute("SELECT nextval('award_id_seq')")
-            # Since all calls to setval() set the is_called flag to false, nextval() returns the actual maximum id
-            max_award_id = cursor.fetchone()[0]
-        assert max_award_id == max([award["id"] for award in TestInitialRunNoPostgresLoader.initial_awards])
-
-        # Since this test just called nextval(), need to reset the sequence with the is_called flag set to false
-        # so that the next call to nextval() will return the same value as previously.
-        with connection.cursor() as cursor:
-            cursor.execute(f"SELECT setval('award_id_seq', {max_award_id}, false)")
-
-        # Also, test that int.award_ids_delete_modified is still empty, since all transactions associated with the
-        # final award were deleted.
-        actual_count = spark.sql(f"SELECT COUNT(*) AS count from int.award_ids_delete_modified").collect()[0]["count"]
-        assert actual_count == 0
-
-        # 3. Test for a single inserted transaction, and another call to load_transaction_in_delta with etl-level of
-        # award_id_lookup.
 
         # Can't use spark.sql to just insert rows with only values for desired columns (need to specify values for
         # all of them), so using model baker to add new rows to Postgres table, and then pushing new table to Delta.
@@ -1228,6 +1186,10 @@ class TestAwardIdLookup:
         query = "SELECT * FROM int.award_id_lookup ORDER BY award_id, transaction_unique_id"
         delta_data = [row.asDict() for row in spark.sql(query).collect()]
 
+        expected_award_id_lookup = deepcopy(expected_initial_award_id_lookup)
+        expected_award_id_lookup.pop()
+        expected_award_id_lookup.pop()
+
         expected_award_id_lookup.append(
             {
                 "award_id": 7,
@@ -1236,19 +1198,35 @@ class TestAwardIdLookup:
                 "generated_unique_award_id": _NEW_ASSIST["unique_award_key"].upper(),
             }
         )
-        assert equal_datasets(expected_award_id_lookup, delta_data, "")
 
+        # Verify the data has been loaded and changed correctly
         # Although the last load date for the source_assistance_transaction was updated above, the code in
         # load_transactions_in_delta takes the minimum last load date of that table and of the
         # source_procurement_transaction table, which has not been updated since the initial load of both tables.
-        assert get_last_load_date("award_id_lookup") == _INITIAL_SOURCE_TABLE_LOAD_DATETIME
+        kwargs = {
+            "expected_last_load_transaction_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
+            "expected_last_load_award_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
+            "expected_last_load_transaction_normalized": _BEGINNING_OF_TIME,
+            "expected_last_load_transaction_fabs": _BEGINNING_OF_TIME,
+            "expected_last_load_transaction_fpds": _BEGINNING_OF_TIME,
+        }
+        TestInitialRun.verify(spark, expected_initial_transaction_id_lookup, expected_award_id_lookup, **kwargs)
 
-        # Also, test that int.award_ids_delete_modified is still empty, since no transactions were deleted since
-        # the last check.
-        actual_count = spark.sql("SELECT COUNT(*) AS count from int.award_ids_delete_modified").collect()[0]["count"]
-        assert actual_count == 0
+        # Make sure award_id_seq hasn't gone backwards
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT nextval('award_id_seq')")
+            # Since all calls to setval() set the is_called flag to false, nextval() returns the actual maximum id
+            max_award_id = cursor.fetchone()[0]
+        assert (
+            max_award_id == max([award["id"] for award in TestInitialRunNoPostgresLoader.initial_awards]) + 1
+        )  # Add one for the insert
 
-        # 4. Make inserts to and deletes from the raw tables, call load_transaction_in_delta with etl-level of
+        # Since this test just called nextval(), need to reset the sequence with the is_called flag set to false
+        # so that the next call to nextval() will return the same value as previously.
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT setval('award_id_seq', {max_award_id}, false)")
+
+        # 3. Make inserts to and deletes from the raw tables, call load_transaction_in_delta with etl-level of
         # award_id_lookup, and test that the results are as expected, and that int.award_ids_delete_modified has
         # tracked the appropriate delete.
         last_procure_load_datetime = datetime.now(timezone.utc)

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta.py
@@ -931,27 +931,17 @@ class TestTransactionIdLookup:
         expected_initial_award_id_lookup,
         expected_transaction_id_lookup_pops,
     ):
-        # 1. Test calling load_transactions_in_delta with the etl-level set to the proper sequencing of
-        # initial_run, then transaction_id_lookup
 
+        # 1. Test deleting the transaction(s) with the last transaction ID(s) from the appropriate raw table,
+        # followed by a call to load_transaction_in_delta with etl-level of transaction_id_lookup
+        # 2. Test for a single inserted transaction, and another call to load_transaction_in_delta with etl-level of
+        # transaction_id_lookup.
+
+        # Call load_transactions_in_delta with the etl-level set to the proper sequencing of initial_run
         # Since these tests only care about the condition of the transaction_id_lookup table after various
         # operations, only load the essential tables to Delta, and don't copy the raw transaction tables to int.
         TestInitialRun.initial_run(s3_data_bucket, load_other_raw_tables=load_other_raw_tables, initial_copy=False)
-        call_command("load_transactions_in_delta", "--etl-level", "transaction_id_lookup")
 
-        # With no deletes or inserts yet, the transaction_id_lookup table should be the same as after the initial run.
-        # Also, the last load dates for the id lookup tables should match the load dates of the source tables.
-        kwargs = {
-            "expected_last_load_transaction_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
-            "expected_last_load_award_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
-            "expected_last_load_transaction_normalized": _BEGINNING_OF_TIME,
-            "expected_last_load_transaction_fabs": _BEGINNING_OF_TIME,
-            "expected_last_load_transaction_fpds": _BEGINNING_OF_TIME,
-        }
-        TestInitialRun.verify(spark, expected_initial_transaction_id_lookup, expected_initial_award_id_lookup, **kwargs)
-
-        # 2. Test deleting the transaction(s) with the last transaction ID(s) from the appropriate raw table,
-        # followed by a call to load_transaction_in_delta with etl-level of transaction_id_lookup
         spark.sql(
             """
             DELETE FROM raw.detached_award_procurement
@@ -1001,6 +991,10 @@ class TestTransactionIdLookup:
         query = "SELECT * FROM int.transaction_id_lookup ORDER BY transaction_id"
         delta_data = [row.asDict() for row in spark.sql(query).collect()]
 
+        expected_transaction_id_lookup = deepcopy(expected_initial_transaction_id_lookup)
+        expected_transaction_id_lookup.pop()
+        expected_transaction_id_lookup.pop()
+
         expected_transaction_id_lookup.append(
             {
                 "transaction_id": 11,
@@ -1008,14 +1002,33 @@ class TestTransactionIdLookup:
                 "transaction_unique_id": _NEW_ASSIST["afa_generated_unique"].upper(),
             }
         )
-        assert equal_datasets(expected_transaction_id_lookup, delta_data, "")
 
+        # Verify the data has been loaded and changed correctly
         # Although the last load date for the source_assistance_transaction was updated above, the code in
         # load_transactions_in_delta takes the minimum last load date of that table and of the
         # source_procurement_transaction table, which has not been updated since the initial load of both tables.
-        assert get_last_load_date("transaction_id_lookup") == _INITIAL_SOURCE_TABLE_LOAD_DATETIME
+        kwargs = {
+            "expected_last_load_transaction_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
+            "expected_last_load_award_id_lookup": _INITIAL_SOURCE_TABLE_LOAD_DATETIME,
+            "expected_last_load_transaction_normalized": _BEGINNING_OF_TIME,
+            "expected_last_load_transaction_fabs": _BEGINNING_OF_TIME,
+            "expected_last_load_transaction_fpds": _BEGINNING_OF_TIME,
+        }
+        TestInitialRun.verify(spark, expected_transaction_id_lookup, expected_initial_award_id_lookup, **kwargs)
 
-        # 4. Make inserts to and deletes from the raw tables, call load_transaction_in_delta with etl-level of
+        # Also, make sure transaction_id_seq hasn't gone backwards
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT nextval('transaction_id_seq')")
+            # Since all calls to setval() set the is_called flag to false, nextval() returns the actual maximum id
+            max_transaction_id = cursor.fetchone()[0]
+        assert max_transaction_id == (len(_INITIAL_ASSISTS) + len(_INITIAL_PROCURES) + 1)  # Add one for the insert
+
+        # Since this test just called nextval(), need to reset the sequence with the is_called flag set to false
+        # so that the next call to nextval() will return the same value as previously.
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT setval('transaction_id_seq', {max_transaction_id}, false)")
+
+        # 3. Make inserts to and deletes from the raw tables, call load_transaction_in_delta with etl-level of
         # transaction_id_lookup, and test that the results are as expected.
         last_procure_load_datetime = datetime.now(timezone.utc)
         insert_datetime = last_procure_load_datetime + timedelta(minutes=-15)

--- a/usaspending_api/etl/tests/unit/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/unit/test_load_transactions_in_delta.py
@@ -1,9 +1,9 @@
-from mock import Mock
+from mock import MagicMock, Mock, patch
 from pytest import raises
 from usaspending_api.etl.management.commands.load_transactions_in_delta import Command
 
 
-def setup_spark_table_exists_mock(return_value):
+def _setup_spark_table_exists_mock(return_value):
     spark_mock = Mock()
     catalog_mock = Mock()
     spark_mock._jsparkSession.catalog.return_value = catalog_mock
@@ -11,31 +11,40 @@ def setup_spark_table_exists_mock(return_value):
     return spark_mock
 
 
-def test_award_id_lookup_pre_delete_throws_exception():
-    command_mock = Mock()
-    command_mock.spark = setup_spark_table_exists_mock(return_value=False)
+def _setup_spark_mock():
+    # Weird mock to get around the 'with self.prepare_spark()' statement
+    spark_mock = MagicMock()
+    spark_mock.__enter__.return_value = None  # This can be any value
+    return spark_mock
 
-    command_mock.etl_level = "award_id_lookup"
+
+@patch("usaspending_api.etl.management.commands.load_transactions_in_delta.get_earliest_load_date", return_value=None)
+@patch(
+    "usaspending_api.etl.management.commands.load_transactions_in_delta.Command.prepare_spark",
+    new_callable=_setup_spark_mock,
+)
+def test_delete_records_sql_throws_exception(patch_prepare_spark, patch_load_date):
+    command = Command()
+    # This is needed along with 'prepare_spark' being patched to get around spark issues
+    command.spark = _setup_spark_table_exists_mock(return_value=False)
+    test_options = {"spark_s3_bucket": "some_bucket", "no_initial_copy": False}
+
+    test_options["etl_level"] = "award_id_lookup"
     with raises(Exception, match="Table: int.award_id_lookup does not exist."):
-        Command.delete_records_sql(command_mock)
+        command.handle(**test_options)
 
-
-def test_delete_records_sql_throws_exception():
-    command_mock = Mock()
-    command_mock.spark = setup_spark_table_exists_mock(return_value=False)
-
-    command_mock.etl_level = "award_id_lookup"
-    with raises(Exception, match="Table: int.award_id_lookup does not exist."):
-        Command.delete_records_sql(command_mock)
-
-    command_mock.etl_level = "transaction_id_lookup"
+    test_options["etl_level"] = "transaction_id_lookup"
     with raises(Exception, match="Table: int.transaction_id_lookup does not exist."):
-        Command.delete_records_sql(command_mock)
+        command.handle(**test_options)
 
-    command_mock.etl_level = "transaction_fabs"
+    test_options["etl_level"] = "transaction_fabs"
     with raises(Exception, match="Table: int.transaction_fabs does not exist."):
-        Command.delete_records_sql(command_mock)
+        command.handle(**test_options)
 
-    command_mock.etl_level = "transaction_fpds"
+    test_options["etl_level"] = "transaction_fpds"
     with raises(Exception, match="Table: int.transaction_fpds does not exist."):
-        Command.delete_records_sql(command_mock)
+        command.handle(**test_options)
+
+    test_options["etl_level"] = "awards"
+    with raises(Exception, match="Table: int.awards does not exist."):
+        command.handle(**test_options)

--- a/usaspending_api/etl/tests/unit/test_load_transactions_in_delta.py
+++ b/usaspending_api/etl/tests/unit/test_load_transactions_in_delta.py
@@ -1,0 +1,41 @@
+from mock import Mock
+from pytest import raises
+from usaspending_api.etl.management.commands.load_transactions_in_delta import Command
+
+
+def setup_spark_table_exists_mock(return_value):
+    spark_mock = Mock()
+    catalog_mock = Mock()
+    spark_mock._jsparkSession.catalog.return_value = catalog_mock
+    catalog_mock.tableExists.return_value = return_value
+    return spark_mock
+
+
+def test_award_id_lookup_pre_delete_throws_exception():
+    command_mock = Mock()
+    command_mock.spark = setup_spark_table_exists_mock(return_value=False)
+
+    command_mock.etl_level = "award_id_lookup"
+    with raises(Exception, match="Table: int.award_id_lookup does not exist."):
+        Command.delete_records_sql(command_mock)
+
+
+def test_delete_records_sql_throws_exception():
+    command_mock = Mock()
+    command_mock.spark = setup_spark_table_exists_mock(return_value=False)
+
+    command_mock.etl_level = "award_id_lookup"
+    with raises(Exception, match="Table: int.award_id_lookup does not exist."):
+        Command.delete_records_sql(command_mock)
+
+    command_mock.etl_level = "transaction_id_lookup"
+    with raises(Exception, match="Table: int.transaction_id_lookup does not exist."):
+        Command.delete_records_sql(command_mock)
+
+    command_mock.etl_level = "transaction_fabs"
+    with raises(Exception, match="Table: int.transaction_fabs does not exist."):
+        Command.delete_records_sql(command_mock)
+
+    command_mock.etl_level = "transaction_fpds"
+    with raises(Exception, match="Table: int.transaction_fpds does not exist."):
+        Command.delete_records_sql(command_mock)


### PR DESCRIPTION
**Description:**
The unit tests in the file `test_load_transactions_in_delta.py` were optimized to not make so many calls that use a Django command. These commands take the majority of the time, so by reducing even a few calls, it helped reduce the overall runtime by over 2 minutes.

**Technical details:**
Some tests were combined and other parts of the code were refactored so that certain functionality could be tested without needing to use the Django command. There is a new unit test file that can run independently from the integration tests.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. N/A - API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. N/A - Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. N/A - Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [x] Jira Ticket [PIPE-509](https://federal-spending-transparency.atlassian.net/jira/software/c/projects/DEV/boards/25?selectedIssue=PIPE-509):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)

**Area for explaining above N/A when needed:**
```
2. API docs do not need update as these changes only affected unit tests
4. Matview was not impacted by any of these changes.
5. Frontend was not impacted by any of these changes
6. None of the current changes would affect the data
7. No operational changes need to be done as part of this PR.
```
