### PR TITLE
[DEV-10623] Hide agency autocomplete api contracts 

### DIFF
--- a/dredd.yml
+++ b/dredd.yml
@@ -29,3 +29,8 @@ hooks-worker-handler-port: 61321
 config: ./dredd.yml
 blueprint: usaspending_api/api_contracts/contracts/**/*.md
 endpoint: '127.0.0.1:8000'
+
+hooks:
+  except:
+    - ^/api/v2/autocomplete/awarding_agency_office/
+    - ^/api/v2/autocomplete/funding_agency_office/

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -56,8 +56,6 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/autocomplete/accounts/main/](/api/v2/autocomplete/accounts/main/)|POST| Returns Treasury Account Symbol/Federal Account Main Account Code (MAIN) filtered by other components provided in the request filter |
 |[/api/v2/autocomplete/accounts/sub/](/api/v2/autocomplete/accounts/sub/)|POST| Returns Treasury Account Symbol Sub-Account Code (SUB) filtered by other components provided in the request filter |
 |[/api/v2/autocomplete/awarding_agency/](/api/v2/autocomplete/awarding_agency/)|POST| Returns awarding agencies matching the specified search text |
-|[/api/v2/autocomplete/awarding_agency_office/](/api/v2/autocomplete/awarding_agency_office/)|POST| Returns awarding agencies and office matching the specified search text |
-|[/api/v2/autocomplete/funding_agency_office/](/api/v2/autocomplete/funding_agency_office/)|POST| Returns funding agencies and office matching the specified search text |
 |[/api/v2/autocomplete/cfda/](/api/v2/autocomplete/cfda/)|POST| Returns CFDA programs matching the specified search text |
 |[/api/v2/autocomplete/city/](/api/v2/autocomplete/city/)|POST| Returns city names matching the search text, sorted by relevance |
 |[/api/v2/autocomplete/funding_agency/](/api/v2/autocomplete/funding_agency/)|POST| Returns funding agencies matching the specified search text |


### PR DESCRIPTION
Hide agency autocomplete api contracts for awarding_agency_office & funding_agency_office

**Description:**
Compliant with [SAM.gov](http://sam.gov/) Terms of Use related to FOUO data, we want to hide the agency autocomplete API contract to limit access to the data (specifically, the office level data).

**Technical details:**
No technical details necessary, just hiding the endpoints

**Requirements for PR merge:**

1. [x] Unit & integration tests updated - N/A
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
4. [x] Appropriate Operations ticket(s) created
5. [x] Jira Ticket [DEV-10623](https://federal-spending-transparency.atlassian.net/browse/DEV-10623):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
