### PR TITLE
[DEV-11009] Spending by Transaction Count - Award Type Codes filter requirment

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
@@ -17,7 +17,6 @@ Returns the counts of transaction records which match the keyword grouped by awa
 
     + Attributes (object)
         + `filters` (required, AdvancedFilterObject)
-            Must at least provide `award_type_codes` in filters object.
     + Body
 
 
@@ -60,4 +59,4 @@ Returns the counts of transaction records which match the keyword grouped by awa
 # Data Structures
 
 ### AdvancedFilterObject (object)
-The filters available are defined in [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object). The one difference is that `keywords` is not required.
+The filters available are defined in [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object). The only difference is that `keywords` and `award_type_codes` are not required.

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_transaction_count.md
@@ -59,4 +59,4 @@ Returns the counts of transaction records which match the keyword grouped by awa
 # Data Structures
 
 ### AdvancedFilterObject (object)
-The filters available are defined in [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object). The only difference is that `keywords` and `award_type_codes` are not required.
+The filters available are defined in [AdvancedFilterObject](./spending_by_transaction.md#advanced-filter-object). The only difference is that the `keywords` and `award_type_codes` filters are not required.

--- a/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_transaction_count.py
@@ -76,11 +76,3 @@ def test_spending_by_transaction_count_success(client, monkeypatch, transaction_
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp_results) > 0
     assert resp_results["contracts"] == 1
-
-
-@pytest.mark.django_db
-def test_spending_by_transaction_count_failure(client):
-
-    # Missing required filter fields test
-    resp = client.post(ENDPOINT, content_type="application/json", data=json.dumps({"filters": {}}))
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/usaspending_api/search/v2/views/search_elasticsearch.py
+++ b/usaspending_api/search/v2/views/search_elasticsearch.py
@@ -319,9 +319,7 @@ class SpendingByTransactionCountVisualizationViewSet(APIView):
         models = []
         models.extend(copy.deepcopy(AWARD_FILTER))
         for m in models:
-            if m["name"] == "award_type_codes":
-                m["optional"] = False
-            elif m["name"] == "keywords":
+            if m["name"] == "keywords":
                 m["optional"] = True
             elif m["name"] == "keyword":
                 m["optional"] = True


### PR DESCRIPTION
**Description:**
Removes `award_type_codes` as a required filter on the Spending by Transaction Count endpoint

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11009](https://federal-spending-transparency.atlassian.net/browse/DEV-11009):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
