### PR TITLE
[DEV-10362] Adds --skip-file-c-to-d-linkage Flag to Submission Loaders

### DIFF
--- a/usaspending_api/etl/management/commands/load_submission.py
+++ b/usaspending_api/etl/management/commands/load_submission.py
@@ -56,6 +56,17 @@ class Command(load_base.Command):
             ),
         )
         parser.add_argument(
+            "--skip-c-to-d-linkage",
+            action="store_true",
+            help=(
+                "This flag skips the step to perform File C to D Linkages, which updates the "
+                "`award_id` field on File C records. File C to D linkages also take place in "
+                "subsequent Databricks steps in the pipeline and only takes place in this "
+                "command for earlier data consistency. It can safely be skipped in the case of "
+                "long running submissions.",
+            ),
+        )
+        parser.add_argument(
             "--file-c-chunk-size",
             type=int,
             default=self.file_c_chunk_size,
@@ -72,6 +83,7 @@ class Command(load_base.Command):
         self.force_reload = options["force_reload"]
         self.file_c_chunk_size = options["file_c_chunk_size"]
         self.skip_final_of_fy_calculation = options["skip_final_of_fy_calculation"]
+        self.skip_c_to_d_linkage = options["skip_c_to_d_linkage"]
         self.db_cursor = db_cursor
 
         logger.info(f"Starting processing for submission {self.submission_id}...")
@@ -137,7 +149,7 @@ class Command(load_base.Command):
         )
         logger.info("Loading File C data")
         start_time = datetime.now()
-        load_file_c(submission_attributes, self.db_cursor, published_award_financial)
+        load_file_c(submission_attributes, self.db_cursor, published_award_financial, self.skip_c_to_d_linkage)
         logger.info(f"Finished loading File C data, took {datetime.now() - start_time}")
 
         if self.skip_final_of_fy_calculation:

--- a/usaspending_api/etl/submission_loader_helpers/file_c.py
+++ b/usaspending_api/etl/submission_loader_helpers/file_c.py
@@ -114,7 +114,7 @@ def get_file_c(submission_attributes, db_cursor, chunk_size):
     return PublishedAwardFinancial(submission_attributes, db_cursor, chunk_size)
 
 
-def load_file_c(submission_attributes, db_cursor, published_award_financial):
+def load_file_c(submission_attributes, db_cursor, published_award_financial, skip_c_to_d_linkage):
     """
     Process and load file C broker data.
     Note: this should run AFTER the D1 and D2 files are loaded because we try to join to those records to retrieve some
@@ -136,8 +136,9 @@ def load_file_c(submission_attributes, db_cursor, published_award_financial):
 
     _save_file_c_rows(published_award_financial, total_rows, start_time, skipped_tas, submission_attributes, reverse)
 
-    update_c_to_d_linkages("contract", False, submission_attributes.submission_id)
-    update_c_to_d_linkages("assistance", False, submission_attributes.submission_id)
+    if not skip_c_to_d_linkage:
+        update_c_to_d_linkages("contract", False, submission_attributes.submission_id)
+        update_c_to_d_linkages("assistance", False, submission_attributes.submission_id)
 
     for tas, count in skipped_tas.items():
         logger.info(f"Skipped {count:,} rows due to {tas}")

--- a/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
+++ b/usaspending_api/etl/tests/integration/test_load_submission_mgmt_cmd.py
@@ -111,9 +111,24 @@ class TestWithMultipleDatabases(TestCase):
         baker.make("search.TransactionSearch", transaction_id=-999)
         baker.make("search.TransactionSearch", transaction_id=-1999)
 
+        # Test loading submission with File C to D Linkage
         call_command("load_submission", "-9999")
 
         expected_results = {"award_ids": [-1999, -999]}
+        actual_results = {
+            "award_ids": sorted(
+                list(
+                    FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+                )
+            )
+        }
+
+        assert expected_results == actual_results
+
+        # Call with Skipping C to D Linkage
+        call_command("load_submission", "-9999", "--force-reload", "--skip-c-to-d-linkage")
+
+        expected_results = {"award_ids": []}
         actual_results = {
             "award_ids": sorted(
                 list(
@@ -132,9 +147,22 @@ class TestWithMultipleDatabases(TestCase):
         baker.make("search.AwardSearch", award_id=-997, uri="RANDOM_LOAD_SUB_URI", latest_transaction_id=-997)
         baker.make("search.TransactionSearch", transaction_id=-997)
 
+        # Test loading submission with File C to D Linkage
         call_command("load_submission", "-9999")
 
         expected_results = {"award_ids": [-997]}
+        actual_results = {
+            "award_ids": list(
+                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+            )
+        }
+
+        assert expected_results == actual_results
+
+        # Call with Skipping C to D Linkage
+        call_command("load_submission", "-9999", "--force-reload", "--skip-c-to-d-linkage")
+
+        expected_results = {"award_ids": []}
         actual_results = {
             "award_ids": list(
                 FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
@@ -151,9 +179,22 @@ class TestWithMultipleDatabases(TestCase):
         baker.make("search.AwardSearch", award_id=-997, fain="RANDOM_LOAD_SUB_FAIN", latest_transaction_id=-997)
         baker.make("search.TransactionSearch", transaction_id=-997)
 
+        # Test loading submission with File C to D Linkage
         call_command("load_submission", "-9999")
 
         expected_results = {"award_ids": [-997]}
+        actual_results = {
+            "award_ids": list(
+                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+            )
+        }
+
+        assert expected_results == actual_results
+
+        # Call with Skipping C to D Linkage
+        call_command("load_submission", "-9999", "--force-reload", "--skip-c-to-d-linkage")
+
+        expected_results = {"award_ids": []}
         actual_results = {
             "award_ids": list(
                 FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
@@ -176,9 +217,22 @@ class TestWithMultipleDatabases(TestCase):
         )
         baker.make("search.TransactionSearch", transaction_id=-997)
 
+        # Test loading submission with File C to D Linkage
         call_command("load_submission", "-9999")
 
         expected_results = {"award_ids": [-997, -997]}
+        actual_results = {
+            "award_ids": list(
+                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+            )
+        }
+
+        assert expected_results == actual_results
+
+        # Call with Skipping C to D Linkage
+        call_command("load_submission", "-9999", "--force-reload", "--skip-c-to-d-linkage")
+
+        expected_results = {"award_ids": []}
         actual_results = {
             "award_ids": list(
                 FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
@@ -201,9 +255,22 @@ class TestWithMultipleDatabases(TestCase):
         )
         baker.make("search.TransactionSearch", transaction_id=-998)
 
+        # Test loading submission with File C to D Linkage
         call_command("load_submission", "-9999")
 
         expected_results = {"award_ids": [-998]}
+        actual_results = {
+            "award_ids": list(
+                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+            )
+        }
+
+        assert expected_results == actual_results
+
+        # Call with Skipping C to D Linkage
+        call_command("load_submission", "-9999", "--force-reload", "--skip-c-to-d-linkage")
+
+        expected_results = {"award_ids": []}
         actual_results = {
             "award_ids": list(
                 FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
@@ -226,9 +293,22 @@ class TestWithMultipleDatabases(TestCase):
         )
         baker.make("search.TransactionSearch", transaction_id=-1234)
 
+        # Test loading submission with File C to D Linkage
         call_command("load_submission", "-9999")
 
         expected_results = {"award_ids": [-1001]}
+        actual_results = {
+            "award_ids": list(
+                FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)
+            )
+        }
+
+        assert expected_results == actual_results
+
+        # Call with Skiping C to D Linkage
+        call_command("load_submission", "-9999", "--force-reload", "--skip-c-to-d-linkage")
+
+        expected_results = {"award_ids": []}
         actual_results = {
             "award_ids": list(
                 FinancialAccountsByAwards.objects.filter(award_id__isnull=False).values_list("award_id", flat=True)


### PR DESCRIPTION
**Description:**
Adds `--skip-file-c-to-d-linkage` flag to `load_submission` and `load_multiple_submissions` commands. Skip file c to d linkage process when flag is present. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. N/A - API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7.  N/A - Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10362](https://federal-spending-transparency.atlassian.net/browse/DEV-10362):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
