### PR TITLE
[DEV-11399] Add spending_level to spending_over_time response

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_over_time.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_over_time.md
@@ -55,6 +55,12 @@ This endpoint returns a list of aggregated award amounts grouped by time period 
                 + `fiscal_year`
                 + `quarter`
                 + `month`
+        + `spending_level` (required, enum[string])
+            Spending level value that was provided in the request.
+            + Members
+                + `transactions`
+                + `awards`
+                + `subawards`
         + `results` (array[TimeResult], fixed-type)
         + `messages` (optional, array[string])
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.

--- a/usaspending_api/search/tests/integration/test_spending_over_time_details.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time_details.py
@@ -693,6 +693,7 @@ def test_spending_over_time_fy_ordering_transactions(
     expected_response = {
         "group": group,
         "results": shared_results_transactions(),
+        "spending_level": "transactions",
         "messages": expected_messages,
     }
 
@@ -728,6 +729,7 @@ def test_spending_over_time_fy_ordering_awards(client, monkeypatch, elasticsearc
 
     expected_response = {
         "group": group,
+        "spending_level": "awards",
         "results": [
             {
                 "aggregated_amount": 100.00,
@@ -815,6 +817,7 @@ def test_spending_over_time_default_date_type(client, monkeypatch, elasticsearch
 
     expected_response = {
         "group": group,
+        "spending_level": "transactions",
         "results": shared_results_transactions(),
         "messages": expected_messages,
     }
@@ -849,6 +852,7 @@ def test_spending_over_time_month_ordering(client, monkeypatch, elasticsearch_tr
     }
     expected_response = {
         "group": group,
+        "spending_level": "transactions",
         "results": [
             {
                 "time_period": {"fiscal_year": "2011", "month": "1"},
@@ -1498,6 +1502,7 @@ def test_spending_over_time_funny_dates_ordering(client, monkeypatch, elasticsea
 
     expected_response = {
         "results": shared_results_2(),
+        "spending_level": "transactions",
         "group": "month",
         "messages": expected_messages,
     }
@@ -1576,6 +1581,7 @@ def test_spending_over_time_new_awards_only_filter(
             },
         ],
         "group": "month",
+        "spending_level": "transactions",
         "messages": expected_messages,
     }
 
@@ -1629,6 +1635,7 @@ def test_spending_over_time_new_awards_only_filter(
             },
         ],
         "group": "month",
+        "spending_level": "transactions",
         "messages": expected_messages,
     }
 
@@ -1665,6 +1672,7 @@ def test_spending_over_time_new_awards_only_filter(
     expected_response = {
         "results": shared_results_2(),
         "group": "month",
+        "spending_level": "transactions",
         "messages": expected_messages,
     }
 
@@ -1718,6 +1726,7 @@ def test_spending_over_time_new_awards_only_filter(
             },
         ],
         "group": "month",
+        "spending_level": "transactions",
         "messages": expected_messages,
     }
 
@@ -1788,6 +1797,7 @@ def test_spending_over_time_new_awards_only_filter(
             },
         ],
         "group": "month",
+        "spending_level": "transactions",
         "messages": expected_messages,
     }
 

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -471,6 +471,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             [
                 ("group", self.group),
                 ("results", results),
+                ("spending_level", self.spending_level),
                 (
                     "messages",
                     [


### PR DESCRIPTION
**Description:**
Add `spending_level` to the JSON response of the spending_over_time endpoint.

**Technical details:**

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11399](https://federal-spending-transparency.atlassian.net/browse/DEV-11399):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
4. Matview impact assessment completed
No matviews are affected by this change.
```
