### PR TITLE
Revert "[Hotfix] [DEV-10961][QAT] Update the COVID19-FABA Elasticsearch index to be un-nested"

### DIFF
--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -753,4 +753,5 @@ class QueryWithFilters:
 
     @classmethod
     def generate_accounts_elasticsearch_query(cls, filters: dict, **options) -> ES_Q:
+        options = {**options, "nested_path": "financial_accounts_by_award"}
         return cls._generate_elasticsearch_query(filters, _QueryType.ACCOUNTS, **options)

--- a/usaspending_api/conftest_helpers.py
+++ b/usaspending_api/conftest_helpers.py
@@ -24,6 +24,7 @@ from usaspending_api.etl.elasticsearch_loader_helpers import (
     create_award_type_aliases,
     execute_sql_statement,
     transform_award_data,
+    transform_covid19_faba_data,
     transform_transaction_data,
 )
 from usaspending_api.etl.elasticsearch_loader_helpers.index_config import create_load_alias
@@ -162,7 +163,7 @@ class TestElasticSearchIndex:
         elif self.index_type == "covid19-faba":
             view_sql_file = f"{settings.ES_COVID19_FABA_ETL_VIEW_NAME}.sql"
             view_name = settings.ES_COVID19_FABA_ETL_VIEW_NAME
-            es_id = "financial_accounts_by_awards_id"
+            es_id = "financial_account_distinct_award_key"
         elif self.index_type == "transaction":
             view_sql_file = f"{settings.ES_TRANSACTIONS_ETL_VIEW_NAME}.sql"
             view_name = settings.ES_TRANSACTIONS_ETL_VIEW_NAME
@@ -188,6 +189,22 @@ class TestElasticSearchIndex:
                 records = transform_award_data(self.worker, records)
             elif self.index_type == "transaction":
                 records = transform_transaction_data(self.worker, records)
+            elif self.index_type == "covid19-faba":
+                records = transform_covid19_faba_data(
+                    TaskSpec(
+                        name="worker",
+                        index=self.index_name,
+                        sql=view_sql_file,
+                        view=view_name,
+                        base_table="financial_accounts_by_awards",
+                        base_table_id="financial_accounts_by_awards_id",
+                        field_for_es_id="financial_account_distinct_award_key",
+                        primary_key="award_id",
+                        partition_number=1,
+                        is_incremental=False,
+                    ),
+                    records,
+                )
 
         for record in records:
             # Special cases where we convert array of JSON to an array of strings to avoid nested types

--- a/usaspending_api/disaster/tests/integration/test_disaster_award_amount.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_award_amount.py
@@ -1,4 +1,5 @@
 import pytest
+
 from rest_framework import status
 
 from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
@@ -94,18 +95,13 @@ def test_award_amount_on_sum_non_zero_outlay(
 def test_award_amount_on_sum_zero_toa(
     client, monkeypatch, multiple_file_c_to_same_award_that_cancel_out, helpers, elasticsearch_account_index
 ):
-    # It was decided that if all of an Award's child FABA records cancel each other out ($0 in obligations and outlays)
-    #   then that Award should still be counted since there WAS disaster spending on the child FABA records.
-    # Awards with child FABA records that have always had $0 in obligations and outlays are still exlcuded since they
-    #   never had disaster spending.
-
     setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
 
     resp = helpers.post_for_amount_endpoint(client, url, ["M"], None)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["award_count"] == 1
+    assert resp.data["award_count"] == 0
     assert resp.data["outlay"] == 0.0
     assert resp.data["obligation"] == 0.0
 

--- a/usaspending_api/disaster/tests/integration/test_disaster_award_count.py
+++ b/usaspending_api/disaster/tests/integration/test_disaster_award_count.py
@@ -1,4 +1,5 @@
 import pytest
+
 from rest_framework import status
 
 from usaspending_api.search.tests.data.utilities import setup_elasticsearch_test
@@ -62,15 +63,11 @@ def test_multiple_faba_per_award(
 def test_multiple_faba_per_award_that_cancel_out(
     client, monkeypatch, multiple_file_c_to_same_award_that_cancel_out, helpers, elasticsearch_account_index
 ):
-    # It was decided that if all of an Award's child FABA records cancel each other out ($0 in obligations and outlays)
-    #   then that Award should still be counted since there WAS disaster spending on the child FABA records.
-    # Awards with child FABA records that have always had $0 in obligations and outlays are still exlcuded since they
-    #   never had disaster spending.
     setup_elasticsearch_test(monkeypatch, elasticsearch_account_index)
     helpers.patch_datetime_now(monkeypatch, 2022, 12, 31)
     helpers.reset_dabs_cache()
     resp = _default_post(client, helpers)
-    assert resp.data["count"] == 1
+    assert resp.data["count"] == 0
 
 
 @pytest.mark.django_db

--- a/usaspending_api/disaster/v2/views/agency/loans.py
+++ b/usaspending_api/disaster/v2/views/agency/loans.py
@@ -1,17 +1,16 @@
 import logging
 from decimal import Decimal
-from typing import List
 
 from django.contrib.postgres.fields import ArrayField
-from django.db.models import F, IntegerField, OuterRef, Subquery, Value
+from django.db.models import F, Value, IntegerField, Subquery, OuterRef
 from django.views.decorators.csrf import csrf_exempt
-
+from typing import List
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.disaster.v2.views.disaster_base import (
     DisasterBase,
-    FabaOutlayMixin,
-    LoansMixin,
     LoansPaginationMixin,
+    LoansMixin,
+    FabaOutlayMixin,
 )
 from usaspending_api.disaster.v2.views.elasticsearch_account_base import ElasticsearchAccountDisasterBase
 from usaspending_api.disaster.v2.views.elasticsearch_base import (
@@ -53,11 +52,11 @@ class LoansByAgencyViewSet(LoansPaginationMixin, ElasticsearchAccountDisasterBas
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/agency/loans.md"
     required_filters = ["def_codes", "query"]
     query_fields = ["funding_toptier_agency_name.contains"]
-    agg_key = "funding_toptier_agency_id"  # primary (tier-1) aggregation key
-    nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
+    agg_key = "financial_accounts_by_award.funding_toptier_agency_id"  # primary (tier-1) aggregation key
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     top_hits_fields = [
-        "funding_toptier_agency_code",
-        "funding_toptier_agency_name",
+        "financial_accounts_by_award.funding_toptier_agency_code",
+        "financial_accounts_by_award.funding_toptier_agency_name",
     ]
 
     @cache_response()
@@ -78,19 +77,12 @@ class LoansByAgencyViewSet(LoansPaginationMixin, ElasticsearchAccountDisasterBas
             "description": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["funding_toptier_agency_name"],
             "children": [],
             # the count of distinct awards contributing to the totals
-            "award_count": len(bucket["group_by_awards"]["buckets"]),
+            "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
                 key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
-                for key, val in self.nonzero_fields.items()
+                for key, val in self.nested_nonzero_fields.items()
             },
-            # Sum all of the loan values together and exclude the `None` values
-            "face_value_of_loan": sum(
-                [
-                    float(award["award_metadata"]["hits"]["hits"][0]["_source"]["total_loan_value"])
-                    for award in bucket["group_by_awards"]["buckets"]
-                    if award["award_metadata"]["hits"]["hits"][0]["_source"]["total_loan_value"] is not None
-                ],
-            ),
+            "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],
         }
 
     @property
@@ -167,11 +159,9 @@ class LoansBySubtierAgencyViewSet(ElasticsearchLoansPaginationMixin, Elasticsear
             "award_count": int(bucket.get("doc_count", 0)),
             **{
                 column: get_summed_value_as_float(
-                    (
-                        bucket.get("nested", {}).get("filtered_aggs", {})
-                        if column != "face_value_of_loan"
-                        else bucket.get("nested", {}).get("filtered_aggs", {}).get("reverse_nested")
-                    ),
+                    bucket.get("nested", {}).get("filtered_aggs", {})
+                    if column != "face_value_of_loan"
+                    else bucket.get("nested", {}).get("filtered_aggs", {}).get("reverse_nested"),
                     self.sum_column_mapping[column],
                 )
                 for column in self.sum_column_mapping

--- a/usaspending_api/disaster/v2/views/agency/spending.py
+++ b/usaspending_api/disaster/v2/views/agency/spending.py
@@ -62,15 +62,15 @@ class SpendingByAgencyViewSet(PaginationMixin, SpendingMixin, FabaOutlayMixin, E
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/agency/spending.md"
     required_filters = ["def_codes", "award_type_codes", "query"]
-    nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     query_fields = [
         "funding_toptier_agency_name",
         "funding_toptier_agency_name.contains",
     ]
-    agg_key = "funding_toptier_agency_id"  # primary (tier-1) aggregation key
+    agg_key = "financial_accounts_by_award.funding_toptier_agency_id"  # primary (tier-1) aggregation key
     top_hits_fields = [
-        "funding_toptier_agency_code",
-        "funding_toptier_agency_name",
+        "financial_accounts_by_award.funding_toptier_agency_code",
+        "financial_accounts_by_award.funding_toptier_agency_name",
     ]
 
     @cache_response()
@@ -108,10 +108,10 @@ class SpendingByAgencyViewSet(PaginationMixin, SpendingMixin, FabaOutlayMixin, E
             "description": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["funding_toptier_agency_name"],
             "children": [],
             # the count of distinct awards contributing to the totals
-            "award_count": len(bucket["group_by_awards"]["buckets"]),
+            "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
                 key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
-                for key, val in self.nonzero_fields.items()
+                for key, val in self.nested_nonzero_fields.items()
             },
             "total_budgetary_resources": None,
         }

--- a/usaspending_api/disaster/v2/views/award/amount.py
+++ b/usaspending_api/disaster/v2/views/award/amount.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 
-from elasticsearch_dsl import A
-from elasticsearch_dsl import Q as ES_Q
+from elasticsearch_dsl import Q as ES_Q, A
 from rest_framework.response import Response
 
 from usaspending_api.awards.v2.lookups.lookups import loan_type_mapping
@@ -11,7 +10,7 @@ from usaspending_api.common.elasticsearch.search_wrappers import AccountSearch
 from usaspending_api.common.exceptions import UnprocessableEntityException
 from usaspending_api.common.query_with_filters import QueryWithFilters
 from usaspending_api.common.validator import TinyShield
-from usaspending_api.disaster.v2.views.disaster_base import AwardTypeMixin, DisasterBase, FabaOutlayMixin
+from usaspending_api.disaster.v2.views.disaster_base import DisasterBase, AwardTypeMixin, FabaOutlayMixin
 from usaspending_api.search.v2.elasticsearch_helper import get_summed_value_as_float
 
 
@@ -41,12 +40,7 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
         if all(x in self.filters for x in ["award_type_codes", "award_type"]):
             raise UnprocessableEntityException("Cannot provide both 'award_type_codes' and 'award_type'")
 
-        self.nonzero_fields = [
-            "transaction_obligated_amount",
-            "gross_outlay_amount_by_award_cpe",
-            "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe",
-            "ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe",
-        ]
+        self.nonzero_fields = ["obligated_sum", "outlay_sum"]
 
         if self.award_type_codes and set(self.award_type_codes) <= set(loan_type_mapping.keys()):
             self.nonzero_fields.append("total_loan_value")
@@ -69,22 +63,32 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
 
         count_agg = create_count_aggregation(count_field)
 
-        filter_agg_query = ES_Q("terms", **{"disaster_emergency_fund_code": self.filters.get("def_codes")})
+        financial_accounts_agg = A("nested", path="financial_accounts_by_award")
+        filter_agg_query = ES_Q(
+            "terms", **{"financial_accounts_by_award.disaster_emergency_fund_code": self.filters.get("def_codes")}
+        )
         filtered_aggs = A("filter", filter_agg_query)
         outlay_sum_agg = A(
             "sum",
-            script="""doc['is_final_balances_for_fy'].value ? (
-                (doc['gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['gross_outlay_amount_by_award_cpe'].value : 0)
-                + (doc['ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
-                + (doc['ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0)
+            script="""doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? (
+                (doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0)
+                + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
+                + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0)
             ) * 100 : 0""",
         )
-        obligation_sum_agg = A("sum", field="transaction_obligated_amount", script="_value * 100")
+        obligation_sum_agg = A(
+            "sum", field="financial_accounts_by_award.transaction_obligated_amount", script="_value * 100"
+        )
+        reverse_nested_agg = A("reverse_nested", **{})
         face_value_of_loan_sum_agg = A("sum", field="total_loan_value", script="_value * 100")
 
-        search.aggs.bucket("filter_agg", filtered_aggs).metric("obligation_sum_agg", obligation_sum_agg).metric(
-            "outlay_sum_agg", outlay_sum_agg
-        ).metric("count_agg", count_agg).metric("face_value_of_loan_sum_agg", face_value_of_loan_sum_agg)
+        search.aggs.bucket("nested_agg", financial_accounts_agg).bucket("filter_agg", filtered_aggs).metric(
+            "obligation_sum_agg", obligation_sum_agg
+        ).metric("outlay_sum_agg", outlay_sum_agg).bucket("reverse_nested_agg", reverse_nested_agg).metric(
+            "count_agg", count_agg
+        ).metric(
+            "face_value_of_loan_sum_agg", face_value_of_loan_sum_agg
+        )
 
         return search
 
@@ -94,30 +98,35 @@ class AmountViewSet(AwardTypeMixin, FabaOutlayMixin, DisasterBase):
         filters["nonzero_fields"] = self.nonzero_fields
 
         if filters.get("def_codes"):
-            filters["def_codes"] = filters.pop("def_codes")
+            filters["nested_def_codes"] = filters.pop("def_codes")
 
         filter_query = QueryWithFilters.generate_accounts_elasticsearch_query(filters)
 
         if award_type_filter:
             is_procurement = award_type_filter == "procurement"
-            exists_query = ES_Q("exists", field="piid")
-            procurement_query = ES_Q("bool", **{f"must{'' if is_procurement else '_not'}": exists_query})
-            filter_query.must.append(procurement_query)
+            exists_query = ES_Q("exists", field="financial_accounts_by_award.piid")
+            nested_query = ES_Q(
+                "nested",
+                path="financial_accounts_by_award",
+                query=ES_Q("bool", **{f"must{'' if is_procurement else '_not'}": exists_query}),
+            )
+            filter_query.must.append(nested_query)
 
         return filter_query
 
     def build_result(self, search: AccountSearch) -> dict:
         response = search.handle_execute()
         response = response.aggs.to_dict()
-        filter_agg = response.get("filter_agg", {})
+        filter_agg = response.get("nested_agg", {}).get("filter_agg", {})
+        reverse_nested_agg = filter_agg.get("reverse_nested_agg", {})
 
         result = {
-            "award_count": filter_agg.get("count_agg", {"value": 0})["value"],
+            "award_count": reverse_nested_agg.get("count_agg", {"value": 0})["value"],
             "obligation": get_summed_value_as_float(filter_agg, "obligation_sum_agg"),
             "outlay": get_summed_value_as_float(filter_agg, "outlay_sum_agg"),
         }
 
         if "total_loan_value" in self.nonzero_fields:
-            result["face_value_of_loan"] = get_summed_value_as_float(filter_agg, "face_value_of_loan_sum_agg")
+            result["face_value_of_loan"] = get_summed_value_as_float(reverse_nested_agg, "face_value_of_loan_sum_agg")
 
         return result

--- a/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_account_base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from elasticsearch_dsl import A
 from elasticsearch_dsl import Q as ES_Q
@@ -20,10 +20,10 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
     bucket_count: int
     filter_query: ES_Q
     has_children: bool = False
-    nonzero_fields: Dict[str, str] = []
+    nested_nonzero_fields: Dict[str, str] = []
     query_fields: List[str]
     sub_agg_group_name: str = "sub_group_by_sub_agg_key"  # name used for the tier-2 aggregation group
-    sub_agg_key: Union[str, None] = None  # will drive including of a sub-bucket-aggregation if overridden by subclasses
+    sub_agg_key: str = None  # will drive including of a sub-bucket-aggregation if overridden by subclasses
     sub_top_hits_fields: List[str]  # list used for top_hits sub aggregation
     top_hits_fields: List[str]  # list used for the top_hits aggregation
 
@@ -34,23 +34,18 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         return Response(self.perform_elasticsearch_search())
 
     def perform_elasticsearch_search(self, loans=False) -> Response:
-        filters = {key: val for key, val in self.filters.items() if key != "award_type_codes"}
+        filters = {f"nested_{key}": val for key, val in self.filters.items() if key != "award_type_codes"}
         if self.filters.get("award_type_codes") is not None:
             filters["award_type_codes"] = self.filters["award_type_codes"]
         # Need to update the value of "query" to have the fields to search on
-        query_text = filters.pop("query", None)
-        if query_text:
-            filters["query"] = {"text": query_text, "fields": self.query_fields}
+        query = filters.pop("nested_query", None)
+        if query:
+            filters["nested_query"] = {"text": query, "fields": self.query_fields}
 
         # Ensure that Awards with File C records that cancel out are not taken into consideration;
         # The records that fall into this criteria share the same DEF Code and that is how the outlay and
         # obligation sum for the Award is able to be used even though the Award can have multiple DEFC
-        filters["nonzero_fields"] = [
-            "transaction_obligated_amount",
-            "gross_outlay_amount_by_award_cpe",
-            "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe",
-            "ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe",
-        ]
+        filters["nonzero_fields"] = ["obligated_sum", "outlay_sum"]
         self.filter_query = QueryWithFilters.generate_accounts_elasticsearch_query(filters)
 
         # using a set value here as doing an extra ES query is detrimental to performance
@@ -85,7 +80,6 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         """
         Using the provided ES_Q object creates an AccountSearch object with the necessary applied aggregations.
         """
-
         # No need to continue if there is no result
         if self.bucket_count == 0:
             return None
@@ -93,48 +87,53 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         # Create the initial search using filters
         search = AccountSearch().filter(self.filter_query)
         # Create the aggregations
+        financial_accounts_agg = A("nested", path="financial_accounts_by_award")
         if "query" in self.filters:
-            terms = ES_Q("terms", **{"disaster_emergency_fund_code": self.filters.get("def_codes")})
+            terms = ES_Q(
+                "terms", **{"financial_accounts_by_award.disaster_emergency_fund_code": self.filters.get("def_codes")}
+            )
             query = ES_Q(
                 "multi_match",
                 query=self.filters["query"],
                 type="phrase_prefix",
-                fields=[f"{query}" for query in self.query_fields],
+                fields=[f"financial_accounts_by_award.{query}" for query in self.query_fields],
             )
             filter_agg_query = ES_Q("bool", should=[terms, query], minimum_should_match=2)
         else:
-            filter_agg_query = ES_Q("terms", **{"disaster_emergency_fund_code": self.filters.get("def_codes")})
+            filter_agg_query = ES_Q(
+                "terms", **{"financial_accounts_by_award.disaster_emergency_fund_code": self.filters.get("def_codes")}
+            )
         filtered_aggs = A("filter", filter_agg_query)
         group_by_dim_agg = A("terms", field=self.agg_key, size=self.bucket_count)
-        # Group the FABA records by their Award key
-        # This is done since the FABA records are no longer nested under their parent Award in the same document
-        group_by_awards_agg = A("terms", field="financial_account_distinct_award_key")
         dim_metadata = A(
             "top_hits",
             size=1,
-            sort=[{"update_date": {"order": "desc"}}],
+            sort=[{"financial_accounts_by_award.update_date": {"order": "desc"}}],
             _source={"includes": self.top_hits_fields},
         )
-        # Fields to include for each Award
-        award_metadata = A("top_hits", size=1, _source={"includes": "total_loan_value"})
         sum_covid_outlay = A(
             "sum",
-            script="""doc['is_final_balances_for_fy'].value ? (
-             ( doc['gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['gross_outlay_amount_by_award_cpe'].value : 0)
-              + (doc['ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
-              + (doc['ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0""",
+            script="""doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? (
+             ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0)
+              + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
+              + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0""",
         )
-        sum_covid_obligation = A("sum", field="transaction_obligated_amount")
+        sum_covid_obligation = A("sum", field="financial_accounts_by_award.transaction_obligated_amount")
+        count_awards_by_dim = A("reverse_nested", **{})
+        award_count = A("value_count", field="financial_account_distinct_award_key")
+        loan_value = A("sum", field="total_loan_value")
 
         # Apply the aggregations
-        search.aggs.bucket("filtered_aggs", filtered_aggs).bucket("group_by_dim_agg", group_by_dim_agg).metric(
-            "dim_metadata", dim_metadata
-        ).metric("sum_transaction_obligated_amount", sum_covid_obligation).metric(
+        search.aggs.bucket(self.agg_group_name, financial_accounts_agg).bucket("filtered_aggs", filtered_aggs).bucket(
+            "group_by_dim_agg", group_by_dim_agg
+        ).metric("dim_metadata", dim_metadata).metric("sum_transaction_obligated_amount", sum_covid_obligation).metric(
             "sum_gross_outlay_amount_by_award_cpe", sum_covid_outlay
         ).bucket(
-            "group_by_awards", group_by_awards_agg
-        ).bucket(
-            "award_metadata", award_metadata
+            "count_awards_by_dim", count_awards_by_dim
+        ).metric(
+            "award_count", award_count
+        ).metric(
+            "sum_loan_value", loan_value
         )
 
         # Apply sub-aggregation for children if applicable
@@ -168,16 +167,16 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
         sub_dim_metadata = A(
             "top_hits",
             size=1,
-            sort=[{"update_date": {"order": "desc"}}],
+            sort=[{"financial_accounts_by_award.update_date": {"order": "desc"}}],
             _source={"includes": self.sub_top_hits_fields},
         )
         sub_sum_covid_outlay = A(
             "sum",
-            script="""doc['is_final_balances_for_fy'].value ? ( ( doc['gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['gross_outlay_amount_by_award_cpe'].value : 0)
-             + (doc['ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
-             + (doc['ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0""",
+            script="""doc['financial_accounts_by_award.is_final_balances_for_fy'].value ? ( ( doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].size() > 0 ? doc['financial_accounts_by_award.gross_outlay_amount_by_award_cpe'].value : 0)
+             + (doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe'].value : 0)
+             + (doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].size() > 0 ? doc['financial_accounts_by_award.ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe'].value : 0) ) : 0""",
         )
-        sub_sum_covid_obligation = A("sum", field="transaction_obligated_amount")
+        sub_sum_covid_obligation = A("sum", field="financial_accounts_by_award.transaction_obligated_amount")
         sub_count_awards_by_dim = A("reverse_nested", **{})
         sub_award_count = A("value_count", field="financial_account_distinct_award_key")
         loan_value = A("sum", field="total_loan_value")
@@ -219,7 +218,12 @@ class ElasticsearchAccountDisasterBase(DisasterBase):
             return {"totals": totals, "results": []}
         response = search.handle_execute()
         response = response.aggs.to_dict()
-        buckets = response.get("filtered_aggs", {}).get("group_by_dim_agg", {}).get("buckets", [])
+        buckets = (
+            response.get(self.agg_group_name, {})
+            .get("filtered_aggs", {})
+            .get("group_by_dim_agg", {})
+            .get("buckets", [])
+        )
         results = self.build_elasticsearch_result(buckets)
         totals = self.build_totals(results, loans)
         sorted_results = self.sort_results(results)

--- a/usaspending_api/disaster/v2/views/elasticsearch_base.py
+++ b/usaspending_api/disaster/v2/views/elasticsearch_base.py
@@ -1,10 +1,9 @@
 from abc import abstractmethod
-from typing import Dict, List, Optional
+from typing import List, Optional, Dict
 
 from django.conf import settings
 from django.utils.functional import cached_property
-from elasticsearch_dsl import A
-from elasticsearch_dsl import Q as ES_Q
+from elasticsearch_dsl import Q as ES_Q, A
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -82,6 +81,14 @@ class ElasticsearchDisasterBase(DisasterBase):
         if query:
             self.filters["query"] = {"text": query, "fields": self.query_fields}
         self.filter_query = QueryWithFilters.generate_awards_elasticsearch_query(self.filters)
+
+        # Ensure that only non-zero values are taken into consideration
+        # TODO: Refactor to use new NonzeroFields filter in QueryWithFilters
+        non_zero_queries = []
+        for field in self.sum_column_mapping.values():
+            non_zero_queries.append(ES_Q("range", **{field: {"gt": 0}}))
+            non_zero_queries.append(ES_Q("range", **{field: {"lt": 0}}))
+        self.filter_query.must.append(ES_Q("bool", should=non_zero_queries, minimum_should_match=1))
 
         self.bucket_count = get_number_of_unique_terms_for_awards(
             self.filter_query, f"{self.agg_key.replace('.keyword', '')}.hash"

--- a/usaspending_api/disaster/v2/views/federal_account/loans.py
+++ b/usaspending_api/disaster/v2/views/federal_account/loans.py
@@ -1,24 +1,23 @@
-from decimal import Decimal
 from typing import List
+from decimal import Decimal
 
 from django.db.models import F
-
 from usaspending_api.accounts.models import TreasuryAppropriationAccount
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.disaster.v2.views.disaster_base import (
-    FabaOutlayMixin,
-    LoansMixin,
     LoansPaginationMixin,
+    LoansMixin,
+    FabaOutlayMixin,
 )
 from usaspending_api.disaster.v2.views.elasticsearch_account_base import ElasticsearchAccountDisasterBase
 
 
 class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, ElasticsearchAccountDisasterBase):
-    """Returns loan disaster spending by federal account."""
+    """ Returns loan disaster spending by federal account. """
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/federal_account/loans.md"
-    agg_key = "treasury_account_id"  # primary (tier-1) aggregation key
-    nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
+    agg_key = "financial_accounts_by_award.treasury_account_id"  # primary (tier-1) aggregation key
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     query_fields = [
         "federal_account_symbol",
         "federal_account_symbol.contains",
@@ -30,11 +29,11 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
         "treasury_account_title.contains",
     ]
     top_hits_fields = [
-        "federal_account_symbol",
-        "federal_account_title",
-        "treasury_account_symbol",
-        "treasury_account_title",
-        "federal_account_id",
+        "financial_accounts_by_award.federal_account_symbol",
+        "financial_accounts_by_award.federal_account_title",
+        "financial_accounts_by_award.treasury_account_symbol",
+        "financial_accounts_by_award.treasury_account_title",
+        "financial_accounts_by_award.federal_account_id",
     ]
 
     @cache_response()
@@ -89,19 +88,12 @@ class LoansViewSet(LoansMixin, LoansPaginationMixin, FabaOutlayMixin, Elasticsea
             "code": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["treasury_account_symbol"],
             "description": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["treasury_account_title"],
             # the count of distinct awards contributing to the totals
-            "award_count": len(bucket["group_by_awards"]["buckets"]),
+            "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
                 key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
-                for key, val in self.nonzero_fields.items()
+                for key, val in self.nested_nonzero_fields.items()
             },
-            # Sum all of the loan values together and exclude the `None` values
-            "face_value_of_loan": sum(
-                [
-                    float(award["award_metadata"]["hits"]["hits"][0]["_source"]["total_loan_value"])
-                    for award in bucket["group_by_awards"]["buckets"]
-                    if award["award_metadata"]["hits"]["hits"][0]["_source"]["total_loan_value"] is not None
-                ],
-            ),
+            "face_value_of_loan": bucket["count_awards_by_dim"]["sum_loan_value"]["value"],
             "parent_data": [
                 bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["federal_account_title"],
                 bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["federal_account_symbol"],

--- a/usaspending_api/disaster/v2/views/federal_account/spending.py
+++ b/usaspending_api/disaster/v2/views/federal_account/spending.py
@@ -1,22 +1,22 @@
-from decimal import Decimal
 from typing import List
+from decimal import Decimal
 
-from django.db.models import Case, DecimalField, F, Func, IntegerField, OuterRef, Q, Subquery, Sum, Value, When
+from django.db.models import Q, Sum, F, Value, DecimalField, Case, When, OuterRef, Subquery, Func, IntegerField
 from django.db.models.functions import Coalesce
 from rest_framework.response import Response
 
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.data_classes import Pagination
 from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
+from usaspending_api.disaster.v2.views.federal_account.federal_account_result import FedAcctResults, FedAccount, TAS
 from usaspending_api.disaster.v2.views.disaster_base import (
     FabaOutlayMixin,
+    latest_gtas_of_each_year_queryset,
     PaginationMixin,
     SpendingMixin,
-    latest_gtas_of_each_year_queryset,
 )
-from usaspending_api.disaster.v2.views.elasticsearch_account_base import ElasticsearchAccountDisasterBase
-from usaspending_api.disaster.v2.views.federal_account.federal_account_result import TAS, FedAccount, FedAcctResults
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
+from usaspending_api.disaster.v2.views.elasticsearch_account_base import ElasticsearchAccountDisasterBase
 
 
 def construct_response(results: list, pagination: Pagination):
@@ -37,8 +37,8 @@ class SpendingViewSet(SpendingMixin, FabaOutlayMixin, ElasticsearchAccountDisast
     """Returns disaster spending by federal account."""
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/disaster/federal_account/spending.md"
-    agg_key = "treasury_account_id"  # primary (tier-1) aggregation key
-    nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
+    agg_key = "financial_accounts_by_award.treasury_account_id"  # primary (tier-1) aggregation key
+    nested_nonzero_fields = {"obligation": "transaction_obligated_amount", "outlay": "gross_outlay_amount_by_award_cpe"}
     query_fields = [
         "federal_account_symbol",
         "federal_account_symbol.contains",
@@ -50,11 +50,11 @@ class SpendingViewSet(SpendingMixin, FabaOutlayMixin, ElasticsearchAccountDisast
         "treasury_account_title.contains",
     ]
     top_hits_fields = [
-        "federal_account_symbol",
-        "federal_account_title",
-        "treasury_account_symbol",
-        "treasury_account_title",
-        "federal_account_id",
+        "financial_accounts_by_award.federal_account_symbol",
+        "financial_accounts_by_award.federal_account_title",
+        "financial_accounts_by_award.treasury_account_symbol",
+        "financial_accounts_by_award.treasury_account_title",
+        "financial_accounts_by_award.federal_account_id",
     ]
 
     @cache_response()
@@ -116,10 +116,10 @@ class SpendingViewSet(SpendingMixin, FabaOutlayMixin, ElasticsearchAccountDisast
             "code": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["treasury_account_symbol"],
             "description": bucket["dim_metadata"]["hits"]["hits"][0]["_source"]["treasury_account_title"],
             # the count of distinct awards contributing to the totals
-            "award_count": len(bucket["group_by_awards"]["buckets"]),
+            "award_count": int(bucket["count_awards_by_dim"]["award_count"]["value"]),
             **{
                 key: Decimal(bucket.get(f"sum_{val}", {"value": 0})["value"])
-                for key, val in self.nonzero_fields.items()
+                for key, val in self.nested_nonzero_fields.items()
             },
             "total_budgetary_resources": None,
             "parent_data": [

--- a/usaspending_api/etl/elasticsearch_loader_helpers/__init__.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/__init__.py
@@ -35,6 +35,7 @@ from usaspending_api.etl.elasticsearch_loader_helpers.index_config import (
 from usaspending_api.etl.elasticsearch_loader_helpers.load_data import load_data
 from usaspending_api.etl.elasticsearch_loader_helpers.transform_data import (
     transform_award_data,
+    transform_covid19_faba_data,
     transform_transaction_data,
 )
 from usaspending_api.etl.elasticsearch_loader_helpers.utilities import (

--- a/usaspending_api/etl/elasticsearch_loader_helpers/index_config.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/index_config.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("script")
 
 ES_AWARDS_UNIQUE_KEY_FIELD = "generated_unique_award_id"
 ES_TRANSACTIONS_UNIQUE_KEY_FIELD = "generated_unique_transaction_id"
-ES_COVID19_FABA_UNIQUE_KEY_FIELD = ""
+ES_COVID19_FABA_UNIQUE_KEY_FIELD = "distinct_award_key"
 ES_RECIPIENT_UNIQUE_KEY_FIELD = "recipient_hash"
 ES_LOCATION_UNIQUE_KEY_FIELD = ""
 ES_SUBAWARD_UNIQUE_KEY_FIELD = "broker_subaward_id"

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -91,6 +91,51 @@ def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[di
     return transform_data(worker, records, converters, agg_key_creations, drop_fields, settings.ES_ROUTING_FIELD)
 
 
+def transform_covid19_faba_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
+    logger.info(format_log("Transforming data", name=worker.name, action="Transform"))
+    start = perf_counter()
+    results = {}
+
+    for record in records:
+        es_id_field = record[worker.field_for_es_id]
+        disinct_award_key = record.pop("financial_account_distinct_award_key")
+        award_id = record.pop("award_id")
+        award_type = record.pop("type")
+        generated_unique_award_id = record.pop("generated_unique_award_id")
+        total_loan_value = record.pop("total_loan_value")
+        obligated_sum = record.get("transaction_obligated_amount") or 0  # record value for key may be None
+        outlay_sum = (
+            (record.get("gross_outlay_amount_by_award_cpe") or 0)
+            + (record.get("ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe") or 0)
+            + (record.get("ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe") or 0)
+        )  # record value for any key may be None
+        temp_key = disinct_award_key
+        if temp_key not in results:
+            results[temp_key] = {
+                "financial_account_distinct_award_key": disinct_award_key,
+                "award_id": award_id,
+                "type": award_type,
+                "generated_unique_award_id": generated_unique_award_id,
+                "total_loan_value": total_loan_value,
+                "financial_accounts_by_award": list(),
+                "obligated_sum": 0,
+                "outlay_sum": 0,
+                "_id": es_id_field,
+            }
+        results[temp_key]["obligated_sum"] += obligated_sum
+        if record.get("is_final_balances_for_fy"):
+            results[temp_key]["outlay_sum"] += outlay_sum
+        results[temp_key]["financial_accounts_by_award"].append(record)
+
+    if len(results) != len(records):
+        msg = f"Transformed {len(records)} database records into {len(results)} documents for ingest"
+        logger.info(format_log(msg, name=worker.name, action="Transform"))
+
+    msg = f"Transformation operation took {perf_counter() - start:.2f}s"
+    logger.info(format_log(msg, name=worker.name, action="Transform"))
+    return list(results.values())  # don't need the dict key, return a list of the dict values
+
+
 def transform_data(
     worker: TaskSpec,
     records: List[dict],

--- a/usaspending_api/etl/es_covid19_faba_template.json
+++ b/usaspending_api/etl/es_covid19_faba_template.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.mapping.ignore_malformed": true,
     "index.max_result_window": null,
+    "index.mapping.nested_objects.limit": 60000,
     "index.refresh_interval": -1,
     "index": {
       "number_of_shards": 5,
@@ -10,332 +11,345 @@
   },
   "mappings": {
     "properties": {
-      "create_date": {
-        "type": "date"
-      },
-      "financial_account_distinct_award_key": {
-        "type": "keyword"
-      },
-      "deobligations_recoveries_refunds_of_prior_year_by_award_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "direct_reimbursable": {
-        "type": "keyword"
-      },
-      "disaster_emergency_fund_code": {
+      "award_id": {
         "null_value": "NULL",
-        "type": "keyword"
-      },
-      "disaster_emergency_fund_code_group_name": {
-        "null_value": "NULL",
-        "type": "keyword"
-      },
-      "generated_unique_award_id": {
-        "type": "keyword"
-      },
-      "distinct_award_key": {
         "type": "keyword"
       },
       "type": {
         "null_value": "NULL",
         "type": "keyword"
       },
-      "award_id": {
-        "null_value": "NULL",
+      "financial_account_distinct_award_key": {
         "type": "keyword"
       },
-      "fain": {
-        "fields": {
-          "keyword": {
+      "financial_accounts_by_award": {
+        "properties": {
+          "create_date": {
+            "type": "date"
+          },
+          "deobligations_recoveries_refunds_of_prior_year_by_award_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "direct_reimbursable": {
             "type": "keyword"
+          },
+          "disaster_emergency_fund_code": {
+            "null_value": "NULL",
+            "type": "keyword"
+          },
+          "disaster_emergency_fund_code_group_name": {
+            "null_value": "NULL",
+            "type": "keyword"
+          },
+          "distinct_award_key": {
+            "type": "keyword"
+          },
+          "fain": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "federal_account_id": {
+            "type": "integer"
+          },
+          "federal_account_symbol": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "federal_account_title": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "financial_accounts_by_awards_id": {
+            "type": "integer"
+          },
+          "funding_toptier_agency_code": {
+            "type": "keyword"
+          },
+          "funding_toptier_agency_id": {
+            "type": "integer"
+          },
+          "funding_toptier_agency_name": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "gross_outlay_amount_by_award_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "gross_outlay_amount_by_award_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "gross_outlays_delivered_orders_paid_total_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "gross_outlays_delivered_orders_paid_total_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "gross_outlays_undelivered_orders_prepaid_total_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "gross_outlays_undelivered_orders_prepaid_total_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "is_final_balances_for_fy": {
+            "type": "boolean"
+          },
+          "is_quarter": {
+            "type": "boolean"
+          },
+          "major_object_class": {
+            "type": "keyword"
+          },
+          "major_object_class_name": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "object_class": {
+            "type": "keyword"
+          },
+          "object_class_id": {
+            "type": "integer"
+          },
+          "object_class_name": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "obligations_delivered_orders_unpaid_total_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "obligations_delivered_orders_unpaid_total_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "obligations_incurred_total_by_award_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "obligations_undelivered_orders_unpaid_total_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "obligations_undelivered_orders_unpaid_total_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "parent_award_id": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "period_end_date": {
+            "type": "date"
+          },
+          "period_start_date": {
+            "type": "date"
+          },
+          "piid": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "program_activity_code": {
+            "type": "keyword"
+          },
+          "program_activity_id": {
+            "type": "integer"
+          },
+          "program_activity_name": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "reporting_period_end": {
+            "type": "date"
+          },
+          "reporting_period_start": {
+            "type": "date"
+          },
+          "submission_fiscal_month": {
+            "type": "integer"
+          },
+          "submission_fiscal_quarter": {
+            "type": "integer"
+          },
+          "submission_fiscal_year": {
+            "type": "integer"
+          },
+          "submission_id": {
+            "type": "integer"
+          },
+          "submission_window_id": {
+            "type": "keyword"
+          },
+          "transaction_obligated_amount": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "treasury_account_id": {
+            "type": "integer"
+          },
+          "treasury_account_symbol": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "treasury_account_title": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "update_date": {
+            "type": "date"
+          },
+          "uri": {
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "ussgl480100_undelivered_orders_obligations_unpaid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl480100_undelivered_orders_obligations_unpaid_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl480200_undelivered_orders_oblig_prepaid_advanced_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl483100_undelivered_orders_oblig_transferred_unpaid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl483200_undeliv_orders_oblig_transferred_prepaid_adv_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl487100_down_adj_pri_unpaid_undel_orders_oblig_recov_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl488100_upward_adjust_pri_undeliv_order_oblig_unpaid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl488200_up_adjust_pri_undeliv_order_oblig_ppaid_adv_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl490100_delivered_orders_obligations_unpaid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl490100_delivered_orders_obligations_unpaid_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl490200_delivered_orders_obligations_paid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl490800_authority_outlayed_not_yet_disbursed_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl490800_authority_outlayed_not_yet_disbursed_fyb": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl493100_delivered_orders_oblig_transferred_unpaid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
+          },
+          "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": {
+            "scaling_factor": 100,
+            "type": "scaled_float"
           }
         },
-        "type": "text"
+        "type": "nested"
       },
-      "federal_account_id": {
-        "type": "integer"
-      },
-      "federal_account_symbol": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "federal_account_title": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "financial_accounts_by_awards_id": {
-        "type": "integer"
-      },
-      "funding_toptier_agency_code": {
+      "generated_unique_award_id": {
         "type": "keyword"
-      },
-      "funding_toptier_agency_id": {
-        "type": "integer"
-      },
-      "funding_toptier_agency_name": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "gross_outlay_amount_by_award_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "gross_outlay_amount_by_award_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "gross_outlays_delivered_orders_paid_total_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "gross_outlays_delivered_orders_paid_total_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "gross_outlays_undelivered_orders_prepaid_total_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "gross_outlays_undelivered_orders_prepaid_total_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "is_final_balances_for_fy": {
-        "type": "boolean"
-      },
-      "is_quarter": {
-        "type": "boolean"
-      },
-      "major_object_class": {
-        "type": "keyword"
-      },
-      "major_object_class_name": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "object_class": {
-        "type": "keyword"
-      },
-      "object_class_id": {
-        "type": "integer"
-      },
-      "object_class_name": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "obligations_delivered_orders_unpaid_total_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "obligations_delivered_orders_unpaid_total_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "obligations_incurred_total_by_award_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "obligations_undelivered_orders_unpaid_total_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "obligations_undelivered_orders_unpaid_total_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "parent_award_id": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "period_end_date": {
-        "type": "date"
-      },
-      "period_start_date": {
-        "type": "date"
-      },
-      "piid": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "program_activity_code": {
-        "type": "keyword"
-      },
-      "program_activity_id": {
-        "type": "integer"
-      },
-      "program_activity_name": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "reporting_period_end": {
-        "type": "date"
-      },
-      "reporting_period_start": {
-        "type": "date"
-      },
-      "submission_fiscal_month": {
-        "type": "integer"
-      },
-      "submission_fiscal_quarter": {
-        "type": "integer"
-      },
-      "submission_fiscal_year": {
-        "type": "integer"
-      },
-      "submission_id": {
-        "type": "integer"
-      },
-      "submission_window_id": {
-        "type": "keyword"
-      },
-      "transaction_obligated_amount": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "treasury_account_id": {
-        "type": "integer"
-      },
-      "treasury_account_symbol": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "treasury_account_title": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "update_date": {
-        "type": "date"
-      },
-      "uri": {
-        "fields": {
-          "keyword": {
-            "type": "keyword"
-          }
-        },
-        "type": "text"
-      },
-      "ussgl480100_undelivered_orders_obligations_unpaid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl480100_undelivered_orders_obligations_unpaid_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl480200_undelivered_orders_oblig_prepaid_advanced_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl483100_undelivered_orders_oblig_transferred_unpaid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl483200_undeliv_orders_oblig_transferred_prepaid_adv_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl487100_down_adj_pri_unpaid_undel_orders_oblig_recov_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl487200_down_adj_pri_ppaid_undel_orders_oblig_refund_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl488100_upward_adjust_pri_undeliv_order_oblig_unpaid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl488200_up_adjust_pri_undeliv_order_oblig_ppaid_adv_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl490100_delivered_orders_obligations_unpaid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl490100_delivered_orders_obligations_unpaid_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl490200_delivered_orders_obligations_paid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl490800_authority_outlayed_not_yet_disbursed_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl490800_authority_outlayed_not_yet_disbursed_fyb": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl493100_delivered_orders_oblig_transferred_unpaid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl497200_down_adj_pri_paid_deliv_orders_oblig_refund_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
-      },
-      "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
       },
       "total_loan_value": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "obligated_sum": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "outlay_sum": {
         "scaling_factor": 100,
         "type": "scaled_float"
       }

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -16,6 +16,7 @@ from usaspending_api.etl.elasticsearch_loader_helpers import (
     format_log,
     toggle_refresh_off,
     transform_award_data,
+    transform_covid19_faba_data,
     transform_transaction_data,
 )
 from usaspending_api.etl.elasticsearch_loader_helpers.controller import (
@@ -243,11 +244,7 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
 
                 Default value: execute_sql_statement
 
-            extra_null_partition: Used when indexing nested parent-child records to prevent indexing issues.
-                Note: This should only be set to `True` when the data is grouped in a parent-child style, where child
-                    records are grouped by the `primary_key` value within a parent record. It is imperative that only
-                    1 indexing operation is performed per parent document which encompasses all of its nested child
-                    documents. Subsequent indexing of the same parent document will overwrite the prior document.
+            extra_null_partition:
 
             field_for_es_id: Field that will be used as the `id` value in the Elasticsearch index.
 
@@ -353,15 +350,15 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
             "base_table": "financial_accounts_by_awards",
             "base_table_id": "financial_accounts_by_awards_id",
             "create_award_type_aliases": False,
-            "data_transform_func": None,
+            "data_transform_func": transform_covid19_faba_data,
             "data_type": "covid19-faba",
             "execute_sql_func": execute_sql_statement,
-            "extra_null_partition": False,
-            "field_for_es_id": "financial_accounts_by_awards_id",
+            "extra_null_partition": True,
+            "field_for_es_id": "financial_account_distinct_award_key",
             "initial_datetime": datetime.strptime("2020-04-01+0000", "%Y-%m-%d%z"),
             "max_query_size": settings.ES_COVID19_FABA_MAX_RESULT_WINDOW,
             "optional_predicate": "",
-            "primary_key": "financial_accounts_by_awards_id",
+            "primary_key": "award_id",
             "query_alias_prefix": settings.ES_COVID19_FABA_QUERY_ALIAS_PREFIX,
             "required_index_name": settings.ES_COVID19_FABA_NAME_SUFFIX,
             "sql_view": settings.ES_COVID19_FABA_ETL_VIEW_NAME,


### PR DESCRIPTION
Reverts fedspendingtransparency/usaspending-api#4094