### PR TITLE
[DEV-11453] Unique program activity autocomplete results

### DIFF
--- a/usaspending_api/references/tests/integration/test_program_activity_autocomplete_v2.py
+++ b/usaspending_api/references/tests/integration/test_program_activity_autocomplete_v2.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 from model_bakery import baker
 from rest_framework import status
@@ -11,6 +12,11 @@ def program_activity_data(db):
     baker.make(RefProgramActivity, program_activity_code="0001", program_activity_name="ELECTRONICS")
     baker.make(RefProgramActivity, program_activity_code="0003", program_activity_name="MEAT")
     baker.make(RefProgramActivity, program_activity_code="0007", program_activity_name="BEANS")
+
+    baker.make(RefProgramActivity, program_activity_code="9999", program_activity_name="COLOR BLUE", budget_year=2024)
+    baker.make(RefProgramActivity, program_activity_code="9999", program_activity_name="COLOR BLUE", budget_year=2023)
+    baker.make(RefProgramActivity, program_activity_code="8888", program_activity_name="COLOR RED", budget_year=2024)
+    baker.make(RefProgramActivity, program_activity_code="7777", program_activity_name="COLOR BLUE", budget_year=2024)
 
 
 @pytest.mark.django_db
@@ -33,3 +39,25 @@ def test_program_activity_autocomplete_success(client, program_activity_data):
     )
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.data["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_only_distinct_program_activities_returned(client, program_activity_data):
+    """
+    Test that no duplicate program_activity_code & program_activity_name combinations are
+    returned.
+    """
+
+    resp = client.post(
+        "/api/v2/autocomplete/program_activity/",
+        content_type="application/json",
+        data=json.dumps({"search_text": "color"}),
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.data["results"]) == 3
+    assert resp.data["results"] == [
+        {"program_activity_code": "7777", "program_activity_name": "COLOR BLUE"},
+        {"program_activity_code": "8888", "program_activity_name": "COLOR RED"},
+        {"program_activity_code": "9999", "program_activity_name": "COLOR BLUE"},
+    ]

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -2,10 +2,11 @@ from django.db.models import Case, F, IntegerField, Q, When
 from django.db.models.functions import Upper
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.generic_helper import deprecated_api_endpoint_message
-from usaspending_api.references.models import Cfda, Definition, NAICS, PSC, RefProgramActivity
+from usaspending_api.references.models import NAICS, PSC, Cfda, Definition, RefProgramActivity
 from usaspending_api.references.v2.views.glossary import DefinitionSerializer
 from usaspending_api.search.models import AgencyAutocompleteMatview, AgencyOfficeAutocompleteMatview
 
@@ -391,7 +392,7 @@ class ProgramActivityAutocompleteViewSet(BaseAutocompleteViewSet):
     def post(self, request):
         search_text, limit = self.get_request_payload(request)
 
-        queryset = RefProgramActivity.objects.all()
+        queryset = RefProgramActivity.objects.distinct("program_activity_code", "program_activity_name")
 
         if len(search_text) == 4 and queryset.filter(program_activity_code=search_text.upper()).exists():
             queryset = queryset.filter(program_activity_code=search_text.upper())


### PR DESCRIPTION
**Description:**
Only return unique combinations of `program_activity_code` and `program_activity_name` for the program_activity autocomplete endpoint. Previously, the same program code and name could be returned since there are multiple program activities with the same code and name for different years or accounts.

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-11453](https://federal-spending-transparency.atlassian.net/browse/DEV-11453):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this change.
```
