### PR TITLE
[DEV-11489] Fix typo in Subaward ES view

### DIFF
--- a/usaspending_api/database_scripts/etl/subaward_es_view.sql
+++ b/usaspending_api/database_scripts/etl/subaward_es_view.sql
@@ -112,7 +112,7 @@ SELECT
     a.disaster_emergency_fund_codes,
     a.recipient_hash,
     a.parent_uei,
-    a.program_activities::JSON
+    s.program_activities::JSON
 FROM
 	rpt.subaward_search s
 LEFT JOIN rpt.award_search a


### PR DESCRIPTION
**Description:**
Fix typo in the Subaward view for Elasticsearch where the `program_activities` column was being pulled from the `award_search` table instead of the `subaward_search` table.