### PR TITLE
Calculating the number of slices that should be used for deleting

### DIFF
--- a/usaspending_api/conftest_helpers.py
+++ b/usaspending_api/conftest_helpers.py
@@ -130,6 +130,7 @@ class TestElasticSearchIndex:
             sql=None,
             transform_func=None,
             view=None,
+            slices="auto"
         )
 
     def delete_index(self):

--- a/usaspending_api/conftest_helpers.py
+++ b/usaspending_api/conftest_helpers.py
@@ -130,7 +130,7 @@ class TestElasticSearchIndex:
             sql=None,
             transform_func=None,
             view=None,
-            slices="auto"
+            slices="auto",
         )
 
     def delete_index(self):

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -3,11 +3,10 @@ from abc import ABC, abstractmethod
 from math import ceil
 from multiprocessing import Event, Pool, Value
 from time import perf_counter
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple
 
 from django.conf import settings
 from django.core.management import call_command
-from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import Index
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 import logging
 from abc import ABC, abstractmethod
 from math import ceil
@@ -144,7 +143,7 @@ class AbstractElasticsearchIndexerController(ABC):
         # the Index object to capture settings we need the actual name.
         index_name = list(index_settings)[0]
 
-        num_shards = index_settings[index_name]["settings"]["index"]["number_of_shards"]
+        num_shards = int(index_settings[index_name]["settings"]["index"]["number_of_shards"])
 
         if num_shards == 5:
             # Anything that is still processing with 5 shards can continue to use 5 slices

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -170,8 +170,8 @@ class AbstractElasticsearchIndexerController(ABC):
 
         max_scroll_contexts = 500
         award_slices = 5
-        award_index_slice_count = (self.config["processes"] * (num_shards * award_slices)) // num_nodes
-        transaction_index_slice_count = ((max_scroll_contexts - award_index_slice_count) * num_nodes) // (
+        award_index_scroll_context_count = (self.config["processes"] * (num_shards * award_slices)) // num_nodes
+        transaction_index_slice_count = ((max_scroll_contexts - award_index_scroll_context_count) * num_nodes) // (
             self.config["processes"] * num_shards
         )
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from math import ceil
 from multiprocessing import Event, Pool, Value
 from time import perf_counter
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 from django.core.management import call_command
 from elasticsearch import Elasticsearch
@@ -125,7 +125,7 @@ class AbstractElasticsearchIndexerController(ABC):
             slices=self.config["slices"],
         )
 
-    def get_slice_count(self, client: Elasticsearch) -> int:
+    def get_slice_count(self, client: Elasticsearch) -> Union[int, str]:
         """
         Retrieves the number of slices that should be used when performing any type
         of scroll operation (e.g., delete_by_query).
@@ -148,7 +148,8 @@ class AbstractElasticsearchIndexerController(ABC):
         if num_shards == 5:
             # Anything that is still processing with 5 shards can continue to use 5 slices
             # because that remains under the half point of 250 slices.
-            return 5
+            # It is assumed that 5 shards is the default value that we provide in settings.
+            return "auto"
 
         shard_stores = index.shard_stores(status="all")
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller.py
@@ -179,8 +179,8 @@ class AbstractElasticsearchIndexerController(ABC):
             )
         )
 
-        award_index = Index(name=settings.ES_AWARDS_WRITE_ALIAS, using=client)
         try:
+            award_index = Index(name=settings.ES_AWARDS_WRITE_ALIAS, using=client)
             award_index_settings = award_index.get_settings()
             award_index_name = list(award_index_settings)[0]
             award_num_shards = int(award_index_settings[award_index_name]["settings"]["index"]["number_of_shards"])

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -633,8 +633,8 @@ def _gather_modified_transactions_pre_fy2008(
 
 def _check_awards_for_deletes(
     id_list: list,
-    spark: "pyspark.sql.SparkSession" = None,
-    awards_table: str = "vw_awards",  # noqa
+    spark: "pyspark.sql.SparkSession" = None,  # noqa
+    awards_table: str = "vw_awards",
 ) -> list:
     """Takes a list of award key values and returns them if they are NOT found in the awards DB table"""
 
@@ -664,9 +664,9 @@ def _check_awards_for_deletes(
 
 
 def _check_awards_for_pre_fy2008(
-    spark: "pyspark.sql.SparkSession" = None,
+    spark: "pyspark.sql.SparkSession" = None,  # noqa
     awards_table: str = "rpt.award_search",
-    days_delta: int = 3,  # noqa
+    days_delta: int = 3,
 ) -> Union[List[Dict], List]:
     """Find all awards that have been modified in the last `days_delta` day(s) that have an `action_date` prior to
         2007-10-01 (FY 2008) and delete them from Elasticsearch if they're present.

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -37,7 +37,7 @@ def delete_docs_by_unique_key(
     index,
     refresh_after: bool = True,
     delete_chunk_size: int = 1000,
-    slices: Union[int, str] = "auto"
+    slices: Union[int, str] = "auto",
 ) -> int:
     """
     Bulk delete a batch of documents whose field identified by ``key`` matches any value provided in the
@@ -376,6 +376,7 @@ def delete_awards(
         task_id=task_id,
         index=config["index_name"],
         delete_chunk_size=config["partition_size"],
+        slices=config["slices"],
     )
 
 
@@ -458,7 +459,7 @@ def delete_transactions(
         task_id="Sync DB Deletes",
         index=config["index_name"],
         delete_chunk_size=config["partition_size"],
-        slices=2
+        slices=config["slices"],
     )
 
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -118,7 +118,7 @@ def delete_docs_by_unique_key(
                 index=index,
                 body=delete_query,
                 conflicts="proceed",
-                slices=1,
+                slices=4,
             )
             # Some subtle errors come back on the response
             if response["timed_out"]:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -118,7 +118,7 @@ def delete_docs_by_unique_key(
                 index=index,
                 body=delete_query,
                 conflicts="proceed",
-                slices=4,
+                slices=3,
             )
             # Some subtle errors come back on the response
             if response["timed_out"]:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -8,8 +8,14 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.mapping import Mapping
 
-from usaspending_api.broker.helpers.last_load_date import get_last_load_date, get_latest_load_date
-from usaspending_api.common.helpers.s3_helpers import access_s3_object, retrieve_s3_bucket_object_list
+from usaspending_api.broker.helpers.last_load_date import (
+    get_last_load_date,
+    get_latest_load_date,
+)
+from usaspending_api.common.helpers.s3_helpers import (
+    access_s3_object,
+    retrieve_s3_bucket_object_list,
+)
 from usaspending_api.etl.elasticsearch_loader_helpers.index_config import (
     ES_AWARDS_UNIQUE_KEY_FIELD,
     ES_TRANSACTIONS_UNIQUE_KEY_FIELD,
@@ -65,7 +71,13 @@ def delete_docs_by_unique_key(
         logger.info(format_log("Nothing to delete", action="Delete", name=task_id))
         return 0
 
-    logger.info(format_log(f"Deleting up to {len(value_list):,} document(s)", action="Delete", name=task_id))
+    logger.info(
+        format_log(
+            f"Deleting up to {len(value_list):,} document(s)",
+            action="Delete",
+            name=task_id,
+        )
+    )
     if not index:
         raise RuntimeError("index name must be provided")
 
@@ -103,7 +115,10 @@ def delete_docs_by_unique_key(
             # response = q.delete()
             delete_query = {"query": {"bool": {"filter": {"terms": {**{key: chunk_of_values}}}}}}
             response = client.delete_by_query(
-                index=index, body=delete_query, scroll_size=10, scroll="5s", conflicts="proceed", slices="auto"
+                index=index,
+                body=delete_query,
+                conflicts="proceed",
+                slices=5,
             )
             # Some subtle errors come back on the response
             if response["timed_out"]:
@@ -327,7 +342,11 @@ def delete_awards(
         )
     else:
         logger.info(
-            format_log(f"Derived {award_keys_len} award keys from transactions in ES", action="Delete", name=task_id)
+            format_log(
+                f"Derived {award_keys_len} award keys from transactions in ES",
+                action="Delete",
+                name=task_id,
+            )
         )
         deleted_award_kvs = _check_awards_for_deletes(award_keys, spark)
         deleted_award_kvs_len = len(deleted_award_kvs)
@@ -405,7 +424,8 @@ def delete_transactions(
     if len(deleted_tx_keys) > 0:
         logger.info(
             format_log(
-                f"{len(deleted_tx_keys)} transactions no longer in the DB will be removed from ES", action="Delete"
+                f"{len(deleted_tx_keys)} transactions no longer in the DB will be removed from ES",
+                action="Delete",
             )
         )
         tx_keys_to_delete.extend(deleted_tx_keys.keys())
@@ -428,7 +448,8 @@ def delete_transactions(
     else:
         logger.info(
             format_log(
-                "None of the recently updated transactions have an action_date prior to FY2008.", action="Delete"
+                "None of the recently updated transactions have an action_date prior to FY2008.",
+                action="Delete",
             )
         )
 
@@ -469,7 +490,12 @@ def _gather_deleted_transaction_keys(
     start = perf_counter()
 
     bucket_objects = retrieve_s3_bucket_object_list(bucket_name=config["s3_bucket"])
-    logger.info(format_log(f"{len(bucket_objects):,} files found in bucket '{config['s3_bucket']}'", action="Delete"))
+    logger.info(
+        format_log(
+            f"{len(bucket_objects):,} files found in bucket '{config['s3_bucket']}'",
+            action="Delete",
+        )
+    )
 
     start_date = get_last_load_date("es_deletes")
     # An `end_date` is used, so we don't try to delete records from ES that have not yet
@@ -518,7 +544,12 @@ def _gather_deleted_transaction_keys(
 
     if config["verbose"]:
         for uid, deleted_dict in deleted_keys.items():
-            logger.info(format_log(f"id: {uid} last modified: {deleted_dict['timestamp']}", action="Delete"))
+            logger.info(
+                format_log(
+                    f"id: {uid} last modified: {deleted_dict['timestamp']}",
+                    action="Delete",
+                )
+            )
 
     logger.info(
         format_log(
@@ -590,12 +621,14 @@ def _gather_modified_transactions_pre_fy2008(
     if len(results) > 0:
         logger.info(
             format_log(
-                f"{len(results)} recently updated transactions have an action_date before FY2008.", action="Delete"
+                f"{len(results)} recently updated transactions have an action_date before FY2008.",
+                action="Delete",
             )
         )
         logger.info(
             format_log(
-                f"These {len(results)} pre-FY2008 transactions will be deleted from ES, if present.", action="Delete"
+                f"These {len(results)} pre-FY2008 transactions will be deleted from ES, if present.",
+                action="Delete",
             )
         )
 
@@ -603,7 +636,9 @@ def _gather_modified_transactions_pre_fy2008(
 
 
 def _check_awards_for_deletes(
-    id_list: list, spark: "pyspark.sql.SparkSession" = None, awards_table: str = "vw_awards"  # noqa
+    id_list: list,
+    spark: "pyspark.sql.SparkSession" = None,
+    awards_table: str = "vw_awards",  # noqa
 ) -> list:
     """Takes a list of award key values and returns them if they are NOT found in the awards DB table"""
 
@@ -625,14 +660,17 @@ def _check_awards_for_deletes(
         ]
     else:
         results = execute_sql_statement(
-            sql.format(ids=formatted_value_ids[:-1], awards_table=awards_table), results=True
+            sql.format(ids=formatted_value_ids[:-1], awards_table=awards_table),
+            results=True,
         )
 
     return results
 
 
 def _check_awards_for_pre_fy2008(
-    spark: "pyspark.sql.SparkSession" = None, awards_table: str = "rpt.award_search", days_delta: int = 3  # noqa
+    spark: "pyspark.sql.SparkSession" = None,
+    awards_table: str = "rpt.award_search",
+    days_delta: int = 3,  # noqa
 ) -> Union[List[Dict], List]:
     """Find all awards that have been modified in the last `days_delta` day(s) that have an `action_date` prior to
         2007-10-01 (FY 2008) and delete them from Elasticsearch if they're present.
@@ -669,7 +707,8 @@ def _check_awards_for_pre_fy2008(
         ]
     else:
         results = execute_sql_statement(
-            pre_fy2008_awards_sql.format(awards_table=awards_table, days_delta=days_delta), results=True
+            pre_fy2008_awards_sql.format(awards_table=awards_table, days_delta=days_delta),
+            results=True,
         )
 
     return results

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -37,6 +37,7 @@ def delete_docs_by_unique_key(
     index,
     refresh_after: bool = True,
     delete_chunk_size: int = 1000,
+    slices: Union[int, str] = "auto"
 ) -> int:
     """
     Bulk delete a batch of documents whose field identified by ``key`` matches any value provided in the
@@ -107,19 +108,12 @@ def delete_docs_by_unique_key(
             # Invoking _delete_by_query as per the elasticsearch-dsl docs:
             #   https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#delete-by-query
             # _refresh is deferred until the end of chunk processing
-            # q = Search(using=client, index=index).filter("terms", **{key: chunk_of_values})  # type: Search
+            q = Search(using=client, index=index).filter("terms", **{key: chunk_of_values})  # type: Search
             # params:
             # conflicts="proceed": Ignores version conflict errors if a doc delete is attempted more than once
             # slices="auto": Will create parallel delete batches per shard
-            # q = q.params(conflicts="proceed", slices="auto")
-            # response = q.delete()
-            delete_query = {"query": {"bool": {"filter": {"terms": {**{key: chunk_of_values}}}}}}
-            response = client.delete_by_query(
-                index=index,
-                body=delete_query,
-                conflicts="proceed",
-                slices=3,
-            )
+            q = q.params(conflicts="proceed", slices=slices)
+            response = q.delete()
             # Some subtle errors come back on the response
             if response["timed_out"]:
                 msg = f"Delete request timed out on cluster after {int(response['took'])/1000:.2f}s"
@@ -464,6 +458,7 @@ def delete_transactions(
         task_id="Sync DB Deletes",
         index=config["index_name"],
         delete_chunk_size=config["partition_size"],
+        slices=2
     )
 
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -118,7 +118,7 @@ def delete_docs_by_unique_key(
                 index=index,
                 body=delete_query,
                 conflicts="proceed",
-                slices=5,
+                slices=1,
             )
             # Some subtle errors come back on the response
             if response["timed_out"]:

--- a/usaspending_api/etl/elasticsearch_loader_helpers/utilities.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/utilities.py
@@ -29,6 +29,7 @@ class TaskSpec:
     primary_key: str
     partition_number: int
     is_incremental: bool
+    slices: Union[str, int]
     execute_sql_func: callable = None
     transform_func: callable = None
 

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -113,6 +113,7 @@ class AbstractElasticsearchIndexer(ABC, BaseCommand):
         error_addition = ""
         controller = self.create_controller(config)
         controller.ensure_view_exists(config["sql_view"])
+        config["slices"] = controller.get_slice_count(elasticsearch_client)
 
         if config["is_incremental_load"]:
             toggle_refresh_off(elasticsearch_client, config["index_name"])  # Turned back on at end.

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -117,9 +117,7 @@ class AbstractElasticsearchIndexer(ABC, BaseCommand):
         controller = self.create_controller(config)
         controller.ensure_view_exists(config["sql_view"])
 
-        config["slices"] = config["slices"] or (
-            "auto" if config["create_new_index"] else controller.get_slice_count(elasticsearch_client)
-        )
+        config["slices"] = controller.get_slice_count(elasticsearch_client)
 
         if config["is_incremental_load"]:
             toggle_refresh_off(elasticsearch_client, config["index_name"])  # Turned back on at end.

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -117,7 +117,7 @@ class AbstractElasticsearchIndexer(ABC, BaseCommand):
         controller = self.create_controller(config)
         controller.ensure_view_exists(config["sql_view"])
 
-        config["slices"] = controller.get_slice_count(elasticsearch_client)
+        controller.set_slice_count(elasticsearch_client)
 
         if config["is_incremental_load"]:
             toggle_refresh_off(elasticsearch_client, config["index_name"])  # Turned back on at end.

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -113,7 +113,8 @@ class AbstractElasticsearchIndexer(ABC, BaseCommand):
         error_addition = ""
         controller = self.create_controller(config)
         controller.ensure_view_exists(config["sql_view"])
-        config["slices"] = controller.get_slice_count(elasticsearch_client)
+
+        config["slices"] = "auto" if config["create_new_index"] else controller.get_slice_count(elasticsearch_client)
 
         if config["is_incremental_load"]:
             toggle_refresh_off(elasticsearch_client, config["index_name"])  # Turned back on at end.

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -117,7 +117,7 @@ class AbstractElasticsearchIndexer(ABC, BaseCommand):
         controller = self.create_controller(config)
         controller.ensure_view_exists(config["sql_view"])
 
-        controller.set_slice_count(elasticsearch_client)
+        controller.set_slice_count()
 
         if config["is_incremental_load"]:
             toggle_refresh_off(elasticsearch_client, config["index_name"])  # Turned back on at end.

--- a/usaspending_api/etl/management/commands/elasticsearch_indexer.py
+++ b/usaspending_api/etl/management/commands/elasticsearch_indexer.py
@@ -100,9 +100,6 @@ class AbstractElasticsearchIndexer(ABC, BaseCommand):
             action="store_true",
             help="After completing the ETL, drop the SQL view used for the data extraction",
         )
-        parser.add_argument(
-            "--slices", type=int, help="Number of slices to use per shard; value that is supplied to delete_by_query."
-        )
 
     def handle(self, *args, **options):
         elasticsearch_client = instantiate_elasticsearch_client()
@@ -185,7 +182,6 @@ def parse_cli_args(options: dict, es_client) -> dict:
         "processes",
         "skip_counts",
         "skip_delete_index",
-        "slices",
     ]
     config = set_config(passthrough_values, options)
 

--- a/usaspending_api/etl/tests/integration/test_elasticsearch_indexer.py
+++ b/usaspending_api/etl/tests/integration/test_elasticsearch_indexer.py
@@ -692,4 +692,5 @@ def _process_es_etl_test_config(client: Elasticsearch, test_es_index: TestElasti
     cli_args, _ = parser.parse_known_args(args=test_args)  # parse the known args programmatically
     cli_opts = {**vars(cli_args), **test_es_index.etl_config}  # update defaults with test config
     es_etl_config = parse_cli_args(cli_opts, client)  # use command's config parser for final config for testing ETL
+    es_etl_config["slices"] = "auto"  # no need to calculate slices for testing
     return es_etl_config


### PR DESCRIPTION
**Description:**
Updating the Elasticsearch loader to calculate the number of slices.

**Technical details:**
Updating the number of Shards on the Transaction Index caused the incremental load of the Transaction Index to fail due to passing the 500 scroll contexts threshold. This change calculates the number of slices that the Transaction Index should use with the assumption that it is running in parallel with the Award Index, and the maximum value is still set to 500. There are further improvements that could be made, but for now this will keep us from hard coding the value and allow us to build it out further as we look to either change the maximum scroll contexts or increase the Shards on Award index

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
