### PR TITLE
[DEV-10415] Fix Pandas 1.3.* Upgrade Encoding Issue

### DIFF
--- a/usaspending_api/references/management/commands/loadcfda.py
+++ b/usaspending_api/references/management/commands/loadcfda.py
@@ -96,7 +96,7 @@ def load_from_url(rfc_path_string):
 
 
 def load_cfda_csv_into_pandas(data_file_handle):
-    df = pd.read_csv(data_file_handle, dtype=str, encoding="cp1252", na_filter=False)
+    df = pd.read_csv(data_file_handle, dtype=str, encoding="cp1252", encoding_errors="ignore", na_filter=False)
     df.rename(columns=clean_col_names, inplace=True)
 
     for field in DATA_CLEANING_MAP.keys():


### PR DESCRIPTION
**Description:**
During testing, an issue was found with the `loadcfda` command after upgrading Pandas to version 1.3.*. The `pandas.read_csv()` command was failing to read [cfda.csv](https://files.usaspending.gov/reference_data/cfda.csv) file because it contains characters that cannot be decoded using the `utf-8` codec.

This was not an issue with 1.1.* because of [a bug](https://github.com/pandas-dev/pandas/issues/39450#issuecomment-769960851) with the version that resulted in these decoding issues not to be raised. When the bug was fixed a new optional parameter was added to the `read_csv()` command called `encoding_errors`, which defaults to `strict`. 

In order to reproduce the behavior that was occurring with the previous version, this PR sets the `encoding_errors` parameter to `ignore`.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10415](https://federal-spending-transparency.atlassian.net/browse/DEV-10415):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
