### PR TITLE
[DEV-10768] Adds required filters to spending_by_transaction

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction.md
@@ -373,6 +373,10 @@ List of filterable award types
 - `IDV_D`
 - `IDV_E`
 
+### DEFC (enum[string])
+List of Disaster Emergency Fund (DEF) Codes (DEFC) defined by legislation at the time of writing.
+A list of current DEFC can be found [here.](https://files.usaspending.gov/reference_data/def_codes.csv)
+
 ## FieldNameObject (array)
 List of column names to request
 

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction.md
@@ -248,6 +248,93 @@ Returns transaction records which match the keyword and award type code filters.
 + `Subsidy Cost` (required, string, nullable)
 + `Transaction Amount` (required, string, nullable)
 
+### AdvancedFilterObject (object)
++ `keywords`: `lockheed` (required, array[string], fixed-type)
++ `award_type_codes` (required, FilterObjectAwardTypes, fixed-type)
++ `place_of_performance_scope` (optional, enum[string])
+    + Members
+        + `domestic`
+        + `foreign`
++ `place_of_performance_locations` (optional, array[LocationObject], fixed-type)
++ `agencies` (optional, array[AgencyObject], fixed-type)
++ `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
+    + Text searched across a recipient’s name, UEI, and DUNS
++ `recipient_scope` (optional, enum[string])
+    + Members
+        + `domestic`
+        + `foreign`
++ `recipient_locations` (optional, array[LocationObject], fixed-type)
++ `recipient_type_names`: [`category_business`, `sole_proprietorship`] (optional, array[string])
++ `award_ids`: [`SPE30018FLGFZ`, `SPE30018FLJFN`] (optional, array[string])
+    Award IDs surrounded by double quotes (e.g. `"SPE30018FLJFN"`) will perform exact matches as opposed to the default, fuzzier full text matches.  Useful for Award IDs that contain spaces or other word delimiters.
++ `award_amounts` (optional, array[AwardAmounts], fixed-type)
++ `program_numbers`: [`10.331`] (optional, array[string])
++ `naics_codes` (optional, NAICSCodeObject)
++ `tas_codes` (optional, array[TASCodeObject], fixed-type)
++ `psc_codes` (optional, enum[PSCCodeObject, array[string]])
+    Supports new PSCCodeObject or legacy array of codes.
++ `contract_pricing_type_codes`: [`J`] (optional, array[string])
++ `set_aside_type_codes`: [`NONE`] (optional, array[string])
++ `extent_competed_type_codes`: [`A`] (optional, array[string])
++ `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
++ `object_class` (optional, array[string])
++ `program_activity` (optional, array[number])
++ `def_codes` (optional, array[DEFC], fixed-type)
+    If the `def_codes` provided are in the COVID-19 or IIJA group, the query will only return transactions that meet two requirements:
+    1. The transaction's associated prime award has at least one File C record with one of the supplied DEFCs.
+    2. The matching DEFC's associated public law has an enactment date prior to the transaction's action_date.
+
+### TimePeriodObject (object)
+These fields are defined in the [TransactionSearchTimePeriodObject](../../../search_filters.md#transaction-search-time-period-object)
+
+### LocationObject (object)
+These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)
+
+### AgencyObject (object)
++ `type` (required, enum[string])
+    + Members
+        + `awarding`
+        + `funding`
++ `tier` (required, enum[string])
+    + Members
+        + `toptier`
+        + `subtier`
++ `name`: `Office of Inspector General` (required, string)
++ `toptier_name`: `Department of the Treasury` (optional, string)
+    Only applicable when `tier` is `subtier`.  Ignored when `tier` is `toptier`.  Provides a means by which to scope subtiers with common names to a
+    specific toptier.  For example, several agencies have an "Office of Inspector General".  If not provided, subtiers may span more than one toptier.
+
+### AwardAmounts (object)
++ `lower_bound` (optional, number)
++ `upper_bound`: 1000000 (optional, number)
+
+### NAICSCodeObject (object)
++ `require`: [`33`] (optional, array[string], fixed-type)
++ `exclude`: [`3333`] (optional, array[string], fixed-type)
+
+### PSCCodeObject (object)
++ `require`: [[`Service`, `B`, `B5`]] (optional, array[array[string]], fixed-type)
++ `exclude`: [[`Service`, `B`, `B5`, `B502`]] (optional, array[array[string]], fixed-type)
+
+### TASCodeObject (object)
++ `require`: [[`091`]] (optional, array[array[string]], fixed-type)
++ `exclude`: [[`091`, `091-0800`]] (optional, array[array[string]], fixed-type)
+
+### TreasuryAccountComponentsObject (object)
++ `ata` (optional, string, nullable)
+    Allocation Transfer Agency Identifier - three characters
++ `aid` (required, string)
+    Agency Identifier - three characters
++ `bpoa` (optional, string, nullable)
+    Beginning Period of Availability - four digits
++ `epoa` (optional, string, nullable)
+    Ending Period of Availability - four digits
++ `a` (optional, string, nullable)
+    Availability Type Code - X or null
++ `main` (required, string)
+    Main Account Code - four digits
++ `sub` (optional, string, nullable)
+    Sub-Account Code - three digits
 
 ## FilterObjectAwardTypes (array)
 List of filterable award types
@@ -307,8 +394,3 @@ List of column names to request
 - `Subsidy Cost` 
 - `Transaction Amount` 
 - `def_codes`
-
-
-## AdvancedFilterObject (object)
-+ `keywords`: `lockheed` (required, array[string], fixed-type)
-+ `award_type_codes` (required, FilterObjectAwardTypes, fixed-type)

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction.md
@@ -5,7 +5,7 @@ HOST: https://api.usaspending.gov
 
 ## POST
 
-Returns transaction records which match the keyword and award type code filters.
+Returns transaction records which match the provided filters.
 
 + Request (application/json)
     + Schema
@@ -208,48 +208,18 @@ Returns transaction records which match the keyword and award type code filters.
 
 # Data Structures
 
-## PageMetaDataObject (object)
+## Request Objects
+
+### PageMetaDataObject (object)
 + `page`: 1 (required, number)
 + `hasNext`: false (required, boolean)
 + `hasPrevious`: false (required, boolean)
 + `next` (required, number, nullable)
 + `previous` (required, number, nullable)
 
-## TransactionResponse (object)
-
-### Sample
-+ `Action Date`: `2018-05-21` (required, string, nullable)
-+ `Award ID`: `DTFAWA05C00031R` (required, string, nullable)
-+ `Award Type`: `INDEFINITE DELIVERY / INDEFINITE QUANTITY` (required, string, nullable)
-+ `Awarding Agency`: `Department of Transportation` (required, string, nullable)
-+ `Awarding Sub Agency`: `Federal Aviation Administration` (required, string, nullable)
-+ `internal_id`: `68856340` (required, string, nullable)
-+ `generated_internal_id`: `CONT_AWD_00013U_7090_KJ88_4735` (required, string, nullable)
-+ `Mod`: `P00206` (required, string, nullable)
-+ `Recipient Name`: `LEIDOS INNOVATIONS CORPORATION` (required, string, nullable)
-+ `Transaction Amount`: `40000000.00` (required, string, nullable)
-
-### Default
-+ `Action Date` (required, string, nullable)
-+ `Award ID` (required, string, nullable)
-+ `Award Type` (required, string, nullable)
-+ `Awarding Agency` (required, string, nullable)
-+ `Awarding Sub Agency` (required, string, nullable)
-+ `awarding_agency_id` (required, string, nullable)
-+ `Funding Agency` (required, string, nullable)
-+ `Funding Sub Agency` (required, string, nullable)
-+ `internal_id` (required, string, nullable)
-+ `generated_internal_id` (required, string, nullable)
-+ `Issued Date` (required, string, nullable)
-+ `Last Date to Order` (required, string, nullable)
-+ `Loan Value` (required, string, nullable)
-+ `Mod` (required, string, nullable)
-+ `Recipient Name` (required, string, nullable)
-+ `Subsidy Cost` (required, string, nullable)
-+ `Transaction Amount` (required, string, nullable)
-
 ### AdvancedFilterObject (object)
 + `keywords`: `lockheed` (required, array[string], fixed-type)
++ `time_period` (optional, array[TimePeriodObject], fixed-type)
 + `award_type_codes` (required, FilterObjectAwardTypes, fixed-type)
 + `place_of_performance_scope` (optional, enum[string])
     + Members
@@ -283,9 +253,6 @@ Returns transaction records which match the keyword and award type code filters.
     If the `def_codes` provided are in the COVID-19 or IIJA group, the query will only return transactions that meet two requirements:
     1. The transaction's associated prime award has at least one File C record with one of the supplied DEFCs.
     2. The matching DEFC's associated public law has an enactment date prior to the transaction's action_date.
-
-### TimePeriodObject (object)
-These fields are defined in the [TransactionSearchTimePeriodObject](../../../search_filters.md#transaction-search-time-period-object)
 
 ### LocationObject (object)
 These fields are defined in the [StandardLocationObject](../../../search_filters.md#standard-location-object)
@@ -336,10 +303,33 @@ These fields are defined in the [StandardLocationObject](../../../search_filters
 + `sub` (optional, string, nullable)
     Sub-Account Code - three digits
 
-## FilterObjectAwardTypes (array)
+###  TimePeriodObject
+
+**Description:**
+Search based on one or more date range using the transaction's `action_date` field. Dates should be in the following format: YYYY-MM-DD
+
+**Example**
+```
+{
+    "time_period": [
+        {
+            "start_date": "2016-10-01",
+            "end_date": "2017-09-30"
+        }
+    ]
+}
+```
+
+Request parameter description:
++ `start_date`: (required)
+    See [Time Period](#time-period)
++ `end_date`: (required)
+    See [Time Period](#time-period)
+
+### FilterObjectAwardTypes (array)
 List of filterable award types
 
-### Sample
+#### Sample
 - `IDV_A`
 - `IDV_B`
 - `IDV_B_A`
@@ -349,7 +339,7 @@ List of filterable award types
 - `IDV_D`
 - `IDV_E`
 
-### Default
+#### Default
 - `02`
 - `03`
 - `04`
@@ -377,9 +367,8 @@ List of filterable award types
 List of Disaster Emergency Fund (DEF) Codes (DEFC) defined by legislation at the time of writing.
 A list of current DEFC can be found [here.](https://files.usaspending.gov/reference_data/def_codes.csv)
 
-## FieldNameObject (array)
+### FieldNameObject (array)
 List of column names to request
-
 - `Action Date` 
 - `Award ID` 
 - `Award Type` 
@@ -398,3 +387,36 @@ List of column names to request
 - `Subsidy Cost` 
 - `Transaction Amount` 
 - `def_codes`
+
+## TransactionResponse (object)
+
+### Sample
++ `Action Date`: `2018-05-21` (required, string, nullable)
++ `Award ID`: `DTFAWA05C00031R` (required, string, nullable)
++ `Award Type`: `INDEFINITE DELIVERY / INDEFINITE QUANTITY` (required, string, nullable)
++ `Awarding Agency`: `Department of Transportation` (required, string, nullable)
++ `Awarding Sub Agency`: `Federal Aviation Administration` (required, string, nullable)
++ `internal_id`: `68856340` (required, string, nullable)
++ `generated_internal_id`: `CONT_AWD_00013U_7090_KJ88_4735` (required, string, nullable)
++ `Mod`: `P00206` (required, string, nullable)
++ `Recipient Name`: `LEIDOS INNOVATIONS CORPORATION` (required, string, nullable)
++ `Transaction Amount`: `40000000.00` (required, string, nullable)
+
+### Default
++ `Action Date` (required, string, nullable)
++ `Award ID` (required, string, nullable)
++ `Award Type` (required, string, nullable)
++ `Awarding Agency` (required, string, nullable)
++ `Awarding Sub Agency` (required, string, nullable)
++ `awarding_agency_id` (required, string, nullable)
++ `Funding Agency` (required, string, nullable)
++ `Funding Sub Agency` (required, string, nullable)
++ `internal_id` (required, string, nullable)
++ `generated_internal_id` (required, string, nullable)
++ `Issued Date` (required, string, nullable)
++ `Last Date to Order` (required, string, nullable)
++ `Loan Value` (required, string, nullable)
++ `Mod` (required, string, nullable)
++ `Recipient Name` (required, string, nullable)
++ `Subsidy Cost` (required, string, nullable)
++ `Transaction Amount` (required, string, nullable)


### PR DESCRIPTION
**Description:**
Previously the `/spending_by_transaction` endpoint only had `keywords` and `award_type_codes` listed as valid filters even though it supported other filters available in Advanced Search. This fixes this inconsistency by adding documentation about the available filters. 

**Requirements for PR merge:**

1. N/A - Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend
4. N/A - Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. N/A - Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10768](https://federal-spending-transparency.atlassian.net/browse/DEV-10768):
    - [ ] Link to this Pull-Request
    - N/A - Performance evaluation of affected (API | Script | Download)
    - N/A - Before / After data comparison

**Area for explaining above N/A when needed:**
```
No code changes other than contracts. 
```
