### PR TITLE
[DEV-11489] Convert program activities JSON to dictionary for Elasticsearch indexer

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/__init__.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/__init__.py
@@ -35,6 +35,7 @@ from usaspending_api.etl.elasticsearch_loader_helpers.index_config import (
 from usaspending_api.etl.elasticsearch_loader_helpers.load_data import load_data
 from usaspending_api.etl.elasticsearch_loader_helpers.transform_data import (
     transform_award_data,
+    transform_subaward_data,
     transform_transaction_data,
 )
 from usaspending_api.etl.elasticsearch_loader_helpers.utilities import (
@@ -70,4 +71,5 @@ __all__ = [
     "transform_award_data",
     "transform_recipient_profile_data",
     "transform_transaction_data",
+    "transform_subaward_data",
 ]

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -111,7 +111,7 @@ def transform_subaward_data(worker: TaskSpec, records: List[dict]) -> List[dict]
     agg_key_creations = {}
     drop_fields = []
 
-    return transform_data(worker, records, converters, agg_key_creations, drop_fields, settings.ES_ROUTING_FIELD)
+    return transform_data(worker, records, converters, agg_key_creations, drop_fields, None)
 
 
 def transform_data(

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -20,6 +20,7 @@ def transform_award_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
         "covid_spending_by_defc": convert_json_data_to_dict,
         "iija_spending_by_defc": convert_json_data_to_dict,
         "federal_accounts": convert_json_array_to_list_of_str,
+        "program_activities": convert_json_data_to_dict(),
     }
     agg_key_creations = {
         "awarding_subtier_agency_agg_key": lambda x: x["awarding_subtier_agency_code"],
@@ -63,6 +64,7 @@ def transform_award_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
 def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
     converters = {
         "federal_accounts": convert_json_array_to_list_of_str,
+        "program_activities": convert_json_data_to_dict(),
     }
     agg_key_creations = {
         "recipient_agg_key": funcs.transaction_recipient_agg_key,
@@ -99,6 +101,16 @@ def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[di
         "recipient_levels",
         "funding_toptier_agency_id",
     ]
+    return transform_data(worker, records, converters, agg_key_creations, drop_fields, settings.ES_ROUTING_FIELD)
+
+
+def transform_subaward_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
+    converters = {
+        "program_activities": convert_json_data_to_dict(),
+    }
+    agg_key_creations = {}
+    drop_fields = []
+
     return transform_data(worker, records, converters, agg_key_creations, drop_fields, settings.ES_ROUTING_FIELD)
 
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/transform_data.py
@@ -20,7 +20,7 @@ def transform_award_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
         "covid_spending_by_defc": convert_json_data_to_dict,
         "iija_spending_by_defc": convert_json_data_to_dict,
         "federal_accounts": convert_json_array_to_list_of_str,
-        "program_activities": convert_json_data_to_dict(),
+        "program_activities": convert_json_data_to_dict,
     }
     agg_key_creations = {
         "awarding_subtier_agency_agg_key": lambda x: x["awarding_subtier_agency_code"],
@@ -64,7 +64,7 @@ def transform_award_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
 def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
     converters = {
         "federal_accounts": convert_json_array_to_list_of_str,
-        "program_activities": convert_json_data_to_dict(),
+        "program_activities": convert_json_data_to_dict,
     }
     agg_key_creations = {
         "recipient_agg_key": funcs.transaction_recipient_agg_key,
@@ -106,7 +106,7 @@ def transform_transaction_data(worker: TaskSpec, records: List[dict]) -> List[di
 
 def transform_subaward_data(worker: TaskSpec, records: List[dict]) -> List[dict]:
     converters = {
-        "program_activities": convert_json_data_to_dict(),
+        "program_activities": convert_json_data_to_dict,
     }
     agg_key_creations = {}
     drop_fields = []

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -16,6 +16,7 @@ from usaspending_api.etl.elasticsearch_loader_helpers import (
     format_log,
     toggle_refresh_off,
     transform_award_data,
+    transform_subaward_data,
     transform_transaction_data,
 )
 from usaspending_api.etl.elasticsearch_loader_helpers.controller import (
@@ -306,7 +307,7 @@ def set_config(passthrough_values: list, arg_parse_options: dict) -> dict:
             "base_table": "subaward_search",
             "base_table_id": "broker_subaward_id",
             "create_award_type_aliases": False,
-            "data_transform_func": None,
+            "data_transform_func": transform_subaward_data,
             "data_type": "subaward",
             "execute_sql_func": execute_sql_statement,
             "extra_null_partition": False,


### PR DESCRIPTION
**Description:**
Convert the `program_activities` JSON data into a dictionary so it can be inserted into the Elasticsearch indices.

**Technical details:**

**Requirements for PR merge:**

3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11489](https://federal-spending-transparency.atlassian.net/browse/DEV-11489):
    - [x] Link to this Pull-Request
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
1. Unit & integration tests updated
No tests were affected by this change.

2. API documentation updated
No API endpoints were affected by this change.

4. Matview impact assessment completed
No matviews were affected by this change.

5. Frontend impact assessment completed
The frontend was not impacted by this change.

```
