### PR TITLE
Fix Makefile and remove project imports from python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,10 +237,7 @@ docker-compose-spark-submit: ## Run spark-submit from within local docker contai
 		-e DATABASE_URL=${DATABASE_URL} \
 	spark-submit \
 	--driver-memory "2g" \
-	--packages \
-		org.postgresql:postgresql:42.2.23, \
-		io.delta:delta-spark_2.12:3.1.0, \
-		org.apache.hadoop:hadoop-aws:3.3.4 \
+	--packages org.postgresql:postgresql:42.2.23,io.delta:delta-spark_2.12:3.1.0,org.apache.hadoop:hadoop-aws:3.3.4 \
 	${if ${python_script}, \
 		${python_script}, \
 		/project/manage.py ${django_command} \
@@ -251,10 +248,7 @@ localhost-spark-submit: ## Run spark-submit from with localhost as the driver an
 	SPARK_LOCAL_IP=127.0.0.1 \
 	spark-submit \
 	--driver-memory "2g" \
-	--packages \
-		org.postgresql:postgresql:42.2.23, \
-		io.delta:delta-spark_2.12:3.1.0, \
-		org.apache.hadoop:hadoop-aws:3.3.4 \
+	--packages org.postgresql:postgresql:42.2.23,io.delta:delta-spark_2.12:3.1.0,org.apache.hadoop:hadoop-aws:3.3.4 \
 	${if ${python_script}, \
 		${python_script}, \
 		manage.py ${django_command} \
@@ -263,10 +257,7 @@ localhost-spark-submit: ## Run spark-submit from with localhost as the driver an
 .PHONY: pyspark-shell
 pyspark-shell: ## Launch a local pyspark REPL shell with all of the packages and spark config pre-set
 	SPARK_LOCAL_IP=127.0.0.1 pyspark \
-	--packages \
-		org.postgresql:postgresql:42.2.23, \
-		io.delta:delta-spark_2.12:3.1.0, \
-		org.apache.hadoop:hadoop-aws:3.3.4 \
+	--packages org.postgresql:postgresql:42.2.23,io.delta:delta-spark_2.12:3.1.0,org.apache.hadoop:hadoop-aws:3.3.4 \
 	--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
 	--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
 	--conf spark.hadoop.fs.s3a.endpoint=localhost:${MINIO_PORT} \

--- a/usaspending_api/database_scripts/job_archive/backfill_renamed_park_fields.py
+++ b/usaspending_api/database_scripts/job_archive/backfill_renamed_park_fields.py
@@ -20,11 +20,14 @@ Purpose:
 import logging
 
 from os import environ
+from pathlib import Path
 from typing import Iterator, Tuple
 
 import psycopg2
 
-from usaspending_api.common.helpers.timing_helpers import Timer
+# Import our USAspending Timer component.  This will not work if we ever add
+# any Django specific stuff to the timing_helpers.py file.
+exec(Path("usaspending_api/common/helpers/timing_helpers.py").read_text())
 
 logging.basicConfig(
     level=logging.INFO, format="[%(asctime)s] [%(levelname)s] - %(message)s", datefmt="%Y-%m-%d %H:%M:%S %Z"
@@ -32,7 +35,7 @@ logging.basicConfig(
 
 
 # Simplify instantiations of Timer to automatically use the correct logger.
-class BackfillTimer(Timer):
+class Timer(Timer):  # noqa - this is imported indirectly and will fail flake8 check
     def __init__(self, message=None):
         super().__init__(message=message, success_logger=logging.info, failure_logger=logging.error)
 
@@ -44,7 +47,7 @@ def id_ranges(min_id: int, max_id: int) -> Iterator[Tuple[int, int]]:
 
 
 def get_min_max_ids(conn: psycopg2.extensions.connection, table_name: str, primary_key: str) -> Tuple[int, int]:
-    with BackfillTimer(f'collecting MIN and MAX values for "{table_name}"."{primary_key}"') as t:
+    with Timer(f'collecting MIN and MAX values for "{table_name}"."{primary_key}"') as t:
         with conn.cursor() as cursor:
             sql = f"""
                 SELECT min({primary_key}), max({primary_key})
@@ -69,7 +72,7 @@ def run_update(
 ) -> None:
     total_row_count = 0
     estimated_id_count = max_id - min_id + 1
-    with BackfillTimer(f'updating PARK values for "{table_name}"."{primary_key}"') as t:
+    with Timer(f'updating PARK values for "{table_name}"."{primary_key}"') as t:
         for chunk_min_id, chunk_max_id in id_ranges(min_id, max_id):
             with conn.cursor() as cursor:
                 sql = f"""


### PR DESCRIPTION
**Description:**
Fix some formatting of inputs in the Makefile and also removing project imports from Python script.

**Technical details:**
Some changes were made to the Makefile in an attempt to improve readability, however, this instead broke some aspects of the Makefile.

Additionally, the backfill Python script for PARK fields was updated to include an import from usaspending_api. With how the jobs are run in Jenkins this caused the job to fail even though it succeeds when run locally. The change is to move back to importing via a workaround.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
