### PR TITLE
[DEV-10072] Assistance obligations added to downloads

### DIFF
--- a/usaspending_api/bulk_download/tests/integration/test_download.py
+++ b/usaspending_api/bulk_download/tests/integration/test_download.py
@@ -460,7 +460,7 @@ def test_download_awards_with_domestic_scope(client, _award_download_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 639
+    assert resp.json()["total_columns"] == 640
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())

--- a/usaspending_api/bulk_download/tests/integration/test_download.py
+++ b/usaspending_api/bulk_download/tests/integration/test_download.py
@@ -342,7 +342,7 @@ def test_download_awards_with_all_award_types(client, _award_download_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 9
-    assert resp.json()["total_columns"] == 639
+    assert resp.json()["total_columns"] == 640
 
 
 @pytest.mark.django_db(transaction=True)
@@ -365,7 +365,7 @@ def test_download_awards_with_all_prime_awards(client, _award_download_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 6
-    assert resp.json()["total_columns"] == 406
+    assert resp.json()["total_columns"] == 407
 
 
 @pytest.mark.django_db(transaction=True)
@@ -483,7 +483,7 @@ def test_download_awards_with_domestic_scope(client, _award_download_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 4
-    assert resp.json()["total_columns"] == 639
+    assert resp.json()["total_columns"] == 640
 
 
 @pytest.mark.django_db(transaction=True)
@@ -532,7 +532,7 @@ def test_download_awards_with_foreign_scope(client, _award_download_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 639
+    assert resp.json()["total_columns"] == 640
 
 
 @pytest.mark.django_db(transaction=True)

--- a/usaspending_api/bulk_download/tests/integration/test_download.py
+++ b/usaspending_api/bulk_download/tests/integration/test_download.py
@@ -509,7 +509,7 @@ def test_download_awards_with_foreign_scope(client, _award_download_data):
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total_rows"] == 5
-    assert resp.json()["total_columns"] == 639
+    assert resp.json()["total_columns"] == 640
 
     # Place of Performance Scope
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())

--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -18,7 +18,6 @@ from django.db.models import (
     When,
 )
 
-from usaspending_api.awards.models.transaction_fabs import FABS_TO_TRANSACTION_SEARCH_COL_MAP
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.awards.models.transaction_normalized import NORM_TO_TRANSACTION_SEARCH_COL_MAP
 from usaspending_api.common.helpers.orm_helpers import ConcatAll, FiscalYear, StringAggWithDefault, CFDAs

--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -18,6 +18,7 @@ from django.db.models import (
     When,
 )
 
+from usaspending_api.awards.models.transaction_fabs import FABS_TO_TRANSACTION_SEARCH_COL_MAP
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.awards.models.transaction_normalized import NORM_TO_TRANSACTION_SEARCH_COL_MAP
 from usaspending_api.common.helpers.orm_helpers import ConcatAll, FiscalYear, StringAggWithDefault, CFDAs
@@ -345,6 +346,14 @@ def transaction_search_annotations(filters: dict, file_type: str = None):
             output_field=TextField(),
         ),
     }
+    # Only d2 should have a value for this column
+    if file_type == "d2":
+        annotation_fields["generated_pragmatic_obligations"] = Case(
+            When(
+                Q(**{f'{FABS_TO_TRANSACTION_SEARCH_COL_MAP["assistance_type"]}__in': ["07", "08"]}),
+                then=F("original_loan_subsidy_cost"),
+            )
+        )
     annotation_fields.update(TXN_SEARCH_CD_DISPLAY_ANNOTATIONS)
     return annotation_fields
 

--- a/usaspending_api/download/helpers/download_annotation_functions.py
+++ b/usaspending_api/download/helpers/download_annotation_functions.py
@@ -346,14 +346,6 @@ def transaction_search_annotations(filters: dict, file_type: str = None):
             output_field=TextField(),
         ),
     }
-    # Only d2 should have a value for this column
-    if file_type == "d2":
-        annotation_fields["generated_pragmatic_obligations"] = Case(
-            When(
-                Q(**{f'{FABS_TO_TRANSACTION_SEARCH_COL_MAP["assistance_type"]}__in': ["07", "08"]}),
-                then=F("original_loan_subsidy_cost"),
-            )
-        )
     annotation_fields.update(TXN_SEARCH_CD_DISPLAY_ANNOTATIONS)
     return annotation_fields
 

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1868,6 +1868,7 @@ query_paths = {
                 ("original_loan_subsidy_cost", NORM_TO_TRANSACTION_SEARCH_COL_MAP["original_loan_subsidy_cost"]),
                 ("total_face_value_of_loan", "award__total_loan_value"),
                 ("total_loan_subsidy_cost", "award__total_subsidy_cost"),
+                ("generated_pragmatic_obligations", None),
                 ("disaster_emergency_fund_codes_for_overall_award", None),  # Annotation is used to create this column
                 (
                     "outlayed_amount_from_COVID-19_supplementals_for_overall_award",

--- a/usaspending_api/download/v2/download_column_historical_lookups.py
+++ b/usaspending_api/download/v2/download_column_historical_lookups.py
@@ -1868,7 +1868,7 @@ query_paths = {
                 ("original_loan_subsidy_cost", NORM_TO_TRANSACTION_SEARCH_COL_MAP["original_loan_subsidy_cost"]),
                 ("total_face_value_of_loan", "award__total_loan_value"),
                 ("total_loan_subsidy_cost", "award__total_subsidy_cost"),
-                ("generated_pragmatic_obligations", None),
+                ("generated_pragmatic_obligations", "generated_pragmatic_obligation"),
                 ("disaster_emergency_fund_codes_for_overall_award", None),  # Annotation is used to create this column
                 (
                     "outlayed_amount_from_COVID-19_supplementals_for_overall_award",


### PR DESCRIPTION
**Description:**
Loans use original loan subsidy cost to measure the value of an award. Non-loans use federal action obligation. This makes it tricky to sum up spending on download files that include both loans and non-loans. The database has a column `generated_pragmatic_obligation`s that can be summed in these cases. For these reasons, this PR adds `generated_pragmatic_obligations` to downloads so that users can aggregate on this column alone to get a total that accounts for these nuisances.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10072](https://federal-spending-transparency.atlassian.net/browse/DEV-10072):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
