### PR TITLE
[DEV-10631] Update NAICS filter for Transactions downloads

### DIFF
--- a/usaspending_api/search/filters/elasticsearch/HierarchicalFilter.py
+++ b/usaspending_api/search/filters/elasticsearch/HierarchicalFilter.py
@@ -20,7 +20,7 @@ class HierarchicalFilter:
                 if node.code not in [neg_node.code for neg_node in negative_nodes]
             ]
         )
-        negative_query = " OR ".join(
+        negative_query = " AND ".join(
             [
                 node.get_query()
                 for node in negative_nodes

--- a/usaspending_api/search/tests/unit/test_naics_hierarchical_filter.py
+++ b/usaspending_api/search/tests/unit/test_naics_hierarchical_filter.py
@@ -1,0 +1,31 @@
+from usaspending_api.search.filters.elasticsearch.filter import _QueryType
+from usaspending_api.search.filters.elasticsearch.naics import NaicsCodes
+
+
+def test_generate_elasticsearch_query_exclude():
+    """Test the generated Elasticsearch query for NAICS codes that should be excluded."""
+
+    assert NaicsCodes.generate_elasticsearch_query({"exclude": [10, 20, 30]}, _QueryType.TRANSACTIONS).to_dict() == {
+        "query_string": {"query": "(NOT 10*) AND (NOT 20*) AND (NOT 30*)", "default_field": "naics_code.keyword"}
+    }
+
+
+def test_generate_elasticsearch_query_require():
+    """Test the generated Elasticsearch query for NAICS codes that should be required."""
+
+    assert NaicsCodes.generate_elasticsearch_query({"require": [70, 80, 90]}, _QueryType.TRANSACTIONS).to_dict() == {
+        "query_string": {"query": "(70*) OR (80*) OR (90*)", "default_field": "naics_code.keyword"}
+    }
+
+
+def test_generate_elasticsearch_query_require_exclude():
+    """Test the generated Elasticsearch query for NAICS codes that should be required and excluded.
+
+    Note: When both `require` and `exclude` are in the API request, we ignore the `exclude` value because
+        only including the values in `require` means that we would be filtering out the values in `exclude`
+        anyway.
+    """
+
+    assert NaicsCodes.generate_elasticsearch_query(
+        {"exclude": [10, 20, 30], "require": [70, 80, 90]}, _QueryType.TRANSACTIONS
+    ).to_dict() == {"query_string": {"query": "(70*) OR (80*) OR (90*)", "default_field": "naics_code.keyword"}}


### PR DESCRIPTION
**Description:**
Update the Elasticsearch query used to exclude transactions in the transactions download based on their NAICS code. The current negative query does not work properly when more than one NAICS value is provided in the `exclude` filter on the `/api/v2/download/transaction` endpoint. Added tests for this type download since none existed previously.

**Technical details:**
Update the Elasticsearch query used to exclude transactions in the transactions download based on their NAICS code. The current negative query does not work properly when more than one NAICS value is provided in the `exclude` filter on the `/api/v2/download/transaction` endpoint. Added tests for this type download since none existed previously.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [ ] Necessary PR reviewers:
    - [ ] Backend
3. [x] Data validation completed
4. [x] Jira Ticket [DEV-10631](https://federal-spending-transparency.atlassian.net/browse/DEV-10631):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
API documentation updated
 - No API documentation is affected by this work.

Matview impact assessment completed
 - No matviews are affected by this work.

Frontend impact assessment completed
 - This work does not affect the frontend.

Appropriate Operations ticket(s) created
 - No operations tickets are needed for this work.
```
