### PR TITLE
[DEV-11402] Update download count endpoint

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -24,7 +24,7 @@ Returns the number of transactions that would be included in a download request 
                 + `subawards`
                 + `transactions`
                 + `awards`
-                + Default: `transactions`
+            + Default: `transactions`
     + Body
 
 

--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -94,7 +94,7 @@ Returns the number of transactions that would be included in a download request 
 + `extent_competed_type_codes`: `A` (optional, array[string])
 + `tas_codes` (optional, array[TASCodeObject], fixed-type)
 + `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
-+ `spending_level` (required, array[string])
++ `spending_level` (optional, array[string])
     Possible values in this list are either awards, transaction, or subawards
 
 ## TimePeriodObject (object)

--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -19,7 +19,11 @@ Returns the number of transactions that would be included in a download request 
 
     + Attributes (object)
         + `filters` (required, AdvancedFilterObject)
-        + `spending_level` (optional, SpendingLevelObject)
+        + `spending_level` (optional, enum[string])
+            + Members
+                + `subawards`
+                + `transactions`
+                + `awards`
     + Body
 
 
@@ -39,21 +43,22 @@ Returns the number of transactions that would be included in a download request 
                     "recipient_type_names": ["higher_education"],
                     "place_of_performance_locations": [{"country": "USA", "state": "WI"}],
                     "psc_codes": {"require": [["Product","10","1035"]]}
-                }
+                },
+                "spending_level": "awards"
             }
 
 + Response 200 (application/json)
     + Attributes (object)
-        + `transaction_rows_gt_limit` (required, boolean)
-            A boolean returning whether the transaction count is over the maximum row limit.
         + `calculated_transaction_count` (required, number)
             The calculated count of all transactions which would be included in the download files.
         + `maximum_transaction_limit` (required, number)
             The current allowed maximum number of transactions in a row-limited download. Visit https://www.usaspending.gov/download_center/custom_award_data to download larger volumes of data.
-        + `spending_level` (required, string)
-            The spending_level provided by the user or the default value of transactions.
+        + `transaction_rows_gt_limit` (required, boolean)
+            A boolean returning whether the transaction count is over the maximum row limit.
         + `calculated_count` (required, number)
             The calculated count of Awards, Transactions, or Subawards included in the download files.
+        + `spending_level` (required, string)
+            The spending_level provided by the user or the default value of transactions.
         + `maximum_limit` (required, number)
             The current allowed maximum number of Awards, Transactions, or Subawards in a row-limited download. Visit https://www.usaspending.gov/download_center/custom_award_data to download larger volumes of data.
         + `rows_gt_limit` (required, boolean)
@@ -103,13 +108,6 @@ Returns the number of transactions that would be included in a download request 
 + `extent_competed_type_codes`: `A` (optional, array[string])
 + `tas_codes` (optional, array[TASCodeObject], fixed-type)
 + `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
-
-## SpendingLevelObject (object)
-+ `spending_level` (optional, enum[string])
-    + Members
-        + `subawards`
-        + `transactions`
-        + `awards`
 
 ## TimePeriodObject (object)
 See the Transaction Search category defined in [TransactionSearchTimePeriodObject](../../../search_filters.md#transaction-search-time-period-object)

--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -94,6 +94,8 @@ Returns the number of transactions that would be included in a download request 
 + `extent_competed_type_codes`: `A` (optional, array[string])
 + `tas_codes` (optional, array[TASCodeObject], fixed-type)
 + `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
++ `spending_level` (required, array[string])
+    Possible values in this list are either awards, transaction, or subawards
 
 ## TimePeriodObject (object)
 See the Transaction Search category defined in [TransactionSearchTimePeriodObject](../../../search_filters.md#transaction-search-time-period-object)

--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -24,6 +24,7 @@ Returns the number of transactions that would be included in a download request 
                 + `subawards`
                 + `transactions`
                 + `awards`
+                + Default: `transactions`
     + Body
 
 
@@ -72,6 +73,10 @@ Returns the number of transactions that would be included in a download request 
                 "calculated_transaction_count": 87343,
                 "maximum_transaction_limit": 500000,
                 "transaction_rows_gt_limit": false,
+                "calculated_count": 87343,
+                "spending_level": "awards",
+                "maximum_limit": 500000,
+                "rows_gt_limit": false,
                 "messages": ["For searches, time period start and end dates are currently limited to an earliest date of 2007-10-01.  For data going back to 2000-10-01, use either the Custom Award Download feature on the website or one of our download or bulk_download API endpoints as listed on https://api.usaspending.gov/docs/endpoints."]
             }
 

--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -19,6 +19,7 @@ Returns the number of transactions that would be included in a download request 
 
     + Attributes (object)
         + `filters` (required, AdvancedFilterObject)
+        + `spending_level` (optional, SpendingLevelObject)
     + Body
 
 
@@ -47,6 +48,10 @@ Returns the number of transactions that would be included in a download request 
             A boolean returning whether the transaction count is over the maximum row limit.
         + `calculated_transaction_count` (required, number)
             The calculated count of all transactions which would be included in the download files.
+        + `calculated_awards_count` (required, number)
+            The calculated count of all awards which would be included in the download files.
+        + `calculated_subawards_count` (required, number)
+            The calculated count of all subawards which would be included in the download files.
         + `maximum_transaction_limit` (required, number)
             The current allowed maximum number of transactions in a row-limited download. Visit https://www.usaspending.gov/download_center/custom_award_data to download larger volumes of data.
         + `messages` (optional, array[string])
@@ -94,8 +99,13 @@ Returns the number of transactions that would be included in a download request 
 + `extent_competed_type_codes`: `A` (optional, array[string])
 + `tas_codes` (optional, array[TASCodeObject], fixed-type)
 + `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
-+ `spending_level` (optional, array[string])
-    Possible values in this list are either awards, transaction, or subawards
+
+## SpendingLevelObject (object)
++ `spending_level` (optional, enum[string])
+    + Members
+        + `subawards`
+        + `transactions`
+        + `awards`
 
 ## TimePeriodObject (object)
 See the Transaction Search category defined in [TransactionSearchTimePeriodObject](../../../search_filters.md#transaction-search-time-period-object)

--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -48,12 +48,16 @@ Returns the number of transactions that would be included in a download request 
             A boolean returning whether the transaction count is over the maximum row limit.
         + `calculated_transaction_count` (required, number)
             The calculated count of all transactions which would be included in the download files.
-        + `calculated_awards_count` (required, number)
-            The calculated count of all awards which would be included in the download files.
-        + `calculated_subawards_count` (required, number)
-            The calculated count of all subawards which would be included in the download files.
         + `maximum_transaction_limit` (required, number)
             The current allowed maximum number of transactions in a row-limited download. Visit https://www.usaspending.gov/download_center/custom_award_data to download larger volumes of data.
+        + `spending_level` (required, string)
+            The spending_level provided by the user or the default value of transactions.
+        + `calculated_count` (required, number)
+            The calculated count of Awards, Transactions, or Subawards included in the download files.
+        + `maximum_limit` (required, number)
+            The current allowed maximum number of Awards, Transactions, or Subawards in a row-limited download. Visit https://www.usaspending.gov/download_center/custom_award_data to download larger volumes of data.
+        + `rows_gt_limit` (required, boolean)
+            A boolean returning whether the Awards, Transactions, or Subawards count is over the maximum row limit.
         + `messages` (optional, array[string])
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
     + Body

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -235,7 +235,10 @@ def get_time_period_message():
         "For searches, time period start and end dates are currently limited to an earliest date of "
         f"{settings.API_SEARCH_MIN_DATE}.  For data going back to {settings.API_MIN_DATE}, use either the Custom "
         "Award Download feature on the website or one of our download or bulk_download API endpoints as "
-        "listed on https://api.usaspending.gov/docs/endpoints."
+        "listed on https://api.usaspending.gov/docs/endpoints. "
+        "Also take note 'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
+        "See documentation for more information. Furthermore, the above fields containing the transaction_ naming convention "
+        "will be deprecated and replaced with fields without the transaction_. "
     )
 
 

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -224,11 +224,22 @@ def get_simple_pagination_metadata(results_plus_one, limit, page):
 
 
 def get_generic_filters_message(original_filters, allowed_filters) -> List[str]:
-    retval = [get_time_period_message()]
+    retval = [get_time_period_message(), deprecation_message1(), deprecation_message2()]
     if set(original_filters).difference(allowed_filters):
         retval.append(unused_filters_message(set(original_filters).difference(allowed_filters)))
     return retval
 
+def deprecation_message1():
+    return (
+        "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
+        "See documentation for more information. "
+    )
+
+def deprecation_message2():
+    return(
+        "The above fields containing the transaction_* naming convention "
+        "will be deprecated and replaced with fields without the transaction_*. "
+    )
 
 def get_time_period_message():
     return (
@@ -236,9 +247,6 @@ def get_time_period_message():
         f"{settings.API_SEARCH_MIN_DATE}.  For data going back to {settings.API_MIN_DATE}, use either the Custom "
         "Award Download feature on the website or one of our download or bulk_download API endpoints as "
         "listed on https://api.usaspending.gov/docs/endpoints. "
-        "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
-        "See documentation for more information. The above fields containing the transaction_ naming convention "
-        "will be deprecated and replaced with fields without the transaction_. "
     )
 
 

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -229,17 +229,20 @@ def get_generic_filters_message(original_filters, allowed_filters) -> List[str]:
         retval.append(unused_filters_message(set(original_filters).difference(allowed_filters)))
     return retval
 
+
 def deprecation_message1():
     return (
         "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
         "See documentation for more information. "
     )
 
+
 def deprecation_message2():
-    return(
+    return (
         "The above fields containing the transaction_* naming convention "
         "will be deprecated and replaced with fields without the transaction_*. "
     )
+
 
 def get_time_period_message():
     return (

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -236,8 +236,8 @@ def get_time_period_message():
         f"{settings.API_SEARCH_MIN_DATE}.  For data going back to {settings.API_MIN_DATE}, use either the Custom "
         "Award Download feature on the website or one of our download or bulk_download API endpoints as "
         "listed on https://api.usaspending.gov/docs/endpoints. "
-        "Also take note 'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
-        "See documentation for more information. Furthermore, the above fields containing the transaction_ naming convention "
+        "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
+        "See documentation for more information. The above fields containing the transaction_ naming convention "
         "will be deprecated and replaced with fields without the transaction_. "
     )
 

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -224,24 +224,11 @@ def get_simple_pagination_metadata(results_plus_one, limit, page):
 
 
 def get_generic_filters_message(original_filters, allowed_filters) -> List[str]:
-    retval = [get_time_period_message(), deprecation_message1(), deprecation_message2()]
+    retval = [get_time_period_message()]
     if set(original_filters).difference(allowed_filters):
         retval.append(unused_filters_message(set(original_filters).difference(allowed_filters)))
     return retval
 
-
-def deprecation_message1():
-    return (
-        "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
-        "See documentation for more information. "
-    )
-
-
-def deprecation_message2():
-    return (
-        "The above fields containing the transaction_* naming convention "
-        "will be deprecated and replaced with fields without the transaction_*. "
-    )
 
 
 def get_time_period_message():

--- a/usaspending_api/common/helpers/generic_helper.py
+++ b/usaspending_api/common/helpers/generic_helper.py
@@ -230,7 +230,6 @@ def get_generic_filters_message(original_filters, allowed_filters) -> List[str]:
     return retval
 
 
-
 def get_time_period_message():
     return (
         "For searches, time period start and end dates are currently limited to an earliest date of "

--- a/usaspending_api/download/tests/integration/test_download_count.py
+++ b/usaspending_api/download/tests/integration/test_download_count.py
@@ -131,9 +131,9 @@ def test_download_count(client, download_test_data, monkeypatch, elasticsearch_t
     resp_json = resp.json()
 
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
-    assert resp_json["calculated_transaction_count"] == 1
-    assert resp_json["maximum_transaction_limit"] == settings.MAX_DOWNLOAD_LIMIT
-    assert resp_json["transaction_rows_gt_limit"] is False
+    assert resp_json["calculated_count"] == 1
+    assert resp_json["maximum_limit"] == settings.MAX_DOWNLOAD_LIMIT
+    assert resp_json["rows_gt_limit"] is False
 
 
 @pytest.mark.django_db(transaction=True)
@@ -157,9 +157,9 @@ def test_download_count_with_date_type_filter_default(
     resp_json = resp.json()
 
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
-    assert resp_json["calculated_transaction_count"] == 3
-    assert resp_json["maximum_transaction_limit"] == settings.MAX_DOWNLOAD_LIMIT
-    assert resp_json["transaction_rows_gt_limit"] is False
+    assert resp_json["calculated_count"] == 3
+    assert resp_json["maximum_limit"] == settings.MAX_DOWNLOAD_LIMIT
+    assert resp_json["rows_gt_limit"] is False
 
 
 @pytest.mark.django_db(transaction=True)
@@ -204,9 +204,9 @@ def test_download_count_with_date_type_filter_date_signed(
     resp_json = resp.json()
 
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
-    assert resp_json["calculated_transaction_count"] == 0
-    assert resp_json["maximum_transaction_limit"] == settings.MAX_DOWNLOAD_LIMIT
-    assert resp_json["transaction_rows_gt_limit"] is False
+    assert resp_json["calculated_count"] == 0
+    assert resp_json["maximum_limit"] == settings.MAX_DOWNLOAD_LIMIT
+    assert resp_json["rows_gt_limit"] is False
 
     resp = client.post(
         "/api/v2/download/count/",
@@ -222,6 +222,6 @@ def test_download_count_with_date_type_filter_date_signed(
     resp_json = resp.json()
 
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
-    assert resp_json["calculated_transaction_count"] == 1
-    assert resp_json["maximum_transaction_limit"] == settings.MAX_DOWNLOAD_LIMIT
-    assert resp_json["transaction_rows_gt_limit"] is False
+    assert resp_json["calculated_count"] == 1
+    assert resp_json["maximum_limit"] == settings.MAX_DOWNLOAD_LIMIT
+    assert resp_json["rows_gt_limit"] is False

--- a/usaspending_api/download/tests/integration/test_download_count.py
+++ b/usaspending_api/download/tests/integration/test_download_count.py
@@ -66,9 +66,15 @@ def download_test_data():
     baker.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False, _fill_optional=True)
 
     # Create Awards
-    award1 = baker.make("search.AwardSearch", award_id=123, display_award_id="123", action_date="2018-01-01", category="idv")
-    award2 = baker.make("search.AwardSearch", award_id=456, display_award_id="456", action_date="2018-01-02", category="contracts")
-    award3 = baker.make("search.AwardSearch", award_id=789, display_award_id="789", action_date="2018-01-03", category="assistance")
+    award1 = baker.make(
+        "search.AwardSearch", award_id=123, display_award_id="123", action_date="2018-01-01", category="idv"
+    )
+    award2 = baker.make(
+        "search.AwardSearch", award_id=456, display_award_id="456", action_date="2018-01-02", category="contracts"
+    )
+    award3 = baker.make(
+        "search.AwardSearch", award_id=789, display_award_id="789", action_date="2018-01-03", category="assistance"
+    )
 
     # Create Transactions
     baker.make(

--- a/usaspending_api/download/tests/integration/test_download_count.py
+++ b/usaspending_api/download/tests/integration/test_download_count.py
@@ -185,9 +185,15 @@ def test_messages_not_nested(client, download_test_data, monkeypatch, elasticsea
     resp_json = resp.json()
 
     assert resp.status_code == status.HTTP_200_OK, "Failed to return 200 Response"
-    assert resp_json["messages"] == get_generic_filters_message(
-        request_data["filters"].keys(), {"time_period", "award_type_codes"}
+    message_list = get_generic_filters_message(request_data["filters"].keys(), {"time_period", "award_type_codes"})
+    message_list.append(
+        "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. See documentation for more information. "
     )
+    message_list.append(
+        "The above fields containing the transaction_* naming convention will be deprecated and replaced with fields without the transaction_*. "
+    )
+
+    assert resp_json["messages"] == message_list
 
 
 @pytest.mark.django_db(transaction=True)

--- a/usaspending_api/download/tests/integration/test_download_count.py
+++ b/usaspending_api/download/tests/integration/test_download_count.py
@@ -66,9 +66,9 @@ def download_test_data():
     baker.make("references.Agency", id=3, toptier_agency=ata3, toptier_flag=False, _fill_optional=True)
 
     # Create Awards
-    award1 = baker.make("search.AwardSearch", award_id=123, category="idv")
-    award2 = baker.make("search.AwardSearch", award_id=456, category="contracts")
-    award3 = baker.make("search.AwardSearch", award_id=789, category="assistance")
+    award1 = baker.make("search.AwardSearch", award_id=123, display_award_id="123", action_date="2018-01-01", category="idv")
+    award2 = baker.make("search.AwardSearch", award_id=456, display_award_id="456", action_date="2018-01-02", category="contracts")
+    award3 = baker.make("search.AwardSearch", award_id=789, display_award_id="789", action_date="2018-01-03", category="assistance")
 
     # Create Transactions
     baker.make(

--- a/usaspending_api/download/v2/download_count.py
+++ b/usaspending_api/download/v2/download_count.py
@@ -40,7 +40,7 @@ class DownloadTransactionCountViewSet(APIView):
         return (
             "The above fields containing the transaction_* naming convention "
             "will be deprecated and replaced with fields without the transaction_*. "
-        ) 
+        )
 
     @cache_response()
     def post(self, request):
@@ -95,13 +95,12 @@ class DownloadTransactionCountViewSet(APIView):
         if total_count is None:
             total_count = 0
 
-
         message_list = get_generic_filters_message(
             self.original_filters.keys(), [elem["name"] for elem in AWARD_FILTER]
         )
         message_list.append(self.deprecation_message1())
         message_list.append(self.deprecation_message2())
-        
+
         result = {
             # TODO: the following fields that follow the transaction_ naming convention will be removed
             # once the front end is ready to implement the new fields.
@@ -112,7 +111,7 @@ class DownloadTransactionCountViewSet(APIView):
             "spending_level": json_request["spending_level"],
             "maximum_limit": settings.MAX_DOWNLOAD_LIMIT,
             "rows_gt_limit": total_count > settings.MAX_DOWNLOAD_LIMIT,
-            "messages": message_list
+            "messages": message_list,
         }
 
         return Response(result)

--- a/usaspending_api/download/v2/download_count.py
+++ b/usaspending_api/download/v2/download_count.py
@@ -51,7 +51,7 @@ class DownloadTransactionCountViewSet(APIView):
         # If no filters in request return empty object to return all transactions
         filters = json_request.get("filters", {})
 
-        # 'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. 
+        # 'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead.
         # See documentation for more information.
         if json_request["subawards"] or json_request["spending_level"] == "subawards":
             total_count = subaward_filter(filters).count()
@@ -84,11 +84,15 @@ class DownloadTransactionCountViewSet(APIView):
             total_count = 0
 
         result = {
+            # TO-DO: the following fields that follow the transaction_ naming convention will be removed
+            # once the front end is ready to implement the new fields.
             "calculated_transaction_count": total_count,
-            "calculated_award_count": total_count,
-            "calculated_subaward_count": total_count,
             "maximum_transaction_limit": settings.MAX_DOWNLOAD_LIMIT,
             "transaction_rows_gt_limit": total_count > settings.MAX_DOWNLOAD_LIMIT,
+            "calculated_count": total_count,
+            "spending_level": json_request["spending_level"],
+            "maximum_limit": settings.MAX_DOWNLOAD_LIMIT,
+            "rows_gt_limit": total_count > settings.MAX_DOWNLOAD_LIMIT,
             "messages": get_generic_filters_message(
                 self.original_filters.keys(), [elem["name"] for elem in AWARD_FILTER]
             ),

--- a/usaspending_api/download/v2/download_count.py
+++ b/usaspending_api/download/v2/download_count.py
@@ -42,7 +42,7 @@ class DownloadTransactionCountViewSet(APIView):
                 "enum_values": ["awards", "transactions", "subawards"],
                 "optional": True,
                 "default": "transactions",
-            }
+            },
         ]
         models.extend(copy.deepcopy(AWARD_FILTER))
         self.original_filters = request.data.get("filters")
@@ -53,7 +53,7 @@ class DownloadTransactionCountViewSet(APIView):
 
         if json_request["subawards"] or json_request["spending_level"] == "subawards":
             total_subaward_count = subaward_filter(filters).count()
-        elif(json_request["spending_level"] == "subawards"):
+        elif json_request["spending_level"] == "subawards":
             options = {}
             time_period_obj = TransactionSearchTimePeriod(
                 default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE

--- a/usaspending_api/download/v2/download_count.py
+++ b/usaspending_api/download/v2/download_count.py
@@ -8,6 +8,7 @@ from rest_framework.views import APIView
 from usaspending_api.awards.v2.filters.sub_award import subaward_filter
 from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.elasticsearch.search_wrappers import TransactionSearch
+from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch
 from usaspending_api.common.helpers.generic_helper import (
     get_generic_filters_message,
 )
@@ -16,6 +17,7 @@ from usaspending_api.common.validator.award_filter import AWARD_FILTER
 from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.search.filters.elasticsearch.filter import _QueryType
 from usaspending_api.search.filters.time_period.query_types import TransactionSearchTimePeriod
+from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod
 from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyTimePeriod
 
 logger = logging.getLogger(__name__)
@@ -31,7 +33,17 @@ class DownloadTransactionCountViewSet(APIView):
     @cache_response()
     def post(self, request):
         """Returns boolean of whether a download request is greater than the max limit. """
-        models = [{"name": "subawards", "key": "subawards", "type": "boolean", "default": False}]
+        models = [
+            {"name": "subawards", "key": "subawards", "type": "boolean", "default": False},
+            {
+                "name": "spending_level",
+                "key": "spending_level",
+                "type": "enum",
+                "enum_values": ["awards", "transactions", "subawards"],
+                "optional": True,
+                "default": "transactions",
+            }
+        ]
         models.extend(copy.deepcopy(AWARD_FILTER))
         self.original_filters = request.data.get("filters")
         json_request = TinyShield(models).block(request.data)
@@ -39,9 +51,9 @@ class DownloadTransactionCountViewSet(APIView):
         # If no filters in request return empty object to return all transactions
         filters = json_request.get("filters", {})
 
-        if json_request["subawards"]:
-            total_count = subaward_filter(filters).count()
-        else:
+        if json_request["subawards"] or json_request["spending_level"] == "subawards":
+            total_subaward_count = subaward_filter(filters).count()
+        elif(json_request["spending_level"] == "subawards"):
             options = {}
             time_period_obj = TransactionSearchTimePeriod(
                 default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
@@ -52,15 +64,33 @@ class DownloadTransactionCountViewSet(APIView):
             options["time_period_obj"] = new_awards_only_decorator
             filter_query = QueryWithFilters.generate_transactions_elasticsearch_query(filters, **options)
             search = TransactionSearch().filter(filter_query)
-            total_count = search.handle_count()
+            total_transaction_count = search.handle_count()
+        else:
+            options = {}
+            time_period_obj = AwardSearchTimePeriod(
+                default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
+            )
+            new_awards_only_decorator = NewAwardsOnlyTimePeriod(
+                time_period_obj=time_period_obj, query_type=_QueryType.TRANSACTIONS
+            )
+            options["time_period_obj"] = new_awards_only_decorator
+            filter_query = QueryWithFilters.generate_transactions_elasticsearch_query(filters, **options)
+            search = AwardSearch().filter(filter_query)
+            total_award_count = search.handle_count()
 
-        if total_count is None:
-            total_count = 0
+        if total_transaction_count is None:
+            total_transaction_count = 0
+        elif total_subaward_count is None:
+            total_subaward_count = 0
+        elif total_award_count is None:
+            total_award_count = 0
 
         result = {
-            "calculated_transaction_count": total_count,
+            "calculated_transaction_count": total_transaction_count,
+            "calculated_award_count": total_award_count,
+            "calculated_subaward_count": total_subaward_count,
             "maximum_transaction_limit": settings.MAX_DOWNLOAD_LIMIT,
-            "transaction_rows_gt_limit": total_count > settings.MAX_DOWNLOAD_LIMIT,
+            "transaction_rows_gt_limit": total_transaction_count > settings.MAX_DOWNLOAD_LIMIT,
             "messages": get_generic_filters_message(
                 self.original_filters.keys(), [elem["name"] for elem in AWARD_FILTER]
             ),

--- a/usaspending_api/download/v2/download_count.py
+++ b/usaspending_api/download/v2/download_count.py
@@ -30,6 +30,18 @@ class DownloadTransactionCountViewSet(APIView):
 
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/download/count.md"
 
+    def deprecation_message1(self):
+        return (
+            "'subawards' will be deprecated in the future. Set ‘spending_level’ to ‘subawards’ instead. "
+            "See documentation for more information. "
+        )
+
+    def deprecation_message2(self):
+        return (
+            "The above fields containing the transaction_* naming convention "
+            "will be deprecated and replaced with fields without the transaction_*. "
+        ) 
+
     @cache_response()
     def post(self, request):
         """Returns boolean of whether a download request is greater than the max limit. """
@@ -83,6 +95,13 @@ class DownloadTransactionCountViewSet(APIView):
         if total_count is None:
             total_count = 0
 
+
+        message_list = get_generic_filters_message(
+            self.original_filters.keys(), [elem["name"] for elem in AWARD_FILTER]
+        )
+        message_list.append(self.deprecation_message1())
+        message_list.append(self.deprecation_message2())
+        
         result = {
             # TODO: the following fields that follow the transaction_ naming convention will be removed
             # once the front end is ready to implement the new fields.
@@ -93,9 +112,7 @@ class DownloadTransactionCountViewSet(APIView):
             "spending_level": json_request["spending_level"],
             "maximum_limit": settings.MAX_DOWNLOAD_LIMIT,
             "rows_gt_limit": total_count > settings.MAX_DOWNLOAD_LIMIT,
-            "messages": get_generic_filters_message(
-                self.original_filters.keys(), [elem["name"] for elem in AWARD_FILTER]
-            ),
+            "messages": message_list
         }
 
         return Response(result)

--- a/usaspending_api/download/v2/download_count.py
+++ b/usaspending_api/download/v2/download_count.py
@@ -84,7 +84,7 @@ class DownloadTransactionCountViewSet(APIView):
             total_count = 0
 
         result = {
-            # TO-DO: the following fields that follow the transaction_ naming convention will be removed
+            # TODO: the following fields that follow the transaction_ naming convention will be removed
             # once the front end is ready to implement the new fields.
             "calculated_transaction_count": total_count,
             "maximum_transaction_limit": settings.MAX_DOWNLOAD_LIMIT,

--- a/usaspending_api/download/v2/urls.py
+++ b/usaspending_api/download/v2/urls.py
@@ -1,7 +1,7 @@
 from django.urls import re_path
 
 from usaspending_api.download.v2 import views
-from usaspending_api.download.v2.download_transaction_count import DownloadTransactionCountViewSet
+from usaspending_api.download.v2.download_count import DownloadTransactionCountViewSet
 from usaspending_api.download.v2.download_status import DownloadStatusViewSet
 
 urlpatterns = [


### PR DESCRIPTION
**Description:**
The changes made in this ticket makes it so that calling the `/api/v2/download/count` endpoint will return the number of records that would be included in a download based on the current spending_level filter (Awards, Transactions, or Subawards), which has a default of transactions. This would allow users to download 3 Awards that have more than 500,000 Transactions, because the endpoint would return 3 in this example regardless of how many Transactions make up those 3 Awards.

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11402](https://federal-spending-transparency.atlassian.net/browse/DEV-11402):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
