### PR TITLE
DEV-10455; Accommodates how usaspending.gov is currently using this endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/autocomplete/awarding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/autocomplete/awarding_agency.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# Awarding Agency Autocomplete [/api/v2/autocomplete/awarding_agency/]
+# Awarding Agency Autocomplete [/api/v2/autocomplete/awarding_agency]
 
 *Deprecated: Please see the following API contract for the new awarding endpoint [usaspending_api/api_contracts/contracts/v2/autocomplete/awarding_agency_office.md](./awarding_agency_office.md).*
 

--- a/usaspending_api/api_contracts/contracts/v2/autocomplete/funding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/autocomplete/funding_agency.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://api.usaspending.gov
 
-# Funding Agency Autocomplete [/api/v2/autocomplete/funding_agency/]
+# Funding Agency Autocomplete [/api/v2/autocomplete/funding_agency]
 
 *Deprecated: Please see the following API contract for the new funding endpoint [usaspending_api/api_contracts/contracts/v2/autocomplete/funding_agency_office.md](./funding_agency_office.md).*
 

--- a/usaspending_api/references/v2/urls_autocomplete.py
+++ b/usaspending_api/references/v2/urls_autocomplete.py
@@ -23,8 +23,8 @@ from usaspending_api.common.views import RemovedEndpointView
 
 
 urlpatterns = [
-    re_path(r"^awarding_agency/$", AwardingAgencyAutocompleteViewSet.as_view()),
-    re_path(r"^funding_agency/$", FundingAgencyAutocompleteViewSet.as_view()),
+    re_path(r"^awarding_agency$", AwardingAgencyAutocompleteViewSet.as_view()),
+    re_path(r"^funding_agency$", FundingAgencyAutocompleteViewSet.as_view()),
     re_path(r"^awarding_agency_office/$", AwardingAgencyOfficeAutocompleteViewSet.as_view()),
     re_path(r"^funding_agency_office/$", FundingAgencyOfficeAutocompleteViewSet.as_view()),
     re_path(r"^cfda", CFDAAutocompleteViewSet.as_view()),


### PR DESCRIPTION
usaspending.gov was using the `awarding_office` and `funding_office` endpoints without a trailing forward slash. However, the lack of a trailing forward slash in use of these endpoints did not match our api contracts. Unfortunately, the code that powers these endpoints did not match the api contracts so usaspending.gov had no issue using the endpoints. In sprint 180 these endpoints were updated to match our api contracts and to enable two new, similar, endpoints to be created. This PR reverts the trailing forward slash so that usaspending.gov does not have to update itself. However, this PR requires us to update our api contracts to match how usaspending.gov wants to use the `awarding_office` and `funding_office` endpoints.