### PR TITLE
DEV-10428 Create autocomplete endpoint for Recipients

### DIFF
--- a/usaspending_api/references/tests/integration/test_recipients_autocomplete_v2.py
+++ b/usaspending_api/references/tests/integration/test_recipients_autocomplete_v2.py
@@ -1,0 +1,75 @@
+import json
+import pytest
+
+from django.conf import settings
+from model_bakery import baker
+
+@pytest.fixture
+def transaction_data_fixture(db):
+    baker.make(
+        "search.RecipientSearch", 
+        id=1,
+        recipient_hash="sample_hash_1",
+        recipient_level="R",
+        recipient_name="Sample Recipient 1",
+        uei="UEI1"
+    )
+
+    baker.make(
+        "search.RecipientSearch",  
+        id=2,
+        recipient_hash="sample_hash_2",
+        recipient_level="C",
+        recipient_name="Sample Recipient 2",
+        uei="UEI2"
+    )
+
+def test_recipient_search_matches_found(client, monkeypatch, transaction_data_fixture, elasticsearch_transaction_index):
+    monkeypatch.setattr(
+        "usaspending_api.common.elasticsearch.search_wrappers.RecipientSearch._index_name",
+        settings.ES_TRANSACTIONS_QUERY_ALIAS_PREFIX,
+    )
+    elasticsearch_transaction_index.update_index()
+    body = {
+        "search_text": "kimberly",
+        "recipient_levels": ["R", "C", "D"],
+        "limit": 20
+    }
+    response = client.post("/api/v2/autocomplete/recipient", content_type="application/json", data=json.dumps(body))
+    assert response.data["count"] == 1
+    for entry in response.data["results"]:
+        assert entry["recipient_name"].lower().find("kimberly") > -1
+
+def test_recipient_search_no_matches(client, monkeypatch, transaction_data_fixture, elasticsearch_transaction_index):
+    monkeypatch.setattr(
+        "usaspending_api.common.elasticsearch.search_wrappers.RecipientSearch._index_name",
+        settings.ES_RECIPIENTS_QUERY_ALIAS_PREFIX,
+    )
+    elasticsearch_transaction_index.update_index()
+    body = {
+        "search_text": "nonexistent",
+        "recipient_levels": ["R", "C", "D"],
+        "limit": 20
+    }
+    response = client.post("/api/v2/autocomplete/recipient", content_type="application/json", data=json.dumps(body))
+    assert response.data["count"] == 0
+    for entry in response.data["results"]:
+        assert False  # this should never be reached
+
+def test_recipient_search_special_characters(client, monkeypatch, transaction_data_fixture, elasticsearch_transaction_index):
+    monkeypatch.setattr(
+        "usaspending_api.common.elasticsearch.search_wrappers.RecipientSearch._index_name",
+        settings.ES_RECIPIENTS_QUERY_ALIAS_PREFIX,
+    )
+    elasticsearch_transaction_index.update_index()
+    body = {
+        "search_text": 'spec|()[]{}?"<>\\',
+        "recipient_levels": ["R", "C", "D"],
+        "limit": 20,
+    }
+    response = client.post("/api/v2/autocomplete/recipient", content_type="application/json", data=json.dumps(body))
+    assert response.data["count"] == 1
+    for entry in response.data["results"]:
+        assert entry["recipient_name"].lower().find("spec") > -1
+
+

--- a/usaspending_api/references/v2/urls_autocomplete.py
+++ b/usaspending_api/references/v2/urls_autocomplete.py
@@ -10,6 +10,7 @@ from usaspending_api.references.v2.views.autocomplete import (
     FundingAgencyOfficeAutocompleteViewSet,
 )
 from usaspending_api.references.v2.views.city import CityAutocompleteViewSet
+from usaspending_api.references.v2.views.recipients import RecipientAutocompleteViewSet
 from usaspending_api.references.v2.views.tas_autocomplete import (
     TASAutocompleteATA,
     TASAutocompleteAID,
@@ -30,7 +31,7 @@ urlpatterns = [
     re_path(r"^cfda", CFDAAutocompleteViewSet.as_view()),
     re_path(r"^naics", NAICSAutocompleteViewSet.as_view()),
     re_path(r"^psc", PSCAutocompleteViewSet.as_view()),
-    re_path(r"^recipient", RemovedEndpointView.as_view({"get": "retrieve", "post": "retrieve"})),
+    re_path(r"^recipient", RecipientAutocompleteViewSet.as_view()),
     re_path(r"^glossary", GlossaryAutocompleteViewSet.as_view()),
     re_path(r"^city", CityAutocompleteViewSet.as_view()),
     re_path(r"^accounts/ata", TASAutocompleteATA.as_view()),

--- a/usaspending_api/references/v2/views/recipients.py
+++ b/usaspending_api/references/v2/views/recipients.py
@@ -1,0 +1,87 @@
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from collections import OrderedDict
+from elasticsearch_dsl import Q as ES_Q, A
+
+from usaspending_api.common.cache_decorator import cache_response
+
+from usaspending_api.common.elasticsearch.search_wrappers import RecipientSearch
+from usaspending_api.search.v2.es_sanitization import es_sanitize
+from usaspending_api.common.validator.tinyshield import validate_post_request
+
+models = [
+    {"key": "search_text", "name": "search_text", "type": "text", "text_type": "search", "optional": False},
+    {"key": "limit", "name": "limit", "type": "integer", "max": 500, "optional": True, "default": 10},
+    {"key": "recipient_levels", "name": "recipient_levels", "type": "array", "items": {"type": "string"}, "optional": True},
+]
+
+@validate_post_request(models)
+class RecipientAutocompleteViewSet(APIView):
+    """
+    This endpoint is used for the Recipient autocomplete filter which returns a list of recipients matching the specified search text.
+    """
+
+    endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/recipient.md"
+
+    @cache_response()
+    def post(self, request, format=None):
+        search_text, recipient_levels = prepare_search_terms(request.data)
+        limit = request.data["limit"]
+
+        query = create_elasticsearch_query(search_text, recipient_levels, limit)
+        sorted_results = query_elasticsearch(query)
+        response = OrderedDict([("count", len(sorted_results)), ("results", sorted_results[:limit])])
+
+        return Response(response)
+
+
+def prepare_search_terms(request_data):
+    fields = [request_data["search_text"], request_data.get("recipient_levels", [])]
+    return [es_sanitize(field).upper() if isinstance(field, str) else field for field in fields]
+
+def create_elasticsearch_query(search_text, recipient_levels, limit):
+    query = create_es_search(search_text, recipient_levels)
+    query.aggs.bucket("recipients", A("terms", field="recipient_name.keyword", size=limit))
+    return query
+
+ # search_text = "kimberly"  # Test recipient name. There is a recipient with this name and a level of "R"
+def create_es_search(search_text, recipient_levels):
+    ES_RECIPIENT_SEARCH_FIELDS = ["recipient_name", "uei"]
+
+    if recipient_levels:
+        # Only return the matches where the `recipient_level` field contains the filter value from
+        #   the HTTP request.
+        query = ES_Q(
+            "bool",
+            must=[
+                ES_Q("match", recipient_level="C"),
+                ES_Q("query_string", query=f"*{search_text}*", fields=ES_RECIPIENT_SEARCH_FIELDS)
+            ]
+        )
+    else:
+        # If we're NOT filtering on the `recipient_level` field then return all results matching the given search text
+        query = ES_Q("query_string", query=f"*{search_text}*", fields=ES_RECIPIENT_SEARCH_FIELDS)
+
+    search = RecipientSearch().filter(query)
+    return search
+
+def query_elasticsearch(query):
+    hits = query.handle_execute()
+    results = []
+    if hits and hits["hits"]["total"]["value"] > 0:
+        results = parse_elasticsearch_response(hits)
+        results = sorted(results, key=lambda x: x.pop("hits"), reverse=True)
+    return results
+
+def parse_elasticsearch_response(hits):
+    results = []
+    for recipient in hits["aggregations"]["recipients"]["buckets"]:
+        results.append(
+            OrderedDict(
+                [
+                    ("recipient_name", recipient["key"]),
+                    ("hits", recipient["doc_count"]),
+                ]
+            )
+        )
+    return results


### PR DESCRIPTION
**Description:**
To support the new autocomplete features in Award Search 2.0 we created a new endpoint for searching through Recipients. This new endpoint builds off of dev-10427, which created the Recipient Elasticsearch index for Recipient profiles.

TESTING
 A new testing file titled test_recipients_autocomplete_v2.py is created to test for any matches in the recipient_name, recipient_level or uei fields and return all of the matches.

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed - N/A
5. [x] Frontend impact assessment completed - N/A
6. [x] Data validation completed - N/A
7. [x] Appropriate Operations ticket(s) created - N/A
8. [x] Jira Ticket [DEV-10428](https://federal-spending-transparency.atlassian.net/browse/DEV-10428):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
