### PR TITLE
Mod/remove django elasticache

### DIFF
--- a/requirements/requirements-server.txt
+++ b/requirements/requirements-server.txt
@@ -1,4 +1,3 @@
-django-elasticache==1.0.*
 django-redis==4.12.*
 packaging==16.8
 pyparsing==2.2.0


### PR DESCRIPTION
**Description:**
`django-elasticache` is no longer being used in the codebase, but the installation process is causing failures when trying to do deploys. This package can be removed. 

Example failure: https://data-transparency-bfs.slack.com/archives/C01L7BH2Q8J/p1721740223084289
Example success after removal: https://data-transparency-bfs.slack.com/archives/C01L7BH2Q8J/p1721749778021749
