### PR TITLE
[DEV-10427] Recipient Profile Spark controller update

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -247,7 +247,7 @@ def extract_transform_load(task: TaskSpec) -> None:
 
     client = instantiate_elasticsearch_client()
     try:
-        if task.transform_func:
+        if task.transform_func is not None:
             records = task.transform_func(task, extract_records(task))
         else:
             records = extract_records(task)

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -207,7 +207,7 @@ def transform_and_load_partition(task: TaskSpec, partition_data) -> List[Tuple[i
 
     client = instantiate_elasticsearch_client()
     try:
-        if task.transform_func:
+        if task.transform_func is not None:
             records = task.transform_func(task, [row.asDict() for row in partition_data])
         else:
             records = [row.asDict() for row in partition_data]

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -15,6 +15,7 @@ from usaspending_api.etl.elasticsearch_loader_helpers import (
     count_of_records_to_process_in_delta,
     delete_awards,
     delete_transactions,
+    extract_records,
     format_log,
     load_data,
     obtain_extract_all_partitions_sql,
@@ -208,7 +209,10 @@ def transform_and_load_partition(task: TaskSpec, partition_data) -> List[Tuple[i
     client = instantiate_elasticsearch_client()
     try:
         extracted_data = [row.asDict() for row in partition_data]
-        records = task.transform_func(task, extracted_data)
+        if task.transform_func:
+            records = task.transform_func(task, extracted_data)
+        else:
+            records = extract_records(task)
         if len(records) > 0:
             success, fail = load_data(task, records, client)
         else:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -15,7 +15,6 @@ from usaspending_api.etl.elasticsearch_loader_helpers import (
     count_of_records_to_process_in_delta,
     delete_awards,
     delete_transactions,
-    extract_records,
     format_log,
     load_data,
     obtain_extract_all_partitions_sql,
@@ -208,11 +207,11 @@ def transform_and_load_partition(task: TaskSpec, partition_data) -> List[Tuple[i
 
     client = instantiate_elasticsearch_client()
     try:
-        extracted_data = [row.asDict() for row in partition_data]
         if task.transform_func:
+            extracted_data = [row.asDict() for row in partition_data]
             records = task.transform_func(task, extracted_data)
         else:
-            records = extract_records(task)
+            records = [row.asDict() for row in partition_data]
         if len(records) > 0:
             success, fail = load_data(task, records, client)
         else:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -208,8 +208,7 @@ def transform_and_load_partition(task: TaskSpec, partition_data) -> List[Tuple[i
     client = instantiate_elasticsearch_client()
     try:
         if task.transform_func:
-            extracted_data = [row.asDict() for row in partition_data]
-            records = task.transform_func(task, extracted_data)
+            records = task.transform_func(task, [row.asDict() for row in partition_data])
         else:
             records = [row.asDict() for row in partition_data]
         if len(records) > 0:


### PR DESCRIPTION
**Description:**
Added an update to allow for the Spark controller to support a transform_func value of `None`. This same change was added to the non-Spark controller, but was the Spark controller was missed in the original PR for DEV-10427.

**Technical details:**
Added an update to allow for the Spark controller to support a transform_func value of `None`. This same change was added to the non-Spark controller, but was the Spark controller was missed in the original PR for DEV-10427.

**Requirements for PR merge:**

3. [ ] Necessary PR reviewers:
    - [ ] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-10427](https://federal-spending-transparency.atlassian.net/browse/DEV-10427):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. Unit & integration tests updated
    There isn't currently a way for us to test this specific function due to the flow of these controllers.
3. API documentation updated
    This work doesn't require any API documents to be updated.
4. Matview impact assessment completed
    This work doesn't impact any matviews.
5. Frontend impact assessment completed
    This work doesn't impact the frontend.
7. Appropriate Operations ticket(s) created
    This fix doesn't require an operations ticket.
```
