### PR TITLE
[DEV-11409] Grafana Migration Part 2

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -87,7 +87,8 @@ OTEL_TRACES_EXPORTER=console,otlp
 OTEL_METRICS_EXPORTER=console
 
 OTEL_PYTHON_LOG_CORRELATION=true
-OTEL_PYTHON_LOG_FORMAT="%(msg)s [span_id=%(span_id)s]"
+OTEL_PYTHON_LOG_FORMAT="%(msg)s [span_id=%(otelSpanID)s trace_id=%(otelTraceID)s]"
+OTEL_EXPORTER_OTLP_CERTIFICATE="/etc/ssl/certs/ca-certificates.crt"
 OTEL_PYTHON_LOG_LEVEL=debug
 OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 DJANGO_SETTINGS_MODULE=usaspending_api.settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,8 @@ COPY . /dockermount
 RUN python3 -m pip install -r requirements/requirements.txt -r requirements/requirements-server.txt && \
     python3 -m pip install ansible==2.9.15 awscli==1.34.19
 
+
+RUN opentelemetry-bootstrap -a install
+
 ##### Ensure Python STDOUT gets sent to container logs
 ENV PYTHONUNBUFFERED=1

--- a/manage.py
+++ b/manage.py
@@ -2,14 +2,14 @@
 import os
 import sys
 
-from opentelemetry.instrumentation.django import DjangoInstrumentor
+# from opentelemetry.instrumentation.django import DjangoInstrumentor
 
 if __name__ == "__main__":
     os.environ.setdefault("DDM_CONTAINER_NAME", "app")
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "usaspending_api.settings")
 
     # This call is what makes the Django application be instrumented
-    DjangoInstrumentor().instrument()
+    # DjangoInstrumentor().instrument()
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/usaspending_api/bulk_download/config/supervisord.conf
+++ b/usaspending_api/bulk_download/config/supervisord.conf
@@ -12,8 +12,23 @@ user=ec2-user
 environment=
     PYTHONPATH="%(ENV_PATH)s:/data-act/backend",
     DATABASE_URL="%(ENV_DATABASE_URL_VAR)s",
-    DOWNLOAD_DATABASE_URL="%(ENV_DOWNLOAD_DATABASE_URL)s"
-command=python3 manage.py download_sqs_worker
+    DOWNLOAD_DATABASE_URL="%(ENV_DOWNLOAD_DATABASE_URL)s",
+    # ==== [Open Telemetry Configuration] ====
+    OTEL_SERVICE_NAME="usaspending-downloader",
+    OTEL_TRACES_EXPORTER="otlp",
+    OTEL_METRICS_EXPORTER="otlp",
+    OTEL_PYTHON_LOG_CORRELATION="true",
+    OTEL_PYTHON_LOG_FORMAT="%(msg)s [span_id=%(otelSpanID)s trace_id=%(otelTraceID)s]",
+    OTEL_PYTHON_LOG_LEVEL="debug",
+    OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED="true",
+    OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf",
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS=".*session.*,set-cookie",
+    OTEL_EXPORTER_OTLP_TIMEOUT="30000",
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="content-length,content-type,host,origin,referer,ua-is-bot,user-agent,x-forwarded-for,x-requested-with,allow,cache-trace,is-dynamically-rendered,key,strict-transport-security",
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE="content-length,content-type,host,origin,referer,ua-is-bot,user-agent,x-forwarded-for,x-requested-with,allow,cache-trace,is-dynamically-rendered,key,strict-transport-security",
+    GRPC_VERBOSITY="debug",
+    GRPC_TRACE="handshaker,connectivity_state,client_channel,call_error,subchannel"
+command=opentelemetry-instrument python3 manage.py download_sqs_worker
 
 [supervisord]
 logfile=/data-act/backend/usaspending_api/logs/supervisord.log

--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -10,8 +10,6 @@ import traceback
 
 from typing import Optional, Callable
 
-# from django.conf import settings
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.sdk.trace import TracerProvider
@@ -19,7 +17,6 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-# from opentelemetry.instrumentation.django import DjangoInstrumentor
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.instrumentation.urllib import URLLibInstrumentor
@@ -262,10 +259,5 @@ def configure_logging(service_name="usaspending-api"):
     LoggingInstrumentor().instrument(tracer_provider=trace.get_tracer_provider(), set_logging_format=True)
     URLLibInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
 
-    # config = DEFAULT_CONFIG
-    # if 'python_config' in CONFIG_LOGGING:
-    # config = deep_merge(config, CONFIG_LOGGING['python_config'])
-    # logging.config.dictConfig(config)
-    # logging.getLogger(__name__).setLevel(logging.CRITICAL)
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
     logging.getLogger("botocore").setLevel(logging.CRITICAL)

--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -1,3 +1,4 @@
+import logging.config
 from django.utils.timezone import now
 from django.utils.deprecation import MiddlewareMixin
 
@@ -17,9 +18,11 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
 # from opentelemetry.instrumentation.django import DjangoInstrumentor
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
+from opentelemetry.instrumentation.urllib import URLLibInstrumentor
 
 
 def get_remote_addr(request):
@@ -257,14 +260,12 @@ def configure_logging(service_name="usaspending-api"):
 
     LoggingInstrumentor(logging_format="%(msg)s [span_id=%(otelSpanID)s trace_id=%(otelTraceID)s]")
     LoggingInstrumentor().instrument(tracer_provider=trace.get_tracer_provider(), set_logging_format=True)
-
-    # LoggingInstrumentor().instrument(tracer_provider=trace.get_tracer_provider(), set_logging_format=True)
-    # URLLibInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
+    URLLibInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
 
     # config = DEFAULT_CONFIG
     # if 'python_config' in CONFIG_LOGGING:
     # config = deep_merge(config, CONFIG_LOGGING['python_config'])
     # logging.config.dictConfig(config)
-
-    # logging.getLogger('boto3').setLevel(logging.CRITICAL)
-    # logging.getLogger('botocore').setLevel(logging.CRITICAL)
+    # logging.getLogger(__name__).setLevel(logging.CRITICAL)
+    logging.getLogger("boto3").setLevel(logging.CRITICAL)
+    logging.getLogger("botocore").setLevel(logging.CRITICAL)

--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -8,6 +8,11 @@ import traceback
 
 from typing import Optional, Callable
 
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+LoggingInstrumentor().instrument(set_logging_format=True)
+LoggingInstrumentor(logging_format="%(msg)s [span_id=%(otelSpanID)s trace_id=%(otelTraceID)s]")
+
 
 def get_remote_addr(request):
     """ Get IP address of user making request can be used for other logging"""

--- a/usaspending_api/common/tests/unit/test_tracing.py
+++ b/usaspending_api/common/tests/unit/test_tracing.py
@@ -138,28 +138,28 @@ def test_logging_trace_spans(otel_tracer_fixture, caplog: LogCaptureFixture):
 #         # Drop this span so it is not sent to the server, and not logged by the trace logger
 #         OpenTelemetryEagerlyDropTraceFilter.drop(span)
 
-    # Do another trace, that is NOT dropped
-    # with otel_tracer_fixture.start_as_current_span(
-    #     name=f"{test}_operation2",
-    #     kind=SpanKind.INTERNAL,
-    #     attributes={"service.name": f"{test}_service2", "resource.name": f"{test}_resource2", "span.type": "TEST"},
-    # ) as span2:
-    #     trace_id2 = span2.trace_id
-    #     logger = logging.getLogger(f"{test}_logger")
-    #     test_msg2 = f"a second test message was logged during {test}"
-    #     logger.warning(test_msg2)
-    #     # do things
-    #     x = 2 ** 7
+# Do another trace, that is NOT dropped
+# with otel_tracer_fixture.start_as_current_span(
+#     name=f"{test}_operation2",
+#     kind=SpanKind.INTERNAL,
+#     attributes={"service.name": f"{test}_service2", "resource.name": f"{test}_resource2", "span.type": "TEST"},
+# ) as span2:
+#     trace_id2 = span2.trace_id
+#     logger = logging.getLogger(f"{test}_logger")
+#     test_msg2 = f"a second test message was logged during {test}"
+#     logger.warning(test_msg2)
+#     # do things
+#     x = 2 ** 7
 
-    # assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
-    # assert f"SPAN#{trace_id1}" not in caplog.text, "span marker still logged when should have been dropped"
-    # assert f"TRACE#{trace_id1}" not in caplog.text, "trace marker still logged when should have been dropped"
-    # assert f"resource {test}_resource" in caplog.text, "traced resource still logged when should have been dropped"
-    # assert test_msg2 in caplog.text
-    # assert f"SPAN#{trace_id2}" in caplog.text, "span marker not found in logging output"
-    # assert f"TRACE#{trace_id2}" in caplog.text, "trace marker not found in logging output"
-    # assert f"resource {test}_resource2" in caplog.text, "traced resource not found in logging output"
-    # assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
+# assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
+# assert f"SPAN#{trace_id1}" not in caplog.text, "span marker still logged when should have been dropped"
+# assert f"TRACE#{trace_id1}" not in caplog.text, "trace marker still logged when should have been dropped"
+# assert f"resource {test}_resource" in caplog.text, "traced resource still logged when should have been dropped"
+# assert test_msg2 in caplog.text
+# assert f"SPAN#{trace_id2}" in caplog.text, "span marker not found in logging output"
+# assert f"TRACE#{trace_id2}" in caplog.text, "trace marker not found in logging output"
+# assert f"resource {test}_resource2" in caplog.text, "traced resource not found in logging output"
+# assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
 
 
 # def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):

--- a/usaspending_api/common/tests/unit/test_tracing.py
+++ b/usaspending_api/common/tests/unit/test_tracing.py
@@ -2,46 +2,65 @@ import inspect
 
 import logging
 
-# import multiprocessing as mp
+import multiprocessing as mp
 import pytest
+import json
 
-# from logging.handlers import QueueHandler
 from _pytest.logging import LogCaptureFixture
 
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import SpanKind
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
-
-
-from usaspending_api.common.tracing import (
-    # OpenTelemetryEagerlyDropTraceFilter,
-    OpenTelemetryLoggingTraceFilter,
-    # SubprocessTrace,
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    ConsoleSpanExporter,
+    SpanExportResult,
 )
 
-# from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from usaspending_api.common.tracing import SubprocessTrace
 
 
-# # Initialize the tracer provider and exporter for testing
-provider = TracerProvider(resource=Resource.create({SERVICE_NAME: "usaspending-api"}))
-exporter = ConsoleSpanExporter()
-span_processor = SimpleSpanProcessor(exporter)
-provider.add_span_processor(span_processor)
+class JsonLoggingSpanExporter(ConsoleSpanExporter):
+    def formatter(self, span):
+        span_data = {
+            "name": span.name,
+            "context": {
+                "trace_id": hex(span.context.trace_id),
+                "span_id": hex(span.context.span_id),
+                "trace_state": str(span.context.trace_state),
+            },
+            "kind": str(span.kind),
+            "start_time": span.start_time,
+            "end_time": span.end_time,
+            "status": str(span.status.status_code),
+            "attributes": dict(span.attributes),
+            "resource": dict(span.resource.attributes),
+        }
+        return json.dumps(span_data, indent=4)  # Pretty-print JSON with indentation
+
+    def export(self, spans):
+        for span in spans:
+            logger.info(self.formatter(span))
+        return SpanExportResult.SUCCESS
+
+
+# Initialize the tracer provider and exporter for testing
+provider = TracerProvider(resource=Resource.create({"service_name": "usaspending-api"}))
 trace.set_tracer_provider(provider)
-otel_tracer = trace.get_tracer(__name__)
+
+exporter = JsonLoggingSpanExporter()
+span_processor = SimpleSpanProcessor(exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+tracer = trace.get_tracer_provider().get_tracer(__name__)
 
 # Instrument logging
 LoggingInstrumentor().instrument(set_logging_format=True)
+log_format = "%(message)s\n"
+logging.basicConfig(format=log_format)
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def otel_tracer_fixture() -> trace:
-    """Fixture to temporarily enable the OpenTelemetry Tracer during a test"""
-    yield otel_tracer
+logger.propagate = True  # Ensure logs propagate
 
 
 @pytest.fixture
@@ -64,187 +83,186 @@ def caplog(caplog):
 
 
 def test_logging_trace_spans_basic(caplog: LogCaptureFixture):
-    caplog.set_level(logging.DEBUG, logger.name)
+    caplog.set_level(logging.INFO, logger.name)
+
     test = f"{inspect.stack()[0][3]}"
-    with otel_tracer.start_as_current_span(
-        name=f"{test}_operation",
-        kind=SpanKind.INTERNAL,
-        attributes={"service.name": f"{test}_service", "resource.name": f"{test}_resource", "span.type": "TEST"},
-    ) as span:
+
+    with tracer.start_as_current_span(name=f"{test}_operation", kind=SpanKind.INTERNAL) as span:
+        span_attributes = {"service.name": f"{test}_service", "resource.name": f"{test}_resource", "span.type": "TEST"}
+        for k, v in span_attributes.items():
+            span.set_attribute(k, v)
+
         trace_id = span.get_span_context().trace_id
         span_id = span.get_span_context().span_id
         logger.info(f"Test log message with trace id: {trace_id}")
         log_span_id = f"The corresponding span id: {span_id}"
         logger.warning(log_span_id)
 
-    log_output = caplog.text
-    assert f"trace id: {trace_id}" in log_output, "trace_id not found in logging output"
-    assert f"span id: {span_id}" in log_output, "span_id not found in logging output"
+    assert f"trace id: {trace_id}" in caplog.text, "trace_id not found in logging output"
+    assert f"span id: {span_id}" in caplog.text, "span_id not found in logging output"
 
 
-def test_logging_trace_spans(otel_tracer_fixture, caplog: LogCaptureFixture):
-    """Test the OpenTelemetryLoggingTraceFilter can actually capture trace span data in log output"""
-
-    # Enable log output for this logger for the duration of this test
-    caplog.set_level(logging.DEBUG, OpenTelemetryLoggingTraceFilter._log.name)
-    OpenTelemetryLoggingTraceFilter.activate()
-
+def test_logging_trace_spans(caplog: LogCaptureFixture):
+    caplog.set_level(logging.INFO)
     test = f"{inspect.stack()[0][3]}"
-    with otel_tracer_fixture.start_as_current_span(
-        name=f"{test}_operation",
-        kind=SpanKind.INTERNAL,
-        attributes={"service.name": f"{test}_service", "resource.name": f"{test}_resource", "span.type": "TEST"},
-    ) as span:
+
+    with tracer.start_as_current_span(name=f"{test}_operation", kind=SpanKind.INTERNAL) as span:
+        span_attributes = {"service.name": f"{test}_service", "resource.name": f"{test}_resource", "span.type": "TEST"}
+        for k, v in span_attributes.items():
+            span.set_attribute(k, v)
+
         trace_id = span.get_span_context().trace_id
         span_id = span.get_span_context().span_id
-        logger = logging.getLogger(f"{test}_logger")
-        test_msg = f"a test message was logged during {test}"
-        logger.warning(test_msg)
+        logger.info(f"Test log message with trace id: {trace_id}")
+        log_span_id = f"The corresponding span id: {span_id}"
+        logger.warning(log_span_id)
         # do things
         x = 2 ** 5
         thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
         assert thirty_two_squares[-1] == 961
 
     log_output = caplog.text
-    assert test_msg in log_output, "caplog.text did not seem to capture logging output during test"
-    assert f"trace_id={trace_id}" in log_output, "trace_id not found in logging output"
-    assert f"span_id={span_id}" in log_output, "span_id not found in logging output"
-    assert f"{span.name}_attributes" in log_output, "traced resource not found in logging output"
+    assert f"trace id: {trace_id}" in log_output, "trace_id not found in logging output"
+    assert f"span id: {span_id}" in log_output, "span_id not found in logging output"
+    assert f"{test}_resource" in log_output, "traced resource not found in logging output"
 
 
-# def test_drop_key_on_trace_spans(otel_tracer_fixture: trace, caplog: LogCaptureFixture):
-#     """Test that traces that have any span with the key that marks them for dropping, are not logged, but those that
-#     do not have this marker, are still logged"""
+def test_subprocess_basic(caplog: LogCaptureFixture):
+    caplog.set_level(logging.INFO)
+    test = f"{inspect.stack()[0][3]}"
 
-#     # Enable log output for this logger for duration of this test
-#     caplog.set_level(logging.DEBUG, OpenTelemetryLoggingTraceFilter._log.name)
-#     test = f"{inspect.stack()[0][3]}"
-#     OpenTelemetryLoggingTraceFilter.activate()
-#     OpenTelemetryEagerlyDropTraceFilter.activate()
-#     with otel_tracer_fixture.start_as_current_span(
-#         name=f"{test}_operation",
-#         kind=SpanKind.INTERNAL,
-#         attributes={"service.name": f"{test}_service", "resource.name": f"{test}_resource", "span.type": "TEST"},
-#     ) as span:
-#         trace_id1 = span.trace_id
-#         logger = logging.getLogger(f"{test}_logger")
-#         test_msg = f"a test message was logged during {test}"
-#         logger.warning(test_msg)
-#         # do things
-#         x = 2 ** 5
-#         thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
-#         assert thirty_two_squares[-1] == 961
+    with SubprocessTrace(
+        name=f"{test}_operation", kind=SpanKind.INTERNAL, service=f"{test}_service"
+    ) as subprocess_trace:
+        subprocess_trace.set_attributes(
+            {"resource": f"{test}_resource", "span_type": "Internal", "message": "A test message"}
+        )
+        trace_id = subprocess_trace.get_span_context().trace_id
+        span_id = subprocess_trace.get_span_context().span_id
+        logger.info(f"Test log message with trace id: {trace_id}")
+        log_span_id = f"The corresponding span id: {span_id}"
+        logger.warning(log_span_id)
 
-#         # Drop this span so it is not sent to the server, and not logged by the trace logger
-#         OpenTelemetryEagerlyDropTraceFilter.drop(span)
+        # do things
+        x = 2 ** 5
+        thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
+        assert thirty_two_squares[-1] == 961
 
-# Do another trace, that is NOT dropped
-# with otel_tracer_fixture.start_as_current_span(
-#     name=f"{test}_operation2",
-#     kind=SpanKind.INTERNAL,
-#     attributes={"service.name": f"{test}_service2", "resource.name": f"{test}_resource2", "span.type": "TEST"},
-# ) as span2:
-#     trace_id2 = span2.trace_id
-#     logger = logging.getLogger(f"{test}_logger")
-#     test_msg2 = f"a second test message was logged during {test}"
-#     logger.warning(test_msg2)
-#     # do things
-#     x = 2 ** 7
-
-# assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
-# assert f"SPAN#{trace_id1}" not in caplog.text, "span marker still logged when should have been dropped"
-# assert f"TRACE#{trace_id1}" not in caplog.text, "trace marker still logged when should have been dropped"
-# assert f"resource {test}_resource" in caplog.text, "traced resource still logged when should have been dropped"
-# assert test_msg2 in caplog.text
-# assert f"SPAN#{trace_id2}" in caplog.text, "span marker not found in logging output"
-# assert f"TRACE#{trace_id2}" in caplog.text, "trace marker not found in logging output"
-# assert f"resource {test}_resource2" in caplog.text, "traced resource not found in logging output"
-# assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
+    log_output = caplog.text
+    assert f"trace id: {trace_id}" in log_output, "trace_id not found in logging output"
+    assert f"span id: {span_id}" in log_output, "span_id not found in logging output"
+    assert f"{test}_resource" in log_output, "traced resource not found in logging output"
 
 
-# def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
-#     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
-#     when wrapped in the SubprocessTracer"""
+def test_subprocess_tracing(caplog: LogCaptureFixture, capsys):
+    """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
+    when wrapped in the SubprocessTracer"""
 
-#     # Enable log output for this logger for duration of this test
-#     caplog.set_level(logging.DEBUG, DatadogLoggingTraceFilter._log.name)
-#     test = f"{inspect.stack()[0][3]}"
-#     # And also send its output through a multiprocessing queue to surface logs from the subprocess
-#     log_queue = mp.Queue()
-#     DatadogLoggingTraceFilter._log.addHandler(QueueHandler(log_queue))
-#     DatadogLoggingTraceFilter.activate()
+    # Enable log output for this logger for duration of this test
+    caplog.set_level(logging.INFO)
+    test = f"{inspect.stack()[0][3]}"
 
-#     subproc_test_msg = f"a test message was logged in a subprocess of {test}"
-#     state = mp.Queue()
-#     stop_sentinel = "-->STOP<--"
+    # And also send its output through a multiprocessing queue to surface logs from the subprocess
+    log_queue = mp.Queue()
 
-#     with ddtrace.tracer.trace(
-#         name=f"{test}_operation",
-#         service=f"{test}_service",
-#         resource=f"{test}_resource",
-#         span_type=SpanTypes.TEST,
-#     ) as span:
-#         trace_id = span.trace_id
-#         logger = logging.getLogger(f"{test}_logger")
-#         test_msg = f"a test message was logged during {test}"
-#         logger.warning(test_msg)
-#         ctx = mp.get_context("fork")
-#         worker = ctx.Process(
-#             name=f"{test}_subproc",
-#             target=_do_things_in_subproc,
-#             args=(
-#                 subproc_test_msg,
-#                 state,
-#             ),
-#         )
-#         worker.start()
-#         worker.join(timeout=10)
-#         DatadogLoggingTraceFilter._log.warning(stop_sentinel)
+    with tracer.start_as_current_span(name=f"{test}_operation", kind=SpanKind.INTERNAL) as span:
+        span_attributes = {"service.name": f"{test}_service", "resource.name": f"{test}_resource", "span.type": "TEST"}
+        for k, v in span_attributes.items():
+            span.set_attribute(k, v)
 
-#     subproc_trace_id, subproc_span_id = state.get(block=True, timeout=10)
-#     assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
-#     assert f"SPAN#{trace_id}" in caplog.text, "span marker not found in logging output"
-#     assert f"TRACE#{trace_id}" in caplog.text, "trace marker not found in logging output"
-#     assert f"resource {test}_resource" in caplog.text, "traced resource not found in logging output"
-#     assert subproc_trace_id == trace_id  # subprocess tracing should be a continuation of the trace in parent process
+        trace_id = span.get_span_context().trace_id
+        span_id = span.get_span_context().span_id
+        test_msg = f"a test message was logged during {test}"
+        logger.warning(test_msg)
 
-#     # Drain the queue and redirect DatadogLoggingTraceFilter log output to the caplog handler
-#     log_records = []
-#     draining = True
-#     while draining:
-#         while not log_queue.empty():
-#             log_record = log_queue.get(block=True, timeout=5)
-#             log_records.append(log_record)
-#         log_msgs = [r.getMessage() for r in log_records]
-#         if stop_sentinel in log_msgs:  # check for sentinel, signaling end of queued records
-#             draining = False
-#     for log_record in log_records:
-#         if log_record.getMessage() != stop_sentinel:
-#             caplog.handler.handle(log_record)
+        logger.info(f"The corresponding trace id: {trace_id}")
+        logger.info(f"The corresponding span id: {span_id}")
 
-#     assert f"{subproc_span_id}" in caplog.text, "subproc span id not found in logging output"
-#     assert (
-#         f"resource {_do_things_in_subproc.__name__}_resource" in caplog.text
-#     ), "subproc traced resource not found in logging output"
+        # Create and start a subprocess, passing the queue to capture logs
+        ctx = mp.get_context("fork")
+        worker = ctx.Process(
+            name=f"{test}_subproc",
+            target=_do_things_in_subproc,
+            args=(caplog, log_queue, trace_id),  # Pass the main trace ID to the subprocess
+        )
+        worker.start()
+        worker.join(timeout=100)
+
+        if worker.is_alive():
+            worker.terminate()
+            try:
+                log_records = []
+                draining = True
+                while draining:
+                    while not log_queue.empty():
+                        log_record = log_queue.get(block=True, timeout=5)
+                        log_records.append(log_record)
+
+                    if log_queue.empty():
+                        draining = False
+
+                for log_record in log_records:
+                    caplog.handler.flush(log_record)
+            except Exception:
+                print("Error draining captured log queue when handling subproc TimeoutError")
+                pass
+            raise mp.TimeoutError(f"subprocess {worker.name} did not complete in timeout")
+
+    subproc_trace_id, subproc_span_id = log_queue.get(block=True, timeout=10)
+    logger.info(f"The corresponding trace id: {subproc_trace_id}")
+    logger.info(f"The corresponding span id: {subproc_span_id}")
+
+    assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
+
+    # Parent Trace ID - this should be the same for the parent span and the child span
+    assert subproc_trace_id == trace_id  # subprocess tracing should be a continuation of the trace in parent process
+    assert f"trace id: {trace_id}" in caplog.text, "trace marker not found in logging output"
+
+    # Parent Span ID
+    assert f"span id: {span_id}" in caplog.text, "span marker not found in logging output"
+    assert f"{test}_resource" in caplog.text, "traced resource not found in logging output"
+
+    # Child Span ID aka subproc span
+    assert f"span id: {subproc_span_id}" in caplog.text, "span marker not found in logging output"
 
 
-# def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
-#     test = f"{inspect.stack()[0][3]}"
-#     with SubprocessTrace(
-#         name=f"{test}_operation",
-#         service=f"{test}_service",
-#         resource=f"{test}_resource",
-#         span_type=SpanTypes.TEST,
-#         subproc_test_msg=subproc_test_msg,
-#     ) as span:
-#         span_ids = (
-#             span.trace_id,
-#             span.span_id,
-#         )
-#         q.put(span_ids, block=True, timeout=5)
-#         logging.getLogger(f"{test}_logger").warning(subproc_test_msg)
-#         # do things
-#         x = 2 ** 5
-#         thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
-#         assert thirty_two_squares[-1] == 961
-#         logging.getLogger(f"{test}_logger").warning("DONE doing things in subproc")
+def _do_things_in_subproc(caplog: LogCaptureFixture, log_queue: mp.Queue, parent_trace_id):
+    # Ensure a StreamHandler is attached in the subprocess
+    if not logger.handlers:
+        stream_handler = logging.StreamHandler()
+        logger.addHandler(stream_handler)
+        logger.setLevel(logging.INFO)
+
+    caplog.set_level(logging.INFO)
+    test = f"{inspect.stack()[0][3]}"
+    message = "This is a subprocess within a subprocess"
+    with SubprocessTrace(
+        name=f"{test}_operation",
+        service=f"{test}_service",
+        kind=SpanKind.INTERNAL,
+        parent_trace_id=parent_trace_id,  # Propagate the parent trace ID to the subprocess
+    ) as subprocess_2:
+        subprocess_2.set_attributes(
+            {
+                "resource": f"{test}_subproc_resource",
+                "span_type": "Internal",
+                "subproc_test_msg": message,
+            }
+        )
+        trace_id = subprocess_2.get_span_context().trace_id
+        span_id = subprocess_2.get_span_context().span_id
+
+        logger.info(message)
+        logger.info(f"The corresponding trace id: {trace_id}")
+        logger.info(f"The corresponding span id: {span_id}")
+
+        # do things
+        x = 2 ** 5
+        thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
+        assert thirty_two_squares[-1] == 961
+        logger.info("DONE doing things in subproc 2")
+        # Return the trace and span ID to the main process
+
+        # Ensure that spans are flushed and properly exported
+        subprocess_2.end()
+        log_queue.put((trace_id, span_id))

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -5,10 +5,6 @@ Specifically leveraging the Grafana Open Telemetry tracing client.
 """
 from opentelemetry import trace
 
-# from opentelemetry.trace import SpanKind
-# from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
-
-# from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.trace.status import Status, StatusCode
 from typing import Optional, Callable
 from opentelemetry.trace import SpanKind
@@ -17,31 +13,6 @@ import logging
 # The tracer provider should only be set up once, typically in the settings or a dedicated setup module
 _logger = logging.getLogger(__name__)
 tracer = trace.get_tracer_provider().get_tracer(__name__)
-
-############################################################
-
-# CUSTOM CONSOLE EXPORTER for debugging
-# class LoggingSpanProcessor(SpanProcessor):
-#     def on_end(self, span: ReadableSpan) -> None:
-#         trace_id = span.context.trace_id
-#         span_id = span.context.span_id
-#         logger = logging.getLogger(__name__)
-#         logger.info(f"Span ended: trace_id={trace_id}, span_id={span_id}, {span.name}_attributes={span.attributes}")
-
-#     def force_flush(self, timeout_millis: int = 30000) -> bool:
-#         return True
-
-
-# logging_span_processor = LoggingSpanProcessor()
-# trace.get_tracer_provider().add_span_processor(logging_span_processor)
-
-############################################################
-
-# DEFAULT CONSOLE EXPORTER for debugging
-# console_exporter = ConsoleSpanExporter()
-# trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(console_exporter))
-
-############################################################
 
 
 def _activate_trace_filter(filter_class: Callable) -> None:

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -4,12 +4,13 @@ Module for Application Performance Monitoring and distributed tracing tools and 
 Specifically leveraging the Grafana Open Telemetry tracing client.
 """
 from opentelemetry import trace
-from opentelemetry.trace import SpanKind
+# from opentelemetry.trace import SpanKind
 # from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.trace.status import Status, StatusCode
 from typing import Optional, Callable
+from opentelemetry.trace import SpanKind
 import logging
 
 # The tracer provider should only be set up once, typically in the settings or a dedicated setup module
@@ -85,12 +86,14 @@ class SubprocessTrace:
     def __init__(
         self,
         name: str,
+        kind: SpanKind,
         service: str = None,
         can_drop_sample: bool = True,
         **tags,
     ) -> None:
         self.name = name
         self.service = service
+        self.kind = kind
         self.can_drop_sample = can_drop_sample
         self.tags = tags
         self.span: Optional[trace.Span] = None
@@ -108,6 +111,7 @@ class SubprocessTrace:
             # span data that is to be flushed (sent to the server)
             self.span.__exit__(exc_type, exc_val, exc_tb)
         finally:
+            # ensures that all spans that haven't been exported yet are immediately sent to the configured exporter.
             trace.get_tracer_provider().force_flush()
 
 

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -8,7 +8,7 @@ from opentelemetry import trace
 # from opentelemetry.trace import SpanKind
 # from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+# from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.trace.status import Status, StatusCode
 from typing import Optional, Callable
 from opentelemetry.trace import SpanKind
@@ -38,8 +38,8 @@ tracer = trace.get_tracer_provider().get_tracer(__name__)
 ############################################################
 
 # DEFAULT CONSOLE EXPORTER for debugging
-console_exporter = ConsoleSpanExporter()
-trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(console_exporter))
+# console_exporter = ConsoleSpanExporter()
+# trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(console_exporter))
 
 ############################################################
 

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -100,7 +100,7 @@ class SubprocessTrace:
         self.span: Optional[trace.Span] = None
 
     def __enter__(self) -> trace.Span:
-        self.span = tracer.start_span(name=self.name)
+        self.span = tracer.start_span(name=self.name, kind=self.kind)
         for key, value in self.tags.items():
             self.span.set_attribute(key, value)
         return self.span

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -4,6 +4,7 @@ Module for Application Performance Monitoring and distributed tracing tools and 
 Specifically leveraging the Grafana Open Telemetry tracing client.
 """
 from opentelemetry import trace
+
 # from opentelemetry.trace import SpanKind
 # from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
@@ -51,7 +52,7 @@ def _activate_trace_filter(filter_class: Callable) -> None:
             tracer._filters.append(filter_class())
         else:
             tracer._filters = [filter_class()]
-        tracer.configure(settings={'FILTERS': tracer._filters})
+        tracer.configure(settings={"FILTERS": tracer._filters})
 
 
 class OpenTelemetryEagerlyDropTraceFilter:
@@ -103,7 +104,6 @@ class SubprocessTrace:
         for key, value in self.tags.items():
             self.span.set_attribute(key, value)
         return self.span
-
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -41,6 +41,7 @@ trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(console_export
 
 ############################################################
 
+
 def _activate_trace_filter(filter_class: Callable) -> None:
     if not hasattr(tracer, "_filters"):
         _logger.warning("OpenTelemetry does not support direct filter activation on tracer")
@@ -49,6 +50,7 @@ def _activate_trace_filter(filter_class: Callable) -> None:
             tracer._filters.append(filter_class())
         else:
             tracer._filters = [filter_class()]
+        tracer.configure(settings={'FILTERS': tracer._filters})
 
 
 class OpenTelemetryEagerlyDropTraceFilter:
@@ -69,28 +71,9 @@ class OpenTelemetryEagerlyDropTraceFilter:
         span.set_status(Status(StatusCode.ERROR))
         span.set_attribute(cls.EAGERLY_DROP_TRACE_KEY, True)
 
-
-# class DatadogEagerlyDropTraceFilter:
-#     """
-#     A trace filter that eagerly drops a trace, by filtering it out before sending it on to the Datadog Server API.
-#     It uses the `self.EAGERLY_DROP_TRACE_KEY` as a sentinel value. If present within any span's tags, the whole
-#     trace that the span is part of will be filtered out before being sent to the server.
-#     """
-
-#     EAGERLY_DROP_TRACE_KEY = "EAGERLY_DROP_TRACE"
-
-#     @classmethod
-#     def activate(cls):
-#         _activate_trace_filter(cls)
-
-#     @classmethod
-#     def drop(cls, span: Span):
-#         tracer.get_call_context().sampling_priority = USER_REJECT
-#         span.set_tag(cls.EAGERLY_DROP_TRACE_KEY, True)
-
-#     def process_trace(self, trace):
-#         """Drop trace if any span tag has tag with key 'EAGERLY_DROP_TRACE'"""
-#         return None if any(span.get_tag(self.EAGERLY_DROP_TRACE_KEY) for span in trace) else trace
+    def process_trace(self, span: trace.Span):
+        """ Drop trace if any span attribute has tag with key 'EAGERLY_DROP_TRACE' """
+        return None if any(span.get_attribute(self.EAGERLY_DROP_TRACE_KEY) for span in trace) else trace
 
 
 class SubprocessTrace:
@@ -103,61 +86,29 @@ class SubprocessTrace:
         self,
         name: str,
         service: str = None,
-        resource: str = None,
-        span_type: SpanKind = None,
         can_drop_sample: bool = True,
         **tags,
     ) -> None:
         self.name = name
         self.service = service
-        self.resource = resource
-        self.span_type = span_type
         self.can_drop_sample = can_drop_sample
         self.tags = tags
         self.span: Optional[trace.Span] = None
 
     def __enter__(self) -> trace.Span:
-        self.span = tracer.start_span(
-            name=self.name, service=self.service, resource=self.resource, span_type=self.span_type
-        )
+        self.span = tracer.start_span(name=self.name)
         for key, value in self.tags.items():
             self.span.set_attribute(key, value)
         return self.span
 
-    # ddtrace implementation
-    # def __enter__(self) -> Span:
-    #     self.span = tracer.trace(name=self.name, service=self.service, resource=self.resource, span_type=self.span_type)
-    #     self.span.set_tags(self.tags)
-    #     if not self.can_drop_sample:
-    #         # Set True to add trace to App Analytics:
-    #         # - https://docs.datadoghq.com/tracing/app_analytics/?tab=python#custom-instrumentation
-    #         self.span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, 1.0)
-    #     return self.span
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.span is not None:
-            if exc_type is not None:
-                self.span.set_status(Status(StatusCode.ERROR, str(exc_val)))
-            self.span.end()
-
-    # ddtrace implementation
-    # def __exit__(self, exc_type, exc_val, exc_tb):
-    #     """This context exit handler ensures that traces get sent to server regardless of how fast this subprocess runs.
-
-    #     Workaround for: https://github.com/DataDog/dd-trace-py/issues/1184
-    #     """
-    #     try:
-    #         # This will call span.finish() which must be done before the queue is flushed in order to enqueue the
-    #         # span data that is to be flushed (sent to the server)
-    #         self.span.__exit__(exc_type, exc_val, exc_tb)
-    #     finally:
-    #         writer_type = type(tracer.writer)
-    #         if writer_type is AgentWriter:
-    #             tracer.writer.flush_queue()
-    #         else:
-    #             _logger.warning(
-    #                 f"Unexpected Datadog tracer.writer type of {writer_type} found. Not flushing trace spans."
-    #             )
+        try:
+            # This will call span.finish() which must be done before the queue is flushed in order to enqueue the
+            # span data that is to be flushed (sent to the server)
+            self.span.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            trace.get_tracer_provider().force_flush()
 
 
 class OpenTelemetryLoggingTraceFilter:
@@ -180,26 +131,3 @@ class OpenTelemetryLoggingTraceFilter:
         if logged:
             self._log.info(f"====[END TRACE#{trace_id}]" + "=" * 35)
         return trace
-
-
-# ddtrace implementation
-# class DatadogLoggingTraceFilter:
-#     """Debugging utility filter that can log trace spans"""
-
-#     _log = logging.getLogger(f"{__name__}.DatadogLoggingTraceFilter")
-
-#     @classmethod
-#     def activate(cls):
-#         _activate_trace_filter(cls)
-
-#     def process_trace(self, trace):
-#         logged = False
-#         trace_id = "???"
-#         for span in trace:
-#             trace_id = span.trace_id or "???"
-#             if not span.get_tag(DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY):
-#                 logged = True
-#                 self._log.info(f"----[SPAN#{trace_id}]" + "-" * 40 + f"\n{span.pprint()}")
-#         if logged:
-#             self._log.info(f"====[END TRACE#{trace_id}]" + "=" * 35)
-#         return trace

--- a/usaspending_api/common/tracing.py
+++ b/usaspending_api/common/tracing.py
@@ -62,6 +62,7 @@ class OpenTelemetryEagerlyDropTraceFilter:
     trace that the span is part of will be filtered out before being sent to the server.
     """
 
+    # we will probably be getting rid of this class once and for all
     EAGERLY_DROP_TRACE_KEY = "EAGERLY_DROP_TRACE"
 
     @classmethod

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -17,8 +17,6 @@ import traceback
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
 
-# from opentelemetry.sdk.trace import TracerProvider
-
 from datetime import datetime, timezone
 from django.conf import settings
 
@@ -70,7 +68,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
     file_name = start_download(download_job)
 
     with SubprocessTrace(
-        name=f"generate_download_{request_type}",
+        name=f"job.{JOB_TYPE}.generate_download_{request_type}",
         kind=SpanKind.INTERNAL,
         service="bulk-download",
     ) as main_trace:
@@ -213,7 +211,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
             )
 
         with SubprocessTrace(
-            name="s3.command",
+            name=f"job.{JOB_TYPE}.s3.command",
             kind=SpanKind.SERVER,
             service="bulk-download",
         ) as s3_span:
@@ -789,15 +787,14 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
     if download_sql.startswith("\\COPY"):
         # Trace library parses the SQL, but cannot understand the psql-specific \COPY command. Use standard COPY here.
         download_sql = download_sql[1:]
+
         # Stack 3 context managers: (1) psql code, (2) Download replica query, (3) (same) Postgres query
-        subprocess_trace = SubprocessTrace(
+        with SubprocessTrace(
             name=f"job.{JOB_TYPE}.download.psql",
             kind=SpanKind.INTERNAL,
             service="bulk-download",
-        )
-
-        with subprocess_trace as span:
-            span.set_attributes(
+        ) as subprocess_trace:
+            subprocess_trace.set_attributes(
                 {
                     "service": "bulk-download",
                     "resource": str(download_sql),
@@ -817,20 +814,23 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
                     "json_request": str(download_job.json_request) if download_job.json_request else "",
                 }
             )
-            # print("\n\n\n got to this point just fine, lets keep going! \n\n\n")
-            # with tracer.start_as_current_span(
-            #     name="postgres.query",
-            #     span_type=SpanKind.INTERNAL,
-            #     attributes={
-            #         "resource": download_sql,
-            #         "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
-            #         "span_type": "Internal",
-            #     },
-            # ), tracer.start_as_current_span(
-            #     name="postgres.query",
-            #     span_type=SpanKind.INTERNAL,
-            #     attributes={"resource": download_sql, "service": "postgres", "span_type": "Internal"},
-            # ):
+
+        with SubprocessTrace(
+            name="postgres.query", span_type=SpanKind.INTERNAL, service="bulk-download"
+        ) as download_replica_query:
+            download_replica_query.set_attributes(
+                {
+                    "resource": download_sql,
+                    "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
+                    "span_type": "Internal",
+                }
+            )
+
+        with SubprocessTrace(
+            name="postgres.query", span_type=SpanKind.INTERNAL, service="bulk-download"
+        ) as postgress_query:
+            postgress_query.set_attributes({"resource": download_sql, "service": "postgres", "span_type": "Internal"})
+
             try:
                 log_time = time.perf_counter()
                 temp_env = os.environ.copy()

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -16,7 +16,8 @@ import traceback
 
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
-from opentelemetry.sdk.trace import TracerProvider
+
+# from opentelemetry.sdk.trace import TracerProvider
 
 from datetime import datetime, timezone
 from django.conf import settings
@@ -50,7 +51,7 @@ JOB_TYPE = "USAspendingDownloader"
 logger = logging.getLogger(__name__)
 
 # Set up the OpenTelemetry tracer provider
-trace.set_tracer_provider(TracerProvider())
+# trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer_provider().get_tracer(__name__)
 
 
@@ -69,7 +70,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
 
     span = tracer.start_span(name=f"generate_download_{request_type}")
     if span and request_type:
-        span.resource = request_type
+        span.set_attribute("resource", request_type)
 
     file_name = start_download(download_job)
     working_dir = None

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -17,6 +17,8 @@ import traceback
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
 
+# from opentelemetry.sdk.trace import TracerProvider
+
 from datetime import datetime, timezone
 from django.conf import settings
 
@@ -68,7 +70,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
     file_name = start_download(download_job)
 
     with SubprocessTrace(
-        name=f"job.{JOB_TYPE}.generate_download_{request_type}",
+        name=f"generate_download_{request_type}",
         kind=SpanKind.INTERNAL,
         service="bulk-download",
     ) as main_trace:
@@ -211,7 +213,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
             )
 
         with SubprocessTrace(
-            name=f"job.{JOB_TYPE}.s3.command",
+            name="s3.command",
             kind=SpanKind.SERVER,
             service="bulk-download",
         ) as s3_span:
@@ -787,14 +789,15 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
     if download_sql.startswith("\\COPY"):
         # Trace library parses the SQL, but cannot understand the psql-specific \COPY command. Use standard COPY here.
         download_sql = download_sql[1:]
-
         # Stack 3 context managers: (1) psql code, (2) Download replica query, (3) (same) Postgres query
-        with SubprocessTrace(
+        subprocess_trace = SubprocessTrace(
             name=f"job.{JOB_TYPE}.download.psql",
             kind=SpanKind.INTERNAL,
             service="bulk-download",
-        ) as subprocess_trace:
-            subprocess_trace.set_attributes(
+        )
+
+        with subprocess_trace as span:
+            span.set_attributes(
                 {
                     "service": "bulk-download",
                     "resource": str(download_sql),
@@ -814,23 +817,20 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
                     "json_request": str(download_job.json_request) if download_job.json_request else "",
                 }
             )
-
-        with SubprocessTrace(
-            name="postgres.query", span_type=SpanKind.INTERNAL, service="bulk-download"
-        ) as download_replica_query:
-            download_replica_query.set_attributes(
-                {
-                    "resource": download_sql,
-                    "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
-                    "span_type": "Internal",
-                }
-            )
-
-        with SubprocessTrace(
-            name="postgres.query", span_type=SpanKind.INTERNAL, service="bulk-download"
-        ) as postgress_query:
-            postgress_query.set_attributes({"resource": download_sql, "service": "postgres", "span_type": "Internal"})
-
+            # print("\n\n\n got to this point just fine, lets keep going! \n\n\n")
+            # with tracer.start_as_current_span(
+            #     name="postgres.query",
+            #     span_type=SpanKind.INTERNAL,
+            #     attributes={
+            #         "resource": download_sql,
+            #         "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
+            #         "span_type": "Internal",
+            #     },
+            # ), tracer.start_as_current_span(
+            #     name="postgres.query",
+            #     span_type=SpanKind.INTERNAL,
+            #     attributes={"resource": download_sql, "service": "postgres", "span_type": "Internal"},
+            # ):
             try:
                 log_time = time.perf_counter()
                 temp_env = os.environ.copy()

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -456,12 +456,12 @@ def split_and_zip_data_files(zip_file_path, source_path, data_file_name, file_fo
     with SubprocessTrace(
         name=f"job.{JOB_TYPE}.download.zip",
         kind=SpanKind.INTERNAL,
-        service= "bulk-download",
+        service="bulk-download",
         attributes={
             "service": "bulk-download",
             "span_type": "Internal",
             "source_path": source_path,
-            "zip_file_path": zip_file_path
+            "zip_file_path": zip_file_path,
         },
     ) as span:
         try:
@@ -700,7 +700,7 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
     with SubprocessTrace(
         name=f"job.{JOB_TYPE}.download.psql",
         kind=SpanKind.INTERNAL,
-        service= "bulk-download",
+        service="bulk-download",
         attributes={
             "service": "bulk-download",
             "resource": download_sql,
@@ -710,19 +710,11 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
     ), tracer.start_as_current_span(
         name="postgres.query",
         span_type=SpanKind.INTERNAL,
-        attributes={
-            "resource":download_sql,
-            "service":f"{settings.DOWNLOAD_DB_ALIAS}db",
-            "span_type": "Internal"
-        }
+        attributes={"resource": download_sql, "service": f"{settings.DOWNLOAD_DB_ALIAS}db", "span_type": "Internal"},
     ), tracer.start_as_current_span(
-        name="postgres.query", 
+        name="postgres.query",
         span_type=SpanKind.INTERNAL,
-        attributes={
-            "resource":download_sql,
-            "service":"postgres",
-            "span_type": "Internal"
-        }
+        attributes={"resource": download_sql, "service": "postgres", "span_type": "Internal"},
     ):
         try:
             log_time = time.perf_counter()

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -70,7 +70,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
     file_name = start_download(download_job)
 
     with SubprocessTrace(
-        name=f"generate_download_{request_type}",
+        name=f"job.{JOB_TYPE}.generate_download_{request_type}",
         kind=SpanKind.INTERNAL,
         service="bulk-download",
     ) as main_trace:
@@ -213,7 +213,7 @@ def generate_download(download_job: DownloadJob, origination: Optional[str] = No
             )
 
         with SubprocessTrace(
-            name="s3.command",
+            name=f"job.{JOB_TYPE}.s3.command",
             kind=SpanKind.SERVER,
             service="bulk-download",
         ) as s3_span:
@@ -817,20 +817,7 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
                     "json_request": str(download_job.json_request) if download_job.json_request else "",
                 }
             )
-            # print("\n\n\n got to this point just fine, lets keep going! \n\n\n")
-            # with tracer.start_as_current_span(
-            #     name="postgres.query",
-            #     span_type=SpanKind.INTERNAL,
-            #     attributes={
-            #         "resource": download_sql,
-            #         "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
-            #         "span_type": "Internal",
-            #     },
-            # ), tracer.start_as_current_span(
-            #     name="postgres.query",
-            #     span_type=SpanKind.INTERNAL,
-            #     attributes={"resource": download_sql, "service": "postgres", "span_type": "Internal"},
-            # ):
+
             try:
                 log_time = time.perf_counter()
                 temp_env = os.environ.copy()

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -817,54 +817,54 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
                     "json_request": str(download_job.json_request) if download_job.json_request else "",
                 }
             )
-            print("\n\n\n got to this point just fine, lets keep going! \n\n\n")
-            with tracer.start_as_current_span(
-                name="postgres.query",
-                span_type=SpanKind.INTERNAL,
-                attributes={
-                    "resource": download_sql,
-                    "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
-                    "span_type": "Internal",
-                },
-            ), tracer.start_as_current_span(
-                name="postgres.query",
-                span_type=SpanKind.INTERNAL,
-                attributes={"resource": download_sql, "service": "postgres", "span_type": "Internal"},
-            ):
-                try:
-                    log_time = time.perf_counter()
-                    temp_env = os.environ.copy()
-                    if download_job and not download_job.monthly_download:
-                        # Since terminating the process isn't guaranteed to end the DB statement, add timeout to client connection
-                        temp_env["PGOPTIONS"] = (
-                            f"--statement-timeout={settings.DOWNLOAD_DB_TIMEOUT_IN_HOURS}h "
-                            f"--work-mem={settings.DOWNLOAD_DB_WORK_MEM_IN_MB}MB"
-                        )
-
-                    cat_command = subprocess.Popen(["cat", temp_sql_file_path], stdout=subprocess.PIPE)
-                    subprocess.check_output(
-                        ["psql", "-q", "-o", source_path, retrieve_db_string(), "-v", "ON_ERROR_STOP=1"],
-                        stdin=cat_command.stdout,
-                        stderr=subprocess.STDOUT,
-                        env=temp_env,
+            # print("\n\n\n got to this point just fine, lets keep going! \n\n\n")
+            # with tracer.start_as_current_span(
+            #     name="postgres.query",
+            #     span_type=SpanKind.INTERNAL,
+            #     attributes={
+            #         "resource": download_sql,
+            #         "service": f"{settings.DOWNLOAD_DB_ALIAS}db",
+            #         "span_type": "Internal",
+            #     },
+            # ), tracer.start_as_current_span(
+            #     name="postgres.query",
+            #     span_type=SpanKind.INTERNAL,
+            #     attributes={"resource": download_sql, "service": "postgres", "span_type": "Internal"},
+            # ):
+            try:
+                log_time = time.perf_counter()
+                temp_env = os.environ.copy()
+                if download_job and not download_job.monthly_download:
+                    # Since terminating the process isn't guaranteed to end the DB statement, add timeout to client connection
+                    temp_env["PGOPTIONS"] = (
+                        f"--statement-timeout={settings.DOWNLOAD_DB_TIMEOUT_IN_HOURS}h "
+                        f"--work-mem={settings.DOWNLOAD_DB_WORK_MEM_IN_MB}MB"
                     )
 
-                    duration = time.perf_counter() - log_time
-                    write_to_log(
-                        message=f"Wrote {os.path.basename(source_path)}, took {duration:.4f} seconds",
-                        download_job=download_job,
-                    )
-                except subprocess.CalledProcessError as e:
-                    write_to_log(message=f"PSQL Error: {e.output.decode()}", is_error=True, download_job=download_job)
-                    raise e
-                except Exception as e:
-                    if not settings.IS_LOCAL:
-                        # Not logging the command as it can contain the database connection string
-                        e.cmd = "[redacted psql command]"
-                    write_to_log(message=e, is_error=True, download_job=download_job)
-                    sql = subprocess.check_output(["cat", temp_sql_file_path]).decode()
-                    write_to_log(message=f"Faulty SQL: {sql}", is_error=True, download_job=download_job)
-                    raise e
+                cat_command = subprocess.Popen(["cat", temp_sql_file_path], stdout=subprocess.PIPE)
+                subprocess.check_output(
+                    ["psql", "-q", "-o", source_path, retrieve_db_string(), "-v", "ON_ERROR_STOP=1"],
+                    stdin=cat_command.stdout,
+                    stderr=subprocess.STDOUT,
+                    env=temp_env,
+                )
+
+                duration = time.perf_counter() - log_time
+                write_to_log(
+                    message=f"Wrote {os.path.basename(source_path)}, took {duration:.4f} seconds",
+                    download_job=download_job,
+                )
+            except subprocess.CalledProcessError as e:
+                write_to_log(message=f"PSQL Error: {e.output.decode()}", is_error=True, download_job=download_job)
+                raise e
+            except Exception as e:
+                if not settings.IS_LOCAL:
+                    # Not logging the command as it can contain the database connection string
+                    e.cmd = "[redacted psql command]"
+                write_to_log(message=e, is_error=True, download_job=download_job)
+                sql = subprocess.check_output(["cat", temp_sql_file_path]).decode()
+                write_to_log(message=f"Faulty SQL: {sql}", is_error=True, download_job=download_job)
+                raise e
 
 
 def retrieve_db_string():

--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -461,8 +461,8 @@ def split_and_zip_data_files(zip_file_path, source_path, data_file_name, file_fo
         attributes={
             "service": "bulk-download",
             "span_type": "Internal",
-            "source_path": source_path,
-            "zip_file_path": zip_file_path,
+            # "source_path": source_path,
+            # "zip_file_path": zip_file_path,
         },
     ) as span:
         try:
@@ -704,9 +704,9 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
         service="bulk-download",
         attributes={
             "service": "bulk-download",
-            "resource": download_sql,
+            # "resource": str(download_sql),
             "span_type": "Internal",
-            "source_path": source_path,
+            # "source_path": source_path,
         },
     ), tracer.start_as_current_span(
         name="postgres.query",

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -2,9 +2,10 @@ import logging
 import time
 import traceback
 
-from opentelemetry import trace
+# from opentelemetry import trace
 from opentelemetry.trace import SpanKind
-from opentelemetry.sdk.trace import TracerProvider
+
+# from opentelemetry.sdk.trace import TracerProvider
 
 from django.core.management.base import BaseCommand
 
@@ -23,8 +24,8 @@ from usaspending_api.download.models.download_job import DownloadJob
 from usaspending_api.common.tracing import OpenTelemetryEagerlyDropTraceFilter, SubprocessTrace
 
 # Initialize OpenTelemetry
-tracer_provider = TracerProvider()
-trace.set_tracer_provider(tracer_provider)
+# tracer_provider = TracerProvider()
+# trace.set_tracer_provider(tracer_provider)
 
 logger = logging.getLogger(__name__)
 JOB_TYPE = "USAspendingDownloader"

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -23,6 +23,7 @@ from usaspending_api.common.tracing import SubprocessTrace
 from opentelemetry.trace import Status, StatusCode
 from opentelemetry import trace, context
 from opentelemetry.trace import set_span_in_context
+from usaspending_api.common.logging import configure_logging
 
 logger = logging.getLogger(__name__)
 JOB_TYPE = "USAspendingDownloader"
@@ -30,7 +31,7 @@ JOB_TYPE = "USAspendingDownloader"
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-
+        configure_logging(service_name='usaspending-downloader')
         # Start a main trace for the SQS worker session
         with SubprocessTrace(
             name=f"job.{JOB_TYPE}.download_sqs_worker",

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -31,14 +31,21 @@ from usaspending_api.common.logging import configure_logging
 # tracer_provider = TracerProvider()
 # trace.set_tracer_provider(tracer_provider)
 
+# from opentelemetry.sdk.trace import TracerProvider
+# from opentelemetry.sdk.resources import Resource
+
+# resource = Resource(attributes={"service.name": "bulk-download"})
+# tracer_provider = TracerProvider(resource=resource)
+# trace.set_tracer_provider(tracer_provider)
+configure_logging(service_name="bulk-download")
+
 logger = logging.getLogger(__name__)
 JOB_TYPE = "USAspendingDownloader"
 
-
+configure_logging(service_name="download-sqs-worker")
 class Command(BaseCommand):
     def handle(self, *args, **options):
         # Configure Tracer to drop traces of polls of the queue that have been flagged as uninteresting
-        configure_logging(service_name="download-sqs-worker")
         OpenTelemetryEagerlyDropTraceFilter.activate()
 
         queue = get_sqs_queue()

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -22,28 +22,28 @@ from usaspending_api.download.helpers.monthly_helpers import download_job_to_log
 from usaspending_api.download.lookups import JOB_STATUS_DICT
 from usaspending_api.download.models.download_job import DownloadJob
 
-from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
-from opentelemetry import trace
-from opentelemetry.instrumentation.django import DjangoInstrumentor
-from opentelemetry.sdk.trace import TracerProvider
+# from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
+# from opentelemetry import trace
+# from opentelemetry.instrumentation.django import DjangoInstrumentor
+# from opentelemetry.sdk.trace import TracerProvider
 from usaspending_api.common.tracing import OpenTelemetryEagerlyDropTraceFilter, SubprocessTrace
 from usaspending_api.common.logging import configure_logging
-from opentelemetry.sdk.resources import Resource
+# from opentelemetry.sdk.resources import Resource
 
 # Initialize OpenTelemetry
-resource = Resource.create(attributes={"service.name": "USAspendingDownloader"})
-tracer_provider = TracerProvider(resource=resource)
-trace.set_tracer_provider(tracer_provider)
+# resource = Resource.create(attributes={"service.name": "USAspendingDownloader"})
+# tracer_provider = TracerProvider(resource=resource)
+# trace.set_tracer_provider(tracer_provider)
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "USAspendingDownloader")
-os.environ["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={service_name}"
+# service_name = os.getenv("OTEL_SERVICE_NAME", "USAspendingDownloader")
+# os.environ["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={service_name}"
 # from opentelemetry.sdk.trace import TracerProvider
 # from opentelemetry.sdk.resources import Resource
 
 logger = logging.getLogger(__name__)
 JOB_TYPE = "USAspendingDownloader"
 
-# configure_logging(service_name="download-sqs-worker")
+configure_logging(service_name="download-sqs-worker")
 class Command(BaseCommand):
     def handle(self, *args, **options):
         # Configure Tracer to drop traces of polls of the queue that have been flagged as uninteresting
@@ -118,14 +118,15 @@ def download_service_app(download_job_id):
             "job_type": JOB_TYPE, #already a string
             # the download job details
             "download_job_id": str(download_job_id),
-            "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
-            "download_file_name": str(download_job.file_name),  # Extract specific field as str
-            "download_file_size": download_job.file_size if download_job.file_size is not None else 0,  # int or fallback to 0
-            "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
-            "number_of_columns": download_job.number_of_columns if download_job.number_of_columns is not None else 0,
-            "error_message": download_job.error_message if download_job.error_message else "",
-            "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
-            "json_request": str(download_job.json_request) if download_job.json_request else "",
+            # will undo the below changes
+            # "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
+            # "download_file_name": str(download_job.file_name),  # Extract specific field as str
+            # "download_file_size": download_job.file_size if download_job.file_size is not None else 0,  # int or fallback to 0
+            # "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
+            # "number_of_columns": download_job.number_of_columns if download_job.number_of_columns is not None else 0,
+            # "error_message": download_job.error_message if download_job.error_message else "",
+            # "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
+            # "json_request": str(download_job.json_request) if download_job.json_request else "",
         
         },
     ) as span:

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -1,12 +1,8 @@
 import logging
 import time
 import traceback
-import os
 
-# from opentelemetry import trace
 from opentelemetry.trace import SpanKind
-
-# from opentelemetry.sdk.trace import TracerProvider
 
 from django.core.management.base import BaseCommand
 
@@ -22,51 +18,37 @@ from usaspending_api.download.helpers.monthly_helpers import download_job_to_log
 from usaspending_api.download.lookups import JOB_STATUS_DICT
 from usaspending_api.download.models.download_job import DownloadJob
 
-# from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
-# from opentelemetry import trace
-# from opentelemetry.instrumentation.django import DjangoInstrumentor
-# from opentelemetry.sdk.trace import TracerProvider
-from usaspending_api.common.tracing import OpenTelemetryEagerlyDropTraceFilter, SubprocessTrace
-from usaspending_api.common.logging import configure_logging
-# from opentelemetry.sdk.resources import Resource
+from usaspending_api.common.tracing import SubprocessTrace
 
-# Initialize OpenTelemetry
-# resource = Resource.create(attributes={"service.name": "USAspendingDownloader"})
-# tracer_provider = TracerProvider(resource=resource)
-# trace.set_tracer_provider(tracer_provider)
-
-# service_name = os.getenv("OTEL_SERVICE_NAME", "USAspendingDownloader")
-# os.environ["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={service_name}"
-# from opentelemetry.sdk.trace import TracerProvider
-# from opentelemetry.sdk.resources import Resource
+from opentelemetry.trace import Status, StatusCode
 
 logger = logging.getLogger(__name__)
 JOB_TYPE = "USAspendingDownloader"
 
-configure_logging(service_name="download-sqs-worker")
+
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        # Configure Tracer to drop traces of polls of the queue that have been flagged as uninteresting
-        OpenTelemetryEagerlyDropTraceFilter.activate()
 
-        queue = get_sqs_queue()
-        log_job_message(logger=logger, message="Starting SQS polling", job_type=JOB_TYPE)
+        # Start a main trace for the SQS worker session
+        with SubprocessTrace(
+            name=f"job.{JOB_TYPE}.download_sqs_worker",
+            kind=SpanKind.INTERNAL,
+            service="bulk-download",
+        ) as main_trace:
+            main_trace.set_attributes(
+                {
+                    "service": "bulk-download",
+                    "job_type": str(JOB_TYPE),
+                    "message": "Starting SQS worker session",
+                }
+            )
+            queue = get_sqs_queue()
+            log_job_message(logger=logger, message="Starting SQS polling", job_type=JOB_TYPE)
 
-        message_found = None
-        keep_polling = True
-        while keep_polling:
+            message_found = None
+            keep_polling = True
 
-            # Start a Trace for this poll iter to capture activity in APM
-            with SubprocessTrace(
-                name=f"job.{JOB_TYPE}",
-                kind=SpanKind.INTERNAL,
-                service="bulk-download",
-                attributes={"service": "bulk-download", "resource": str(queue.url), "span_type": "Internal"},
-            ) as span:
-                # Set True to add trace to App Analytics:
-                # - https://docs.datadoghq.com/tracing/app_analytics/?tab=python#custom-instrumentation
-                span.set_attribute("analytics_sample_rate", 1.0)
-
+            while keep_polling:
                 # Setup dispatcher that coordinates job activity on SQS
                 dispatcher = SQSWorkDispatcher(
                     queue,
@@ -74,30 +56,60 @@ class Command(BaseCommand):
                     worker_can_start_child_processes=True,
                 )
 
-                try:
+                # Mark the job as failed if: there was an error processing the download; retries after interrupt
+                # are not allowed; or all retries have been exhausted
+                # If the job is interrupted by an OS signal, the dispatcher's signal handling logic will log and
+                # handle this case
+                # Retries are allowed or denied by the SQS queue's RedrivePolicy config
+                # That is, if maxReceiveCount > 1 in the policy, then retries are allowed
+                # - if queue retries are allowed, the queue message will retry to the max allowed by the queue
+                # - As coded, no cleanup should be needed to retry a download
+                #   - the psql -o will overwrite the output file
+                #   - the zip will use 'w' write mode to create from scratch each time
+                # The worker function controls the maximum allowed runtime of the job
 
+                try:
                     # Check the queue for work and hand it to the given processing function
                     message_found = dispatcher.dispatch(download_service_app)
 
-                    # Mark the job as failed if: there was an error processing the download; retries after interrupt
-                    # are not allowed; or all retries have been exhausted
-                    # If the job is interrupted by an OS signal, the dispatcher's signal handling logic will log and
-                    # handle this case
-                    # Retries are allowed or denied by the SQS queue's RedrivePolicy config
-                    # That is, if maxReceiveCount > 1 in the policy, then retries are allowed
-                    # - if queue retries are allowed, the queue message will retry to the max allowed by the queue
-                    # - As coded, no cleanup should be needed to retry a download
-                    #   - the psql -o will overwrite the output file
-                    #   - the zip will use 'w' write mode to create from scratch each time
-                    # The worker function controls the maximum allowed runtime of the job
+                    # Start a new span only if a message is found
+                    if message_found:
+                        with SubprocessTrace(
+                            name=f"job.{JOB_TYPE}.message_processing",
+                            kind=SpanKind.INTERNAL,
+                            service="bulk-download",
+                        ) as poll_span:
+                            poll_span.set_attributes(
+                                {
+                                    "service": "bulk-download",
+                                    "job_type": str(JOB_TYPE),
+                                    "resource": str(queue.url),
+                                    "span_type": "Internal",
+                                    "message": "Processing download job message",
+                                }
+                            )
 
                 except (QueueWorkerProcessError, QueueWorkDispatcherError) as exc:
                     _handle_queue_error(exc)
 
+                    # Start a span only for the error, capturing details
+                    with SubprocessTrace(
+                        name=f"job.{JOB_TYPE}.error_handling",
+                        kind=SpanKind.INTERNAL,
+                        service="bulk-download",
+                    ) as error_span:
+                        error_span.set_attributes(
+                            {
+                                "service": "bulk-download",
+                                "span_type": "Internal",
+                                "message": "Error processing message",
+                                "error": str(exc),
+                            }
+                        )
+                        error_span.set_status(Status(StatusCode.ERROR, str(exc)))
+
                 if not message_found:
-                    # Flag the the Datadog trace for dropping, since no trace-worthy activity happened on this poll
-                    OpenTelemetryEagerlyDropTraceFilter.drop(span)
-                    # When you receive an empty response from the queue, wait before trying again
+                    # Not using the EagerlyDropTraceFilter since we are no longer sending traces every iteration. Only when actionabe events happen
                     time.sleep(1)
 
                 # If this process is exiting, don't poll for more work
@@ -105,31 +117,38 @@ class Command(BaseCommand):
 
 
 def download_service_app(download_job_id):
+
     download_job = _retrieve_download_job_from_db(download_job_id)
     download_job_details = download_job_to_log_dict(download_job)
+
     with SubprocessTrace(
         name=f"job.{JOB_TYPE}.download.start",
         kind=SpanKind.INTERNAL,
         service="bulk-download",
-        attributes={
-            "message": "Starting processing of download request",
-            "service": "bulk-download",
-            "span_type": str(SpanKind.INTERNAL),  # Convert Enum to str
-            "job_type": JOB_TYPE, #already a string
-            # the download job details
-            "download_job_id": str(download_job_id),
-            # will undo the below changes
-            # "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
-            # "download_file_name": str(download_job.file_name),  # Extract specific field as str
-            # "download_file_size": download_job.file_size if download_job.file_size is not None else 0,  # int or fallback to 0
-            # "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
-            # "number_of_columns": download_job.number_of_columns if download_job.number_of_columns is not None else 0,
-            # "error_message": download_job.error_message if download_job.error_message else "",
-            # "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
-            # "json_request": str(download_job.json_request) if download_job.json_request else "",
-        
-        },
     ) as span:
+        span.set_attributes(
+            {
+                "message": "Starting processing of download request",
+                "service": "bulk-download",
+                "span_type": str(SpanKind.INTERNAL),
+                "job_type": str(JOB_TYPE),
+                # download job details
+                "download_job_id": str(download_job_id),
+                "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
+                "download_file_name": str(download_job.file_name),  # Extract specific field as str
+                "download_file_size": download_job.file_size
+                if download_job.file_size is not None
+                else 0,  # int or fallback to 0
+                "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
+                "number_of_columns": download_job.number_of_columns
+                if download_job.number_of_columns is not None
+                else 0,
+                "error_message": download_job.error_message if download_job.error_message else "",
+                "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
+                "json_request": str(download_job.json_request) if download_job.json_request else "",
+            }
+        )
+
         log_job_message(
             logger=logger,
             message="Starting processing of download request",
@@ -137,35 +156,52 @@ def download_service_app(download_job_id):
             job_id=download_job_id,
             other_params=download_job_details,
         )
-        span.set_attributes(download_job_details)
+
         generate_download(download_job=download_job)
 
 
 def _retrieve_download_job_from_db(download_job_id):
+
     download_job = DownloadJob.objects.filter(download_job_id=download_job_id).first()
     download_job_details = download_job_to_log_dict(download_job)
+
     with SubprocessTrace(
         name=f"job.{JOB_TYPE}.download.retrieve",
         kind=SpanKind.INTERNAL,
         service="bulk-download",
-        attributes={
-            "message": "Retreiving Download Job From DB",
-            "service": "bulk-download",
-            # "span_type": SpanKind.INTERNAL,
-            # "job_type": JOB_TYPE,
-            # "download_job_id": download_job_id,
-            # "download_job": download_job,
-            # "download_job_details" : download_job_details
-        },
     ) as span:
+
+        span.set_attributes(
+            {
+                "message": "Retreiving Download Job From DB",
+                "service": "bulk-download",
+                "span_type": str(SpanKind.INTERNAL),
+                "job_type": str(JOB_TYPE),
+                # download job details
+                "download_job_id": str(download_job_id),
+                "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
+                "download_file_name": str(download_job.file_name),  # Extract specific field as str
+                "download_file_size": download_job.file_size
+                if download_job.file_size is not None
+                else 0,  # int or fallback to 0
+                "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
+                "number_of_columns": download_job.number_of_columns
+                if download_job.number_of_columns is not None
+                else 0,
+                "error_message": download_job.error_message if download_job.error_message else "",
+                "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
+                "json_request": str(download_job.json_request) if download_job.json_request else "",
+            }
+        )
+
         log_job_message(
             logger=logger,
             message="Retreiving Download Job From DB",
             job_type=JOB_TYPE,
             job_id=download_job_id,
-            other_params=download_job_to_log_dict(download_job),  # download job details
+            other_params=download_job_details,  # download job details
         )
-        span.set_attribute(download_job_to_log_dict(download_job))
+
         if download_job is None:
             raise DownloadJobNoneError(download_job_id)
 
@@ -183,23 +219,37 @@ def _update_download_job_status(download_job_id, status, error_message=None, ove
         overwrite_error_message (bool): if explicitly set to True, and error_message is not None, the provided error
             message will overwrite an existing error message on the DownloadJob object. By default it will not.
     """
+
     download_job = _retrieve_download_job_from_db(download_job_id)
     download_job_details = download_job_to_log_dict(download_job)
+
     with SubprocessTrace(
         name=f"job.{JOB_TYPE}.download.update",
         kind=SpanKind.INTERNAL,
         service="bulk-download",
-        attributes={
-            "message": "Updating Download Job Status",
-            "service": "bulk-download",
-            # "span_type": SpanKind.INTERNAL,
-            # "job_type": JOB_TYPE,
-            # "download_job_id": download_job_id,
-            # "download_job": download_job,
-            # "download_job_details" : download_job_details
-        },
     ) as span:
-        # download_job = _retrieve_download_job_from_db(download_job_id)
+        span.set_attributes(
+            {
+                "message": "Updating Download Job Status",
+                "service": "bulk-download",
+                "span_type": str(SpanKind.INTERNAL),
+                "job_type": str(JOB_TYPE),
+                # download job details
+                "download_job_id": str(download_job_id),
+                "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
+                "download_file_name": str(download_job.file_name),  # Extract specific field as str
+                "download_file_size": download_job.file_size
+                if download_job.file_size is not None
+                else 0,  # int or fallback to 0
+                "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
+                "number_of_columns": download_job.number_of_columns
+                if download_job.number_of_columns is not None
+                else 0,
+                "error_message": download_job.error_message if download_job.error_message else "",
+                "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
+                "json_request": str(download_job.json_request) if download_job.json_request else "",
+            }
+        )
 
         download_job.job_status_id = JOB_STATUS_DICT[status]
         if overwrite_error_message or (error_message and not download_job.error_message):
@@ -210,9 +260,8 @@ def _update_download_job_status(download_job_id, status, error_message=None, ove
             message="Updating Download Job Status",
             job_type=JOB_TYPE,
             job_id=download_job_id,
-            other_params=download_job_to_log_dict(download_job),  # retreived download job status details
+            other_params=download_job_details,  # retreived download job status details
         )
-        span.set_attribute(download_job_to_log_dict(download_job))
 
         download_job.save()
 

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -20,6 +20,8 @@ from usaspending_api.download.helpers.monthly_helpers import download_job_to_log
 from usaspending_api.download.lookups import JOB_STATUS_DICT
 from usaspending_api.download.models.download_job import DownloadJob
 
+from usaspending_api.common.tracing import OpenTelemetryEagerlyDropTraceFilter, SubprocessTrace
+
 # Initialize OpenTelemetry
 tracer_provider = TracerProvider()
 trace.set_tracer_provider(tracer_provider)
@@ -30,17 +32,26 @@ JOB_TYPE = "USAspendingDownloader"
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
+        # Configure Tracer to drop traces of polls of the queue that have been flagged as uninteresting
+        OpenTelemetryEagerlyDropTraceFilter.activate()
+        
         queue = get_sqs_queue()
         log_job_message(logger=logger, message="Starting SQS polling", job_type=JOB_TYPE)
 
         message_found = None
         keep_polling = True
         while keep_polling:
-
-            # Start a Datadog Trace for this poll iter to capture activity in APM
-            with tracer_provider.get_tracer(__name__).start_as_current_span(
+            
+            # Start a Trace for this poll iter to capture activity in APM
+            with SubprocessTrace(
                 name=f"job.{JOB_TYPE}",
-                attributes={"service": "bulk-download", "resource": queue.url, "span_type": SpanKind.WORKER},
+                kind=SpanKind.INTERNAL,
+                service= "bulk-download", 
+                attributes={
+                    "service": "bulk-download", 
+                    "resource": queue.url,
+                    "span_type":"Internal"
+                },
             ) as span:
                 # Set True to add trace to App Analytics:
                 # - https://docs.datadoghq.com/tracing/app_analytics/?tab=python#custom-instrumentation
@@ -48,7 +59,7 @@ class Command(BaseCommand):
 
                 # Setup dispatcher that coordinates job activity on SQS
                 dispatcher = SQSWorkDispatcher(
-                    queue, worker_process_name=JOB_TYPE, worker_can_start_child_processes=True
+                    queue, worker_process_name=JOB_TYPE, worker_can_start_child_processes=True,
                 )
 
                 try:
@@ -72,7 +83,8 @@ class Command(BaseCommand):
                     _handle_queue_error(exc)
 
                 if not message_found:
-
+                    # Flag the the Datadog trace for dropping, since no trace-worthy activity happened on this poll
+                    OpenTelemetryEagerlyDropTraceFilter.drop(span)
                     # When you receive an empty response from the queue, wait before trying again
                     time.sleep(1)
 
@@ -81,8 +93,13 @@ class Command(BaseCommand):
 
 
 def download_service_app(download_job_id):
-    with tracer_provider.get_tracer(__name__).start_as_current_span(
-        name=f"job.{JOB_TYPE}.download", attributes={"service": "bulk-download", "span_type": SpanKind.Server}
+    with SubprocessTrace(
+        name=f"job.{JOB_TYPE}.download", 
+        kind=SpanKind.SERVER,
+        attributes={
+            "service": "bulk-download", 
+            "span_type": SpanKind.Server
+        }
     ) as span:
         download_job = _retrieve_download_job_from_db(download_job_id)
         download_job_details = download_job_to_log_dict(download_job)

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -114,11 +114,19 @@ def download_service_app(download_job_id):
         attributes={
             "message": "Starting processing of download request",
             "service": "bulk-download",
-            "span_type": SpanKind.INTERNAL,
-            "job_type": JOB_TYPE,
+            "span_type": str(SpanKind.INTERNAL),  # Convert Enum to str
+            "job_type": JOB_TYPE, #already a string
+            # the download job details
             "download_job_id": str(download_job_id),
-            "download_job": download_job,
-            "download_job_details": download_job_details,
+            "download_job_status": str(download_job.job_status.name),  # Convert to relevant field as str
+            "download_file_name": str(download_job.file_name),  # Extract specific field as str
+            "download_file_size": download_job.file_size if download_job.file_size is not None else 0,  # int or fallback to 0
+            "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
+            "number_of_columns": download_job.number_of_columns if download_job.number_of_columns is not None else 0,
+            "error_message": download_job.error_message if download_job.error_message else "",
+            "monthly_download": str(download_job.monthly_download),  # Convert boolean to str
+            "json_request": str(download_job.json_request) if download_job.json_request else "",
+        
         },
     ) as span:
         log_job_message(

--- a/usaspending_api/download/management/commands/download_sqs_worker.py
+++ b/usaspending_api/download/management/commands/download_sqs_worker.py
@@ -21,8 +21,6 @@ from usaspending_api.download.models.download_job import DownloadJob
 from usaspending_api.common.tracing import SubprocessTrace
 
 from opentelemetry.trace import Status, StatusCode
-from opentelemetry import trace, context
-from opentelemetry.trace import set_span_in_context
 from usaspending_api.common.logging import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -31,7 +29,7 @@ JOB_TYPE = "USAspendingDownloader"
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        configure_logging(service_name='usaspending-downloader')
+        configure_logging(service_name="usaspending-downloader")
         # Start a main trace for the SQS worker session
         with SubprocessTrace(
             name=f"job.{JOB_TYPE}.download_sqs_worker",
@@ -49,7 +47,6 @@ class Command(BaseCommand):
             # Creates a Context object with parent set as current span
             # any Child span using .start_span() will automatically be the child of the parent
             # Refer to this link: https://github.com/open-telemetry/opentelemetry-python/issues/2787
-            ctx = trace.set_span_in_context(parent)
 
             queue = get_sqs_queue()
             log_job_message(logger=logger, message="Starting SQS polling", job_type=JOB_TYPE)

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -11,32 +11,9 @@ from django.db import DEFAULT_DB_ALIAS
 from django.utils.crypto import get_random_string
 
 from usaspending_api.config import CONFIG
-from usaspending_api.common.logging import configure_logging
-
-from opentelemetry import trace
-
-from opentelemetry.instrumentation.django import DjangoInstrumentor
 
 ALLOWED_HOSTS = ["*"]
 ROOT_URLCONF = "usaspending_api.urls"
-############################################################
-# ==== [Open Telemetry Configuration] ====
-
-# Django Instrumentation
-DjangoInstrumentor().instrument()
-
-configure_logging(service_name="usaspending-api")
-
-# Optionally, set other OpenTelemetry configurations
-service_name = os.getenv("OTEL_SERVICE_NAME", "usaspending-api")
-os.environ["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={service_name}"
-
-# Define additional settings for OpenTelemetry integration
-TRACER = trace.get_tracer_provider().get_tracer(__name__)
-OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces")
-OTEL_RESOURCE_ATTRIBUTES = f"service.name={service_name}"
-
-############################################################
 
 # All paths inside the project should be additive to REPO_DIR or APP_DIR
 APP_DIR = Path(__file__).resolve().parent

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -21,7 +21,7 @@ from opentelemetry.instrumentation.django import DjangoInstrumentor
 ############################################################
 # ==== [Open Telemetry Configuration] ====
 
-# Instrument Django
+# Django Instrumentation
 DjangoInstrumentor().instrument()
 
 # Optionally, set other OpenTelemetry configurations

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -29,6 +29,7 @@ ROOT_URLCONF = "usaspending_api.urls"
 
 # Django Instrumentation
 DjangoInstrumentor().instrument()
+
 configure_logging(service_name="usaspending-api")
 OpenTelemetryEagerlyDropTraceFilter.activate()
 

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -237,6 +237,7 @@ INSTALLED_APPS = [
     "django_spaghetti",
     "rest_framework",
     "rest_framework_tracking",
+    "opentelemetry",
     # Project applications
     "usaspending_api.accounts",
     "usaspending_api.agency",

--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -15,12 +15,7 @@ from usaspending_api.common.logging import configure_logging
 
 from opentelemetry import trace
 
-# from opentelemetry.sdk.trace import TracerProvider
-# from opentelemetry.sdk.resources import Resource
-# from opentelemetry.sdk.trace.export import BatchSpanProcessor
-# from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.django import DjangoInstrumentor
-from usaspending_api.common.tracing import OpenTelemetryEagerlyDropTraceFilter
 
 ALLOWED_HOSTS = ["*"]
 ROOT_URLCONF = "usaspending_api.urls"
@@ -31,24 +26,10 @@ ROOT_URLCONF = "usaspending_api.urls"
 DjangoInstrumentor().instrument()
 
 configure_logging(service_name="usaspending-api")
-OpenTelemetryEagerlyDropTraceFilter.activate()
 
 # Optionally, set other OpenTelemetry configurations
 service_name = os.getenv("OTEL_SERVICE_NAME", "usaspending-api")
 os.environ["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={service_name}"
-
-# # Set up the OpenTelemetry tracer provider
-# resource = Resource(attributes={"service.name": "usaspending-api"})
-# trace.set_tracer_provider(TracerProvider())
-
-# Set up the OTLP exporter
-# Check out https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
-# for more exporter configuration
-# otlp_exporter = OTLPSpanExporter(
-#     endpoint=os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces"),
-# )
-# span_processor = BatchSpanProcessor(otlp_exporter)
-# trace.get_tracer_provider().add_span_processor(span_processor)
 
 # Define additional settings for OpenTelemetry integration
 TRACER = trace.get_tracer_provider().get_tracer(__name__)

--- a/usaspending_api/wsgi.py
+++ b/usaspending_api/wsgi.py
@@ -15,6 +15,7 @@ from usaspending_api.common.logging import configure_logging
 from opentelemetry import trace
 from opentelemetry.instrumentation.django import DjangoInstrumentor
 
+
 def request_hook(span, environ):
     print("\n")
     print("Request hook executed\n")
@@ -42,7 +43,7 @@ def request_hook(span, environ):
 
 
 def response_hook(span, environ, status, response_headers):
-    print("Response hook executed\n")
+    print("\nResponse hook executed\n")
     if span and span.is_recording():
         headers_to_capture = [
             "content-length",

--- a/usaspending_api/wsgi.py
+++ b/usaspending_api/wsgi.py
@@ -14,7 +14,8 @@ from django.core.wsgi import get_wsgi_application
 
 
 def request_hook(span, environ):
-    print("Request hook executed")
+    print("\n")
+    print("Request hook executed\n")
     if span and span.is_recording():
         headers_to_capture = [
             "CONTENT_LENGTH",
@@ -39,7 +40,7 @@ def request_hook(span, environ):
 
 
 def response_hook(span, environ, status, response_headers):
-    print("Response hook executed")
+    print("Response hook executed\n")
     if span and span.is_recording():
         headers_to_capture = [
             "content-length",


### PR DESCRIPTION
Description:
This ticket/PR was created to continue the Grafana Migration from DataDog. Specifically, we addressed the issue of subprocess tracing inside the bulk_downloader and further streamlined alot of the information we were capturing. Logs inside loki and traces inside tempo have also been aligned. The testing suite was also updated. This PR contains the initial changes implemented inside of DEV-11215. 

NOTE: This PR was supposed to go into the main feature Branch DEV-11215, however since we are no longer tracking that. The changes from this branch DEV-11409 will get directly merged into QAT and other environments. Therefore this PR is getting closed and another PR for that is up. The link to that can be found [here](https://github.com/fedspendingtransparency/usaspending-api/pull/4221). 

Technical details:
Since, Otel does not support filtering of traces and spans, there is some left over code that was being utilized with Datadog. That code has been left inside the tracing file in case of future uses but can be safely taken out if need be.

Additional Details:
Previously, we were able to perform some foundational work regarding the Grafana Migration from Datadog. Baseline functionality was implemented so UsaSpending API endpoints could be traced and relevant information such as traces could be ingested in Tempo and logging could be ingested in Loki. This goal was accomplished with [DEV-11215.](https://federal-spending-transparency.atlassian.net/browse/DEV-11215)

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
