### PR TITLE
[DEV-11467] subawards elasticsearch spending over time

### DIFF
--- a/usaspending_api/common/etl/postgres/operations.py
+++ b/usaspending_api/common/etl/postgres/operations.py
@@ -1,4 +1,4 @@
-""" Functions to generate SQL for several higher level ETL operations. """
+"""Functions to generate SQL for several higher level ETL operations."""
 
 from psycopg2.sql import SQL, Identifier
 from typing import List

--- a/usaspending_api/common/long_to_terse.py
+++ b/usaspending_api/common/long_to_terse.py
@@ -1,7 +1,7 @@
 """
-    Mapping dictionaries
-        - used for converting terse_labels from broker to semi-terse labels used in the datastore)
-   TERSE_TO_LONG was removed.  IF NEEDED, change LONG_TO_TERSE to a bidict or invert the dict. """
+ Mapping dictionaries
+     - used for converting terse_labels from broker to semi-terse labels used in the datastore)
+TERSE_TO_LONG was removed.  IF NEEDED, change LONG_TO_TERSE to a bidict or invert the dict."""
 
 LONG_TO_TERSE_LABELS = {
     "allocation_transfer_agency_id": "allocation_transfer_agency_id",

--- a/usaspending_api/etl/es_subaward_template.json
+++ b/usaspending_api/etl/es_subaward_template.json
@@ -329,7 +329,12 @@
         }
       },
       "subaward_type": {
-        "type": "text"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
       },
       "subaward_report_year": {
         "type": "integer"

--- a/usaspending_api/etl/tests/integration/test_model.py
+++ b/usaspending_api/etl/tests/integration/test_model.py
@@ -1,4 +1,4 @@
-""" Creating a Test Model and table spec to be agnostic to the actual data """
+"""Creating a Test Model and table spec to be agnostic to the actual data"""
 
 from django.db import models
 

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -531,9 +531,11 @@ def awards_and_transactions(db):
         subaward_amount=12345,
         sub_place_of_perform_country_co="CAN",
         sub_legal_entity_country_code="USA",
-        sub_action_date="2020-01-07",
-        sub_fiscal_year=2020,
+        sub_action_date="2019-01-07",
+        action_date="2019-01-07",
+        sub_fiscal_year=2019,
         subaward_type="sub-contract",
+        program_activities=[{"name": "PROGRAM_1", "code": "0001"}],
     )
     baker.make(
         "search.SubawardSearch",
@@ -542,9 +544,11 @@ def awards_and_transactions(db):
         subaward_amount=678910,
         sub_place_of_perform_country_co="USA",
         sub_legal_entity_country_code="JPN",
-        sub_action_date="2020-01-07",
-        sub_fiscal_year=2020,
+        sub_action_date="2021-01-07",
+        action_date="2021-01-07",
+        sub_fiscal_year=2021,
         subaward_type="sub-contract",
+        program_activities=[{"name": "PROGRAM_2", "code": "0002"}],
     )
     baker.make(
         "search.SubawardSearch",
@@ -554,9 +558,11 @@ def awards_and_transactions(db):
         sub_place_of_perform_country_co="USA",
         sub_legal_entity_country_code="USA",
         sub_action_date="2020-01-07",
+        action_date="2020-01-07",
         prime_award_group="grant",
         sub_fiscal_year=2020,
         subaward_type="sub-grant",
+        program_activities=[{"name": "PROGRAM_ACTIVITY_123", "code": "0003"}],
     )
 
     # References State Data

--- a/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
+++ b/usaspending_api/search/tests/integration/spending_by_category/spending_test_fixtures.py
@@ -544,9 +544,9 @@ def awards_and_transactions(db):
         subaward_amount=678910,
         sub_place_of_perform_country_co="USA",
         sub_legal_entity_country_code="JPN",
-        sub_action_date="2021-01-07",
-        action_date="2021-01-07",
-        sub_fiscal_year=2021,
+        sub_action_date="2020-01-07",
+        action_date="2020-01-07",
+        sub_fiscal_year=2020,
         subaward_type="sub-contract",
         program_activities=[{"name": "PROGRAM_2", "code": "0002"}],
     )

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -335,7 +335,10 @@ def test_spending_over_time_failure(client, monkeypatch, elasticsearch_transacti
 
 
 @pytest.mark.django_db
-def test_spending_over_time_subawards_success(client):
+def test_spending_over_time_subawards_success(client, monkeypatch, elasticsearch_subaward_index):
+
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
     resp = client.post(
         "/api/v2/search/spending_over_time",
         content_type="application/json",
@@ -345,9 +348,11 @@ def test_spending_over_time_subawards_success(client):
 
 
 @pytest.mark.django_db
-def test_spending_over_time_subawards_failure(client):
+def test_spending_over_time_subawards_failure(client, monkeypatch, elasticsearch_subaward_index):
     """Verify error on bad autocomplete request for budget function."""
 
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+    
     resp = client.post(
         "/api/v2/search/spending_over_time",
         content_type="application/json",

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -4975,3 +4975,76 @@ def test_spending_over_time_awards_spending_level(client, monkeypatch, elasticse
     ]
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json().get("results") == expected_result, "Time Period filter does not match expected result"
+
+
+@pytest.mark.django_db
+def test_spending_over_time_subawards_spending_level(client, monkeypatch, elasticsearch_subaward_index):
+    baker.make(
+        "search.SubawardSearch",
+        broker_subaward_id=3,
+        award_id=1,
+        subaward_amount=0,
+        sub_place_of_perform_country_co="USA",
+        sub_legal_entity_country_code="USA",
+        sub_action_date="2020-01-07",
+        action_date="2020-01-07",
+        prime_award_group="grant",
+        sub_fiscal_year=2020,
+        subaward_type="sub-grant",
+        program_activities=[{"name": "PROGRAM_ACTIVITY_1", "code": "0001"}],
+    )
+
+    baker.make(
+        "search.SubawardSearch",
+        broker_subaward_id=3,
+        award_id=1,
+        subaward_amount=300,
+        sub_place_of_perform_country_co="USA",
+        sub_legal_entity_country_code="USA",
+        sub_action_date="2021-01-07",
+        action_date="2021-01-07",
+        prime_award_group="grant",
+        sub_fiscal_year=2021,
+        subaward_type="sub-grant",
+        program_activities=[{"name": "PROGRAM_ACTIVITY_123", "code": "0003"}],
+    )
+
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
+    resp = client.post(
+        "/api/v2/search/spending_over_time",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "group": "fiscal_year",
+                "filters": {
+                    "time_period": [
+                        {"start_date": "2020-01-01", "end_date": "2021-01-08"},
+                    ]
+                },
+                "spending_level": "subawards",
+            }
+        ),
+    )
+    expected_result = [
+        {
+            "aggregated_amount": 0,
+            "total_outlays": None,
+            "time_period": {"fiscal_year": "2020"},
+            "Contract_Obligations": 0,
+            "Contract_Outlays": None,
+            "Grant_Obligations": 0,
+            "Grant_Outlays": None,
+        },
+        {
+            "aggregated_amount": 300,
+            "total_outlays": None,
+            "time_period": {"fiscal_year": "2021"},
+            "Contract_Obligations": 0,
+            "Contract_Outlays": None,
+            "Grant_Obligations": 300,
+            "Grant_Outlays": None,
+        },
+    ]
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json().get("results") == expected_result, "Time Period filter does not match expected result"

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -352,7 +352,7 @@ def test_spending_over_time_subawards_failure(client, monkeypatch, elasticsearch
     """Verify error on bad autocomplete request for budget function."""
 
     setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
-    
+
     resp = client.post(
         "/api/v2/search/spending_over_time",
         content_type="application/json",

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -295,6 +295,7 @@ def spending_over_time_test_data():
                 prime_award_type="07",
                 subaward_number=i,
                 subaward_amount=(i + 1) * 2,
+                action_date="2011-05-05",
             )
 
 
@@ -4750,9 +4751,10 @@ def test_transactions_defc_date_filter(client, monkeypatch, elasticsearch_transa
 
 @pytest.mark.django_db
 def test_spending_over_time_program_activity_subawards(
-    client, monkeypatch, elasticsearch_award_index, awards_and_transactions
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, awards_and_transactions
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
     resp = client.post(
         "/api/v2/search/spending_over_time",
         content_type="application/json",

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -109,22 +109,20 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         if validated_data.get("filters", None) is None:
             raise InvalidParameterException("Missing request parameters: filters")
 
-        return validated_data, models
-    
+        return validated_data, models   
     def subawards_group_by_time_period_agg(self) -> any:
         if self.group == "fiscal_year":
-                return A("terms", field="sub_fiscal_year")
+            return A("terms", field="sub_fiscal_year")
         else:
             return A(
                 "date_histogram",
                 field="sub_action_date",
                 interval="year" if (self.group == "calendar_year") else self.group,
                 format="yyyy-MM-dd",
-            )
-        
+            )        
     def awards_group_by_time_period_agg(self) -> any:
         if self.group == "fiscal_year":
-                return A("terms", field="fiscal_year")
+            return A("terms", field="fiscal_year")
         else:
             return A(
                 "date_histogram",
@@ -267,7 +265,9 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         }
 
         # Outlays are only supported on Awards
-        outlay_dictionary = {v: 0 if self.spending_level == "awards" else None for v in outlay_map.values()}
+        outlay_dictionary = {v: None for v in outlay_map.values()}
+        if self.spending_level == "awards":
+            outlay_dictionary = {v: 0 for v in outlay_map.values()}
 
         # Populate the category dictionary based on the award breakdown for a given bucket.
         for category in categories_breakdown:
@@ -279,7 +279,6 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
             if self.spending_level == "awards" and key in outlay_map:
                 outlay_dictionary[outlay_map[key]] += category.get("sum_as_dollars_outlay", {"value": 0})["value"]
-
         response_object = {
             "aggregated_amount": sum(obligation_dictionary.values()),
             "time_period": time_period,
@@ -440,7 +439,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         response = search.handle_execute()
         overall_results = self.build_elasticsearch_result_awards_subawards(response.aggs, time_periods)
 
-         # if there is no data for that fiscal year, set overall_results for that
+        # if there is no data for that fiscal year, set overall_results for that
         min_date, max_date = min_and_max_from_date_ranges(time_periods)
         date_range = generate_date_range(min_date, max_date, self.group)
         if date_range.count != overall_results.count:

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -378,26 +378,6 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return results
 
-    def build_elasticsearch_result_subawards(self, agg_response: AggResponse, time_periods: list) -> list:
-
-        results = []
-
-        db_results, order_by_cols = self.database_data_layer_for_subawards()
-        results = bolster_missing_time_periods(
-            filter_time_periods=time_periods,
-            queryset=db_results,
-            date_range_type=order_by_cols[-1],
-            columns={
-                "obligation_amount": "obligation_amount",
-                "total_outlays": "total_outlays",
-                "subaward_type": "subaward_type",
-            },
-        )
-
-        results = clean_subaward_spending_over_time_results(results, order_by_cols[-1])
-
-        return results
-
     def query_elasticsearch_for_transactions(self, time_periods: list) -> list:
         """Get spending over time amounts based on Transactions"""
 
@@ -493,7 +473,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             date_range = generate_date_range(min_date, max_date, self.group)
             if date_range.count != results.count:
                 for year in date_range:
-                    if not (any(result["time_period"] == {"fiscal_year":  str(year["fiscal_year"])} for result in results)):
+                    if not (any(result["time_period"] == {"fiscal_year": str(year["fiscal_year"])} for result in results)):
                         results.append({
                             "aggregated_amount": 0,
                             "total_outlays": None,

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -272,7 +272,9 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         }
 
         # Outlays are only supported on Awards
-        outlay_dictionary = {v: 0 if self.spending_level == SpendingLevel.AWARD.value else None for v in outlay_map.values()}
+        outlay_dictionary = {
+            v: 0 if self.spending_level == SpendingLevel.AWARD.value else None for v in outlay_map.values()
+        }
 
         # Populate the category dictionary based on the award breakdown for a given bucket.
         for category in categories_breakdown:
@@ -474,10 +476,10 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         self.original_filters = request.data.get("filters")
         json_request, models = self.validate_request_data(request.data)
         self.group = GROUPING_LOOKUP[json_request["group"]]
-        self.subawards = (
-            json_request["subawards"] or json_request.get("spending_level") == SpendingLevel.SUBAWARD.value
+        self.subawards = json_request["subawards"] or json_request.get("spending_level") == SpendingLevel.SUBAWARD.value
+        self.spending_level = (
+            SpendingLevel.SUBAWARD.value if self.subawards else json_request.get("spending_level").lower()
         )
-        self.spending_level = SpendingLevel.SUBAWARD.value if self.subawards else json_request.get("spending_level").lower()
         self.filters = json_request["filters"]
 
         # time_period is optional so we're setting a default window from API_SEARCH_MIN_DATE to end of the current FY.

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -6,17 +6,15 @@ from datetime import datetime, timezone
 from typing import Tuple
 
 from django.conf import settings
-from django.db.models import F, IntegerField, Sum, Value
 from elasticsearch_dsl import A, Search
 from elasticsearch_dsl.response import AggResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from usaspending_api.awards.v2.filters.sub_award import subaward_filter
 from usaspending_api.common.api_versioning import API_TRANSFORM_FUNCTIONS, api_transformations
 from usaspending_api.common.cache_decorator import cache_response
-from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch, TransactionSearch
+from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch, SubawardSearch, TransactionSearch
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.fiscal_year_helpers import (
     bolster_missing_time_periods,
@@ -29,14 +27,17 @@ from usaspending_api.common.helpers.generic_helper import (
     get_generic_filters_message,
     min_and_max_from_date_ranges,
 )
-from usaspending_api.common.helpers.orm_helpers import FiscalMonth, FiscalQuarter
 from usaspending_api.common.query_with_filters import QueryWithFilters
 from usaspending_api.common.validator.award_filter import AWARD_FILTER_W_FILTERS
 from usaspending_api.common.validator.pagination import PAGINATION
 from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.search.filters.elasticsearch.filter import _QueryType
 from usaspending_api.search.filters.time_period.decorators import NewAwardsOnlyTimePeriod
-from usaspending_api.search.filters.time_period.query_types import AwardSearchTimePeriod, TransactionSearchTimePeriod
+from usaspending_api.search.filters.time_period.query_types import (
+    AwardSearchTimePeriod,
+    SubawardSearchTimePeriod,
+    TransactionSearchTimePeriod,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,38 +111,6 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return validated_data, models
 
-    def database_data_layer_for_subawards(self) -> tuple:
-        queryset = subaward_filter(self.filters)
-        obligation_column = "subaward_amount"
-
-        # Note: SubawardSearch already has an "fy" field that corresponds to the prime award's fiscal year.
-        #       This, however, needs "fy" to be the fiscal year of the sub_action_date (i.e. "sub_fiscal_year").
-        #       And so, Django gets confused simply aliasing it to "fy" as "fy" is already a field in the model.
-        #       To get around that, we're doing this little dance of annotate() and values().
-        queryset = queryset.annotate(prime_fy=F("fy"))
-
-        month_quarter_cols = []
-        if self.group == "month":
-            queryset = queryset.annotate(month=FiscalMonth("sub_action_date"))
-            month_quarter_cols.append("month")
-        elif self.group == "quarter":
-            queryset = queryset.annotate(quarter=FiscalQuarter("sub_action_date"))
-            month_quarter_cols.append("quarter")
-
-        first_values = ["sub_fiscal_year"] + month_quarter_cols
-        second_values = ["obligation_amount", "total_outlays", "subaward_type"] + month_quarter_cols
-        second_values_dict = {"fy": F("sub_fiscal_year")}
-        order_by_cols = ["fy"] + month_quarter_cols
-        queryset = (
-            queryset.values(*first_values)
-            .annotate(obligation_amount=Sum(obligation_column))
-            .annotate(total_outlays=Value(None, output_field=IntegerField()))
-            .values(*second_values, **second_values_dict)
-            .order_by(*order_by_cols)
-        )
-
-        return queryset, order_by_cols
-
     def apply_elasticsearch_aggregations(self, search: Search) -> None:
         """
         Takes in an instance of the elasticsearch-dsl.Search object and applies the necessary
@@ -153,6 +122,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         if isinstance(search, AwardSearch):
             category_field = "category.keyword"
+            obligation_field = "generated_pragmatic_obligation"
 
             if self.group == "fiscal_year":
                 group_by_time_period_agg = A("terms", field="fiscal_year")
@@ -165,12 +135,28 @@ class SpendingOverTimeVisualizationViewSet(APIView):
                 )
         elif isinstance(search, TransactionSearch):
             category_field = "award_category"
+            obligation_field = "generated_pragmatic_obligation"
+
             group_by_time_period_agg = A(
                 "date_histogram",
                 field="action_date" if self.group == "calendar_year" else "fiscal_action_date",
                 interval="year" if (self.group == "fiscal_year" or self.group == "calendar_year") else self.group,
                 format="yyyy-MM-dd",
             )
+
+        elif isinstance(search, SubawardSearch):
+            category_field = "subaward_type.keyword"
+            obligation_field = "subaward_amount"
+
+            if self.group == "fiscal_year":
+                group_by_time_period_agg = A("terms", field="sub_fiscal_year")
+            else:
+                group_by_time_period_agg = A(
+                    "date_histogram",
+                    field="sub_action_date",
+                    interval="year" if (self.group == "calendar_year") else self.group,
+                    format="yyyy-MM-dd",
+                )
 
         """
         The individual aggregations that are needed; with two different sum aggregations to handle issues with
@@ -183,9 +169,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             script="params.sum_as_cents_outlay / 100",
         )
 
-        sum_as_cents_agg_obligation = A(
-            "sum", field="generated_pragmatic_obligation", script={"source": "_value * 100"}
-        )
+        sum_as_cents_agg_obligation = A("sum", field=obligation_field, script={"source": "_value * 100"})
         sum_as_dollars_agg_obligation = A(
             "bucket_script",
             buckets_path={"sum_as_cents_obligation": "sum_as_cents_obligation"},
@@ -221,7 +205,9 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         """
         time_period = {}
 
-        if self.group == "fiscal_year" and self.spending_level == "awards":
+        if self.group == "fiscal_year" and (
+            self.spending_level == "awards" or (self.spending_level == "subawards" or self.subawards == True)
+        ):
             key_as_date = datetime.strptime(str(bucket["key"]), "%Y")
         else:
             key_as_date = datetime.strptime(bucket["key_as_string"], "%Y-%m-%d")
@@ -237,14 +223,33 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         categories_breakdown = bucket["group_by_category"]["buckets"]
 
         # Initialize a dictionary to hold the query results for each obligation type.
-        obligation_dictionary = {
-            "Contract_Obligations": 0,
-            "Direct_Obligations": 0,
-            "Grant_Obligations": 0,
-            "Idv_Obligations": 0,
-            "Loan_Obligations": 0,
-            "Other_Obligations": 0,
-        }
+        if self.spending_level == "subawards" or self.subawards:
+            obligation_dictionary = {
+                "Contract_Obligations": 0,
+                "Grant_Obligations": 0,
+            }
+            outlay_map = {
+                "contract": "Contract_Outlays",
+                "grant": "Grant_Outlays",
+            }
+        else:
+            obligation_dictionary = {
+                "Contract_Obligations": 0,
+                "Direct_Obligations": 0,
+                "Grant_Obligations": 0,
+                "Idv_Obligations": 0,
+                "Loan_Obligations": 0,
+                "Other_Obligations": 0,
+            }
+            outlay_map = {
+                "contract": "Contract_Outlays",
+                "direct payment": "Direct_Outlays",
+                "grant": "Grant_Outlays",
+                "idv": "Idv_Outlays",
+                "loans": "Loan_Outlays",
+                "other": "Other_Outlays",
+                "insurance": "Other_Outlays",
+            }
 
         # Mapping of category keys to their corresponding obligation types.
         obligation_map = {
@@ -255,16 +260,8 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             "loans": "Loan_Obligations",
             "other": "Other_Obligations",
             "insurance": "Other_Obligations",
-        }
-
-        outlay_map = {
-            "contract": "Contract_Outlays",
-            "direct payment": "Direct_Outlays",
-            "grant": "Grant_Outlays",
-            "idv": "Idv_Outlays",
-            "loans": "Loan_Outlays",
-            "other": "Other_Outlays",
-            "insurance": "Other_Outlays",
+            "sub-contract": "Contract_Obligations",
+            "sub-grant": "Grant_Obligations",
         }
 
         # Outlays are only supported on Awards
@@ -354,7 +351,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return results
 
-    def build_elasticsearch_result_awards(self, agg_response: AggResponse, time_periods: list) -> list:
+    def build_elasticsearch_result_awards_subawards(self, agg_response: AggResponse, time_periods: list) -> list:
         """
         In this function we are just taking the elasticsearch aggregate response and looping through the
         buckets to create a results object for each time interval.
@@ -381,6 +378,26 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return results
 
+    def build_elasticsearch_result_subawards(self, agg_response: AggResponse, time_periods: list) -> list:
+
+        results = []
+
+        db_results, order_by_cols = self.database_data_layer_for_subawards()
+        results = bolster_missing_time_periods(
+            filter_time_periods=time_periods,
+            queryset=db_results,
+            date_range_type=order_by_cols[-1],
+            columns={
+                "obligation_amount": "obligation_amount",
+                "total_outlays": "total_outlays",
+                "subaward_type": "subaward_type",
+            },
+        )
+
+        results = clean_subaward_spending_over_time_results(results, order_by_cols[-1])
+
+        return results
+
     def query_elasticsearch_for_transactions(self, time_periods: list) -> list:
         """Get spending over time amounts based on Transactions"""
 
@@ -388,17 +405,19 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         time_period_obj = TransactionSearchTimePeriod(
             default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
         )
+
         new_awards_only_decorator = NewAwardsOnlyTimePeriod(
             time_period_obj=time_period_obj, query_type=_QueryType.TRANSACTIONS
         )
+
         filter_options["time_period_obj"] = new_awards_only_decorator
 
         filter_query = QueryWithFilters.generate_transactions_elasticsearch_query(self.filters, **filter_options)
+
         search = TransactionSearch().filter(filter_query)
         self.apply_elasticsearch_aggregations(search)
         response = search.handle_execute()
         overall_results = self.build_elasticsearch_result_transactions(response.aggs, time_periods)
-
         return overall_results
 
     def query_elasticsearch_for_awards(self, time_periods: list) -> list:
@@ -417,7 +436,27 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         search = AwardSearch().filter(filter_query)
         self.apply_elasticsearch_aggregations(search)
         response = search.handle_execute()
-        overall_results = self.build_elasticsearch_result_awards(response.aggs, time_periods)
+        overall_results = self.build_elasticsearch_result_awards_subawards(response.aggs, time_periods)
+
+        return overall_results
+
+    def query_elasticsearch_for_subawards(self, time_periods: list) -> list:
+        """Get spending over time amounts based on Subawards"""
+
+        filter_options = {}
+        time_period_obj = SubawardSearchTimePeriod(
+            default_end_date=settings.API_MAX_DATE, default_start_date=settings.API_SEARCH_MIN_DATE
+        )
+        new_awards_only_decorator = NewAwardsOnlyTimePeriod(
+            time_period_obj=time_period_obj, query_type=_QueryType.SUBAWARDS
+        )
+        filter_options["time_period_obj"] = new_awards_only_decorator
+
+        filter_query = QueryWithFilters.generate_subawards_elasticsearch_query(self.filters, **filter_options)
+        search = SubawardSearch().filter(filter_query)
+        self.apply_elasticsearch_aggregations(search)
+        response = search.handle_execute()
+        overall_results = self.build_elasticsearch_result_awards_subawards(response.aggs, time_periods)
 
         return overall_results
 
@@ -447,21 +486,8 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         # if time periods have been passed in use those, otherwise use the one calculated above
         time_periods = self.filters.get("time_period", [default_time_period])
-
-        if self.subawards:
-            db_results, order_by_cols = self.database_data_layer_for_subawards()
-            results = bolster_missing_time_periods(
-                filter_time_periods=time_periods,
-                queryset=db_results,
-                date_range_type=order_by_cols[-1],
-                columns={
-                    "obligation_amount": "obligation_amount",
-                    "total_outlays": "total_outlays",
-                    "subaward_type": "subaward_type",
-                },
-            )
-            results = clean_subaward_spending_over_time_results(results, order_by_cols[-1])
-
+        if self.spending_level == "subawards" or self.subawards:
+            results = self.query_elasticsearch_for_subawards(time_periods)
         elif self.spending_level == "transactions":
             results = self.query_elasticsearch_for_transactions(time_periods)
         elif self.spending_level == "awards":

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -4,6 +4,7 @@ from calendar import monthrange
 from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Tuple
+from dataclasses import dataclass
 
 from django.conf import settings
 from elasticsearch_dsl import A, Search
@@ -52,6 +53,11 @@ GROUPING_LOOKUP = {
     "month": "month",
     "m": "month",
 }
+
+
+@dataclass
+class TimePeriodMetadata:
+    data: dict[str, str]
 
 
 @api_transformations(api_version=API_VERSION, function_list=API_TRANSFORM_FUNCTIONS)
@@ -296,7 +302,9 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return response_object
 
-    def build_elasticsearch_result_transactions(self, agg_response: AggResponse, time_periods: list) -> list:
+    def build_elasticsearch_result_transactions(
+        self, agg_response: AggResponse, time_periods: TimePeriodMetadata
+    ) -> list:
         """
         In this function we are just taking the elasticsearch aggregate response and looping through the
         buckets to create a results object for each time interval.
@@ -359,7 +367,9 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return results
 
-    def build_elasticsearch_result_awards_subawards(self, agg_response: AggResponse, time_periods: list) -> list:
+    def build_elasticsearch_result_awards_subawards(
+        self, agg_response: AggResponse, time_periods: TimePeriodMetadata
+    ) -> list:
         """
         In this function we are just taking the elasticsearch aggregate response and looping through the
         buckets to create a results object for each time interval.
@@ -386,7 +396,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return results
 
-    def query_elasticsearch_for_transactions(self, time_periods: list) -> list:
+    def query_elasticsearch_for_transactions(self, time_periods: TimePeriodMetadata) -> list:
         """Get spending over time amounts based on Transactions"""
 
         filter_options = {}
@@ -408,7 +418,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         overall_results = self.build_elasticsearch_result_transactions(response.aggs, time_periods)
         return overall_results
 
-    def query_elasticsearch_for_awards(self, time_periods: list) -> list:
+    def query_elasticsearch_for_awards(self, time_periods: TimePeriodMetadata) -> list:
         """Get spending over time amounts based on Awards"""
 
         filter_options = {}
@@ -428,7 +438,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return overall_results
 
-    def query_elasticsearch_for_subawards(self, time_periods: list) -> list:
+    def query_elasticsearch_for_subawards(self, time_periods: TimePeriodMetadata) -> list:
         """Get spending over time amounts based on Subawards"""
 
         filter_options = {}

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -59,7 +59,7 @@ GROUPING_LOOKUP = {
 class TimePeriod:
     start_date: str
     end_date: str
-    date_type: Optional[dict]
+    date_type: Optional[str] = None
 
 
 @api_transformations(api_version=API_VERSION, function_list=API_TRANSFORM_FUNCTIONS)
@@ -130,7 +130,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
                 format="yyyy-MM-dd",
             )
 
-    def awards_group_by_time_period_agg(self) -> any:
+    def awards_group_by_time_period_agg(self) -> A:
         if self.group == "fiscal_year":
             return A("terms", field="fiscal_year")
         else:

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -206,7 +206,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         time_period = {}
 
         if self.group == "fiscal_year" and (
-            self.spending_level == "awards" or (self.spending_level == "subawards" or self.subawards == True)
+            self.spending_level == "awards" or (self.spending_level == "subawards" or self.subawards)
         ):
             key_as_date = datetime.strptime(str(bucket["key"]), "%Y")
         else:
@@ -438,6 +438,23 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         response = search.handle_execute()
         overall_results = self.build_elasticsearch_result_awards_subawards(response.aggs, time_periods)
 
+         # if there is no data for that fiscal year, set overall_results for that
+        min_date, max_date = min_and_max_from_date_ranges(time_periods)
+        date_range = generate_date_range(min_date, max_date, self.group)
+        if date_range.count != overall_results.count:
+            for year in date_range:
+                if not (any(overall_result["time_period"] == {"fiscal_year": str(year["fiscal_year"])} for overall_result in overall_results)):
+                    overall_results.append({
+                        "aggregated_amount": 0,
+                        "total_outlays": None,
+                        "time_period": {"fiscal_year": str(year["fiscal_year"])},
+                        "Contract_Obligations": 0,
+                        "Contract_Outlays": None,
+                        "Grant_Obligations": 0,
+                        "Grant_Outlays": None,
+                    })
+            overall_results = sorted(overall_results, key=lambda x: x["time_period"]["fiscal_year"])
+
         return overall_results
 
     @cache_response()
@@ -468,22 +485,6 @@ class SpendingOverTimeVisualizationViewSet(APIView):
         time_periods = self.filters.get("time_period", [default_time_period])
         if self.spending_level == "subawards" or self.subawards:
             results = self.query_elasticsearch_for_subawards(time_periods)
-            #if there is no data for that fiscal year, set results for that
-            min_date, max_date = min_and_max_from_date_ranges(time_periods)
-            date_range = generate_date_range(min_date, max_date, self.group)
-            if date_range.count != results.count:
-                for year in date_range:
-                    if not (any(result["time_period"] == {"fiscal_year": str(year["fiscal_year"])} for result in results)):
-                        results.append({
-                            "aggregated_amount": 0,
-                            "total_outlays": None,
-                            "time_period": {"fiscal_year": str(year["fiscal_year"])},
-                            "Contract_Obligations": 0,
-                            "Contract_Outlays": None,
-                            "Grant_Obligations": 0,
-                            "Grant_Outlays": None,
-                        })
-                results = sorted(results, key=lambda x: x["time_period"]["fiscal_year"])
         elif self.spending_level == "transactions":
             results = self.query_elasticsearch_for_transactions(time_periods)
         elif self.spending_level == "awards":

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -110,7 +110,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             raise InvalidParameterException("Missing request parameters: filters")
 
         return validated_data, models
-    
+
     def subawards_group_by_time_period_agg(self) -> any:
         if self.group == "fiscal_year":
             return A("terms", field="sub_fiscal_year")
@@ -121,7 +121,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
                 interval="year" if (self.group == "calendar_year") else self.group,
                 format="yyyy-MM-dd",
             )
-    
+
     def awards_group_by_time_period_agg(self) -> any:
         if self.group == "fiscal_year":
             return A("terms", field="fiscal_year")
@@ -209,7 +209,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
             time_period["quarter"] = str(quarter)
         elif self.group == "month":
             time_period["month"] = str(key_as_date.month)
-        
+
         return time_period
 
     def parse_elasticsearch_bucket(self, bucket: dict) -> dict:

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -17,8 +17,6 @@ from usaspending_api.common.cache_decorator import cache_response
 from usaspending_api.common.elasticsearch.search_wrappers import AwardSearch, SubawardSearch, TransactionSearch
 from usaspending_api.common.exceptions import InvalidParameterException
 from usaspending_api.common.helpers.fiscal_year_helpers import (
-    bolster_missing_time_periods,
-    clean_subaward_spending_over_time_results,
     generate_date_range,
     generate_fiscal_month,
     generate_fiscal_year,

--- a/usaspending_api/search/v2/views/spending_over_time.py
+++ b/usaspending_api/search/v2/views/spending_over_time.py
@@ -367,8 +367,7 @@ class SpendingOverTimeVisualizationViewSet(APIView):
 
         return results
 
-    def build_elasticsearch_result_awards_subawards(
-        self, agg_response: AggResponse) -> list:
+    def build_elasticsearch_result_awards_subawards(self, agg_response: AggResponse) -> list:
         """
         In this function we are just taking the elasticsearch aggregate response and looping through the
         buckets to create a results object for each time interval.


### PR DESCRIPTION
**Description:**
Updates spending_over_time to use elasticsearch to query subawards. 

**Technical details:**
Added similar functionality that awards and transactions is using within spending_over_time. Decided not to consolidate the three methods (query_elasticsearch_for_awards, transactions, and subawards) due to the amount of varied methods names within each method

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [X] Matview impact assessment completed
5. [X] Frontend impact assessment completed
6. [X] Data validation completed
7. [X] Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123): https://federal-spending-transparency.atlassian.net/jira/software/c/projects/Dev/boards/25?selectedIssue=DEV-11467
    - [X] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
