### PR TITLE
[DEV-11590] Sort location autocomplete results by occurrences

### DIFF
--- a/usaspending_api/etl/es_location_template.json
+++ b/usaspending_api/etl/es_location_template.json
@@ -66,7 +66,10 @@
             "type": "keyword"
           }
         }
+      },
+      "occurrences": {
+        "type": "integer"
       }
-  }
+    }
   }
 }

--- a/usaspending_api/references/tests/integration/test_location_autocomplete_v2.py
+++ b/usaspending_api/references/tests/integration/test_location_autocomplete_v2.py
@@ -122,8 +122,8 @@ def test_multiple_types_of_matches(client, monkeypatch, location_data_fixture, e
         "countries": ["DENMARK"],
         "cities": ["DENVER, COLORADO"],
         "counties": [
-            {"county_fips": "22222", "county_name": "DENVER COUNTY, COLORADO"},
             {"county_fips": "13444", "county_name": "CAMDEN COUNTY, GEORGIA"},
+            {"county_fips": "22222", "county_name": "DENVER COUNTY, COLORADO"},
         ],
     }
 

--- a/usaspending_api/references/v2/views/location_autocomplete.py
+++ b/usaspending_api/references/v2/views/location_autocomplete.py
@@ -65,7 +65,8 @@ class LocationAutocompleteViewSet(APIView):
         ]
 
         query = ES_Q("bool", should=should_query, minimum_should_match=1)
-        search: LocationSearch = LocationSearch().extra(size=limit).query(query)
+        # Sort by the `occurences` field in descending order
+        search: LocationSearch = LocationSearch().extra(size=limit).query(query).sort("-occurrences")
         results: ES_Response = search.execute()
 
         return results


### PR DESCRIPTION
**Description:**
Added an `occurrences` field to the location index in Elasticsearch. This new field is then used to sort the results that match the given `search_text`, in descending order. This puts the locations that appear the most in our Transaction data at the top of the search results.

**Technical details:**


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
6. [x] Data validation completed
7. [x] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11590](https://federal-spending-transparency.atlassian.net/browse/DEV-11590):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

5. Frontend impact assessment completed
The frontend is not impacted by this change.
```
