### PR TITLE
[DEV-10988] Add def_codes to filter of award download api contract

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -163,10 +163,6 @@ This route sends a request to the backend to begin generating a zipfile of award
     Filter awards by keywords in the award's transactions.
 + `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
 
-### AwardAmount (object)
-+ `lower_bound` (optional, number)
-+ `upper_bound` (optional, number)
-
 ### Agency (object)
 + `name` (required, string)
 + `tier` (required, enum[string])
@@ -180,11 +176,14 @@ This route sends a request to the backend to begin generating a zipfile of award
 + `toptier_name` (optional, string)
     Provided when the `name` belongs to a subtier agency
 
+### AwardAmount (object)
++ `lower_bound` (optional, number)
++ `upper_bound` (optional, number)
 
-### TimePeriod (object)
-+ `start_date` (required, string)
-+ `end_date` (required, string)
-+ `date_type` (optional, enum[string])
+### DEFC (enum[string])
+List of Disaster Emergency Fund (DEF) Codes (DEFC) defined by legislation at the time of writing.
+A list of current DEFC can be found [here.](https://files.usaspending.gov/reference_data/def_codes.csv)
+
 
 ### Location (object)
 + `country`(required, string)
@@ -216,6 +215,11 @@ This route sends a request to the backend to begin generating a zipfile of award
 ### TASCodeObject (object)
 + `require`: [[`091`]] (optional, array[array[string]], fixed-type)
 + `exclude`: [[`091`, `091-0800`]] (optional, array[array[string]], fixed-type)
+
+### TimePeriod (object)
++ `start_date` (required, string)
++ `end_date` (required, string)
++ `date_type` (optional, enum[string])
 
 ### TreasuryAccountComponentsObject (object)
 + `ata` (optional, string, nullable)

--- a/usaspending_api/api_contracts/contracts/v2/download/awards.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/awards.md
@@ -133,14 +133,13 @@ This route sends a request to the backend to begin generating a zipfile of award
 ## Filter Objects
 
 ### Filters (object)
++ `agencies` (optional, array[Agency], fixed-type)
 + `award_amounts` (optional, array[AwardAmount], fixed-type)
 + `award_ids` (optional, array[string])
     Award IDs surrounded by double quotes (e.g. `"SPE30018FLJFN"`) will perform exact matches as opposed to the default, fuzzier full text matches.  Useful for Award IDs that contain spaces or other word delimiters.
 + `award_type_codes` (optional, array[string])
-+ `agencies` (optional, array[Agency], fixed-type)
 + `contract_pricing_type_codes` (optional, array[string])
-+ `transaction_keyword_search` (optional, string)
-    Filter awards by keywords in the award's transactions.
++ `def_codes` (optional, array[DEFC], fixed-type)
 + `extent_competed_type_codes` (optional, array[string])
 + `federal_account_ids` (optional, array[string])
 + `keywords` (optional, array[string])
@@ -154,12 +153,14 @@ This route sends a request to the backend to begin generating a zipfile of award
 + `psc_codes` (optional, enum[PSCCodeObject, array[string]])
     Supports new PSCCodeObject or legacy array of codes.
 + `recipient_locations` (optional, array[Location], fixed-type)
-+ `recipient_search_text` (optional, string)
 + `recipient_scope` (optional, string)
-+ `recipient_type_names` (optional, array[string])
++ `recipient_search_text` (optional, string)
 + `set_aside_type_codes` (optional, array[string])
-+ `time_period` (optional, array[TimePeriod], fixed-type)
++ `recipient_type_names` (optional, array[string])
 + `tas_codes` (optional, array[TASCodeObject], fixed-type)
++ `time_period` (optional, array[TimePeriod], fixed-type)
++ `transaction_keyword_search` (optional, string)
+    Filter awards by keywords in the award's transactions.
 + `treasury_account_components` (optional, array[TreasuryAccountComponentsObject], fixed-type)
 
 ### AwardAmount (object)


### PR DESCRIPTION
**Description:**
Adding `def_codes` property to the `Filters` object of the award download api contract.

**Technical details:**
I used the `DEFC` type.  The filter properties and filter objects seemed to be sorted in roughly alphabetical order, but there were some deviations from alpha ordering, so I put everything in alpha.  The only new lines are line 142 and lines 183-185.

**Requirements for PR merge:**

2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
8. [x] Jira Ticket [DEV-10988](https://federal-spending-transparency.atlassian.net/browse/DEV-10988):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
This is a text change, so the following requirements are not necessary:

1. [ ] Unit & integration tests updated
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created

```
