### PR TITLE
Pin the Python Patch Version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: bionic
 language: python
 
 python:
-  - '3.10.12'
+  - '3.10.14'
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     before_install: ""  # override default to no-op
     install:
     - travis_retry pip install setuptools==68.1.2
-    - travis_retry pip install .[dev]
+    - travis_retry pip install .[dev] --no-cache-dir
     - travis_retry pip install coveralls
     before_script: ""  # override default to no-op
     script: ""  # override default to no-op

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: bionic
 language: python
 
 python:
-  - '3.10'
+  - '3.10.12'
 
 cache: pip
 
@@ -56,7 +56,7 @@ jobs:
     before_install: ""  # override default to no-op
     install:
     - travis_retry pip install setuptools==68.1.2
-    - travis_retry pip install .[dev] --no-cache-dir
+    - travis_retry pip install .[dev]
     - travis_retry pip install coveralls
     before_script: ""  # override default to no-op
     script: ""  # override default to no-op


### PR DESCRIPTION
**Description:**
Pinning the Python patch version used in Travis CI.

**Technical details:**
There were some build failures due to Travis trying to use Python 3.10.1 instead of a later version.