### PR TITLE
[DEV-8150] Sort the award spending by sub-agency results alphabetically

### DIFF
--- a/usaspending_api/disaster/tests/integration/test_disaster_agency_spending.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_agency_spending.py
@@ -121,7 +121,7 @@ def test_basic_success(client, disaster_account_data, elasticsearch_account_inde
 
 
 @pytest.mark.django_db
-def test_award_type_sorting(client, disaster_account_data, elasticsearch_account_index, monkeypatch, helpers):
+def test_spending_by_agency_sorting(client, disaster_account_data, elasticsearch_account_index, monkeypatch, helpers):
     # Test sorting by description in descending order
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     bad_date_window = DABSSubmissionWindowSchedule.objects.get(id=2022071)
@@ -206,6 +206,171 @@ def test_award_type_sorting(client, disaster_account_data, elasticsearch_account
         },
     ]
 
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+
+@pytest.mark.django_db
+def test_spending_by_subtier_agency_sorting(
+    client, disaster_account_data, elasticsearch_award_index, monkeypatch, helpers
+):
+    # Test sorting by description in descending order
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 30)
+
+    resp = helpers.post_for_spending_endpoint(
+        client,
+        url,
+        award_type_codes=["A", "07", "02"],
+        def_codes=["O"],
+        spending_type="award",
+        sort="description",
+        order="desc",
+    )
+    expected_results = [
+        {
+            "id": 4,
+            "code": "009",
+            "description": "Agency 009",
+            "award_count": 1,
+            "obligation": 1000.0,
+            "outlay": 1000.0,
+            "children": [
+                {
+                    "id": 4,
+                    "code": "3008",
+                    "description": "Subtier 3008",
+                    "award_count": 1,
+                    "obligation": 1000.0,
+                    "outlay": 1000.0,
+                }
+            ],
+        },
+        {
+            "id": 2,
+            "code": "008",
+            "description": "Agency 008",
+            "award_count": 3,
+            "obligation": 21999998.0,
+            "outlay": 200000022.0,
+            "children": [
+                {
+                    "code": "2008",
+                    "award_count": 2,
+                    "description": "Subtier 2008",
+                    "id": 2,
+                    "obligation": 19999998.0,
+                    "outlay": 200000002.0,
+                },
+                {
+                    "code": "1008",
+                    "award_count": 1,
+                    "description": "Subtier 1008",
+                    "id": 2,
+                    "obligation": 2000000.0,
+                    "outlay": 20.0,
+                },
+            ],
+        },
+        {
+            "id": 1,
+            "code": "007",
+            "description": "Agency 007",
+            "award_count": 1,
+            "obligation": 2000.0,
+            "outlay": 20000.0,
+            "children": [
+                {
+                    "id": 1,
+                    "code": "1007",
+                    "description": "Subtier 1007",
+                    "award_count": 1,
+                    "obligation": 2000.0,
+                    "outlay": 20000.0,
+                }
+            ],
+        },
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == expected_results
+
+    # Test sorting by description in ascending order
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    helpers.patch_datetime_now(monkeypatch, 2022, 12, 30)
+
+    resp = helpers.post_for_spending_endpoint(
+        client,
+        url,
+        award_type_codes=["A", "07", "02"],
+        def_codes=["O"],
+        spending_type="award",
+        sort="description",
+        order="asc",
+    )
+    expected_results = [
+        {
+            "id": 1,
+            "code": "007",
+            "description": "Agency 007",
+            "award_count": 1,
+            "obligation": 2000.0,
+            "outlay": 20000.0,
+            "children": [
+                {
+                    "id": 1,
+                    "code": "1007",
+                    "description": "Subtier 1007",
+                    "award_count": 1,
+                    "obligation": 2000.0,
+                    "outlay": 20000.0,
+                }
+            ],
+        },
+        {
+            "id": 2,
+            "code": "008",
+            "description": "Agency 008",
+            "award_count": 3,
+            "obligation": 21999998.0,
+            "outlay": 200000022.0,
+            "children": [
+                {
+                    "code": "1008",
+                    "award_count": 1,
+                    "description": "Subtier 1008",
+                    "id": 2,
+                    "obligation": 2000000.0,
+                    "outlay": 20.0,
+                },
+                {
+                    "code": "2008",
+                    "award_count": 2,
+                    "description": "Subtier 2008",
+                    "id": 2,
+                    "obligation": 19999998.0,
+                    "outlay": 200000002.0,
+                },
+            ],
+        },
+        {
+            "id": 4,
+            "code": "009",
+            "description": "Agency 009",
+            "award_count": 1,
+            "obligation": 1000.0,
+            "outlay": 1000.0,
+            "children": [
+                {
+                    "id": 4,
+                    "code": "3008",
+                    "description": "Subtier 3008",
+                    "award_count": 1,
+                    "obligation": 1000.0,
+                    "outlay": 1000.0,
+                }
+            ],
+        },
+    ]
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["results"] == expected_results
 


### PR DESCRIPTION
**Description:**
Updates the `/api/v2/disaster/agency/spending` endpoint to sort the sub-tier agency results by their top-tier agency names in lowercase when sorting by agency names. This allows agencies like "Department of the Interior" and "Department of the Treasury" to be correctly sorted and not just added to the end of the agencies list.


**Technical details:**
This does **not** sort the child (sub-tier) agency results alphabetically in the results, only the parent (top-tier) agency. We've discussed adding sorting the child results in the same way in the future.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-8150](https://federal-spending-transparency.atlassian.net/browse/DEV-8150):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is impacted by this fix.

4. Matview impact assessment completed
No matviews are impacted by this fix.

5. Frontend impact assessment completed
The frontend is not impacted by this fix.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this fix.
```
