### PR TITLE
[DEV-12209] Update spending_by_award to accept new unique_award_id filter

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
@@ -297,7 +297,7 @@ Non Loan Assistance Awards can be searched for specifically by using the Non Loa
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward flag is set to `False`, the query will only return prime awards that have at least one File C record with the supplied DEFC and also have non-zero COVID-19 or IIJA related obligations or outlays.
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward parameter is set to `True`, the query will only return results that have a sub_action_date on or after the enactment date of the public law associated with that disaster code.
     + Example: Providing the `Z` DEF code and setting the subaward parameter to `True` will only return results where the `sub_action_date` is on or after `11/15/2021` since this is the enactment date of the public law associated with disaster code `Z`.
-+ `prime_award_unique_id` (optional, string)
++ `award_unique_id` (optional, string)
 
 ### TimePeriodObject (object)
 This TimePeriodObject can fall into different categories based on the request.

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
@@ -297,6 +297,7 @@ Non Loan Assistance Awards can be searched for specifically by using the Non Loa
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward flag is set to `False`, the query will only return prime awards that have at least one File C record with the supplied DEFC and also have non-zero COVID-19 or IIJA related obligations or outlays.
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward parameter is set to `True`, the query will only return results that have a sub_action_date on or after the enactment date of the public law associated with that disaster code.
     + Example: Providing the `Z` DEF code and setting the subaward parameter to `True` will only return results where the `sub_action_date` is on or after `11/15/2021` since this is the enactment date of the public law associated with disaster code `Z`.
++ `prime_award_unique_id` (optional, string) Only defined for subawards.
 
 ### TimePeriodObject (object)
 This TimePeriodObject can fall into different categories based on the request.

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
@@ -297,7 +297,7 @@ Non Loan Assistance Awards can be searched for specifically by using the Non Loa
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward flag is set to `False`, the query will only return prime awards that have at least one File C record with the supplied DEFC and also have non-zero COVID-19 or IIJA related obligations or outlays.
   If the `def_codes` provided are in the COVID-19 or IIJA group and the subaward parameter is set to `True`, the query will only return results that have a sub_action_date on or after the enactment date of the public law associated with that disaster code.
     + Example: Providing the `Z` DEF code and setting the subaward parameter to `True` will only return results where the `sub_action_date` is on or after `11/15/2021` since this is the enactment date of the public law associated with disaster code `Z`.
-+ `prime_award_unique_id` (optional, string) Only defined for subawards.
++ `prime_award_unique_id` (optional, string)
 
 ### TimePeriodObject (object)
 This TimePeriodObject can fall into different categories based on the request.

--- a/usaspending_api/common/helpers/api_helper.py
+++ b/usaspending_api/common/helpers/api_helper.py
@@ -25,6 +25,9 @@ INCOMPATIBLE_DISTRICT_LOCATION_PARAMETERS = 'Incompatible parameters: `state` mu
 DUPLICATE_DISTRICT_LOCATION_PARAMETERS = (
     "Incompatible parameters: `district_current` and `district_original` are not allowed in the same locations object."
 )
+PRIME_AWARDS_DO_NOT_HAVE_PARENTS_PARAMETERS = (
+    "Incompatible parameters: `prime_award_unique_id` is only defined for subawards."
+)
 
 
 def alias_response(field_to_alias_dict, results):

--- a/usaspending_api/common/helpers/api_helper.py
+++ b/usaspending_api/common/helpers/api_helper.py
@@ -25,9 +25,7 @@ INCOMPATIBLE_DISTRICT_LOCATION_PARAMETERS = 'Incompatible parameters: `state` mu
 DUPLICATE_DISTRICT_LOCATION_PARAMETERS = (
     "Incompatible parameters: `district_current` and `district_original` are not allowed in the same locations object."
 )
-PRIME_AWARDS_DO_NOT_HAVE_PARENTS_PARAMETERS = (
-    "Incompatible parameters: `prime_award_unique_id` is only defined for subawards."
-)
+NOT_DEFINED_FOR_TRANSACTIONS = "Incompatible parameters: `prime_award_unique_id` is not defined for transactions."
 
 
 def alias_response(field_to_alias_dict, results):

--- a/usaspending_api/common/helpers/api_helper.py
+++ b/usaspending_api/common/helpers/api_helper.py
@@ -25,7 +25,7 @@ INCOMPATIBLE_DISTRICT_LOCATION_PARAMETERS = 'Incompatible parameters: `state` mu
 DUPLICATE_DISTRICT_LOCATION_PARAMETERS = (
     "Incompatible parameters: `district_current` and `district_original` are not allowed in the same locations object."
 )
-NOT_DEFINED_FOR_TRANSACTIONS = "Incompatible parameters: `prime_award_unique_id` is not defined for transactions."
+NOT_DEFINED_FOR_TRANSACTIONS = "Incompatible parameters: `award_unique_id` is not defined for transactions."
 
 
 def alias_response(field_to_alias_dict, results):

--- a/usaspending_api/common/query_with_filters.py
+++ b/usaspending_api/common/query_with_filters.py
@@ -908,10 +908,10 @@ class _NonzeroFields(_Filter):
         return ES_Q("bool", should=non_zero_queries, minimum_should_match=1)
 
 
-class _PrimeAwardUniqueId(_Filter):
+class _AwardUniqueId(_Filter):
     """String that represents the unique ID of the prime award of a queried award/subaward."""
 
-    underscore_name = "prime_award_unique_id"
+    underscore_name = "award_unique_id"
 
     @classmethod
     def generate_elasticsearch_query(cls, filter_values: str, query_type: QueryType, **options) -> ES_Q:
@@ -959,7 +959,7 @@ class QueryWithFilters:
             _QueryText.underscore_name: _QueryText,
             _NonzeroFields.underscore_name: _NonzeroFields,
             _ProgramActivities.underscore_name: _ProgramActivities,
-            _PrimeAwardUniqueId.underscore_name: _PrimeAwardUniqueId,
+            _AwardUniqueId.underscore_name: _AwardUniqueId,
         }
         if self.query_type == QueryType.SUBAWARDS:
             result[_SubawardsPrimeSubAwardTypes.underscore_name] = _SubawardsPrimeSubAwardTypes

--- a/usaspending_api/common/validator/award_filter.py
+++ b/usaspending_api/common/validator/award_filter.py
@@ -198,6 +198,7 @@ AWARD_FILTER = [
     },
     {"name": "def_codes", "type": "array", "array_type": "text", "text_type": "search"},
     {"name": "description", "type": "text", "text_type": "search"},
+    {"name": "prime_award_unique_id", "type": "text", "text_type": "search"},
 ]
 
 for a in AWARD_FILTER:

--- a/usaspending_api/common/validator/award_filter.py
+++ b/usaspending_api/common/validator/award_filter.py
@@ -198,7 +198,7 @@ AWARD_FILTER = [
     },
     {"name": "def_codes", "type": "array", "array_type": "text", "text_type": "search"},
     {"name": "description", "type": "text", "text_type": "search"},
-    {"name": "prime_award_unique_id", "type": "text", "text_type": "search"},
+    {"name": "award_unique_id", "type": "text", "text_type": "search"},
 ]
 
 for a in AWARD_FILTER:

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -2244,3 +2244,82 @@ def test_spending_by_award_unique_id_award(
 
     assert resp.status_code == status.HTTP_200_OK
     assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+
+@pytest.mark.django_db
+def test_spending_by_award_unique_id_subaward(
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, spending_by_award_test_data
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
+    # Test with multiple subawards
+    test_payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {
+            "award_type_codes": ["A", "B", "C", "D"],
+            "award_unique_id": "CONT_AWD_TESTING_1",
+        },
+    }
+    expected_response = [
+        {
+            "internal_id": "22222",
+            "prime_award_internal_id": 1,
+            "Sub-Award ID": "22222",
+            "prime_award_generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+        {
+            "internal_id": "11111",
+            "prime_award_internal_id": 1,
+            "Sub-Award ID": "11111",
+            "prime_award_generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+    ]
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+    # Test with a single subaward
+    test_payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {
+            "award_type_codes": ["A", "B", "C", "D"],
+            "award_unique_id": "CONT_AWD_TESTING_2",
+        },
+    }
+    expected_response = [
+        {
+            "internal_id": "33333",
+            "prime_award_internal_id": 2,
+            "Sub-Award ID": "33333",
+            "prime_award_generated_internal_id": "CONT_AWD_TESTING_2",
+        },
+    ]
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+    # Test with no subawards
+    test_payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {
+            "award_type_codes": ["A", "B", "C", "D"],
+            "award_unique_id": "CONT_AWD_TESTING_4",
+        },
+    }
+    expected_response = []
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -2196,3 +2196,51 @@ def test_spending_by_award_subawards_award_id_filter(
 
     assert resp.status_code == status.HTTP_200_OK
     assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+
+@pytest.mark.django_db
+def test_spending_by_award_prime_award_unique_id_award(
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, spending_by_award_test_data
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
+    # Test with a real prime_award_unique_id
+    test_payload = {
+        "subawards": False,
+        "fields": ["Award ID"],
+        "filters": {
+            "award_type_codes": ["A", "B", "C", "D"],
+            "prime_award_unique_id": "CONT_AWD_TESTING_1",
+        },
+    }
+    expected_response = [
+        {
+            "internal_id": 1,
+            "Award ID": "abc111",
+            "generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+    ]
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+    # Test with an undefined prime_award_unique_id
+    test_payload = {
+        "subawards": False,
+        "fields": ["Award ID"],
+        "filters": {
+            "award_type_codes": ["A", "B", "C", "D"],
+            "prime_award_unique_id": "CONT_AWD_TESTING_4",
+        },
+    }
+    expected_response = []
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -2199,19 +2199,19 @@ def test_spending_by_award_subawards_award_id_filter(
 
 
 @pytest.mark.django_db
-def test_spending_by_award_prime_award_unique_id_award(
+def test_spending_by_award_unique_id_award(
     client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, spending_by_award_test_data
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
     setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
 
-    # Test with a real prime_award_unique_id
+    # Test with a real award_unique_id
     test_payload = {
         "subawards": False,
         "fields": ["Award ID"],
         "filters": {
             "award_type_codes": ["A", "B", "C", "D"],
-            "prime_award_unique_id": "CONT_AWD_TESTING_1",
+            "award_unique_id": "CONT_AWD_TESTING_1",
         },
     }
     expected_response = [
@@ -2228,13 +2228,13 @@ def test_spending_by_award_prime_award_unique_id_award(
     assert resp.status_code == status.HTTP_200_OK
     assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
 
-    # Test with an undefined prime_award_unique_id
+    # Test with an undefined award_unique_id
     test_payload = {
         "subawards": False,
         "fields": ["Award ID"],
         "filters": {
             "award_type_codes": ["A", "B", "C", "D"],
-            "prime_award_unique_id": "CONT_AWD_TESTING_4",
+            "award_unique_id": "CONT_AWD_TESTING_4",
         },
     }
     expected_response = []


### PR DESCRIPTION
**Description:**
Adds a filter to `spending_by_award` to allow users to filter their `spending_by_award` query by the unique ID for a given prime award.

**Technical details:**
No particularly interesting technical details, although this does make a change to the `spending_by_award` API contract.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [X] Necessary PR reviewers:
    - [X] Backend
6. [X] Data validation completed
8. [X] Jira Ticket [DEV-12209](https://federal-spending-transparency.atlassian.net/browse/DEV-12209):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
- Matview impact assessment completed
Does not impact any Matviews.

- Appropriate Operations ticket(s) created
No data changes are required for this ticket.

- Frontend <OPTIONAL>
- Frontend impact assessment completed
Only adds a filter, so should not impact frontend functionality.
```
