### PR TITLE
[Pipe-528] Fix for test_trigger_test_db_setup error

### DIFF
--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -9,7 +9,7 @@ django-cors-headers==4.3.1
 django-debug-toolbar==4.3.0
 django-extensions==3.2.3
 django-spaghetti-and-meatballs==0.4.2
-Django==5.0.3
+Django==4.2.11
 django_cte==1.3.2
 djangorestframework==3.14.0
 docutils==0.20.1
@@ -28,7 +28,7 @@ pandas==2.2.1
 psutil==5.9.8
 psycopg2-binary==2.9.*
 py-gfm==2.0.0
-pydantic[dotenv]==1.10.*
+pydantic[dotenv]==1.9.*
 python-json-logger==2.0.7
 requests==2.31.0
 retrying==1.3.4


### PR DESCRIPTION
**Description:**
The testing suite for the usaspending backend failed to run because the very first test "test_trigger_test_db_setup" that sets up the dbs for testing failed to run. It seemed to be resulting from Django >= 5.*.

**Technical details:**
Reverted the Django dependency to an older version. 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] Necessary PR reviewers:
    - [x] Backend
3. [x] Appropriate Operations ticket(s) created
4. [x] Jira Ticket [PIPE-528](https://federal-spending-transparency.atlassian.net/browse/PIPE-528):
    - [x] Link to this Pull-Request


**Area for explaining above N/A when needed:**
```
```
