### PR TITLE
 [DEV-11345] Don't use the DB writer instance for reading [hotfix] [qat]

### DIFF
--- a/usaspending_api/routers/replicas.py
+++ b/usaspending_api/routers/replicas.py
@@ -17,16 +17,16 @@ class ReadReplicaRouter:
     def __init__(self):
         self.usaspending_databases = [self.writable_database] + self.read_replicas
 
-    def db_for_read(self, model, **hints):
+    def db_for_read(self, model, **hints) -> str:
         """
         FilterHash and DownloadJob are writable tables so always read from source (default) to
         mitigate replication lag.  Otherwise, choose a connection randomly.
         """
         if model in [FilterHash, DownloadJob]:
             return self.writable_database
-        return self.read_replicas
+        return self.read_replicas[0]
 
-    def db_for_write(self, model, **hints):
+    def db_for_write(self, model, **hints) -> str:
         return self.writable_database
 
     def allow_relation(self, obj1, obj2, **hints):

--- a/usaspending_api/routers/replicas.py
+++ b/usaspending_api/routers/replicas.py
@@ -24,7 +24,11 @@ class ReadReplicaRouter:
         """
         if model in [FilterHash, DownloadJob]:
             return self.writable_database
-        return self.read_replicas[0]
+
+        if len(self.read_replicas) > 0:
+            return self.read_replicas[0]
+        else:
+            return self.writable_database
 
     def db_for_write(self, model, **hints) -> str:
         return self.writable_database


### PR DESCRIPTION
**Description:**
Previously, we were randomly choosing between our DB writer instance and the read replicas when choosing a database to use for read operations. This sets the read replicas as the only options for read operations to reduce unnecessary load on the writer instance.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-11345](https://federal-spending-transparency.atlassian.net/browse/DEV-11345):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

4. Matview impact assessment completed
No matviews are affected by this change.

5. Frontend impact assessment completed
The frontend is not affected by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this change.

```
