### PR TITLE
[DEV-11422] Total Outlay Award Type Breakdown

### DIFF
--- a/usaspending_api/transactions/delta_models/summary_state_view.py
+++ b/usaspending_api/transactions/delta_models/summary_state_view.py
@@ -47,7 +47,12 @@ summary_state_view_load_sql_string = [
         transaction_normalized.type,
         CONCAT_WS(
             ',',
-            SORT_ARRAY(COLLECT_SET(transaction_normalized.award_id))
+            COLLECT_SET(
+                CASE
+                    WHEN transaction_normalized.id = awards.latest_transaction_id THEN transaction_normalized.award_id
+                    ELSE NULL
+                END
+            )
         ) AS distinct_awards,
         COALESCE(
             transaction_fpds.place_of_perform_country_c,
@@ -96,6 +101,8 @@ summary_state_view_load_sql_string = [
         int.transaction_fpds ON (transaction_normalized.id = transaction_fpds.transaction_id)
     LEFT OUTER JOIN
         int.transaction_fabs ON (transaction_normalized.id = transaction_fabs.transaction_id)
+    INNER JOIN
+        int.awards ON (transaction_normalized.award_id = awards.id)
     WHERE
         transaction_normalized.action_date >= '2007-10-01'
         AND COALESCE(transaction_fpds.place_of_perform_country_c, transaction_fabs.place_of_perform_country_c, 'USA') = 'USA'


### PR DESCRIPTION
**Description:**
A problem was found with the calculation of Total Outlays in Summary State View. Funds were being double counted because Transactions Award Types are not Unique to a single Award.

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [ ] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11422](https://federal-spending-transparency.atlassian.net/browse/DEV-11422):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
