### PR TITLE
[DEV-11345] Don't use the DB writer instance for reading [hotfix] [qat]

### DIFF
--- a/usaspending_api/routers/replicas.py
+++ b/usaspending_api/routers/replicas.py
@@ -1,8 +1,7 @@
-import random
-
 from django.db import DEFAULT_DB_ALIAS
-from usaspending_api.references.models import FilterHash
+
 from usaspending_api.download.models.download_job import DownloadJob
+from usaspending_api.references.models import FilterHash
 
 
 class ReadReplicaRouter:
@@ -25,21 +24,21 @@ class ReadReplicaRouter:
         """
         if model in [FilterHash, DownloadJob]:
             return self.writable_database
-        return random.choice(self.usaspending_databases)
+        return self.read_replicas
 
     def db_for_write(self, model, **hints):
         return self.writable_database
 
     def allow_relation(self, obj1, obj2, **hints):
-        """ Relations are currently only allowed in USAspending.  Cross database relations are not allowed. """
+        """Relations are currently only allowed in USAspending.  Cross database relations are not allowed."""
         return obj1._state.db in self.usaspending_databases and obj2._state.db == obj1._state.db
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        """ Migrations should only run in USAspending against the writable database. """
+        """Migrations should only run in USAspending against the writable database."""
         return db == self.writable_database
 
 
 class DefaultOnlyRouter(ReadReplicaRouter):
-    """ For when only the default connection is used.  Prevents model access/migrations to Broker. """
+    """For when only the default connection is used.  Prevents model access/migrations to Broker."""
 
     read_replicas = []


### PR DESCRIPTION
**Description:**
Previously, we were randomly choosing between our DB writer instance and the read replicas when choosing a database to use for read operations. This sets the read replicas as the only options for read operations to reduce unnecessary load on the writer instance.

**Technical details:**

**Requirements for PR merge:**

3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-11345](https://federal-spending-transparency.atlassian.net/browse/DEV-11345):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. Unit & integration tests updated
There are no tests for the application settings.

2. API documentation updated
No API documentation is affected by this change.

4. Matview impact assessment completed
No matviews are affected by this change.

5. Frontend impact assessment completed
The frontend is not affected by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this change.

```
