### PR TITLE
[DEV-11876] Update PARK field names

### DIFF
--- a/usaspending_api/accounts/tests/integration/test_federal_account_v2.py
+++ b/usaspending_api/accounts/tests/integration/test_federal_account_v2.py
@@ -243,8 +243,8 @@ def fixture_data(db):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
     baker.make(
@@ -268,8 +268,8 @@ def fixture_data(db):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
     baker.make(

--- a/usaspending_api/agency/tests/integration/conftest.py
+++ b/usaspending_api/agency/tests/integration/conftest.py
@@ -128,8 +128,8 @@ def bureau_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",
@@ -159,8 +159,8 @@ def bureau_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",
@@ -190,8 +190,8 @@ def bureau_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",
@@ -425,8 +425,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -451,8 +451,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -477,8 +477,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -503,8 +503,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -529,8 +529,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -555,8 +555,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -581,8 +581,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -607,8 +607,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -633,8 +633,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -659,8 +659,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -685,8 +685,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -709,8 +709,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -733,8 +733,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -757,8 +757,8 @@ def agency_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
 
 
@@ -835,8 +835,8 @@ def tas_mulitple_pas_per_oc():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
     baker.make(
@@ -862,8 +862,8 @@ def tas_mulitple_pas_per_oc():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
 

--- a/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
+++ b/usaspending_api/agency/tests/integration/test_agency_budgetary_resources.py
@@ -168,8 +168,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -191,8 +191,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -214,8 +214,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -237,8 +237,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -260,8 +260,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -283,8 +283,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -306,8 +306,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -329,8 +329,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -352,8 +352,8 @@ def _build_dabs_reporting_data(fy_reported):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     for fy in range(2017, current_fiscal_year() + 1):
         baker.make("references.GTASSF133Balances", fiscal_year=fy, fiscal_period=12, total_budgetary_resources_cpe=fy)

--- a/usaspending_api/agency/tests/integration/test_agency_tas_program_activity.py
+++ b/usaspending_api/agency/tests/integration/test_agency_tas_program_activity.py
@@ -361,8 +361,8 @@ def tas_mulitple_oc_per_tas():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         fabpaoc,
@@ -387,8 +387,8 @@ def tas_mulitple_oc_per_tas():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         fabpaoc,
@@ -413,6 +413,6 @@ def tas_mulitple_oc_per_tas():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )

--- a/usaspending_api/agency/tests/integration/test_subcomponents.py
+++ b/usaspending_api/agency/tests/integration/test_subcomponents.py
@@ -122,8 +122,8 @@ def test_exclusion_bureau_codes(client):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "accounts.AppropriationAccountBalances",

--- a/usaspending_api/awards/migrations/0108_stage_renamed_park_columns_faba.py
+++ b/usaspending_api/awards/migrations/0108_stage_renamed_park_columns_faba.py
@@ -1,0 +1,28 @@
+# Manually created to support stage and swap of renamed columns
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("awards", "0107_alter_financialaccountsbyawards_pa_reporting_key_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='financialaccountsbyawards',
+            name='program_activity_reporting_key',
+            field=models.TextField(blank=True, help_text="A unique identifier for a Program Activity", null=True),
+        ),
+        migrations.AddField(
+            model_name='financialaccountsbyawards',
+            name='ussgl480110_rein_undel_ord_cpe',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=23, null=True),
+        ),
+        migrations.AddField(
+            model_name='financialaccountsbyawards',
+            name='ussgl490110_rein_deliv_ord_cpe',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=23, null=True),
+        ),
+    ]

--- a/usaspending_api/awards/migrations/0109_delete_old_park_columns_faba.py
+++ b/usaspending_api/awards/migrations/0109_delete_old_park_columns_faba.py
@@ -1,4 +1,5 @@
 # Manually created to support stage and swap of renamed columns
+from pathlib import Path
 
 from django.db import migrations
 
@@ -21,5 +22,10 @@ class Migration(migrations.Migration):
         migrations.RemoveField(
             model_name="financialaccountsbyawards",
             name="ussgl490110_reinstated_del_cpe",
+        ),
+        # Need to recreate view after columns were dropped
+        migrations.RunSQL(
+            sql=[f"{Path('usaspending_api/download/sql/vw_financial_accounts_by_awards_download.sql').read_text()}"],
+            reverse_sql=["DROP VIEW IF EXISTS vw_financial_accounts_by_awards_download;"],
         ),
     ]

--- a/usaspending_api/awards/migrations/0109_delete_old_park_columns_faba.py
+++ b/usaspending_api/awards/migrations/0109_delete_old_park_columns_faba.py
@@ -1,0 +1,25 @@
+# Manually created to support stage and swap of renamed columns
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("awards", "0108_stage_renamed_park_columns_faba"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="financialaccountsbyawards",
+            name="pa_reporting_key",
+        ),
+        migrations.RemoveField(
+            model_name="financialaccountsbyawards",
+            name="ussgl480110_reinstated_del_cpe",
+        ),
+        migrations.RemoveField(
+            model_name="financialaccountsbyawards",
+            name="ussgl490110_reinstated_del_cpe",
+        ),
+    ]

--- a/usaspending_api/awards/models/financial_accounts_by_awards.py
+++ b/usaspending_api/awards/models/financial_accounts_by_awards.py
@@ -18,7 +18,9 @@ class AbstractFinancialAccountsByAwards(DataSourceTrackedModel):
     fain = models.TextField(blank=True, null=True)
     uri = models.TextField(blank=True, null=True)
     prior_year_adjustment = models.TextField(blank=True, null=True)
-    pa_reporting_key = models.TextField(blank=True, null=True, help_text="A unique identifier for a Program Activity")
+    program_activity_reporting_key = models.TextField(
+        blank=True, null=True, help_text="A unique identifier for a Program Activity"
+    )
     disaster_emergency_fund = models.ForeignKey(
         "references.DisasterEmergencyFundCode",
         models.DO_NOTHING,
@@ -33,7 +35,7 @@ class AbstractFinancialAccountsByAwards(DataSourceTrackedModel):
     ussgl480100_undelivered_orders_obligations_unpaid_cpe = models.DecimalField(
         max_digits=23, decimal_places=2, blank=True, null=True
     )
-    ussgl480110_reinstated_del_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
+    ussgl480110_rein_undel_ord_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
     ussgl483100_undelivered_orders_oblig_transferred_unpaid_cpe = models.DecimalField(
         max_digits=23, decimal_places=2, blank=True, null=True
     )
@@ -46,7 +48,7 @@ class AbstractFinancialAccountsByAwards(DataSourceTrackedModel):
     ussgl490100_delivered_orders_obligations_unpaid_cpe = models.DecimalField(
         max_digits=23, decimal_places=2, blank=True, null=True
     )
-    ussgl490110_reinstated_del_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
+    ussgl490110_rein_deliv_ord_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
     ussgl493100_delivered_orders_oblig_transferred_unpaid_cpe = models.DecimalField(
         max_digits=23, decimal_places=2, blank=True, null=True
     )

--- a/usaspending_api/common/calculations/file_b.py
+++ b/usaspending_api/common/calculations/file_b.py
@@ -37,8 +37,8 @@ def _obligation_columns() -> Dict[str, Union[str, F]]:
             "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe",
         ],
         "pya_p": [
-            Coalesce("ussgl480110_reinstated_del_cpe", 0, output_field=DecimalField(max_digits=23, decimal_places=2)),
-            Coalesce("ussgl490110_reinstated_del_cpe", 0, output_field=DecimalField(max_digits=23, decimal_places=2)),
+            Coalesce("ussgl480110_rein_undel_ord_cpe", 0, output_field=DecimalField(max_digits=23, decimal_places=2)),
+            Coalesce("ussgl490110_rein_deliv_ord_cpe", 0, output_field=DecimalField(max_digits=23, decimal_places=2)),
         ],
         "pya_x": ["deobligations_recoveries_refund_pri_program_object_class_cpe"],
     }

--- a/usaspending_api/common/tests/integration/test_calculations_for_file_b.py
+++ b/usaspending_api/common/tests/integration/test_calculations_for_file_b.py
@@ -28,8 +28,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -50,8 +50,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=-100,
-        ussgl490110_reinstated_del_cpe=-100,
+        ussgl480110_rein_undel_ord_cpe=-100,
+        ussgl490110_rein_deliv_ord_cpe=-100,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -72,8 +72,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -94,8 +94,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -116,8 +116,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -138,8 +138,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -160,8 +160,8 @@ def non_zero_test_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
 
@@ -194,8 +194,8 @@ def obligation_and_outlay_data():
             ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=1000,
             ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=1000,
             ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=1000,
-            ussgl480110_reinstated_del_cpe=10000,
-            ussgl490110_reinstated_del_cpe=10000,
+            ussgl480110_rein_undel_ord_cpe=10000,
+            ussgl490110_rein_deliv_ord_cpe=10000,
         )
 
 

--- a/usaspending_api/database_scripts/job_archive/backfill_renamed_park_fields.py
+++ b/usaspending_api/database_scripts/job_archive/backfill_renamed_park_fields.py
@@ -1,0 +1,114 @@
+"""
+Jira Ticket Number: DEV-11876
+
+    Change Broker PARK columns in USAspending
+
+Expected CLI:
+
+    $ python3 usaspending_api/database_scripts/job_archive/backfill_renamed_park_fields.py
+
+Purpose:
+
+    Multiple fields were renamed in Broker and thus renamed in USAspending accordingly.
+    Performing a single RENAME operation will hold an AccessExclusiveLock on the DB and
+    potentially interfere with normal operations of the API and Downloads. To prevent any
+    outage this script iterates over all File B and C records to copy values from the old
+    columns to their renamed counterparts, taking a lock on the File B and C tables intermittently.
+
+"""
+
+import logging
+
+from os import environ
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import psycopg2
+
+# Import our USAspending Timer component.  This will not work if we ever add
+# any Django specific stuff to the timing_helpers.py file.
+exec(Path("usaspending_api/common/helpers/timing_helpers.py").read_text())
+
+logging.basicConfig(
+    level=logging.INFO, format="[%(asctime)s] [%(levelname)s] - %(message)s", datefmt="%Y-%m-%d %H:%M:%S %Z"
+)
+
+
+# Simplify instantiations of Timer to automatically use the correct logger.
+class Timer(Timer):  # noqa - this is imported indirectly and will fail flake8 check
+    def __init__(self, message=None):
+        super().__init__(message=message, success_logger=logging.info, failure_logger=logging.error)
+
+
+def id_ranges(min_id: int, max_id: int) -> Iterator[Tuple[int, int]]:
+    chunk_size = 500_000
+    for n in range(min_id, max_id + 1, chunk_size):
+        yield n, min(n + chunk_size, max_id)
+
+
+def get_min_max_ids(conn: psycopg2.extensions.connection, table_name: str, primary_key: str) -> Tuple[int, int]:
+    with Timer(f'collecting MIN and MAX values for "{table_name}"."{primary_key}"') as t:
+        with conn.cursor() as cursor:
+            sql = f"""
+                SELECT min({primary_key}), max({primary_key})
+                FROM   {table_name}
+                WHERE  pa_reporting_key IS NOT NULL
+                       OR ussgl480110_reinstated_del_cpe IS NOT NULL
+                       OR ussgl490110_reinstated_del_cpe IS NOT NULL
+            """
+            cursor.execute(sql)
+            min_id, max_id = cursor.fetchone()
+
+            # Using -1 to denote that no valid ID values were found
+            min_id = min_id or -1
+            max_id = max_id or -1
+
+    logging.info(f'Found MIN and MAX values ({min_id:,d} to {max_id:,d}) for "{table_name}"."{primary_key}" in {t}')
+    return min_id, max_id
+
+
+def run_update(
+    conn: psycopg2.extensions.connection, table_name: str, primary_key: str, min_id: int, max_id: int
+) -> None:
+    total_row_count = 0
+    estimated_id_count = max_id - min_id + 1
+    with Timer(f'updating PARK values for "{table_name}"."{primary_key}"') as t:
+        for chunk_min_id, chunk_max_id in id_ranges(min_id, max_id):
+            with conn.cursor() as cursor:
+                sql = f"""
+                    UPDATE {table_name}
+                    SET    program_activity_reporting_key = pa_reporting_key,
+                           ussgl480110_rein_undel_ord_cpe = ussgl480110_reinstated_del_cpe,
+                           ussgl490110_rein_deliv_ord_cpe = ussgl490110_reinstated_del_cpe
+                    WHERE  {primary_key} >= {chunk_min_id}
+                           AND {primary_key} <= {chunk_max_id}
+                """
+                cursor.execute(sql)
+            row_count = cursor.rowcount
+            total_row_count += row_count
+            ratio = (chunk_max_id - min_id + 1) / estimated_id_count
+            logging.info(
+                f'Updated {row_count:,d} rows with "{primary_key}" between {chunk_min_id:,d} and {chunk_max_id:,d}.'
+                f" Estimated time remaining: {t.estimated_remaining_runtime(ratio)}"
+            )
+
+    logging.info(f'Finished updating {total_row_count:,d} rows for "{table_name}"."{primary_key}" in {t}')
+
+
+if __name__ == "__main__":
+
+    tables_to_update = ["financial_accounts_by_program_activity_object_class", "financial_accounts_by_awards"]
+
+    # In psycopg2 v2.9 it was changed such that connections created as a context manager will utilize
+    # a transaction regardless of the "autocommit" setting. To avoid transactions we instead instantiate
+    # the connection and then make sure to close it.
+    connection = psycopg2.connect(dsn=environ["DATABASE_URL"])
+    connection.autocommit = True
+
+    try:
+        for temp_table_name in tables_to_update:
+            temp_primary_key = f"{temp_table_name}_id"
+            overall_min_id, overall_max_id = get_min_max_ids(connection, temp_table_name, temp_primary_key)
+            run_update(connection, temp_table_name, temp_primary_key, overall_min_id, overall_max_id)
+    finally:
+        connection.close()

--- a/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/disaster_account_data.py
@@ -359,8 +359,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -386,8 +386,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -413,8 +413,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -440,8 +440,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -467,8 +467,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -494,8 +494,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -521,8 +521,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -548,8 +548,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -575,8 +575,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -600,8 +600,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         fabpaoc,
@@ -625,8 +625,8 @@ def disaster_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
 
     a1 = baker.make(

--- a/usaspending_api/disaster/tests/fixtures/federal_account_data.py
+++ b/usaspending_api/disaster/tests/fixtures/federal_account_data.py
@@ -207,8 +207,8 @@ def generic_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
         disaster_emergency_fund=defc_m,
         treasury_account=tre_acct1,
     )
@@ -232,8 +232,8 @@ def generic_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
         disaster_emergency_fund=defc_l,
         treasury_account=tre_acct2,
     )
@@ -258,8 +258,8 @@ def generic_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
         treasury_account=tre_acct2,
     )
     baker.make(
@@ -283,8 +283,8 @@ def generic_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
         treasury_account=tre_acct2,
     )
     baker.make(
@@ -308,8 +308,8 @@ def generic_account_data():
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
         treasury_account=tre_acct3,
     )
     baker.make(

--- a/usaspending_api/disaster/tests/fixtures/object_class_data.py
+++ b/usaspending_api/disaster/tests/fixtures/object_class_data.py
@@ -117,8 +117,8 @@ def basic_fa_by_object_class_with_object_class(award_count_sub_schedule, award_c
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -142,8 +142,8 @@ def basic_fa_by_object_class_with_object_class(award_count_sub_schedule, award_c
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -167,8 +167,8 @@ def basic_fa_by_object_class_with_object_class(award_count_sub_schedule, award_c
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -192,8 +192,8 @@ def basic_fa_by_object_class_with_object_class(award_count_sub_schedule, award_c
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=13,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=9,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=14,
-        ussgl480110_reinstated_del_cpe=75,
-        ussgl490110_reinstated_del_cpe=63,
+        ussgl480110_rein_undel_ord_cpe=75,
+        ussgl490110_rein_deliv_ord_cpe=63,
     )
 
 

--- a/usaspending_api/etl/submission_loader_helpers/file_b.py
+++ b/usaspending_api/etl/submission_loader_helpers/file_b.py
@@ -49,7 +49,7 @@ def get_file_b(submission_attributes, db_cursor):
         from        published_object_class_program_activity
         where       submission_id = %s and length(object_class) = 4
         group by    account_num, program_activity_code, object_class, disaster_emergency_fund_code,
-                    upper(prior_year_adjustment), upper(pa_reporting_key)
+                    upper(prior_year_adjustment), upper(program_activity_reporting_key)
         having      count(*) > 1
     """
     db_cursor.execute(check_dupe_oc, [submission_id])
@@ -74,7 +74,7 @@ def get_file_b(submission_attributes, db_cursor):
             "disaster_emergency_fund_code",
         ],
         "left": ["object_class"],
-        "upper": ["prior_year_adjustment", "pa_reporting_key"],
+        "upper": ["prior_year_adjustment", "program_activity_reporting_key"],
         "numeric": [
             "deobligations_recov_by_pro_cpe",
             "gross_outlay_amount_by_pro_cpe",
@@ -90,7 +90,7 @@ def get_file_b(submission_attributes, db_cursor):
             "obligations_undelivered_or_fyb",
             "ussgl480100_undelivered_or_cpe",
             "ussgl480100_undelivered_or_fyb",
-            "ussgl480110_reinstated_del_cpe",
+            "ussgl480110_rein_undel_ord_cpe",
             "ussgl480200_undelivered_or_cpe",
             "ussgl480200_undelivered_or_fyb",
             "ussgl483100_undelivered_or_cpe",
@@ -101,7 +101,7 @@ def get_file_b(submission_attributes, db_cursor):
             "ussgl488200_upward_adjustm_cpe",
             "ussgl490100_delivered_orde_cpe",
             "ussgl490100_delivered_orde_fyb",
-            "ussgl490110_reinstated_del_cpe",
+            "ussgl490110_rein_deliv_ord_cpe",
             "ussgl490200_delivered_orde_cpe",
             "ussgl490800_authority_outl_cpe",
             "ussgl490800_authority_outl_fyb",

--- a/usaspending_api/financial_activities/migrations/0012_stage_renamed_park_columns_fabpaoc.py
+++ b/usaspending_api/financial_activities/migrations/0012_stage_renamed_park_columns_fabpaoc.py
@@ -1,0 +1,28 @@
+# Manually created to support stage and swap of renamed columns
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("financial_activities", "0011_alter_financialaccountsbyprogramactivityobjectclass_pa_reporting_key"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="financialaccountsbyprogramactivityobjectclass",
+            name='program_activity_reporting_key',
+            field=models.TextField(blank=True, help_text="A unique identifier for a Program Activity", null=True),
+        ),
+        migrations.AddField(
+            model_name="financialaccountsbyprogramactivityobjectclass",
+            name='ussgl480110_rein_undel_ord_cpe',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=23, null=True),
+        ),
+        migrations.AddField(
+            model_name="financialaccountsbyprogramactivityobjectclass",
+            name='ussgl490110_rein_deliv_ord_cpe',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=23, null=True),
+        ),
+    ]

--- a/usaspending_api/financial_activities/migrations/0013_delete_old_park_columns_fabpaoc.py
+++ b/usaspending_api/financial_activities/migrations/0013_delete_old_park_columns_fabpaoc.py
@@ -1,4 +1,5 @@
 # Manually created to support stage and swap of renamed columns
+from pathlib import Path
 
 from django.db import migrations
 
@@ -21,5 +22,10 @@ class Migration(migrations.Migration):
         migrations.RemoveField(
             model_name="financialaccountsbyprogramactivityobjectclass",
             name="ussgl490110_reinstated_del_cpe",
+        ),
+        # Need to recreate view after columns were dropped
+        migrations.RunSQL(
+            sql=[f"{Path('usaspending_api/download/sql/vw_financial_accounts_by_program_activity_object_class_download.sql').read_text()}"],
+            reverse_sql=["DROP VIEW IF EXISTS vw_financial_accounts_by_program_activity_object_class_download;"],
         ),
     ]

--- a/usaspending_api/financial_activities/migrations/0013_delete_old_park_columns_fabpaoc.py
+++ b/usaspending_api/financial_activities/migrations/0013_delete_old_park_columns_fabpaoc.py
@@ -1,0 +1,25 @@
+# Manually created to support stage and swap of renamed columns
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("financial_activities", "0012_stage_renamed_park_columns_fabpaoc"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="financialaccountsbyprogramactivityobjectclass",
+            name="pa_reporting_key",
+        ),
+        migrations.RemoveField(
+            model_name="financialaccountsbyprogramactivityobjectclass",
+            name="ussgl480110_reinstated_del_cpe",
+        ),
+        migrations.RemoveField(
+            model_name="financialaccountsbyprogramactivityobjectclass",
+            name="ussgl490110_reinstated_del_cpe",
+        ),
+    ]

--- a/usaspending_api/financial_activities/models.py
+++ b/usaspending_api/financial_activities/models.py
@@ -14,7 +14,9 @@ class AbstractFinancialAccountsByProgramActivityObjectClass(DataSourceTrackedMod
         "accounts.TreasuryAppropriationAccount", models.CASCADE, related_name="program_balances", null=True
     )
     prior_year_adjustment = models.TextField(blank=True, null=True)
-    pa_reporting_key = models.TextField(blank=True, null=True, help_text="A unique identifier for a Program Activity")
+    program_activity_reporting_key = models.TextField(
+        blank=True, null=True, help_text="A unique identifier for a Program Activity"
+    )
     disaster_emergency_fund = models.ForeignKey(
         "references.DisasterEmergencyFundCode",
         models.DO_NOTHING,
@@ -25,12 +27,12 @@ class AbstractFinancialAccountsByProgramActivityObjectClass(DataSourceTrackedMod
     )
     ussgl480100_undelivered_orders_obligations_unpaid_fyb = models.DecimalField(max_digits=23, decimal_places=2)
     ussgl480100_undelivered_orders_obligations_unpaid_cpe = models.DecimalField(max_digits=23, decimal_places=2)
-    ussgl480110_reinstated_del_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
+    ussgl480110_rein_undel_ord_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
     ussgl483100_undelivered_orders_oblig_transferred_unpaid_cpe = models.DecimalField(max_digits=23, decimal_places=2)
     ussgl488100_upward_adjust_pri_undeliv_order_oblig_unpaid_cpe = models.DecimalField(max_digits=23, decimal_places=2)
     ussgl490100_delivered_orders_obligations_unpaid_fyb = models.DecimalField(max_digits=23, decimal_places=2)
     ussgl490100_delivered_orders_obligations_unpaid_cpe = models.DecimalField(max_digits=23, decimal_places=2)
-    ussgl490110_reinstated_del_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
+    ussgl490110_rein_deliv_ord_cpe = models.DecimalField(max_digits=23, decimal_places=2, blank=True, null=True)
     ussgl493100_delivered_orders_oblig_transferred_unpaid_cpe = models.DecimalField(max_digits=23, decimal_places=2)
     ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe = models.DecimalField(max_digits=23, decimal_places=2)
     ussgl480200_undelivered_orders_oblig_prepaid_advanced_fyb = models.DecimalField(max_digits=23, decimal_places=2)

--- a/usaspending_api/references/tests/integration/test_financial_spending.py
+++ b/usaspending_api/references/tests/integration/test_financial_spending.py
@@ -49,8 +49,8 @@ def financial_spending_data(db):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
     # Object 2 (contains 2 fabpaoc s)
@@ -89,8 +89,8 @@ def financial_spending_data(db):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
     baker.make(
         "financial_activities.FinancialAccountsByProgramActivityObjectClass",
@@ -114,8 +114,8 @@ def financial_spending_data(db):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
     # 2018, not reported by 2017 api call
@@ -155,8 +155,8 @@ def financial_spending_data(db):
         ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe=0,
         ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe=0,
         ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe=0,
-        ussgl480110_reinstated_del_cpe=0,
-        ussgl490110_reinstated_del_cpe=0,
+        ussgl480110_rein_undel_ord_cpe=0,
+        ussgl490110_rein_deliv_ord_cpe=0,
     )
 
 

--- a/usaspending_api/reporting/management/sql/populate_reporting_agency_tas.sql
+++ b/usaspending_api/reporting/management/sql/populate_reporting_agency_tas.sql
@@ -35,8 +35,8 @@ FROM (
                     WHEN prior_year_adjustment = 'X' OR prior_year_adjustment IS NULL
                         THEN obligations_incurred_by_program_object_class_cpe
                             + deobligations_recoveries_refund_pri_program_object_class_cpe
-                            + COALESCE(ussgl480110_reinstated_del_cpe, 0)
-                            + COALESCE(ussgl490110_reinstated_del_cpe, 0)
+                            + COALESCE(ussgl480110_rein_undel_ord_cpe, 0)
+                            + COALESCE(ussgl490110_rein_deliv_ord_cpe, 0)
                     ELSE 0
                 END
             ) AS object_class_pa_obligated_amount

--- a/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_tas.py
+++ b/usaspending_api/reporting/tests/integration/test_populate_reporting_agency_tas.py
@@ -163,8 +163,8 @@ def setup_test_data(db):
             obligations_incurred_by_program_object_class_cpe=ocpa["ob_incur"],
             deobligations_recoveries_refund_pri_program_object_class_cpe=ocpa["deobligation"],
             prior_year_adjustment=ocpa["pya"],
-            ussgl480110_reinstated_del_cpe=ocpa["ussgl480110"],
-            ussgl490110_reinstated_del_cpe=ocpa["ussgl490110"],
+            ussgl480110_rein_undel_ord_cpe=ocpa["ussgl480110"],
+            ussgl490110_rein_deliv_ord_cpe=ocpa["ussgl490110"],
         )
 
 

--- a/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
+++ b/usaspending_api/spending_explorer/tests/integration/test_spending_explorer.py
@@ -90,8 +90,8 @@ GLOBAL_MOCK_DICT = [
         "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": 0,
         "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": 0,
         "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": 0,
-        "ussgl480110_reinstated_del_cpe": 0,
-        "ussgl490110_reinstated_del_cpe": 0,
+        "ussgl480110_rein_undel_ord_cpe": 0,
+        "ussgl490110_rein_deliv_ord_cpe": 0,
     },
     {
         "model": FinancialAccountsByProgramActivityObjectClass,
@@ -114,8 +114,8 @@ GLOBAL_MOCK_DICT = [
         "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": 0,
         "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": 0,
         "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": 0,
-        "ussgl480110_reinstated_del_cpe": 0,
-        "ussgl490110_reinstated_del_cpe": 0,
+        "ussgl480110_rein_undel_ord_cpe": 0,
+        "ussgl490110_rein_deliv_ord_cpe": 0,
     },
     {
         "model": FinancialAccountsByProgramActivityObjectClass,
@@ -139,8 +139,8 @@ GLOBAL_MOCK_DICT = [
         "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": 0,
         "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": 0,
         "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": 0,
-        "ussgl480110_reinstated_del_cpe": 0,
-        "ussgl490110_reinstated_del_cpe": 0,
+        "ussgl480110_rein_undel_ord_cpe": 0,
+        "ussgl490110_rein_deliv_ord_cpe": 0,
     },
 ]
 
@@ -1007,8 +1007,8 @@ def test_unreported_file_c(client):
             "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": 0,
             "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": 0,
             "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": 0,
-            "ussgl480110_reinstated_del_cpe": 0,
-            "ussgl490110_reinstated_del_cpe": 0,
+            "ussgl480110_rein_undel_ord_cpe": 0,
+            "ussgl490110_rein_deliv_ord_cpe": 0,
         },
         {
             "model": FinancialAccountsByProgramActivityObjectClass,
@@ -1031,8 +1031,8 @@ def test_unreported_file_c(client):
             "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": 0,
             "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": 0,
             "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": 0,
-            "ussgl480110_reinstated_del_cpe": 0,
-            "ussgl490110_reinstated_del_cpe": 0,
+            "ussgl480110_rein_undel_ord_cpe": 0,
+            "ussgl490110_rein_deliv_ord_cpe": 0,
         },
         {
             "model": FinancialAccountsByProgramActivityObjectClass,
@@ -1055,8 +1055,8 @@ def test_unreported_file_c(client):
             "ussgl497100_down_adj_pri_unpaid_deliv_orders_oblig_recov_cpe": 0,
             "ussgl498100_upward_adjust_pri_deliv_orders_oblig_unpaid_cpe": 0,
             "ussgl498200_upward_adjust_pri_deliv_orders_oblig_paid_cpe": 0,
-            "ussgl480110_reinstated_del_cpe": 0,
-            "ussgl490110_reinstated_del_cpe": 0,
+            "ussgl480110_rein_undel_ord_cpe": 0,
+            "ussgl490110_rein_deliv_ord_cpe": 0,
         },
         {
             "model": TransactionSearch,


### PR DESCRIPTION
**Description:**
Rename some USAspending fields to match new Broker names.

**Technical details:**
The changes are pretty straightforward, but the migrations are a little bit involved. The order of events is as follows:
- Run `stage` migrations for both File B and C tables to create the new columns
- Run `backfill` script to populate the new field while minimizing the time that a lock is held
- Run `delete` migrations for both File B and C tables to remove the old columns

Afterwards, an additional step to VACUUM the File B and C tables will be added to the deploy coordination to help reduce bloat.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11876](https://federal-spending-transparency.atlassian.net/browse/DEV-11876):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
