### PR TITLE
[PIPE-529] Database queries to db_download fix

### DIFF
--- a/usaspending_api/download/tests/integration/test_download_status.py
+++ b/usaspending_api/download/tests/integration/test_download_status.py
@@ -3,6 +3,7 @@ import pytest
 import random
 
 from model_bakery import baker
+from pytest import mark
 from rest_framework import status
 from unittest.mock import Mock
 
@@ -182,6 +183,7 @@ def test_download_assistance_status(client, download_test_data):
     assert resp.json()["total_columns"] == 4
 
 
+@mark.django_db(databases=["db_download", "default"])
 def test_download_awards_status(client, download_test_data, monkeypatch, elasticsearch_award_index):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())
@@ -300,6 +302,7 @@ def test_download_idv_status(client, download_test_data):
     assert resp.json()["total_columns"] == 5
 
 
+@mark.django_db(databases=["db_download", "default"], transaction=True)
 def test_download_transactions_status(client, download_test_data, monkeypatch, elasticsearch_transaction_index):
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())
@@ -349,6 +352,7 @@ def test_download_transactions_status(client, download_test_data, monkeypatch, e
     assert resp.json()["total_columns"] == 3
 
 
+@mark.django_db(databases=["db_download", "default"], transaction=True)
 def test_download_transactions_limit(client, download_test_data, monkeypatch, elasticsearch_transaction_index):
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string())

--- a/usaspending_api/download/tests/integration/test_download_transactions.py
+++ b/usaspending_api/download/tests/integration/test_download_transactions.py
@@ -129,7 +129,7 @@ def test_download_transactions_without_columns(
     assert ".zip" in resp.json()["file_url"]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["db_download", "default"], transaction=True)
 def test_download_transactions_with_columns(client, monkeypatch, download_test_data, elasticsearch_transaction_index):
     setup_elasticsearch_test(monkeypatch, elasticsearch_transaction_index)
     download_generation.retrieve_db_string = Mock(return_value=get_database_dsn_string(settings.DOWNLOAD_DB_ALIAS))
@@ -263,7 +263,7 @@ def test_download_transactions_new_awards_only(
     assert ".zip" in resp.json()["file_url"]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["db_download", "default"], transaction=True)
 def test_download_transactions_naics_exclude_single_value(
     client, monkeypatch, download_test_data, elasticsearch_transaction_index
 ):
@@ -297,7 +297,7 @@ def test_download_transactions_naics_exclude_single_value(
     assert download_job.number_of_rows == 2  # Rows with NAICS codes of 200 and 300 should be present
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["db_download", "default"], transaction=True)
 def test_download_transactions_naics_exclude_multiple_values(
     client, monkeypatch, download_test_data, elasticsearch_transaction_index
 ):
@@ -331,7 +331,7 @@ def test_download_transactions_naics_exclude_multiple_values(
     assert download_job.number_of_rows == 1  # Only NAICS code of 300 should be present
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["db_download", "default"], transaction=True)
 def test_download_transactions_naics_require(client, monkeypatch, download_test_data, elasticsearch_transaction_index):
     """Require only Transactions that have a `naics_code` that starts with 10. This should only return the Transaction
     with a `naics_code` value of 100 in the test data.


### PR DESCRIPTION
**Description:**
This ticket was created to fix some tests that were failing within the travis job `Non-Spark Integration Tests`. The error that was the culprit for many test failures was `Database queries to 'db_download' are not allowed`. 

**Technical details:**
N/A

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Appropriate Operations ticket(s) created
5. [x] Jira Ticket [PIPE-529](https://federal-spending-transparency.atlassian.net/browse/PIPE-529):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
