### PR TITLE
[DEV-10806] Optimize Covid Download

### DIFF
--- a/usaspending_api/common/etl/spark.py
+++ b/usaspending_api/common/etl/spark.py
@@ -612,7 +612,7 @@ def write_csv_file(
     start = time.time()
     logger.info(f"Writing source data DataFrame to csv part files for file {parts_dir}...")
     df_record_count = df.count()
-    df.coalesce(num_partitions).write.options(
+    df.repartition(num_partitions).write.options(
         # NOTE: this is a suggestion, to be used by Spark if partitions yield multiple files
         maxRecordsPerFile=max_records_per_file,
     ).csv(


### PR DESCRIPTION
**Description:**
Optimizes the covid-19 download generation job.

**Technical details:**
The job ran in 1h 12m 22s in QAT with these changes. Additionally, this code is shared with the `unlinked_awards` generation job. These changes showed no increase in runtime for that job.

Through my research I was able to determine that coalesce has an issue where if you're calling it using a number smaller than your current number of executors, the number of executors used to process that step will be limited by the number you passed in to the coalesce function.

The repartition function avoids this issue by shuffling the data. I discovered a good rule of thumb, that is, in any scenario where you're reducing the data down to a single partition (or really, less than half your number of executors), you should almost always use repartition over coalesce because of this. The shuffle caused by repartition is a small price to pay compared to the single-threaded operation of a call to coalesce(1)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10806](https://federal-spending-transparency.atlassian.net/browse/DEV-10806):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
