### PR TITLE
[DEV-11452] Update DEFC logic to filter with existing defc filter

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -63,6 +63,7 @@ def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[di
         "funding_toptier_agency_agg_key": lambda x: x["funding_agency_code"],
         "naics_agg_key": lambda x: x["naics_code"],
         "psc_agg_key": lambda x: x["product_or_service_code"],
+        "defc_agg_key": lambda x: x["disaster_emergency_fund_codes"],
         "pop_country_agg_key": lambda x: x["pop_country_code"],
         "pop_state_agg_key": lambda x: x["pop_state_code"],
         "pop_county_agg_key": funcs.pop_county_agg_key,

--- a/usaspending_api/search/v2/views/spending_by_category_views/spending_by_category.py
+++ b/usaspending_api/search/v2/views/spending_by_category_views/spending_by_category.py
@@ -67,10 +67,18 @@ class AbstractSpendingByCategoryViewSet(APIView, metaclass=ABCMeta):
         original_filters = request.data.get("filters")
         validated_payload = TinyShield(models).block(request.data)
 
-        # Because Subawards and Transactions are associated with DEFCs via their Prime Award, which contains a list of all DEFCs from its associated File C records, we need to limit results to records with a sub_action_date and action_date, respectively, earlier than the enactment date of the public law for each DEFC. This provides a more accurate breakdown of funds by DEFC. This can be accomplished by simply adding an extra filter for all DEFCs because DEFC filtering logic already takes this into account in query_with_filters.py. Because we are grouping by DEFC, it is safe to filter down to only records that include one.
+        # Because Subawards and Transactions are associated with DEFCs via their Prime Award, which
+        # contains a list of all DEFCs from its associated File C records, we need to limit results
+        # to records with a sub_action_date and action_date, respectively, earlier than the enactment date
+        # of the public law for each DEFC. This provides a more accurate breakdown of funds by DEFC.
+        # This can be accomplished by simply adding an extra filter for all DEFCs because DEFC filtering
+        # logic already takes this into account in query_with_filters.py. Because we are grouping by DEFC,
+        # it is safe to filter down to only records that include one.
         # Check if it's the Spending by DEFC endpoint
         if self.category.name == "defc":
             # Get the list of DEFCs and add the filter if it doesn't already exist
+            if "filters" not in validated_payload:
+                validated_payload["filters"] = {}
             if "def_codes" not in validated_payload["filters"]:
                 def_codes = list(DisasterEmergencyFundCode.objects.values_list("code", flat=True))
                 validated_payload["filters"]["def_codes"] = def_codes


### PR DESCRIPTION
**Description:**
Continuing on DEV-11452, the Spending by DEFC endpoint needed additional changes that included logic to ensure that the defc are filtering properly whether or not if the user was searching by transactions or subawards.

**Technical details:**
A hardcoded filter was added under the `post` method in `spending_by_category.py` that passes the `def_codes` filter with all of the DEFCs.

**Requirements for PR merge:**

1. [ ] Necessary PR reviewers:
    - [ ] Backend
2. [x] Jira Ticket [DEV-11452](https://federal-spending-transparency.atlassian.net/browse/DEV-11452):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentations needed to be updated.

4. Matview impact assessment completed.
No matviews were affected by this change.

5. Frontend impact assessment completed
The frontend is not affected by this change.

6. Data validation completed
No data validation is needed by this change.

8. Appropriate Operations ticket(s) created
No operation tickets needed for these changes.

```
