### PR TITLE
[DEV-9633] Use latest_transaction_search instead of latest_transaction

### DIFF
--- a/usaspending_api/spending_explorer/v2/filters/spending_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/spending_filter.py
@@ -1,9 +1,9 @@
 import logging
 
 from django.db.models import Q
-from usaspending_api.references.models import ToptierAgency
-from usaspending_api.common.exceptions import InvalidParameterException
 
+from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.references.models import ToptierAgency
 
 logger = logging.getLogger(__name__)
 
@@ -64,10 +64,7 @@ def spending_filter(alt_set, queryset, filters, _type):
 
             # recipient
             elif key == "recipient":
-                alt_set = alt_set.filter(
-                    Q(award__latest_transaction__assistance_data__awardee_or_recipient_legal=value)
-                    | Q(award__latest_transaction__contract_data__awardee_or_recipient_legal=value)
-                )
+                alt_set = alt_set.filter(Q(award__latest_transaction_search__recipient_name_raw=value))
 
             # award, award_category
             elif key == "award" or key == "award_category":
@@ -106,8 +103,7 @@ def spending_filter(alt_set, queryset, filters, _type):
             elif key == "recipient":
                 queryset = queryset.filter(
                     treasury_account__in=alt_set.filter(
-                        Q(award__latest_transaction__contract_data__awardee_or_recipient_legal=value)
-                        | Q(award__latest_transaction__assistance_data__awardee_or_recipient_legal=value)
+                        Q(award__latest_transaction_search__recipient_name_raw=value)
                     ).values_list("treasury_account_id", flat=True)
                 )
 

--- a/usaspending_api/spending_explorer/v2/filters/spending_filter.py
+++ b/usaspending_api/spending_explorer/v2/filters/spending_filter.py
@@ -64,7 +64,7 @@ def spending_filter(alt_set, queryset, filters, _type):
 
             # recipient
             elif key == "recipient":
-                alt_set = alt_set.filter(Q(award__latest_transaction_search__recipient_name_raw=value))
+                alt_set = alt_set.filter(Q(award__latest_transaction_search__recipient_name=value))
 
             # award, award_category
             elif key == "award" or key == "award_category":


### PR DESCRIPTION
**Description:**
Use the `latest_transaction_search` field instead of the `latest_transaction` field in spending_filter to reduce the number of joins to the transaction_search table.

**Technical details:**
Use the `latest_transaction_search` field instead of the `latest_transaction` field in spending_filter to reduce the number of joins to the transaction_search table. Previously, this filter was joining to the `transaction_search` table multiples times through different views and this was causing poor performance. This change uses the `transaction_search` table directly to reduce those JOINs to just one.

**Requirements for PR merge:**

3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-9633](https://federal-spending-transparency.atlassian.net/browse/DEV-9633):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. Unit & integration tests updated
No new tests are needed for this change since we're still using the same table for the same data, just reducing the number of JOIN statements.

2. API documentation updated
No API documentation is affected by this change.

5. Frontend impact assessment completed
The frontend is not affected by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this change.
```
