### PR TITLE
[DEV-9234] Use is_final_balances_for_fy instead of final_of_fy for total_budgetary_resources calculations

### DIFF
--- a/usaspending_api/accounts/tests/integration/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/integration/test_federal_account_v2.py
@@ -85,33 +85,64 @@ def fixture_data(db):
     ta3 = baker.make("accounts.TreasuryAppropriationAccount", federal_account=fa3, tas_rendering_label="tas-label-3")
     ta4 = baker.make("accounts.TreasuryAppropriationAccount", federal_account=fa4, tas_rendering_label="tas-label-4")
 
+    dabs100 = baker.make(
+        "submissions.DABSSubmissionWindowSchedule", submission_reveal_date="2017-11-01", submission_fiscal_year=2017
+    )
+    sub101 = baker.make(
+        "submissions.SubmissionAttributes",
+        submission_id="101",
+        reporting_fiscal_year=2017,
+        is_final_balances_for_fy=True,
+        submission_window_id=dabs100.id,
+        reporting_period_start="2017-06-01",
+    )
+    sub102 = baker.make(
+        "submissions.SubmissionAttributes",
+        submission_id="102",
+        reporting_fiscal_year=2017,
+        is_final_balances_for_fy=False,
+        submission_window_id=dabs100.id,
+        reporting_period_start="2017-06-01",
+    )
+    sub103 = baker.make(
+        "submissions.SubmissionAttributes",
+        submission_id="103",
+        reporting_fiscal_year=2017,
+        is_final_balances_for_fy=True,
+        submission_window_id=dabs100.id,
+        reporting_period_start="2017-06-01",
+    )
+
     baker.make(
         "accounts.AppropriationAccountBalances",
         final_of_fy=True,
         treasury_account_identifier=ta0,
         total_budgetary_resources_amount_cpe=1000,
-        submission__reporting_period_start="2017-06-01",
+        # submission__reporting_period_start="2017-06-01",
+        submission=sub101,
     )
+    # Will be filtered out because it's submission's "is_final_balances_for_fy" is False
     baker.make(
         "accounts.AppropriationAccountBalances",
-        final_of_fy=False,  # so filter it out
         treasury_account_identifier=ta0,
         total_budgetary_resources_amount_cpe=100,
         submission__reporting_period_start="2017-03-01",
+        submission=sub102,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",
         final_of_fy=True,
         treasury_account_identifier=ta0,
         total_budgetary_resources_amount_cpe=2000,
-        submission__reporting_period_start="2017-06-01",
+        # submission__reporting_period_start="2017-06-01",
+        submission=sub101,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",
         final_of_fy=True,
         treasury_account_identifier=ta1,
         total_budgetary_resources_amount_cpe=9000,
-        submission__reporting_period_start="2017-06-01",
+        submission=sub103,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",
@@ -188,7 +219,6 @@ def fixture_data(db):
         is_final_balances_for_fy=True,
         submission_window_id=dabs99.id,
     )
-
     sub100 = baker.make(
         "submissions.SubmissionAttributes",
         submission_id="100",
@@ -505,9 +535,9 @@ def test_federal_account_dod_cgac(client, fixture_data):
     response_data = resp.json()
 
     assert len(response_data["results"]) == 6
-    assert "CGAC_DOD" in response_data["results"][0]["account_name"]
-    assert "CGAC_DOD" in response_data["results"][1]["account_name"]
-    assert "Something" in response_data["results"][2]["account_name"]
-    assert "Nothing1" in response_data["results"][3]["account_name"]
+    assert "Something" in response_data["results"][0]["account_name"]
+    assert "Nothing1" in response_data["results"][1]["account_name"]
+    assert "CGAC_DOD(NAVY)" in response_data["results"][2]["account_name"]
+    assert "CGAC_DOD" in response_data["results"][3]["account_name"]
     assert "Nothing2" in response_data["results"][4]["account_name"]
     assert "Custom 99" in response_data["results"][5]["account_name"]

--- a/usaspending_api/accounts/tests/integration/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/integration/test_federal_account_v2.py
@@ -94,7 +94,6 @@ def fixture_data(db):
         reporting_fiscal_year=2017,
         is_final_balances_for_fy=True,
         submission_window_id=dabs100.id,
-        reporting_period_start="2017-06-01",
     )
     sub102 = baker.make(
         "submissions.SubmissionAttributes",
@@ -102,7 +101,6 @@ def fixture_data(db):
         reporting_fiscal_year=2017,
         is_final_balances_for_fy=False,
         submission_window_id=dabs100.id,
-        reporting_period_start="2017-06-01",
     )
     sub103 = baker.make(
         "submissions.SubmissionAttributes",
@@ -110,7 +108,6 @@ def fixture_data(db):
         reporting_fiscal_year=2017,
         is_final_balances_for_fy=True,
         submission_window_id=dabs100.id,
-        reporting_period_start="2017-06-01",
     )
 
     baker.make(
@@ -118,7 +115,6 @@ def fixture_data(db):
         final_of_fy=True,
         treasury_account_identifier=ta0,
         total_budgetary_resources_amount_cpe=1000,
-        # submission__reporting_period_start="2017-06-01",
         submission=sub101,
     )
     # Will be filtered out because it's submission's "is_final_balances_for_fy" is False
@@ -134,7 +130,6 @@ def fixture_data(db):
         final_of_fy=True,
         treasury_account_identifier=ta0,
         total_budgetary_resources_amount_cpe=2000,
-        # submission__reporting_period_start="2017-06-01",
         submission=sub101,
     )
     baker.make(

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -689,9 +689,7 @@ class FederalAccountsViewSet(APIView):
                 budgetary_resources=Subquery(
                     AppropriationAccountBalances.objects.filter(
                         submission__reporting_fiscal_year=fy,
-                        submission__submission_window__submission_reveal_date__lte=now(),
                         submission__is_final_balances_for_fy=True,
-                        submission__reporting_period_start__fy=fy,
                         treasury_account_identifier__federal_account_id=OuterRef("id"),
                     )
                     .annotate(the_sum=Func(F("total_budgetary_resources_amount_cpe"), function="SUM"))

--- a/usaspending_api/accounts/views/federal_accounts_v2.py
+++ b/usaspending_api/accounts/views/federal_accounts_v2.py
@@ -2,15 +2,15 @@ import ast
 from collections import OrderedDict
 from typing import List
 
-from django.db.models import F, Q, Sum, OuterRef, Subquery, Func, DecimalField, Exists
+from django.db.models import DecimalField, Exists, F, Func, OuterRef, Q, Subquery, Sum
 from django.utils.dateparse import parse_date
 from django.utils.functional import cached_property
 from django_cte import With
+from fiscalyear import FiscalDateTime
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from fiscalyear import FiscalDateTime
 from usaspending_api.accounts.models import AppropriationAccountBalances, FederalAccount, TreasuryAppropriationAccount
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.exceptions import InvalidParameterException
@@ -175,21 +175,24 @@ class SpendingOverTimeFederalAccountsViewSet(APIView):
                 if key not in group_results:
                     group_results[key] = {
                         "outlay": trans["outlay"] if trans["outlay"] else 0,
-                        "obligations_incurred_filtered": trans["obligations_incurred_filtered"]
-                        if trans["obligations_incurred_filtered"]
-                        else 0,
+                        "obligations_incurred_filtered": (
+                            trans["obligations_incurred_filtered"] if trans["obligations_incurred_filtered"] else 0
+                        ),
                         "obligations_incurred_other": 0,
                         "unobliged_balance": 0,
                     }
                 else:
                     group_results[key] = {
-                        "outlay": group_results[key]["outlay"] + trans["outlay"]
-                        if trans["outlay"]
-                        else group_results[key]["outlay"],
-                        "obligations_incurred_filtered": group_results[key]["obligations_incurred_filtered"]
-                        + trans["obligations_incurred_filtered"]
-                        if trans["obligations_incurred_filtered"]
-                        else group_results[key]["obligations_incurred_filtered"],
+                        "outlay": (
+                            group_results[key]["outlay"] + trans["outlay"]
+                            if trans["outlay"]
+                            else group_results[key]["outlay"]
+                        ),
+                        "obligations_incurred_filtered": (
+                            group_results[key]["obligations_incurred_filtered"] + trans["obligations_incurred_filtered"]
+                            if trans["obligations_incurred_filtered"]
+                            else group_results[key]["obligations_incurred_filtered"]
+                        ),
                         "obligations_incurred_other": group_results[key]["obligations_incurred_other"],
                         "unobliged_balance": group_results[key]["unobliged_balance"],
                     }
@@ -205,22 +208,25 @@ class SpendingOverTimeFederalAccountsViewSet(APIView):
                     group_results[key] = {
                         "outlay": 0,
                         "obligations_incurred_filtered": 0,
-                        "obligations_incurred_other": trans["obligations_incurred_other"]
-                        if trans["obligations_incurred_other"]
-                        else 0,
+                        "obligations_incurred_other": (
+                            trans["obligations_incurred_other"] if trans["obligations_incurred_other"] else 0
+                        ),
                         "unobliged_balance": trans["unobliged_balance"] if trans["unobliged_balance"] else 0,
                     }
                 else:
                     group_results[key] = {
                         "outlay": group_results[key]["outlay"],
                         "obligations_incurred_filtered": group_results[key]["obligations_incurred_filtered"],
-                        "obligations_incurred_other": group_results[key]["obligations_incurred_other"]
-                        + trans["obligations_incurred_other"]
-                        if trans["obligations_incurred_other"]
-                        else group_results[key]["obligations_incurred_other"],
-                        "unobliged_balance": group_results[key]["unobliged_balance"] + trans["unobliged_balance"]
-                        if trans["unobliged_balance"]
-                        else group_results[key]["unobliged_balance"],
+                        "obligations_incurred_other": (
+                            group_results[key]["obligations_incurred_other"] + trans["obligations_incurred_other"]
+                            if trans["obligations_incurred_other"]
+                            else group_results[key]["obligations_incurred_other"]
+                        ),
+                        "unobliged_balance": (
+                            group_results[key]["unobliged_balance"] + trans["unobliged_balance"]
+                            if trans["unobliged_balance"]
+                            else group_results[key]["unobliged_balance"]
+                        ),
                     }
 
         else:  # quarterly, take months and add them up
@@ -258,21 +264,24 @@ class SpendingOverTimeFederalAccountsViewSet(APIView):
                 if key not in group_results:
                     group_results[key] = {
                         "outlay": trans["outlay"] if trans["outlay"] else 0,
-                        "obligations_incurred_filtered": trans["obligations_incurred_filtered"]
-                        if trans["obligations_incurred_filtered"]
-                        else 0,
+                        "obligations_incurred_filtered": (
+                            trans["obligations_incurred_filtered"] if trans["obligations_incurred_filtered"] else 0
+                        ),
                         "obligations_incurred_other": 0,
                         "unobliged_balance": 0,
                     }
                 else:
                     group_results[key] = {
-                        "outlay": group_results[key]["outlay"] + trans["outlay"]
-                        if trans["outlay"]
-                        else group_results[key]["outlay"],
-                        "obligations_incurred_filtered": group_results[key]["obligations_incurred_filtered"]
-                        + trans["obligations_incurred_filtered"]
-                        if trans["obligations_incurred_filtered"]
-                        else group_results[key]["obligations_incurred_filtered"],
+                        "outlay": (
+                            group_results[key]["outlay"] + trans["outlay"]
+                            if trans["outlay"]
+                            else group_results[key]["outlay"]
+                        ),
+                        "obligations_incurred_filtered": (
+                            group_results[key]["obligations_incurred_filtered"] + trans["obligations_incurred_filtered"]
+                            if trans["obligations_incurred_filtered"]
+                            else group_results[key]["obligations_incurred_filtered"]
+                        ),
                         "obligations_incurred_other": group_results[key]["obligations_incurred_other"],
                         "unobliged_balance": group_results[key]["unobliged_balance"],
                     }
@@ -287,22 +296,25 @@ class SpendingOverTimeFederalAccountsViewSet(APIView):
                     group_results[key] = {
                         "outlay": 0,
                         "obligations_incurred_filtered": 0,
-                        "obligations_incurred_other": trans["obligations_incurred_other"]
-                        if trans["obligations_incurred_other"]
-                        else 0,
+                        "obligations_incurred_other": (
+                            trans["obligations_incurred_other"] if trans["obligations_incurred_other"] else 0
+                        ),
                         "unobliged_balance": trans["unobliged_balance"] if trans["unobliged_balance"] else 0,
                     }
                 else:
                     group_results[key] = {
                         "outlay": group_results[key]["outlay"],
                         "obligations_incurred_filtered": group_results[key]["obligations_incurred_filtered"],
-                        "obligations_incurred_other": group_results[key]["obligations_incurred_other"]
-                        + trans["obligations_incurred_other"]
-                        if trans["obligations_incurred_other"]
-                        else group_results[key]["obligations_incurred_other"],
-                        "unobliged_balance": group_results[key]["unobliged_balance"] + trans["unobliged_balance"]
-                        if trans["unobliged_balance"]
-                        else group_results[key]["unobliged_balance"],
+                        "obligations_incurred_other": (
+                            group_results[key]["obligations_incurred_other"] + trans["obligations_incurred_other"]
+                            if trans["obligations_incurred_other"]
+                            else group_results[key]["obligations_incurred_other"]
+                        ),
+                        "unobliged_balance": (
+                            group_results[key]["unobliged_balance"] + trans["unobliged_balance"]
+                            if trans["unobliged_balance"]
+                            else group_results[key]["unobliged_balance"]
+                        ),
                     }
             nested_order = "quarter"
 
@@ -315,9 +327,11 @@ class SpendingOverTimeFederalAccountsViewSet(APIView):
         # }]
         sorted_group_results = sorted(
             group_results.items(),
-            key=lambda k: (ast.literal_eval(k[0])["fiscal_year"], int(ast.literal_eval(k[0])[nested_order]))
-            if nested_order
-            else (ast.literal_eval(k[0])["fiscal_year"]),
+            key=lambda k: (
+                (ast.literal_eval(k[0])["fiscal_year"], int(ast.literal_eval(k[0])[nested_order]))
+                if nested_order
+                else (ast.literal_eval(k[0])["fiscal_year"])
+            ),
         )
 
         for key, value in sorted_group_results:
@@ -345,7 +359,7 @@ def orred_filter_list(prefix, subfilters):
     result = Q()
     for filter in subfilters:
         subresult = Q()
-        for (key, values) in filter.items():
+        for key, values in filter.items():
             subresult &= filter_on(prefix, key, values)
         result |= subresult
     return result
@@ -373,7 +387,7 @@ def orred_date_filter_list(date_ranges):
 def federal_account_filter(filters, extra=""):
 
     result = Q()
-    for (key, values) in filters.items():
+    for key, values in filters.items():
         if key == "object_class":
             result &= orred_filter_list(prefix=extra + "object_class", subfilters=values)
         elif key == "program_activity":
@@ -674,7 +688,9 @@ class FederalAccountsViewSet(APIView):
                 account_number=F("federal_account_code"),
                 budgetary_resources=Subquery(
                     AppropriationAccountBalances.objects.filter(
-                        final_of_fy=True,
+                        submission__reporting_fiscal_year=fy,
+                        submission__submission_window__submission_reveal_date__lte=now(),
+                        submission__is_final_balances_for_fy=True,
                         submission__reporting_period_start__fy=fy,
                         treasury_account_identifier__federal_account_id=OuterRef("id"),
                     )


### PR DESCRIPTION
**Description:**
Update the calculation for the total budgetary resource amount on the `/v2/federal_accounts/` endpoint to use the `is_final_balances_for_fy` column from the submission_attributes table instead of the `final_of_fy` column from the appropriation_account_balances table.

**Technical details:**
Update the calculation for the total budgetary resource amount on the `/v2/federal_accounts/` endpoint to use the `is_final_balances_for_fy` column from the submission_attributes table instead of the `final_of_fy` column from the appropriation_account_balances table.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-9234](https://federal-spending-transparency.atlassian.net/browse/DEV-9234):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

4. Matview impact assessment completed
No matviews are affected by this change.

5. Frontend impact assessment completed
The frontend is not affected by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this change.
```
