### PR TITLE
[DEV-12248] Update Award ID query for Subawards [hotfix][staging]

### DIFF
--- a/usaspending_api/search/tests/integration/hierarchical_filters/test_tas_filter_basic_cases_subaward.py
+++ b/usaspending_api/search/tests/integration/hierarchical_filters/test_tas_filter_basic_cases_subaward.py
@@ -1,10 +1,10 @@
 import pytest
 
 from usaspending_api.search.tests.integration.hierarchical_filters.tas_fixtures import (
-    BASIC_TAS,
-    ATA_TAS,
-    BPOA_TAS,
     ATA_BPOA_TAS,
+    ATA_TAS,
+    BASIC_TAS,
+    BPOA_TAS,
     TAS_DICTIONARIES,
     TAS_STRINGS,
     UNINTUITIVE_AGENCY,

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -2145,3 +2145,54 @@ def test_spending_by_award_program_activity(client, monkeypatch, elasticsearch_a
 
     assert resp.status_code == status.HTTP_200_OK
     assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+
+@pytest.mark.django_db
+def test_spending_by_award_subawards_award_id_filter(
+    client, monkeypatch, spending_by_award_test_data, elasticsearch_subaward_index
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
+    # Test finding a Subaward by it's `subaward_number`
+    payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {
+            "award_type_codes": ["07"],
+            "award_ids": ["99999"],
+        },
+    }
+    expected_response = [
+        {
+            "internal_id": "99999",
+            "prime_award_internal_id": 4,
+            "Sub-Award ID": "99999",
+            "prime_award_generated_internal_id": "ASST_NON_DECF0000058_8900",
+        }
+    ]
+    resp = client.post("/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(payload))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+    # Test finding a Subaward by it's `award_piid_fain`
+    payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {
+            "award_type_codes": ["07"],
+            "award_ids": ["PIID6003"],
+        },
+    }
+    expected_response = [
+        {
+            "internal_id": "99999",
+            "prime_award_internal_id": 4,
+            "Sub-Award ID": "99999",
+            "prime_award_generated_internal_id": "ASST_NON_DECF0000058_8900",
+        }
+    ]
+    resp = client.post("/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(payload))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"


### PR DESCRIPTION
**Description:**
Update the `spending_by_awards` endpoint to search `award_piid_fain` and `subaward_number` when searching by **Award ID** for Subawards.

**Technical details:**


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-12248](https://federal-spending-transparency.atlassian.net/browse/DEV-12248):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
No API documentation is affected by this change.

4. Matview impact assessment completed
No matviews are affected by this change.

5. Frontend impact assessment completed
The frontend is not impacted by this change.

7. Appropriate Operations ticket(s) created
No operations tickets are required for this change.
```
