### PR TITLE
[DEV-11832] Add funding_opportunity_* to Award endpoint response

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
+++ b/usaspending_api/api_contracts/contracts/v2/awards/award_id.md
@@ -7,15 +7,19 @@ This endpoint is used to power USAspending.gov's award profile pages. This data 
 
 ## GET
 
-This endpoint returns a list of data that is associated with the award profile page.
+This endpoint returns a list of data that is associated with the Award.
 
-+ Parameters
-    + `award_id`: `TEST` (required, string)
-        Accepts the v2 generated award hash or internal database id.
++ Request (application/json)
+    A request with a contract id; accepts the v2 generated award hash or internal database id.
+    + Schema
 
-+ Request A request with a contract id (application/json)
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "string"
+            }
+
     + Parameters
-        + `award_id`: `CONT_AWD_H907_9700_SPE2DX16D1500_9700`
+        + `award_id`: `CONT_AWD_H907_9700_SPE2DX16D1500_9700` (required, string)
 
 + Response 200 (application/json)
     + Attributes (ContractResponse)
@@ -282,9 +286,17 @@ This endpoint returns a list of data that is associated with the award profile p
                 ]
             }
 
-+ Request A request with a financial assistance id (application/json)
++ Request (application/json)
+    A request with a financial assistance id; accepts the v2 generated award hash or internal database id.
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "string"
+            }
+
     + Parameters
-        + `award_id`: `ASST_NON_12FA00PY54661041_12D2`
+        + `award_id`: `ASST_NON_12FA00PY54661041_12D2` (required, string)
 
 + Response 200 (application/json)
     + Attributes (FinancialAssistanceResponse)
@@ -457,12 +469,24 @@ This endpoint returns a list of data that is associated with the award profile p
                         "code": "L",
                         "amount": 1.0
                     }
-                ]
+                ],
+                "funding_opportunity": {
+                    "number": "NOT APPLICABLE",
+                    "goals": : "NOT APPLICABLE"
+                }
             }
 
-+ Request A request with an IDV id (application/json)
++ Request (application/json)
+    A request with an IDV id; accepts the v2 generated award hash or internal database id.
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "string"
+            }
+
     + Parameters
-        + `award_id`: `CONT_IDV_FA304715A0037_9700`
+        + `award_id`: `CONT_IDV_FA304715A0037_9700` (required, string)
 
 + Response 200 (application/json)
     + Attributes (IDVResponse)
@@ -860,6 +884,11 @@ This endpoint returns a list of data that is associated with the award profile p
 + `total_account_obligation` (required, number)
 + `account_obligations_by_defc` (required, array[DEFCAmount], fixed-type)
 + `account_outlays_by_defc` (required, array[DEFCAmount], fixed-type)
++ `funding_opportunty` (required, FundingOpportunity, fixed-type)
+
+## FundingOpportunity (object)
++ `number` (required, string, nullable)
++ `goals` (required, string, nullable)
 
 ## CFDAInfo (object)
 + `applicant_eligibility` (required, string, nullable)

--- a/usaspending_api/awards/tests/integration/test_awards_v2.py
+++ b/usaspending_api/awards/tests/integration/test_awards_v2.py
@@ -152,6 +152,8 @@ def awards_and_transactions(db):
         "parent_uei": "ABC",
         "parent_recipient_unique_id": "123",
         "business_categories": ["small_business"],
+        "funding_opportunity_goals": "SAMPLE FUNDING GOALS",
+        "funding_opportunity_number": "SAMPLE FUNDING NUMBER",
     }
     asst_trans_2 = {
         "is_fpds": False,
@@ -1506,6 +1508,10 @@ expected_response_asst = {
     "total_account_obligation": 0,
     "total_account_outlay": 0,
     "total_outlay": None,
+    "funding_opportunity": {
+        "number": "SAMPLE FUNDING NUMBER",
+        "goals": "SAMPLE FUNDING GOALS",
+    },
 }
 
 

--- a/usaspending_api/awards/v2/data_layer/orm.py
+++ b/usaspending_api/awards/v2/data_layer/orm.py
@@ -77,6 +77,10 @@ def construct_assistance_response(requested_award_dict: dict) -> OrderedDict:
     response["executive_details"] = create_officers_object(award)
     response["place_of_performance"] = create_place_of_performance_object(transaction)
     response["total_outlay"] = fetch_total_outlays(award["id"])
+    response["funding_opportunity"] = {
+        "number": transaction["_funding_opportunity_number"],
+        "goals": transaction["_funding_opportunity_goals"],
+    }
     return delete_keys_from_dict(response)
 
 

--- a/usaspending_api/awards/v2/data_layer/orm_mappers.py
+++ b/usaspending_api/awards/v2/data_layer/orm_mappers.py
@@ -88,6 +88,8 @@ FABS_ASSISTANCE_FIELDS = OrderedDict(
         ("cfda_number", "cfda_number"),
         ("cfda_title", "cfda_title"),
         ("modified_at", "_modified_at"),
+        ("funding_opportunity_goals", "_funding_opportunity_goals"),
+        ("funding_opportunity_number", "_funding_opportunity_number"),
         # "Recipient" fields below
         ("awardee_or_recipient_legal", "_recipient_name"),
         ("uei", "_recipient_uei"),


### PR DESCRIPTION
**Description:**
Add the `funding_opportunity_*` fields to the Assistance Award response.

**Technical details:**
To support displaying the Funding Opportunity on the Award Profile Page the `funding_opportunity_number` and `funding_opportunity_goals` have been added to the Assistance Award response. The Assistance Award response doesn't use the same pattern as the Contract Award response where it groups all transaction related info together so a decision was made to simply group the `funding_opportunity` details together. For any Award that doesn't contain these fields the object will still appear but the values will be NULL.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [N/A] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11832](https://federal-spending-transparency.atlassian.net/browse/DEV-11832):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
