### PR TITLE
[DEV-11525] Update recipient states endpoint [hotfix][staging]

### DIFF
--- a/usaspending_api/recipient/tests/integration/test_state.py
+++ b/usaspending_api/recipient/tests/integration/test_state.py
@@ -3,11 +3,11 @@ import datetime
 import decimal
 
 import pytest
-from model_bakery import baker
 
 # Core Django imports
 # Third-party app imports
 from rest_framework import status
+from model_bakery import baker
 
 # Imports from your apps
 from usaspending_api.common.helpers.fiscal_year_helpers import generate_fiscal_year

--- a/usaspending_api/recipient/v2/views/states.py
+++ b/usaspending_api/recipient/v2/views/states.py
@@ -111,7 +111,7 @@ def get_all_states(year=None, award_type_codes=None, subawards=False):
             .values("pop_state_code", "total", "distinct_awards", "outlay_total")
         )
 
-        if len(queryset) > 0:
+        if len(queryset) > 1:
             results = [
                 {
                     "pop_state_code": row["pop_state_code"],

--- a/usaspending_api/recipient/v2/views/states.py
+++ b/usaspending_api/recipient/v2/views/states.py
@@ -122,6 +122,7 @@ def get_all_states(year=None, award_type_codes=None, subawards=False):
                 for row in list(queryset)
             ]
         # In the case where there were no results, return a list of state codes with 0 for the amounts
+        # This is a common case on the first day of a new fiscal year
         else:
             queryset = SummaryStateView.objects.all().distinct("pop_state_code").values("pop_state_code")
             results = [

--- a/usaspending_api/recipient/v2/views/states.py
+++ b/usaspending_api/recipient/v2/views/states.py
@@ -98,7 +98,10 @@ def get_all_states(year=None, award_type_codes=None, subawards=False):
     if award_type_codes:
         filters["type__in"] = award_type_codes
 
-    if not subawards:
+    if subawards:
+        # Currently, subawards are not supported by this function
+        return []
+    else:
         # calculate award total filtered by state
         fiscal_year_queryset = (
             SummaryStateView.objects.filter(**filters)
@@ -120,10 +123,12 @@ def get_all_states(year=None, award_type_codes=None, subawards=False):
             for row in list(fiscal_year_queryset)
         ]
 
+        existing_state_codes = [state["pop_state_code"] for state in results]
+
         # Get all other states and return `0` for their award count and totals
         all_states_queryset = SummaryStateView.objects.all().distinct("pop_state_code").values("pop_state_code")
         for row in all_states_queryset:
-            if row["pop_state_code"] not in [state["pop_state_code"] for state in results]:
+            if row["pop_state_code"] not in existing_state_codes:
                 results.append(
                     {
                         "pop_state_code": row["pop_state_code"],


### PR DESCRIPTION
**Description:**
Return all states and set their award count and spending amounts to 0 if no results were found in the previous database query. This is a common case on the first day of a new fiscal year when we don't have any spending for that fiscal year yet.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-11525](https://federal-spending-transparency.atlassian.net/browse/DEV-11525):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

4. Matview impact assessment completed
No matviews are affected by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are needed for this change.
```
