### PR TITLE
[DEV-10384] Increases max nested objects limit to 12k on Covid FABA Index

### DIFF
--- a/usaspending_api/etl/es_covid19_faba_template.json
+++ b/usaspending_api/etl/es_covid19_faba_template.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.mapping.ignore_malformed": true,
     "index.max_result_window": null,
+    "index.mapping.nested_objects.limit": 12000,
     "index.refresh_interval": -1,
     "index": {
       "number_of_shards" : 5,


### PR DESCRIPTION
**Description:**
Covid FABA index is currently failing because it has a single document with over 10k nested objects. Increasing the limit to allow this record to be successfully indexed. 

**Requirements for PR merge:**

1. N/A - Unit & integration tests updated
2. N/A -API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. N/A - Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10384](https://federal-spending-transparency.atlassian.net/browse/DEV-10384):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - N/A - Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
