### PR TITLE
[DEV-10148] New Endpoint for Award Counts by Agency

### DIFF
--- a/usaspending_api/agency/tests/integration/test_award_count.py
+++ b/usaspending_api/agency/tests/integration/test_award_count.py
@@ -2,7 +2,6 @@ import pytest
 from model_bakery import baker
 
 from rest_framework import status
-from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
 from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
 
 url = "/api/v2/agency/awards/count/{filters}"
@@ -52,7 +51,7 @@ def award_data(db):
         latest_transaction_id=10,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department',
+        awarding_toptier_agency_name="Department",
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -66,7 +65,7 @@ def award_data(db):
         latest_transaction_id=20,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department',
+        awarding_toptier_agency_name="Department",
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -80,7 +79,7 @@ def award_data(db):
         latest_transaction_id=30,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department',
+        awarding_toptier_agency_name="Department",
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -94,7 +93,7 @@ def award_data(db):
         latest_transaction_id=40,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department',
+        awarding_toptier_agency_name="Department",
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -108,7 +107,7 @@ def award_data(db):
         latest_transaction_id=50,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department',
+        awarding_toptier_agency_name="Department",
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -122,7 +121,7 @@ def award_data(db):
         latest_transaction_id=60,
         awarding_agency_id=ag3.id,
         awarding_toptier_agency_code=ta3.toptier_code,
-        awarding_toptier_agency_name='Department of Commerce',
+        awarding_toptier_agency_name="Department of Commerce",
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -142,21 +141,22 @@ def test_award_count_success(client, monkeypatch, award_data, helpers, elasticse
     helpers.mock_current_fiscal_year(monkeypatch)
 
     resp = client.get(url.format(filters=""))
-    results = resp.data['results']
+    results = resp.data["results"]
     assert resp.status_code == status.HTTP_200_OK
     assert len(results) == 1
+
 
 @pytest.mark.django_db
 def test_award_count_specific_year(client, monkeypatch, award_data, helpers, elasticsearch_award_index):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
     resp = client.get(url.format(filters="?fiscal_year=2019"))
-    results = resp.data['results']
+    results = resp.data["results"]
     assert resp.status_code == status.HTTP_200_OK
     assert len(results) == 1
 
     resp = client.get(url.format(filters="?fiscal_year=2021"))
-    results = resp.data['results']
+    results = resp.data["results"]
     assert resp.status_code == status.HTTP_200_OK
     assert len(results) == 1
 
@@ -166,6 +166,6 @@ def test_award_count_cfo_agencies_only(client, monkeypatch, award_data, helpers,
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
     resp = client.get(url.format(filters="?group=cfo"))
-    results = resp.data['results']
+    results = resp.data["results"]
     assert resp.status_code == status.HTTP_200_OK
     assert len(results) == 1

--- a/usaspending_api/agency/tests/integration/test_award_count.py
+++ b/usaspending_api/agency/tests/integration/test_award_count.py
@@ -1,0 +1,164 @@
+import pytest
+from model_bakery import baker
+
+from rest_framework import status
+from usaspending_api.common.helpers.fiscal_year_helpers import current_fiscal_year
+from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
+
+url = "/api/v2/agency/awards/count/{filters}"
+
+
+@pytest.fixture
+def award_data(db):
+    dabs_submission_window_lazy_ref = "submissions.DABSSubmissionWindowSchedule"
+    dabs = baker.make(
+        dabs_submission_window_lazy_ref,
+        submission_reveal_date="2021-08-09",
+        submission_fiscal_year=2021,
+        submission_fiscal_month=11,
+        submission_fiscal_quarter=4,
+        is_quarter=False,
+        period_start_date="2021-10-01",
+        period_end_date="2021-11-01",
+    )
+
+    submission_attributes_lazy_ref = "submissions.SubmissionAttributes"
+    baker.make(
+        submission_attributes_lazy_ref,
+        reporting_fiscal_year=2021,
+        reporting_fiscal_period=11,
+        is_final_balances_for_fy=True,
+        submission_window_id=dabs.id,
+    )
+
+    toptier_agency_lazy_ref = "references.ToptierAgency"
+    ta1 = baker.make(toptier_agency_lazy_ref, toptier_agency_id=1, toptier_code=123)
+    ta2 = baker.make(toptier_agency_lazy_ref, toptier_agency_id=2, toptier_code=456)
+    ta3 = baker.make(toptier_agency_lazy_ref, toptier_agency_id=3, toptier_code=789)
+
+    agency_lazy_ref = "references.Agency"
+    ag1 = baker.make(agency_lazy_ref, id=1, toptier_agency=ta1)
+    ag2 = baker.make(agency_lazy_ref, id=2, toptier_agency=ta2)
+    ag3 = baker.make(agency_lazy_ref, id=3, toptier_agency=ta3)
+
+    awards_lazy_ref = "search.AwardSearch"
+    award1 = baker.make(
+        awards_lazy_ref,
+        award_id=1,
+        type="A",
+        date_signed="2019-10-15",
+        action_date="2019-10-15",
+        earliest_transaction_id=10,
+        latest_transaction_id=10,
+        awarding_agency_id=ag1.id,
+        awarding_toptier_agency_code=ta1.toptier_code,
+        awarding_toptier_agency_name='Department of Defense',
+        funding_agency_id=ag2.id,
+        funding_toptier_agency_code=ta2.toptier_code,
+    )
+    award2 = baker.make(
+        awards_lazy_ref,
+        award_id=2,
+        type="B",
+        date_signed="2019-12-15",
+        action_date="2019-12-15",
+        earliest_transaction_id=20,
+        latest_transaction_id=20,
+        awarding_agency_id=ag1.id,
+        awarding_toptier_agency_code=ta1.toptier_code,
+        awarding_toptier_agency_name='Department of Defense',
+        funding_agency_id=ag2.id,
+        funding_toptier_agency_code=ta2.toptier_code,
+    )
+    award3 = baker.make(
+        awards_lazy_ref,
+        award_id=3,
+        type="07",
+        date_signed="2020-01-30",
+        action_date="2020-01-30",
+        earliest_transaction_id=30,
+        latest_transaction_id=30,
+        awarding_agency_id=ag1.id,
+        awarding_toptier_agency_code=ta1.toptier_code,
+        awarding_toptier_agency_name='Department of Defense',
+        funding_agency_id=ag2.id,
+        funding_toptier_agency_code=ta2.toptier_code,
+    )
+    award4 = baker.make(
+        awards_lazy_ref,
+        award_id=4,
+        type="B",
+        date_signed="2019-09-30",
+        action_date="2019-09-30",
+        earliest_transaction_id=40,
+        latest_transaction_id=40,
+        awarding_agency_id=ag1.id,
+        awarding_toptier_agency_code=ta1.toptier_code,
+        awarding_toptier_agency_name='Department of Defense',
+        funding_agency_id=ag2.id,
+        funding_toptier_agency_code=ta2.toptier_code,
+    )
+    award5 = baker.make(
+        awards_lazy_ref,
+        award_id=5,
+        type="08",
+        date_signed="2020-12-15",
+        action_date="2020-12-15",
+        earliest_transaction_id=50,
+        latest_transaction_id=50,
+        awarding_agency_id=ag1.id,
+        awarding_toptier_agency_code=ta1.toptier_code,
+        awarding_toptier_agency_name='Department of Defense',
+        funding_agency_id=ag2.id,
+        funding_toptier_agency_code=ta2.toptier_code,
+    )
+    award6 = baker.make(
+        awards_lazy_ref,
+        award_id=6,
+        type="08",
+        date_signed="2021-07-05",
+        action_date="2021-07-05",
+        earliest_transaction_id=60,
+        latest_transaction_id=60,
+        awarding_agency_id=ag3.id,
+        awarding_toptier_agency_code=ta3.toptier_code,
+        awarding_toptier_agency_name='Department of Agriculture',
+        funding_agency_id=ag2.id,
+        funding_toptier_agency_code=ta2.toptier_code,
+    )
+
+    transaction_search_lazy_ref = "search.TransactionSearch"
+    baker.make(transaction_search_lazy_ref, transaction_id=10, award=award1, action_date="2019-10-15")
+    baker.make(transaction_search_lazy_ref, transaction_id=20, award=award2, action_date="2020-12-15")
+    baker.make(transaction_search_lazy_ref, transaction_id=30, award=award3, action_date="2020-01-30")
+    baker.make(transaction_search_lazy_ref, transaction_id=40, award=award4, action_date="2019-09-30")
+    baker.make(transaction_search_lazy_ref, transaction_id=50, award=award5, action_date="2020-12-15")
+    baker.make(transaction_search_lazy_ref, transaction_id=60, award=award6, action_date="2021-07-05")
+
+
+@pytest.mark.django_db
+def test_award_count_success(client, monkeypatch, award_data, helpers, elasticsearch_award_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    helpers.mock_current_fiscal_year(monkeypatch)
+
+    resp = client.get(url.format(filters=""))
+    results = resp.data['results']
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(results) == 1
+
+@pytest.mark.django_db
+def test_award_count_specific_year(client, monkeypatch, award_data, helpers, elasticsearch_award_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+
+    resp = client.get(url.format(filters="?fiscal_year=2019"))
+    print(resp.data)
+    results = resp.data['results']
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(results) == 1
+
+    resp = client.get(url.format(filters="?fiscal_year=2021"))
+    results = resp.data['results']
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(results) == 1
+
+

--- a/usaspending_api/agency/tests/integration/test_award_count.py
+++ b/usaspending_api/agency/tests/integration/test_award_count.py
@@ -52,7 +52,7 @@ def award_data(db):
         latest_transaction_id=10,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department of Defense',
+        awarding_toptier_agency_name='Department',
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -66,7 +66,7 @@ def award_data(db):
         latest_transaction_id=20,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department of Defense',
+        awarding_toptier_agency_name='Department',
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -80,7 +80,7 @@ def award_data(db):
         latest_transaction_id=30,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department of Defense',
+        awarding_toptier_agency_name='Department',
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -94,7 +94,7 @@ def award_data(db):
         latest_transaction_id=40,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department of Defense',
+        awarding_toptier_agency_name='Department',
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -108,7 +108,7 @@ def award_data(db):
         latest_transaction_id=50,
         awarding_agency_id=ag1.id,
         awarding_toptier_agency_code=ta1.toptier_code,
-        awarding_toptier_agency_name='Department of Defense',
+        awarding_toptier_agency_name='Department',
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -122,7 +122,7 @@ def award_data(db):
         latest_transaction_id=60,
         awarding_agency_id=ag3.id,
         awarding_toptier_agency_code=ta3.toptier_code,
-        awarding_toptier_agency_name='Department of Agriculture',
+        awarding_toptier_agency_name='Department of Commerce',
         funding_agency_id=ag2.id,
         funding_toptier_agency_code=ta2.toptier_code,
     )
@@ -151,7 +151,6 @@ def test_award_count_specific_year(client, monkeypatch, award_data, helpers, ela
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
 
     resp = client.get(url.format(filters="?fiscal_year=2019"))
-    print(resp.data)
     results = resp.data['results']
     assert resp.status_code == status.HTTP_200_OK
     assert len(results) == 1
@@ -162,3 +161,11 @@ def test_award_count_specific_year(client, monkeypatch, award_data, helpers, ela
     assert len(results) == 1
 
 
+@pytest.mark.django_db
+def test_award_count_cfo_agencies_only(client, monkeypatch, award_data, helpers, elasticsearch_award_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+
+    resp = client.get(url.format(filters="?group=cfo"))
+    results = resp.data['results']
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(results) == 1

--- a/usaspending_api/agency/tests/integration/test_award_count.py
+++ b/usaspending_api/agency/tests/integration/test_award_count.py
@@ -164,6 +164,7 @@ def test_award_count_specific_year(client, monkeypatch, award_data, helpers, ela
 @pytest.mark.django_db
 def test_award_count_cfo_agencies_only(client, monkeypatch, award_data, helpers, elasticsearch_award_index):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    helpers.mock_current_fiscal_year(monkeypatch)
 
     resp = client.get(url.format(filters="?group=cfo"))
     results = resp.data["results"]

--- a/usaspending_api/agency/v2/urls.py
+++ b/usaspending_api/agency/v2/urls.py
@@ -31,13 +31,13 @@ urlpatterns = [
         r"^treasury_account/(?P<tas>{})/program_activity/$".format(tas_with_slashes_pattern),
         TASProgramActivityList.as_view(),
     ),
+    path("awards/count/", AwardCount.as_view()),
     re_path(
         "(?P<toptier_code>[0-9]{3,4})/",
         include(
             [
                 path("", AgencyOverview.as_view()),
                 path("awards/", Awards.as_view()),
-                path("awards/count/", AwardCount.as_view()),
                 path("awards/new/count/", NewAwardCount.as_view()),
                 path("budget_function/", BudgetFunctionList.as_view()),
                 path("budget_function/count/", BudgetFunctionCount.as_view()),

--- a/usaspending_api/agency/v2/urls.py
+++ b/usaspending_api/agency/v2/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path, re_path
 from usaspending_api.agency.v2.views.agency_overview import AgencyOverview
+from usaspending_api.agency.v2.views.award_count import AwardCount
 from usaspending_api.agency.v2.views.awards import Awards
 from usaspending_api.agency.v2.views.budget_function_count import BudgetFunctionCount
 from usaspending_api.agency.v2.views.budget_function import BudgetFunctionList
@@ -53,6 +54,7 @@ urlpatterns = [
                 re_path(
                     "sub_components/(?P<bureau_slug>[a-z0-9]+(?:-[a-z0-9]*)*)/", BureauFederalAccountList.as_view()
                 ),
+                path("award_count/", AwardCount.as_view()),
             ]
         ),
     ),

--- a/usaspending_api/agency/v2/urls.py
+++ b/usaspending_api/agency/v2/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
             [
                 path("", AgencyOverview.as_view()),
                 path("awards/", Awards.as_view()),
+                path("awards/count/", AwardCount.as_view()),
                 path("awards/new/count/", NewAwardCount.as_view()),
                 path("budget_function/", BudgetFunctionList.as_view()),
                 path("budget_function/count/", BudgetFunctionCount.as_view()),
@@ -54,7 +55,6 @@ urlpatterns = [
                 re_path(
                     "sub_components/(?P<bureau_slug>[a-z0-9]+(?:-[a-z0-9]*)*)/", BureauFederalAccountList.as_view()
                 ),
-                path("award_count/", AwardCount.as_view()),
             ]
         ),
     ),

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -85,7 +85,9 @@ class AwardCount(AgencyBase):
         )
         filter_options["time_period_obj"] = new_awards_only_decorator
         for awarding_toptier_agency_name in self._toptier_awarding_agencies_to_include:
-            awarding_toptier_agency_code = ToptierAgency.objects.filter(name=awarding_toptier_agency_name).first().toptier_code
+            awarding_toptier_agency_code = (
+                ToptierAgency.objects.filter(name=awarding_toptier_agency_name).first().toptier_code
+            )
             filters.update(self._generate_filters(awarding_toptier_agency_name))
             filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
             s = AwardSearch().filter(filter_query)

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -4,7 +4,6 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 from usaspending_api.agency.v2.views.agency_base import AgencyBase
-from usaspending_api.awards.v2.filters.sub_award import subaward_filter
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch
 from usaspending_api.common.query_with_filters import QueryWithFilters
@@ -12,17 +11,20 @@ from usaspending_api.search.filters.elasticsearch.filter import _QueryType
 from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyTimePeriod
 from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod
 from django.conf import settings
-from django.db.models import Count
 from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings
 from elasticsearch_dsl import Q
-from usaspending_api.common.helpers.fiscal_year_helpers import (get_fiscal_year_end_datetime, get_fiscal_year_start_datetime)
+from usaspending_api.common.helpers.fiscal_year_helpers import (
+    get_fiscal_year_end_datetime,
+    get_fiscal_year_start_datetime,
+)
+
 
 class AwardCount(AgencyBase):
     """
     Obtain the count of awards for a specific agency in a single fiscal year
     """
 
-    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/award_count/count.md"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -36,10 +38,7 @@ class AwardCount(AgencyBase):
         award_types_counted = {"contracts": 0, "idvs": 0, "grants": 0, "direct_payments": 0, "loans": 0, "other": 0}
         award_types_counted.update(self.query_elasticsearch_for_prime_awards(filters))
 
-        raw_response = {
-            "results": award_types_counted,
-            "messages": []
-        }
+        raw_response = {"results": award_types_counted, "messages": []}
 
         return Response(raw_response)
 
@@ -48,7 +47,6 @@ class AwardCount(AgencyBase):
             "agencies": [{"type": self.agency_type, "tier": "toptier", "toptier_code": self.toptier_code}],
             "time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}],
         }
-
 
     def query_elasticsearch_for_prime_awards(self, filters) -> list:
         filter_options = {}

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -1,11 +1,13 @@
-from typing import Any
+from enum import Enum
+from typing import Any, List
 
 
 from rest_framework.request import Request
 from rest_framework.response import Response
-from usaspending_api.agency.v2.views.agency_base import AgencyBase
+from usaspending_api.agency.v2.views.agency_base import AgencyBase, PaginationMixin
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch
+from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
 from usaspending_api.common.query_with_filters import QueryWithFilters
 from usaspending_api.references.models.toptier_agency import ToptierAgency
 from usaspending_api.search.filters.elasticsearch.filter import _QueryType
@@ -20,7 +22,12 @@ from usaspending_api.common.helpers.fiscal_year_helpers import (
 )
 
 
-class AwardCount(AgencyBase):
+class GroupEnum(Enum):
+    ALL = "all"
+    CFO = "cfo"
+
+
+class AwardCount(PaginationMixin, AgencyBase):
     """
     Obtain the count of awards for a specific agency in a single fiscal year.
     """
@@ -28,9 +35,24 @@ class AwardCount(AgencyBase):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/awards/count.md"
 
     def __init__(self, *args, **kwargs):
+        self.additional_models = [
+            {
+                "key": "group",
+                "name": "group",
+                "type": "enum",
+                "enum_values": ["all", "cfo"],
+                "optional": True,
+                "default": "all",
+            },
+        ]
+        self.sortable_columns = ["awarding_toptier_agency_name.keyword"]
+        self.default_sort_column = "awarding_toptier_agency_name.keyword"
+        self.params_to_validate = ["fiscal_year", "group"]
         super().__init__(*args, **kwargs)
-        self.params_to_validate = ["fiscal_year"]
-        self._toptier_awarding_agencies_to_include = [
+        # The following are awarding toptier agency names
+        # that will be the only agencies returned when the
+        # cfo filter is used
+        self._toptier_cfo_agency_names = [
             "Agency for International Development",
             "Department of Agriculture",
             "Department of Commerce",
@@ -57,25 +79,26 @@ class AwardCount(AgencyBase):
             "Social Security Administration",
         ]
 
+    @property
+    def group(self):
+        return self._query_params.get("group")
+
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         self._fy_end = get_fiscal_year_end_datetime(self.fiscal_year).date()
         self._fy_start = get_fiscal_year_start_datetime(self.fiscal_year).date()
-
         results = self.query_elasticsearch_for_prime_awards({})
+        page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
+        results = results[self.pagination.lower_limit : self.pagination.upper_limit],
+        return Response(
+            {
+                "results": results[: self.pagination.limit],
+                "page_metadata": page_metadata,
+                "messages": self.standard_response_messages,
+            }
+        )
 
-        raw_response = {"results": results, "messages": []}
-
-        return Response(raw_response)
-
-    def _generate_filters(self, awarding_toptier_agency_name):
-        return {
-            "agencies": [{"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name}],
-            "time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}],
-        }
-
-    def query_elasticsearch_for_prime_awards(self, filters) -> list:
-        toptier_awarding_agencies_to_include_results = []
+    def query_elasticsearch_for_prime_awards(self, filters) -> List:
         filter_options = {}
         time_period_obj = AwardSearchTimePeriod(
             default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
@@ -84,31 +107,45 @@ class AwardCount(AgencyBase):
             time_period_obj=time_period_obj, query_type=_QueryType.AWARDS
         )
         filter_options["time_period_obj"] = new_awards_only_decorator
-        for awarding_toptier_agency_name in self._toptier_awarding_agencies_to_include:
-            awarding_toptier_agency_code = (
-                ToptierAgency.objects.filter(name=awarding_toptier_agency_name).first().toptier_code
-            )
-            filters.update(self._generate_filters(awarding_toptier_agency_name))
-            filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
-            s = AwardSearch().filter(filter_query)
+        filters.update({"time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}]})
+        if self.group == GroupEnum.CFO.value:
+                filters.update({"agencies": [{"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name} for awarding_toptier_agency_name in self._toptier_cfo_agency_names]})
+        agency_award_count_results = self._get_award_counts_response(filters, filter_options)
+        return agency_award_count_results
 
-            s.aggs.bucket(
-                "types",
-                "filters",
-                filters={category: Q("terms", type=types) for category, types in all_award_types_mappings.items()},
-            )
-            results = s.handle_execute()
+    def _get_award_counts_response(self, filters: List[dict], filter_options: dict) -> List[dict]:
+        """Returns counts of awards filtered by the filter parameters.
 
-            contracts = results.aggregations.types.buckets.contracts.doc_count
-            idvs = results.aggregations.types.buckets.idvs.doc_count
-            grants = results.aggregations.types.buckets.grants.doc_count
-            direct_payments = results.aggregations.types.buckets.direct_payments.doc_count
-            loans = results.aggregations.types.buckets.loans.doc_count
-            other = results.aggregations.types.buckets.other_financial_assistance.doc_count
+        Args:
+            filters: Filters to filter data on
+            filter_options: Additional filters to apply
 
-            response = {
-                "awarding_toptier_agency_name": awarding_toptier_agency_name,
-                "awarding_toptier_agency_code": awarding_toptier_agency_code,
+        Returns:
+            List[dict]: A dictionary containing award types and the number of their awards.
+        """
+        filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
+        record_num = (self.pagination.page - 1) * self.pagination.limit
+        sorts = [{self.default_sort_column: self.pagination.sort_order}]
+        s = AwardSearch().filter(filter_query).sort(*sorts)
+
+        s.aggs.bucket("agencies", "terms", field="awarding_toptier_agency_name.keyword", size=999999)
+        s.aggs["agencies"].bucket(
+            "types",
+            "filters",
+            filters={category: Q("terms", type=types) for category, types in all_award_types_mappings.items()},
+        )
+        results = s.handle_execute()
+
+        response = []
+        for agency in results.aggregations.agencies.buckets:
+            contracts = agency.types.buckets.contracts.doc_count
+            idvs = agency.types.buckets.idvs.doc_count
+            grants = agency.types.buckets.grants.doc_count
+            direct_payments = agency.types.buckets.direct_payments.doc_count
+            loans = agency.types.buckets.loans.doc_count
+            other = agency.types.buckets.other_financial_assistance.doc_count
+            agency_response = {
+                "awarding_toptier_agency_name": agency.key,
                 "contracts": contracts,
                 "direct_payments": direct_payments,
                 "grants": grants,
@@ -116,5 +153,5 @@ class AwardCount(AgencyBase):
                 "loans": loans,
                 "other": other,
             }
-            toptier_awarding_agencies_to_include_results.append(response)
-        return toptier_awarding_agencies_to_include_results
+            response.append(agency_response)
+        return response

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -29,7 +29,7 @@ class GroupEnum(Enum):
 
 class AwardCount(PaginationMixin, AgencyBase):
     """
-    Obtain the count of awards for a specific agency in a single fiscal year.
+    Obtain a count of Awards types for agencies in a single fiscal year.
     """
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/awards/count.md"

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -1,0 +1,113 @@
+from typing import Any
+
+from fiscalyear import FiscalYear
+from rest_framework.request import Request
+from rest_framework.response import Response
+from usaspending_api.agency.v2.views.agency_base import AgencyBase
+from usaspending_api.awards.v2.filters.sub_award import subaward_filter
+from usaspending_api.common.cache_decorator import cache_response
+from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch
+from usaspending_api.common.query_with_filters import QueryWithFilters
+from usaspending_api.search.filters.elasticsearch.filter import _QueryType
+from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyTimePeriod
+from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod
+from django.conf import settings
+from django.db.models import Count
+from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings
+from elasticsearch_dsl import Q
+
+class AwardCount(AgencyBase):
+    """
+    Obtain the count of awards for a specific agency in a single fiscal year
+    """
+
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/award_count/count.md"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params_to_validate = ["fiscal_year", "agency_type"]
+
+    @cache_response()
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # TODO validate fiscal year
+        # TODO: move this to the fiscal year helper module
+        fiscal_year = FiscalYear(self.fiscal_year)
+        self._fy_end = fiscal_year.end.date()
+        self._fy_start = fiscal_year.start.date()
+        filters = self._generate_filters()
+        # TODO: filter response by toptier agency code
+        award_types_counted = {"contracts": 0, "idvs": 0, "grants": 0, "direct_payments": 0, "loans": 0, "other": 0, "subcontracts": 0, "subgrants": 0}
+        # award_types_counted.update(self.handle_subawards(filters))
+        award_types_counted.update(self.query_elasticsearch_for_prime_awards(filters))
+
+        raw_response = {
+            "results": award_types_counted,
+            "messages": []
+        }
+
+        return Response(raw_response)
+
+    def _generate_filters(self):
+        return {
+            "agencies": [{"type": self.agency_type, "tier": "toptier", "toptier_code": self.toptier_code}],
+            "time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}],
+        }
+
+    @staticmethod
+    def handle_subawards(filters: dict) -> dict:
+        """Turn the filters into the result dictionary when dealing with Sub-Awards
+
+        Note: Due to how the Django ORM joins to the awards table as an
+        INNER JOIN, it is necessary to explicitly enforce the aggregations
+        to only count Sub-Awards that are linked to a Prime Award.
+
+        Remove the filter and update if we can move away from this behavior.
+        """
+        queryset = (
+            subaward_filter(filters)
+            .filter(award_id__isnull=False)
+            .values("prime_award_group")
+            .annotate(count=Count("broker_subaward_id"))
+        )
+
+        results = {}
+        results["subgrants"] = sum([sub["count"] for sub in queryset if sub["prime_award_group"] == "grant"])
+        results["subcontracts"] = sum([sub["count"] for sub in queryset if sub["prime_award_group"] == "procurement"])
+
+        return results
+
+    def query_elasticsearch_for_prime_awards(self, filters) -> list:
+        filter_options = {}
+        time_period_obj = AwardSearchTimePeriod(
+            default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
+        )
+        new_awards_only_decorator = NewAwardsOnlyTimePeriod(
+            time_period_obj=time_period_obj, query_type=_QueryType.AWARDS
+        )
+        filter_options["time_period_obj"] = new_awards_only_decorator
+        filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
+        s = AwardSearch().filter(filter_query)
+
+        s.aggs.bucket(
+            "types",
+            "filters",
+            filters={category: Q("terms", type=types) for category, types in all_award_types_mappings.items()},
+        )
+        results = s.handle_execute()
+
+        contracts = results.aggregations.types.buckets.contracts.doc_count
+        idvs = results.aggregations.types.buckets.idvs.doc_count
+        grants = results.aggregations.types.buckets.grants.doc_count
+        direct_payments = results.aggregations.types.buckets.direct_payments.doc_count
+        loans = results.aggregations.types.buckets.loans.doc_count
+        other = results.aggregations.types.buckets.other_financial_assistance.doc_count
+
+        response = {
+            "contracts": contracts,
+            "direct_payments": direct_payments,
+            "grants": grants,
+            "idvs": idvs,
+            "loans": loans,
+            "other": other,
+        }
+        return response

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -108,7 +108,7 @@ class AwardCount(PaginationMixin, AgencyBase):
         filter_options["time_period_obj"] = new_awards_only_decorator
         filters.update({"time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}]})
         if self.group == GroupEnum.CFO.value:
-                filters.update({"agencies": [{"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name} for awarding_toptier_agency_name in self._toptier_cfo_agency_names]})
+            filters.update({"agencies": [{"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name} for awarding_toptier_agency_name in self._toptier_cfo_agency_names]})
         agency_award_count_results = self._get_award_counts_response(filters, filter_options)
         return agency_award_count_results
 

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -21,34 +21,59 @@ from usaspending_api.common.helpers.fiscal_year_helpers import (
 
 class AwardCount(AgencyBase):
     """
-    Obtain the count of awards for a specific agency in a single fiscal year
+    Obtain the count of awards for a specific agency in a single fiscal year.
     """
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.params_to_validate = ["fiscal_year", "agency_type"]
+        self.params_to_validate = ["fiscal_year"]
+        self._toptier_awarding_agencies_to_include = [
+            "Agency for International Development",
+            "Department of Agriculture",
+            "Department of Commerce",
+            "Department of Defense",
+            "Department of Education",
+            "Department of Energy",
+            "Department of Health and Human Services",
+            "Department of Homeland Security",
+            "Department of Housing and Urban Development",
+            "Department of the Interior",
+            "Department of Justice",
+            "Department of Labor",
+            "Department of State",
+            "Department of Transportation",
+            "Department of the Treasury",
+            "Department of Veterans Affairs",
+            "Environmental Protection Agency",
+            "General Services Administration",
+            "National Aeronautics and Space Administration",
+            "National Science Foundation",
+            "Nuclear Regulatory Commission",
+            "Office of Personnel Management",
+            "Small Business Administration",
+            "Social Security Administration",
+        ]
 
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         self._fy_end = get_fiscal_year_end_datetime(self.fiscal_year).date()
         self._fy_start = get_fiscal_year_start_datetime(self.fiscal_year).date()
-        filters = self._generate_filters()
-        award_types_counted = {"contracts": 0, "idvs": 0, "grants": 0, "direct_payments": 0, "loans": 0, "other": 0}
-        award_types_counted.update(self.query_elasticsearch_for_prime_awards(filters))
+        results = self.query_elasticsearch_for_prime_awards({})
 
-        raw_response = {"results": award_types_counted, "messages": []}
+        raw_response = {"results": results, "messages": []}
 
         return Response(raw_response)
 
-    def _generate_filters(self):
+    def _generate_filters(self, awarding_toptier_agency_name):
         return {
-            "agencies": [{"type": self.agency_type, "tier": "toptier", "toptier_code": self.toptier_code}],
+            "agencies": [{"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name}],
             "time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}],
         }
 
     def query_elasticsearch_for_prime_awards(self, filters) -> list:
+        toptier_awarding_agencies_to_include_results = []
         filter_options = {}
         time_period_obj = AwardSearchTimePeriod(
             default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
@@ -57,29 +82,33 @@ class AwardCount(AgencyBase):
             time_period_obj=time_period_obj, query_type=_QueryType.AWARDS
         )
         filter_options["time_period_obj"] = new_awards_only_decorator
-        filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
-        s = AwardSearch().filter(filter_query)
+        for awarding_toptier_agency_name in self._toptier_awarding_agencies_to_include:
+            filters.update(self._generate_filters(awarding_toptier_agency_name))
+            filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
+            s = AwardSearch().filter(filter_query)
 
-        s.aggs.bucket(
-            "types",
-            "filters",
-            filters={category: Q("terms", type=types) for category, types in all_award_types_mappings.items()},
-        )
-        results = s.handle_execute()
+            s.aggs.bucket(
+                "types",
+                "filters",
+                filters={category: Q("terms", type=types) for category, types in all_award_types_mappings.items()},
+            )
+            results = s.handle_execute()
 
-        contracts = results.aggregations.types.buckets.contracts.doc_count
-        idvs = results.aggregations.types.buckets.idvs.doc_count
-        grants = results.aggregations.types.buckets.grants.doc_count
-        direct_payments = results.aggregations.types.buckets.direct_payments.doc_count
-        loans = results.aggregations.types.buckets.loans.doc_count
-        other = results.aggregations.types.buckets.other_financial_assistance.doc_count
+            contracts = results.aggregations.types.buckets.contracts.doc_count
+            idvs = results.aggregations.types.buckets.idvs.doc_count
+            grants = results.aggregations.types.buckets.grants.doc_count
+            direct_payments = results.aggregations.types.buckets.direct_payments.doc_count
+            loans = results.aggregations.types.buckets.loans.doc_count
+            other = results.aggregations.types.buckets.other_financial_assistance.doc_count
 
-        response = {
-            "contracts": contracts,
-            "direct_payments": direct_payments,
-            "grants": grants,
-            "idvs": idvs,
-            "loans": loans,
-            "other": other,
-        }
-        return response
+            response = {
+                "awarding_toptier_agency_name": awarding_toptier_agency_name,
+                "contracts": contracts,
+                "direct_payments": direct_payments,
+                "grants": grants,
+                "idvs": idvs,
+                "loans": loans,
+                "other": other,
+            }
+            toptier_awarding_agencies_to_include_results.append(response)
+        return toptier_awarding_agencies_to_include_results

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -88,7 +88,7 @@ class AwardCount(PaginationMixin, AgencyBase):
         self._fy_start = get_fiscal_year_start_datetime(self.fiscal_year).date()
         results = self.query_elasticsearch_for_prime_awards({})
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
-        results = results[self.pagination.lower_limit : self.pagination.upper_limit],
+        results = (results[self.pagination.lower_limit : self.pagination.upper_limit],)
         return Response(
             {
                 "results": results[: self.pagination.limit],
@@ -108,7 +108,14 @@ class AwardCount(PaginationMixin, AgencyBase):
         filter_options["time_period_obj"] = new_awards_only_decorator
         filters.update({"time_period": [{"start_date": self._fy_start, "end_date": self._fy_end}]})
         if self.group == GroupEnum.CFO.value:
-            filters.update({"agencies": [{"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name} for awarding_toptier_agency_name in self._toptier_cfo_agency_names]})
+            filters.update(
+                {
+                    "agencies": [
+                        {"type": "awarding", "tier": "toptier", "name": awarding_toptier_agency_name}
+                        for awarding_toptier_agency_name in self._toptier_cfo_agency_names
+                    ]
+                }
+            )
         agency_award_count_results = self._get_award_counts_response(filters, filter_options)
         return agency_award_count_results
 

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -24,7 +24,7 @@ class AwardCount(AgencyBase):
     Obtain the count of awards for a specific agency in a single fiscal year.
     """
 
-    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md"
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/awards/count.md"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -28,7 +28,7 @@ class GroupEnum(Enum):
 
 class AwardCount(PaginationMixin, AgencyBase):
     """
-    Obtain a count of Awards types for agencies in a single fiscal year.
+    Obtain a count of Awards grouped by Award Type under Agencies
     """
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/agency/awards/count.md"

--- a/usaspending_api/agency/v2/views/award_count.py
+++ b/usaspending_api/agency/v2/views/award_count.py
@@ -14,7 +14,7 @@ from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyT
 from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod
 from django.conf import settings
 from usaspending_api.awards.v2.lookups.lookups import all_award_types_mappings
-from elasticsearch_dsl import Q, A
+from elasticsearch_dsl import Q
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     get_fiscal_year_end_datetime,
     get_fiscal_year_start_datetime,
@@ -132,7 +132,7 @@ class AwardCount(PaginationMixin, AgencyBase):
         filter_query = QueryWithFilters.generate_awards_elasticsearch_query(filters, **filter_options)
         record_num = (self.pagination.page - 1) * self.pagination.limit
         sorts = [{self.default_sort_column: self.pagination.sort_order}]
-        s = AwardSearch().filter(filter_query).sort(*sorts)
+        s = AwardSearch().filter(filter_query).sort(*sorts)[record_num : record_num + self.pagination.limit]
 
         s.aggs.bucket("agencies", "terms", field="awarding_toptier_agency_name.keyword", size=999999)
         s.aggs["agencies"].bucket("codes", "terms", field="awarding_toptier_agency_code.keyword", size=999999)

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -18,11 +18,12 @@ Return the count of Awards under Agencies
     + Parameters
         + `group`: (optional, enum[string])
             The agencies to return award counts for. Defaults to "all".
-          + Members
-            +  `cfo`
-                Only return award counts for CFO designated agencies
-            + `all`
-                Return award counts for all awarding toptier agencies.
+            + Members
+                +  `cfo`
+                    Only return award counts for CFO designated agencies
+                + `all`
+                    Return award counts for all awarding toptier agencies.
+            + Default: `all`
         + `fiscal_year` (optional, number)
             The desired appropriations fiscal year. Defaults to the current FY
         + `order` (optional, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -1,9 +1,9 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# Overview of awards for Agency [/api/v2/agency/awards/count{?fiscal_year}]
+# Count of awards for Agencies [/api/v2/agency/awards/count{?fiscal_year,group}]
 
-Return the count of Awards under the Agency
+Return the count of Awards under Agencies
 
 ## GET
 
@@ -16,13 +16,34 @@ Return the count of Awards under the Agency
             }
 
     + Parameters
-
+        + `group`: (optional, enum[GroupType])
+            The agencies to return award counts for. Defaults to "all".
         + `fiscal_year` (optional, number)
             The desired appropriations fiscal year. Defaults to the current FY
-
+        + `order` (optional, enum[string])
+            Indicates what direction results should be sorted by. Valid options include asc for ascending order or desc for descending order.
+            + Default: `desc`
+            + Members
+                + `desc`
+                + `asc`
+        + `sort` (optional, enum[string])
+            Optional parameter indicating what value results should be sorted by.
+            + Default: `obligated_amount`
+            + Members
+                + `name`
+                + `obligated_amount`
+                + `gross_outlay_amount`
+        + `page` (optional, number)
+            The page number that is currently returned.
+            + Default: 1
+        + `limit` (optional, number)
+            How many results are returned
+            + Default: 10
 
 + Response 200 (application/json)
     + Attributes
+        + `page_metadata` (required, PageMetadata, fixed-type)
+            Information used for pagination of results.
         + `results` (required, array[AgencyResult], fixed-type)
         + `messages` (required, array[string], fixed-type)
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
@@ -30,18 +51,37 @@ Return the count of Awards under the Agency
     + Body
 
             {
-                "results": {
+                "page_metadata": {
+                    "limit": 1,
+                    "page": 1,
+                    "next": 2,
+                    "previous": null,
+                    "hasNext": false,
+                    "hasPrevious": false,
+                    "count": 10
+                },
+                "results": [
+                    {
+                    "awarding_toptier_agency_name": "Department of Defense",
+                    "awarding_toptier_agency_code": "079",
                     "contracts": 2724,
                     "idvs": 45,
                     "grants": 0,
                     "direct_payments": 0,
                     "loans": 0,
                     "other": 0
-                },
+                    }
+                ],
                 "messages": []
             }
 
 # Data Structures
+
+## GroupType (object)
++ `cfo` (optional, string)
+    Only return award counts for CFO designated agencies
++ `all` (optional, string)
+    Return award counts for all awarding toptier agencies.
 
 ## AgencyResult (object)
 + `award_types` (required, AwardTypes, fixed-type)
@@ -56,4 +96,12 @@ Return the count of Awards under the Agency
 + `other` (required, number)
 + `idvs` (required, number)
 
+## PageMetadata (object)
++ `limit` (required, number)
++ `page` (required, number)
++ `next` (required, number, nullable)
++ `previous` (required, number, nullable)
++ `hasNext` (required, boolean)
++ `hasPrevious` (required, boolean)
++ `total` (required, number)
 

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# Overview of awards for Agency [/api/v2/agency/{toptier_code}/awards/count{?fiscal_year,agency_type}]
+# Overview of awards for Agency [/api/v2/agency/awards/count{?fiscal_year}]
 
 Return the count of Awards under the Agency
 
@@ -16,21 +16,14 @@ Return the count of Awards under the Agency
             }
 
     + Parameters
-        + `toptier_code`: 086 (required, number)
-            The toptier code of an agency (could be a CGAC or FREC) so only numeric character strings of length 3-4 are accepted.
+
         + `fiscal_year` (optional, number)
             The desired appropriations fiscal year. Defaults to the current FY
-        + `agency_type` (optional, enum[string])
-            The agency type to pull the count for.
-            + Default: `awarding`
-            + Members
-                + `awarding`
-                + `funding`
 
 
 + Response 200 (application/json)
     + Attributes
-        + `results` (required, array[AwardTypeResult], fixed-type)
+        + `results` (required, array[AgencyAwardCountResult], fixed-type)
         + `messages` (required, array[string], fixed-type)
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
@@ -50,6 +43,10 @@ Return the count of Awards under the Agency
 
 # Data Structures
 
+## AgencyResult (object)
++ `AwardTypeResult`
++ `Awarding Toptier Agency Name`
+
 ## AwardTypeResult (object)
 + `grants` (required, number)
 + `loans` (required, number)
@@ -57,3 +54,5 @@ Return the count of Awards under the Agency
 + `direct_payments` (required, number)
 + `other` (required, number)
 + `idvs` (required, number)
+
+

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -16,13 +16,12 @@ Returns the count of Awards grouped by Award Type under Agencies
             }
 
     + Parameters
-        + `group`: (optional, enum[string], fixed-type)
+        + `group` (optional, enum[string])
+            Use `cfo` to get results where CFO designated agencies are returned. Otherwise use `all`.
+            + Default: `all`
             + Members
                 + `cfo`
-                    Only return award counts for CFO designated agencies
                 + `all`
-                    Return award counts for all awarding toptier agencies.
-            + Default: `all`
         + `fiscal_year` (optional, number)
             The desired appropriations fiscal year. Defaults to the current FY
         + `order` (optional, enum[string])

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -16,8 +16,13 @@ Return the count of Awards under Agencies
             }
 
     + Parameters
-        + `group`: (optional, enum[GroupType])
+        + `group`: (optional, enum[string])
             The agencies to return award counts for. Defaults to "all".
+          + Members
+            +  `cfo`
+                Only return award counts for CFO designated agencies
+            + `all`
+                Return award counts for all awarding toptier agencies.
         + `fiscal_year` (optional, number)
             The desired appropriations fiscal year. Defaults to the current FY
         + `order` (optional, enum[string])
@@ -76,12 +81,6 @@ Return the count of Awards under Agencies
             }
 
 # Data Structures
-
-## GroupType (object)
-+ `cfo` (optional, string)
-    Only return award counts for CFO designated agencies
-+ `all` (optional, string)
-    Return award counts for all awarding toptier agencies.
 
 ## AgencyResult (object)
 + `award_types` (required, AwardTypes, fixed-type)

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -16,8 +16,7 @@ Return the count of Awards under Agencies
             }
 
     + Parameters
-        + `group`: (optional, enum[string])
-            The agencies to return award counts for. Defaults to "all".
+        + `group`: (optional, enum[string], fixed-type)
             + Members
                 + `cfo`
                     Only return award counts for CFO designated agencies

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -19,7 +19,7 @@ Return the count of Awards under Agencies
         + `group`: (optional, enum[string])
             The agencies to return award counts for. Defaults to "all".
             + Members
-                +  `cfo`
+                + `cfo`
                     Only return award counts for CFO designated agencies
                 + `all`
                     Return award counts for all awarding toptier agencies.
@@ -104,4 +104,3 @@ Return the count of Awards under Agencies
 + `hasNext` (required, boolean)
 + `hasPrevious` (required, boolean)
 + `total` (required, number)
-

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -23,7 +23,7 @@ Return the count of Awards under the Agency
 
 + Response 200 (application/json)
     + Attributes
-        + `results` (required, array[AgencyAwardCountResult], fixed-type)
+        + `results` (required, array[AgencyResult], fixed-type)
         + `messages` (required, array[string], fixed-type)
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 
@@ -44,10 +44,11 @@ Return the count of Awards under the Agency
 # Data Structures
 
 ## AgencyResult (object)
-+ `AwardTypeResult`
-+ `Awarding Toptier Agency Name`
++ `award_types` (required, AwardTypes, fixed-type)
++ `awarding_toptier_agency_name` (required, string)
++ `awarding_toptier_agency_code` (required, string)
 
-## AwardTypeResult (object)
+## AwardTypes (object)
 + `grants` (required, number)
 + `loans` (required, number)
 + `contracts` (required, number)

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -14,7 +14,6 @@ Returns the count of Awards grouped by Award Type under Agencies
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "number"
             }
-
     + Parameters
         + `group` (optional, enum[string])
             Use `cfo` to get results where CFO designated agencies are returned. Otherwise use `all`.

--- a/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/awards/count.md
@@ -3,7 +3,7 @@ HOST: https://api.usaspending.gov
 
 # Count of awards for Agencies [/api/v2/agency/awards/count{?fiscal_year,group}]
 
-Return the count of Awards under Agencies
+Returns the count of Awards grouped by Award Type under Agencies
 
 ## GET
 

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md
@@ -14,6 +14,7 @@ Return the count of Awards under the Agency
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "number"
             }
+
     + Parameters
         + `toptier_code`: 086 (required, number)
             The toptier code of an agency (could be a CGAC or FREC) so only numeric character strings of length 3-4 are accepted.
@@ -35,17 +36,17 @@ Return the count of Awards under the Agency
 
     + Body
 
-        {
-            "results": {
-                "contracts": 2724,
-                "idvs": 45,
-                "grants": 0,
-                "direct_payments": 0,
-                "loans": 0,
-                "other": 0
-            },
-            "messages": []
-        }
+            {
+                "results": {
+                    "contracts": 2724,
+                    "idvs": 45,
+                    "grants": 0,
+                    "direct_payments": 0,
+                    "loans": 0,
+                    "other": 0
+                },
+                "messages": []
+            }
 
 # Data Structures
 

--- a/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/agency/toptier_code/awards/count.md
@@ -1,0 +1,58 @@
+FORMAT: 1A
+HOST: https://api.usaspending.gov
+
+# Overview of awards for Agency [/api/v2/agency/{toptier_code}/awards/count{?fiscal_year,agency_type}]
+
+Return the count of Awards under the Agency
+
+## GET
+
++ Request (application/json)
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "number"
+            }
+    + Parameters
+        + `toptier_code`: 086 (required, number)
+            The toptier code of an agency (could be a CGAC or FREC) so only numeric character strings of length 3-4 are accepted.
+        + `fiscal_year` (optional, number)
+            The desired appropriations fiscal year. Defaults to the current FY
+        + `agency_type` (optional, enum[string])
+            The agency type to pull the count for.
+            + Default: `awarding`
+            + Members
+                + `awarding`
+                + `funding`
+
+
++ Response 200 (application/json)
+    + Attributes
+        + `results` (required, array[AwardTypeResult], fixed-type)
+        + `messages` (required, array[string], fixed-type)
+            An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
+
+    + Body
+
+        {
+            "results": {
+                "contracts": 2724,
+                "idvs": 45,
+                "grants": 0,
+                "direct_payments": 0,
+                "loans": 0,
+                "other": 0
+            },
+            "messages": []
+        }
+
+# Data Structures
+
+## AwardTypeResult (object)
++ `grants` (required, number)
++ `loans` (required, number)
++ `contracts` (required, number)
++ `direct_payments` (required, number)
++ `other` (required, number)
++ `idvs` (required, number)

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -31,6 +31,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/](/api/v2/agency/012/)|GET| Returns agency overview information for USAspending.gov's Agency Details page for agencies that have ever awarded |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/](/api/v2/agency/012/awards/)|GET| Returns agency summary information, specifically the number of transactions and award obligations for the sub agency section of USAspending.gov's Agency Details page |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/new/count/](/api/v2/agency/012/awards/new/count/)|GET| Returns a count of New Awards for the agency in a single fiscal year |
+|[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/count/](/api/v2/agency/012/awards/count/)|GET| Returns a count of  Awards for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budget_function/](/api/v2/agency/012/budget_function/)|GET| Returns a list of Budget Functions and Budget Subfunctions for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budget_function/count/](/api/v2/agency/012/budget_function/count/)|GET| Returns the count of Budget Functions for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budgetary_resources/](/api/v2/agency/012/budgetary_resources/)|GET| Returns budgetary resources and obligations for the agency and fiscal year requested |

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -31,7 +31,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/](/api/v2/agency/012/)|GET| Returns agency overview information for USAspending.gov's Agency Details page for agencies that have ever awarded |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/](/api/v2/agency/012/awards/)|GET| Returns agency summary information, specifically the number of transactions and award obligations for the sub agency section of USAspending.gov's Agency Details page |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/new/count/](/api/v2/agency/012/awards/new/count/)|GET| Returns a count of New Awards for the agency in a single fiscal year |
-|[/api/v2/agency/awards/count/](/api/v2/agency/awards/count/)|GET| Returns a count of  Awards for a subset of Toptier agencies in a single fiscal year |
+|[/api/v2/agency/awards/count/](/api/v2/agency/awards/count/)|GET| Returns a count of Awards types for agencies in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budget_function/](/api/v2/agency/012/budget_function/)|GET| Returns a list of Budget Functions and Budget Subfunctions for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budget_function/count/](/api/v2/agency/012/budget_function/count/)|GET| Returns the count of Budget Functions for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budgetary_resources/](/api/v2/agency/012/budgetary_resources/)|GET| Returns budgetary resources and obligations for the agency and fiscal year requested |

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -31,7 +31,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/](/api/v2/agency/012/)|GET| Returns agency overview information for USAspending.gov's Agency Details page for agencies that have ever awarded |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/](/api/v2/agency/012/awards/)|GET| Returns agency summary information, specifically the number of transactions and award obligations for the sub agency section of USAspending.gov's Agency Details page |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/new/count/](/api/v2/agency/012/awards/new/count/)|GET| Returns a count of New Awards for the agency in a single fiscal year |
-|[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/awards/count/](/api/v2/agency/012/awards/count/)|GET| Returns a count of  Awards for the agency in a single fiscal year |
+|[/api/v2/agency/awards/count/](/api/v2/agency/awards/count/)|GET| Returns a count of  Awards for a subset of Toptier agencies in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budget_function/](/api/v2/agency/012/budget_function/)|GET| Returns a list of Budget Functions and Budget Subfunctions for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budget_function/count/](/api/v2/agency/012/budget_function/count/)|GET| Returns the count of Budget Functions for the agency in a single fiscal year |
 |[/api/v2/agency/<TOPTIER_AGENCY_CODE\>/budgetary_resources/](/api/v2/agency/012/budgetary_resources/)|GET| Returns budgetary resources and obligations for the agency and fiscal year requested |

--- a/usaspending_api/common/helpers/fiscal_year_helpers.py
+++ b/usaspending_api/common/helpers/fiscal_year_helpers.py
@@ -26,6 +26,7 @@ def get_fiscal_year_end_datetime(fiscal_year: int) -> FiscalDateTime:
     fiscal_year = FiscalYear(fiscal_year)
     return fiscal_year.end
 
+
 def get_fiscal_year_start_datetime(fiscal_year: int) -> FiscalDateTime:
     """Provides a fiscal year date time start date given a fiscal year
 
@@ -38,7 +39,8 @@ def get_fiscal_year_start_datetime(fiscal_year: int) -> FiscalDateTime:
         provided.
     """
     fiscal_year = FiscalYear(fiscal_year)
-    return fiscal_year.start
+    return fiscal_year.start()
+
 
 def current_fiscal_date() -> FiscalDateTime:
     """FiscalDateTime.today() returns calendar date! Add 3 months to convert to fiscal"""
@@ -68,7 +70,7 @@ def create_fiscal_year_list(start_year=2000, end_year=None):
 
 
 def generate_fiscal_year(date):
-    """ Generate fiscal year based on the date provided """
+    """Generate fiscal year based on the date provided"""
     validate_date(date)
 
     year = date.year
@@ -78,7 +80,7 @@ def generate_fiscal_year(date):
 
 
 def generate_fiscal_month(date):
-    """ Generate fiscal period based on the date provided """
+    """Generate fiscal period based on the date provided"""
     validate_date(date)
 
     if date.month in [10, 11, 12]:
@@ -87,7 +89,7 @@ def generate_fiscal_month(date):
 
 
 def generate_fiscal_quarter(date):
-    """ Generate fiscal quarter based on the date provided """
+    """Generate fiscal quarter based on the date provided"""
     validate_date(date)
     return FiscalDate(date.year, date.month, date.day).quarter
 
@@ -107,7 +109,7 @@ def generate_fiscal_year_and_quarter(date):
 
 
 def dates_are_fiscal_year_bookends(start, end):
-    """ Returns true if the start and end dates fall on fiscal year(s) start and end date """
+    """Returns true if the start and end dates fall on fiscal year(s) start and end date"""
     try:
         if start.month == 10 and start.day == 1 and end.month == 9 and end.day == 30 and start.year < end.year:
             return True
@@ -226,7 +228,7 @@ def calculate_last_completed_fiscal_quarter(fiscal_year):
 
 
 def is_valid_period(period: int) -> bool:
-    """ There is no period 1. """
+    """There is no period 1."""
     return isinstance(period, int) and 2 <= period <= 12
 
 
@@ -255,7 +257,7 @@ def get_final_period_of_quarter(quarter: int) -> Optional[int]:
 
 
 def get_periods_in_quarter(quarter: int) -> Optional[Tuple[int]]:
-    """ There is no period 1. """
+    """There is no period 1."""
     return {1: (2, 3), 2: (4, 5, 6), 3: (7, 8, 9), 4: (10, 11, 12)}[quarter] if is_valid_quarter(quarter) else None
 
 

--- a/usaspending_api/common/helpers/fiscal_year_helpers.py
+++ b/usaspending_api/common/helpers/fiscal_year_helpers.py
@@ -39,7 +39,7 @@ def get_fiscal_year_start_datetime(fiscal_year: int) -> FiscalDateTime:
         provided.
     """
     fiscal_year = FiscalYear(fiscal_year)
-    return fiscal_year.start()
+    return fiscal_year.start
 
 
 def current_fiscal_date() -> FiscalDateTime:

--- a/usaspending_api/common/helpers/fiscal_year_helpers.py
+++ b/usaspending_api/common/helpers/fiscal_year_helpers.py
@@ -2,7 +2,7 @@ import logging
 
 from datetime import datetime, MAXYEAR, MINYEAR
 from dateutil.relativedelta import relativedelta
-from fiscalyear import FiscalDate, FiscalDateTime
+from fiscalyear import FiscalDate, FiscalDateTime, FiscalYear
 from typing import Optional, Tuple
 from django.db.models import Q, Max
 from usaspending_api.common.helpers.generic_helper import validate_date, min_and_max_from_date_ranges
@@ -11,6 +11,34 @@ from usaspending_api.submissions.models import DABSSubmissionWindowSchedule
 
 logger = logging.getLogger(__name__)
 
+
+def get_fiscal_year_end_datetime(fiscal_year: int) -> FiscalDateTime:
+    """Provides a fiscal year date time end date given a fiscal year
+
+    Args:
+        fiscal_year: The fiscal year in which you want to
+        obtain a end date for.
+
+    Returns:
+        FiscalDateTime: The datetime representing the end of the fiscal year
+        provided.
+    """
+    fiscal_year = FiscalYear(fiscal_year)
+    return fiscal_year.end
+
+def get_fiscal_year_start_datetime(fiscal_year: int) -> FiscalDateTime:
+    """Provides a fiscal year date time start date given a fiscal year
+
+    Args:
+        fiscal_year: The fiscal year in which you want to
+        obtain a start date for.
+
+    Returns:
+        FiscalDateTime: The datetime representing the start of the fiscal year
+        provided.
+    """
+    fiscal_year = FiscalYear(fiscal_year)
+    return fiscal_year.start
 
 def current_fiscal_date() -> FiscalDateTime:
     """FiscalDateTime.today() returns calendar date! Add 3 months to convert to fiscal"""


### PR DESCRIPTION
**Description:**
GSA generates a yearly report with award counts for the previous FY by agency and award type. Their current method requires them to run dozens of separate searches and manually copy the award counts by type into a table. This allows them to count prime award summaries where the date range from the earliest to the latest transaction overlaps with the FY. This process takes them several hours per year. They need to continue pulling these same numbers once a year indefinitely. If we change how advance search counts prime award summaries (only count awards with a transaction in the selected FY) they would no longer be able to use that feature for their purposes. There are several possible solutions to support this use case. The ideal solution for GSA would be to create a custom GET endpoint which would return all the numbers they need using their current technique to count awards. This PR addresses that ideal solution.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10148](https://federal-spending-transparency.atlassian.net/browse/DEV-10148):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
