### PR TITLE
[DEV-12006] Update recipient ES query [hotfix][staging]

### DIFF
--- a/usaspending_api/etl/es_recipient_profile_template.json
+++ b/usaspending_api/etl/es_recipient_profile_template.json
@@ -15,6 +15,20 @@
           "filter": [
             "uppercase"
           ]
+        },
+        "edge_ngram_analyzer": {
+          "tokenizer": "edge_ngram_tokenizer"
+        }
+      },
+      "tokenizer": {
+        "edge_ngram_tokenizer": {
+          "type": "edge_ngram",
+          "min_gram": 2,
+          "max_gram": 10,
+          "token_char": [
+            "letter",
+            "digit"
+          ]
         }
       }
     }

--- a/usaspending_api/references/tests/integration/test_recipients_autocomplete_v2.py
+++ b/usaspending_api/references/tests/integration/test_recipients_autocomplete_v2.py
@@ -90,11 +90,11 @@ def test_create_es_search():
                             "should": [
                                 {
                                     "bool": {
-                                        "minimum_should_match": 1,
                                         "should": [
                                             {"match": {"recipient_level": "C"}},
                                             {"match": {"recipient_level": "P"}},
                                         ],
+                                        "minimum_should_match": 1,
                                     }
                                 }
                             ]
@@ -105,29 +105,26 @@ def test_create_es_search():
                             "should": [
                                 {
                                     "bool": {
-                                        "minimum_should_match": 1,
                                         "should": [
+                                            {"match_phrase_prefix": {"recipient_name": {"query": "test", "boost": 5}}},
                                             {
-                                                "query_string": {
-                                                    "fields": [
-                                                        "recipient_name",
-                                                        "uei",
-                                                        "duns",
-                                                    ],
-                                                    "query": "*test*",
+                                                "match_phrase_prefix": {
+                                                    "recipient_name.contains": {"query": "test", "boost": 3}
                                                 }
                                             },
                                             {
-                                                "multi_match": {
-                                                    "fields": [
-                                                        "recipient_name",
-                                                        "uei",
-                                                        "duns",
-                                                    ],
-                                                    "query": "test",
+                                                "match": {
+                                                    "recipient_name": {"query": "test", "operator": "and", "boost": 1}
                                                 }
                                             },
+                                            {"match_phrase_prefix": {"uei": {"query": "test", "boost": 5}}},
+                                            {"match_phrase_prefix": {"uei.contains": {"query": "test", "boost": 3}}},
+                                            {"match": {"uei": {"query": "test", "operator": "and", "boost": 1}}},
+                                            {"match_phrase_prefix": {"duns": {"query": "test", "boost": 5}}},
+                                            {"match_phrase_prefix": {"duns.contains": {"query": "test", "boost": 3}}},
+                                            {"match": {"duns": {"query": "test", "operator": "and", "boost": 1}}},
                                         ],
+                                        "minimum_should_match": 1,
                                     }
                                 }
                             ]
@@ -147,21 +144,18 @@ def test_create_es_search():
     expected_query = {
         "query": {
             "bool": {
-                "minimum_should_match": 1,
                 "should": [
-                    {
-                        "query_string": {
-                            "fields": ["recipient_name", "uei", "duns"],
-                            "query": "*test*",
-                        }
-                    },
-                    {
-                        "multi_match": {
-                            "fields": ["recipient_name", "uei", "duns"],
-                            "query": "test",
-                        }
-                    },
+                    {"match_phrase_prefix": {"recipient_name": {"query": "test", "boost": 5}}},
+                    {"match_phrase_prefix": {"recipient_name.contains": {"query": "test", "boost": 3}}},
+                    {"match": {"recipient_name": {"query": "test", "operator": "and", "boost": 1}}},
+                    {"match_phrase_prefix": {"uei": {"query": "test", "boost": 5}}},
+                    {"match_phrase_prefix": {"uei.contains": {"query": "test", "boost": 3}}},
+                    {"match": {"uei": {"query": "test", "operator": "and", "boost": 1}}},
+                    {"match_phrase_prefix": {"duns": {"query": "test", "boost": 5}}},
+                    {"match_phrase_prefix": {"duns.contains": {"query": "test", "boost": 3}}},
+                    {"match": {"duns": {"query": "test", "operator": "and", "boost": 1}}},
                 ],
+                "minimum_should_match": 1,
             }
         },
         "from": 0,

--- a/usaspending_api/references/v2/views/recipients.py
+++ b/usaspending_api/references/v2/views/recipients.py
@@ -86,9 +86,20 @@ class RecipientAutocompleteViewSet(APIView):
             An Elasticsearch search query.
         """
         es_recipient_search_fields = ["recipient_name", "uei", "duns"]
-        query_string_query = ES_Q("query_string", query=f"*{search_text}*", fields=es_recipient_search_fields)
-        multi_match_query = ES_Q("multi_match", query=search_text, fields=es_recipient_search_fields)
-        query = ES_Q("bool", should=[query_string_query, multi_match_query], minimum_should_match=1)
+
+        should_query = []
+        for search_field in es_recipient_search_fields:
+            should_query.append(
+                ES_Q("match_phrase_prefix", **{f"{search_field}": {"query": search_text, "boost": 5}}),
+            )
+            should_query.append(
+                ES_Q("match_phrase_prefix", **{f"{search_field}.contains": {"query": search_text, "boost": 3}}),
+            )
+            should_query.append(
+                ES_Q("match", **{f"{search_field}": {"query": search_text, "operator": "and", "boost": 1}})
+            )
+
+        query = ES_Q("bool", should=should_query, minimum_should_match=1)
 
         if recipient_levels:
             recipient_should_clause = [

--- a/usaspending_api/references/v2/views/recipients.py
+++ b/usaspending_api/references/v2/views/recipients.py
@@ -87,17 +87,15 @@ class RecipientAutocompleteViewSet(APIView):
         """
         es_recipient_search_fields = ["recipient_name", "uei", "duns"]
 
-        should_query = []
-        for search_field in es_recipient_search_fields:
-            should_query.append(
+        should_query = [
+            query
+            for search_field in es_recipient_search_fields
+            for query in [
                 ES_Q("match_phrase_prefix", **{f"{search_field}": {"query": search_text, "boost": 5}}),
-            )
-            should_query.append(
                 ES_Q("match_phrase_prefix", **{f"{search_field}.contains": {"query": search_text, "boost": 3}}),
-            )
-            should_query.append(
-                ES_Q("match", **{f"{search_field}": {"query": search_text, "operator": "and", "boost": 1}})
-            )
+                ES_Q("match", **{f"{search_field}": {"query": search_text, "operator": "and", "boost": 1}}),
+            ]
+        ]
 
         query = ES_Q("bool", should=should_query, minimum_should_match=1)
 


### PR DESCRIPTION
**Description:**
Update the Elasticsearch query used in the recipient autocomplete endpoint.

**Technical details:**
QAT with old query: 178ms to return more than 10,000 results
QAT with new query: 55ms to return 43 results

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-12006](https://federal-spending-transparency.atlassian.net/browse/DEV-12006):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

4. Matview impact assessment completed
No matviews are affected by this change.

5. Frontend impact assessment completed
The frontend is not impacted by this change.
```
