### PR TITLE
[DEV-10555][Master] Increases nested objects limit to 25k on Covid Index

### DIFF
--- a/usaspending_api/etl/es_covid19_faba_template.json
+++ b/usaspending_api/etl/es_covid19_faba_template.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.mapping.ignore_malformed": true,
     "index.max_result_window": null,
-    "index.mapping.nested_objects.limit": 12000,
+    "index.mapping.nested_objects.limit": 25000,
     "index.refresh_interval": -1,
     "index": {
       "number_of_shards" : 5,


### PR DESCRIPTION
**Description:**
Increases nested objects limit to 25k on Covid Index to address the job failing due a record with a 17k nested objects, which is over the current limit of 12k. 

**Requirements for PR merge:**

1. N/A - Unit & integration tests updated
2. N/A - API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Operations
4. N/A -  Matview impact assessment completed
5. N/A - Frontend impact assessment completed
6. N/A - Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10555](https://federal-spending-transparency.atlassian.net/browse/DEV-10555):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
