### PR TITLE
[DEV-10675] Adds unique constraint to office code only in office table

### DIFF
--- a/usaspending_api/references/migrations/0065_alter_office_unique_together.py
+++ b/usaspending_api/references/migrations/0065_alter_office_unique_together.py
@@ -2,20 +2,22 @@
 
 from django.db import migrations, models
 
+
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('references', '0064_add_latest_pop_col'),
+        ("references", "0064_add_latest_pop_col"),
     ]
 
-    operations = [
-        migrations.RunSQL(
-            sql="""
-                ALTER TABLE office DROP CONSTRAINT IF EXISTS unique_agency_sub_tier_office;
-                ALTER TABLE office ADD CONSTRAINT unique_agency_sub_tier_office UNIQUE (agency_code, sub_tier_code, office_name, office_code);
-            """,
-            reverse_sql="""
-                ALTER TABLE office DROP CONSTRAINT IF EXISTS unique_agency_sub_tier_office;
-            """
-        )
-    ]
+
+#     operations = [
+#         migrations.RunSQL(
+#             sql="""
+#                 ALTER TABLE office DROP CONSTRAINT IF EXISTS unique_agency_sub_tier_office;
+#                 ALTER TABLE office ADD CONSTRAINT unique_agency_sub_tier_office UNIQUE (agency_code, sub_tier_code, office_name, office_code);
+#             """,
+#             reverse_sql="""
+#                 ALTER TABLE office DROP CONSTRAINT IF EXISTS unique_agency_sub_tier_office;
+#             """
+#         )
+#     ]

--- a/usaspending_api/references/migrations/0066_alter_office_unique_index_code_only.py
+++ b/usaspending_api/references/migrations/0066_alter_office_unique_index_code_only.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("references", "0065_alter_office_unique_together")]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                """ALTER TABLE office DROP CONSTRAINT IF EXISTS unique_agency_sub_tier_office;
+                ALTER TABLE office ADD CONSTRAINT unique_office_code UNIQUE (office_code);"""
+            ],
+            reverse_sql=["ALTER TABLE office DROP CONSTRAINT IF EXISTS unique_agency_sub_tier_office;"],
+        ),
+    ]

--- a/usaspending_api/references/models/office.py
+++ b/usaspending_api/references/models/office.py
@@ -4,7 +4,7 @@ from django.db import models
 class Office(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     updated_at = models.DateTimeField(auto_now=True, null=True)
-    office_code = models.TextField(null=False)
+    office_code = models.TextField(null=False, unique=True)
     office_name = models.TextField(null=True)
     sub_tier_code = models.TextField(null=False)
     agency_code = models.TextField(null=False)


### PR DESCRIPTION
**Description:**
This PR is a continuation of DEV-10573. After DEV-10573 was implemented we realized the “Tech Notes” were incorrect. The tech notes allow multiple offices to appear in our office table when such offices have different sub teir agencies. This behavior is not what we originally discussed. This PR should address that.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created (N/A)
8. [x] Jira Ticket [DEV-10662](https://federal-spending-transparency.atlassian.net/browse/DEV-10662):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
1. No tests were impacted and thus nothing needed to be changed
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
7. No operation tickets needed
