### PR TITLE
Fix: cd_city_grouped Duplicates

### DIFF
--- a/usaspending_api/search/delta_models/subaward_search.py
+++ b/usaspending_api/search/delta_models/subaward_search.py
@@ -286,6 +286,20 @@ subaward_search_load_sql_string = fr"""
             county_numeric,
             county_name,
             state_alpha
+    ),
+    cd_city_grouped_rownum AS (
+      SELECT
+        *,
+        ROW_NUMBER() OVER (PARTITION BY(city_name, state_abbreviation) ORDER BY city_name, state_abbreviation ASC) AS row_num
+      FROM global_temp.cd_city_grouped
+    ),
+    cd_city_grouped_distinct AS (
+        SELECT
+            city_name,
+            state_abbreviation,
+            congressional_district_no
+        FROM cd_city_grouped_rownum
+        WHERE row_num = 1
     )
     INSERT OVERWRITE {{DESTINATION_DATABASE}}.{{DESTINATION_TABLE}}
     (
@@ -633,12 +647,12 @@ subaward_search_load_sql_string = fr"""
             AND rl_cd_zips_grouped.state_abbreviation=UPPER(bs.sub_legal_entity_state_code)
         )
     LEFT OUTER JOIN
-        global_temp.cd_city_grouped pop_cd_city_grouped ON (
+        cd_city_grouped_distinct pop_cd_city_grouped ON (
             pop_cd_city_grouped.city_name=UPPER(bs.sub_place_of_perform_city_name)
             AND pop_cd_city_grouped.state_abbreviation=UPPER(bs.sub_place_of_perform_state_code)
         )
     LEFT OUTER JOIN
-        global_temp.cd_city_grouped rl_cd_city_grouped ON (
+        cd_city_grouped_distinct rl_cd_city_grouped ON (
             rl_cd_city_grouped.city_name=UPPER(bs.sub_legal_entity_city_name)
             AND rl_cd_city_grouped.state_abbreviation=UPPER(bs.sub_legal_entity_state_code)
         )


### PR DESCRIPTION
**Description:**
The Broker table `cd_city_grouped` was updated to support city codes which affected its uniqueness. This adjusts the several loaders (subaward_search, transaction_current_cd_lookup) that use that table to group by its previous uniqueness.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket N/A
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
