### PR TITLE
[DEV-10812] Filters in Txn Count Endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
@@ -17,7 +17,7 @@ Returns the counts of transaction records which match the keyword grouped by awa
 
     + Attributes (object)
         + `filters` (required, AdvancedFilterObject)
-            Must at least provide `keywords` and `award_type_codes` in filters.
+            Must at least provide `award_type_codes` in filters object.
     + Body
 
 
@@ -60,4 +60,4 @@ Returns the counts of transaction records which match the keyword grouped by awa
 # Data Structures
 
 ### AdvancedFilterObject (object)
-The filters available are defined in the [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object)
+The filters available are defined in [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object). The one difference is that `keywords` is not required.

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
@@ -17,11 +17,21 @@ Returns the counts of transaction records which match the keyword grouped by awa
 
     + Attributes (object)
         + `filters` (required, AdvancedFilterObject)
-        The `keywords` filter is mandatory for this endpoint
+            Must at least provide `keywords` and `award_type_codes` in filters.
     + Body
 
 
-            {"filters":{"keywords":["test"]}}
+            {
+                "filters": {
+                    "keywords": ["test"],
+                    "award_type_codes": [
+                        "A",
+                        "B",
+                        "C",
+                        "D"
+                    ]
+                }
+            }
 
 + Response 200 (application/json)
     + Attributes (object)
@@ -49,5 +59,5 @@ Returns the counts of transaction records which match the keyword grouped by awa
 
 # Data Structures
 
-## AdvancedFilterObject (object)
-+ `keywords`: [[`lockheed`]] (required, array[string], fixed-type)
+### AdvancedFilterObject (object)
+The filters available are defined in the [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object)

--- a/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
@@ -34,7 +34,7 @@ def test_spending_by_transaction_count_success(client, monkeypatch, transaction_
     resp = client.post(
         ENDPOINT,
         content_type="application/json",
-        data=json.dumps({"filters": {"keyword": "DEV-10812", "award_type_codes": ["A"]}}),
+        data=json.dumps({"filters": {"keywords": ["DEV-10812"], "award_type_codes": ["A"]}}),
     )
 
     resp_results = resp.data.get("results", {})
@@ -45,13 +45,37 @@ def test_spending_by_transaction_count_success(client, monkeypatch, transaction_
     resp = client.post(
         ENDPOINT,
         content_type="application/json",
-        data=json.dumps({"filters": {"keyword": "DEV-10812", "award_type_codes": ["B"]}}),
+        data=json.dumps({"filters": {"keywords": ["DEV-10812"], "award_type_codes": ["B"]}}),
     )
 
     resp_results = resp.data.get("results", {})
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp_results) == 0
     assert resp_results["contracts"] == 0
+
+    # Test that `keyword` can be used
+    resp = client.post(
+        ENDPOINT,
+        content_type="application/json",
+        data=json.dumps({"filters": {"keyword": "DEV-10812", "award_type_codes": ["A"]}}),
+    )
+
+    resp_results = resp.data.get("results", {})
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp_results) > 0
+    assert resp_results["contracts"] == 1
+
+    # Test that `keyword` or `keywords` is not required
+    resp = client.post(
+        ENDPOINT,
+        content_type="application/json",
+        data=json.dumps({"filters": {"award_type_codes": ["A"]}}),
+    )
+
+    resp_results = resp.data.get("results", {})
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp_results) > 0
+    assert resp_results["contracts"] == 1
 
 
 @pytest.mark.django_db

--- a/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
@@ -1,0 +1,62 @@
+import json
+import pytest
+
+from model_bakery import baker
+from rest_framework import status
+
+from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
+
+ENDPOINT = "/api/v2/search/spending_by_transaction_count/"
+
+
+@pytest.fixture
+def transaction_data(db):
+    baker.make(
+        "search.TransactionSearch",
+        transaction_id=1,
+        award_id=1,
+        action_date="2010-10-01",
+        is_fpds=True,
+        type="A",
+        transaction_description="DEV-10812",
+        recipient_location_zip5="abcde",
+        piid="IND12PB00323",
+        recipient_uei="testuei",
+        parent_uei="test_parent_uei",
+    )
+    baker.make("search.AwardSearch", award_id=1, latest_transaction_id=1, is_fpds=True, type="A", piid="IND12PB00323")
+
+
+@pytest.mark.django_db
+def test_spending_by_transaction_count_success(client, monkeypatch, transaction_data, elasticsearch_transaction_index):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
+
+    resp = client.post(
+        ENDPOINT,
+        content_type="application/json",
+        data=json.dumps({"filters": {"keyword": "DEV-10812", "award_type_codes": ["A"]}}),
+    )
+
+    resp_results = resp.data.get("results", {})
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp_results) > 0
+    assert resp_results["contracts"] == 1
+
+    resp = client.post(
+        ENDPOINT,
+        content_type="application/json",
+        data=json.dumps({"filters": {"keyword": "DEV-10812", "award_type_codes": ["B"]}}),
+    )
+
+    resp_results = resp.data.get("results", {})
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp_results) == 0
+    assert resp_results["contracts"] == 0
+
+
+@pytest.mark.django_db
+def test_spending_by_transaction_count_failure(client):
+
+    # Missing required filter fields test
+    resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps({"filters": {}}))
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
@@ -50,7 +50,7 @@ def test_spending_by_transaction_count_success(client, monkeypatch, transaction_
 
     resp_results = resp.data.get("results", {})
     assert resp.status_code == status.HTTP_200_OK
-    assert len(resp_results) == 0
+    assert len(resp_results) > 0
     assert resp_results["contracts"] == 0
 
     # Test that `keyword` can be used

--- a/usaspending_api/search/v2/elasticsearch_helper.py
+++ b/usaspending_api/search/v2/elasticsearch_helper.py
@@ -27,7 +27,7 @@ def swap_keys(dictionary_):
 
 
 def format_for_frontend(response):
-    """ calls reverse key from TRANSACTIONS_LOOKUP """
+    """calls reverse key from TRANSACTIONS_LOOKUP"""
     response = [result["_source"] for result in response]
     return [swap_keys(result) for result in response]
 
@@ -54,18 +54,27 @@ def get_total_results(keyword):
         return None
 
 
-def spending_by_transaction_count(request_data):
-    keyword = request_data["filters"]["keywords"]
+def spending_by_transaction_count(search_query):
+    group_by_agg_key_values = {
+        "filters": {category: {"terms": {"type": types}} for category, types in INDEX_ALIASES_TO_AWARD_TYPES.items()}
+    }
+    aggs = A("filters", **group_by_agg_key_values)
+    search_query.aggs.bucket("types", aggs)
+    query_response = search_query.handle_execute()
+
+    results = None
+    if query_response is not None:
+        results = query_response["aggregations"]["types"]["buckets"]
+
+    if results is None:
+        return None
+
     response = {}
-    results = get_total_results(keyword)
     for category in INDEX_ALIASES_TO_AWARD_TYPES.keys():
-        if results is not None:
-            if category == "directpayments":
-                response["direct_payments"] = results[category]["doc_count"]
-            else:
-                response[category] = results[category]["doc_count"]
+        if category == "directpayments":
+            response["direct_payments"] = results[category]["doc_count"]
         else:
-            return results
+            response[category] = results[category]["doc_count"]
     return response
 
 


### PR DESCRIPTION
**Description:**
The `/api/v2/search/spending_by_transaction_count/` only currently supports the keywords filter. It should be updated to support all the filters supported by `/api/v2/search/spending_by_transaction/`. That ask, is implemented by this PR> 

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [x] Frontend <OPTIONAL> (N/A)
    - [x] Operations <OPTIONAL> (N/A)
    - [x] Domain Expert <OPTIONAL> (N/A)
4. [x] Matview impact assessment completed (N/A)
5. [x] Frontend impact assessment completed (N/A)
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-10812](https://federal-spending-transparency.atlassian.net/browse/DEV-10812):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
3b, 3c, 3d The nature of this work does not require PR reviews from these groups
4. The nature of this work does not impact materialized views
5. The nature of this work does not require an impact assessment from the frontend
