### PR TITLE
[DEV-11100] Add DUNS to recipient profile index in Elastic-search

### DIFF
--- a/usaspending_api/database_scripts/etl/recipient_profile_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/recipient_profile_delta_view.sql
@@ -2,11 +2,15 @@ DROP VIEW IF EXISTS recipient_profile_delta_view;
 
 CREATE VIEW recipient_profile_delta_view AS
 SELECT
-  "id",
-  "recipient_hash",
-  "recipient_name",
-  "uei",
-  "recipient_level",
-  "duns"
+  rp.id,
+  rp.recipient_hash,
+  rp.recipient_name,
+  rp.uei,
+  rp.recipient_level,
+  rl.duns
 FROM
-  "recipient_profile"
+  recipient_profile rp
+JOIN
+  recipient_lookup rl
+ON
+  rp.recipient_hash = rl.recipient_hash;

--- a/usaspending_api/database_scripts/etl/recipient_profile_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/recipient_profile_delta_view.sql
@@ -2,15 +2,12 @@ DROP VIEW IF EXISTS recipient_profile_delta_view;
 
 CREATE VIEW recipient_profile_delta_view AS
 SELECT
-  rp.id,
-  rp.recipient_hash,
-  rp.recipient_name,
-  rp.uei,
-  rp.recipient_level,
-  rl.duns
+  "id",
+  "recipient_hash",
+  "recipient_name",
+  "uei",
+  "recipient_level",
+  "recipient_unique_id" AS "duns"
 FROM
-  recipient_profile rp
-JOIN
-  recipient_lookup rl
-ON
-  rp.recipient_hash = rl.recipient_hash;
+  "recipient_profile";
+

--- a/usaspending_api/database_scripts/etl/recipient_profile_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/recipient_profile_delta_view.sql
@@ -6,6 +6,7 @@ SELECT
   "recipient_hash",
   "recipient_name",
   "uei",
-  "recipient_level"
+  "recipient_level",
+  "duns"
 FROM
   "recipient_profile"

--- a/usaspending_api/etl/es_recipient_profile_template.json
+++ b/usaspending_api/etl/es_recipient_profile_template.json
@@ -53,6 +53,18 @@
       },
       "recipient_level": {
         "type": "keyword"
+      },
+      "duns": {
+        "type": "text",
+        "fields": {
+          "contains": {
+            "type": "text",
+            "analyzer": "contains_analyzer"
+          },
+          "keyword": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/usaspending_api/references/tests/integration/test_recipients_autocomplete_v2.py
+++ b/usaspending_api/references/tests/integration/test_recipients_autocomplete_v2.py
@@ -18,6 +18,7 @@ def recipient_data_fixture(db):
         recipient_hash="521bb024-054c-4c81-8615-372f81629664",
         uei="UEI-01",
         recipient_name="Spiderman",
+        recipient_unique_id="hero1",  # aka duns
     )
 
     baker.make(
@@ -27,6 +28,7 @@ def recipient_data_fixture(db):
         recipient_hash="a70b86c3-5a12-4623-963b-9d96c4810163",
         uei="UEI-02",
         recipient_name="Batman",
+        recipient_unique_id="hero2",
     )
 
     baker.make(
@@ -36,6 +38,7 @@ def recipient_data_fixture(db):
         recipient_hash="a70b86c3-5a12-4623-963b-9d96c4810345",
         uei="UEI-03",
         recipient_name="Batman",
+        recipient_unique_id="hero3",
     )
 
     baker.make(
@@ -45,6 +48,7 @@ def recipient_data_fixture(db):
         recipient_hash="9159db20-d2f7-42d4-88e2-a69759987520",
         uei="UEI-04",
         recipient_name="Superman",
+        recipient_unique_id="hero4",
     )
 
     baker.make(
@@ -54,6 +58,7 @@ def recipient_data_fixture(db):
         recipient_hash="9159db20-d2f7-42d4-88e2-a69759987908",
         uei="UEI-05",
         recipient_name="sdfsdg",
+        recipient_unique_id="hero5",
     )
 
 


### PR DESCRIPTION
**Description:**
To support Advanced Search 2.0 we need to support searching for recipients by their DUNS value. Currently only Recipient Name, UEI, and Recipient Level are supported by Elasticsearch, so DUNS was also added. 

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Jira Ticket [DEV-11100](https://federal-spending-transparency.atlassian.net/browse/DEV-11100):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
