### PR TITLE
[DEV-12208] Update spending_by_award_count to use Elasticsearch

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
@@ -45,6 +45,9 @@ This endpoint takes award filters, and returns the number of awards in each awar
 + `other` (required, number)
 + `idvs` (required, number)
 
+## SubawardTypeResult (object)
++ `subgrants` (required, number)
++ `subcontracts` (required, number)
 
 ## Filter Objects
 ### AdvancedFilterObject (object)

--- a/usaspending_api/search/tests/integration/test_spending_by_award_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award_count.py
@@ -176,14 +176,20 @@ def award_data_fixture(db):
         broker_subaward_id=1,
         award=award1,
         sub_action_date="2023-01-01",
+        action_date="2023-01-01",
         prime_award_group="grant",
+        prime_award_type="07",
+        program_activities=[{"name": "PROGRAM_ACTIVITY_123", "code": "0123"}],
     )
     baker.make(
         "search.SubawardSearch",
         broker_subaward_id=2,
         award=award1,
         sub_action_date="2023-01-01",
+        action_date="2023-01-01",
         prime_award_group="procurement",
+        prime_award_type="07",
+        program_activities=[{"name": "PROGRAM_ACTIVITY_123", "code": "0123"}],
     )
     ref_program_activity1 = baker.make(
         "references.RefProgramActivity",
@@ -319,9 +325,10 @@ def test_spending_by_award_count_new_awards_only(client, monkeypatch, elasticsea
 
 @pytest.mark.django_db
 def test_spending_by_award_count_program_activity_subawards(
-    client, monkeypatch, elasticsearch_award_index, award_data_fixture
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, award_data_fixture
 ):
     setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
 
     # Program Activites filter test
     test_payload = {

--- a/usaspending_api/search/tests/integration/test_spending_by_award_type_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award_type_count.py
@@ -133,8 +133,10 @@ def test_spending_by_award_no_intersection(client, monkeypatch, elasticsearch_aw
 
 
 @pytest.mark.django_db
-def test_spending_by_award_subawards_no_intersection(client):
-    baker.make("search.AwardSearch", award_id=90)
+def test_spending_by_award_subawards_no_intersection(
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index
+):
+    baker.make("search.AwardSearch", award_id=90, action_date="2023-01-01")
     baker.make(
         "search.SubawardSearch",
         broker_subaward_id=9999,
@@ -144,7 +146,11 @@ def test_spending_by_award_subawards_no_intersection(client):
         awarding_toptier_agency_name="Toptier Agency 1",
         awarding_toptier_agency_abbreviation="TA1",
         subaward_amount=10,
+        action_date="2023-01-01",
     )
+
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
 
     request = {
         "subawards": True,

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -155,7 +155,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
     def query_elasticsearch_for_subawards(self, filters) -> list:
         query_with_filters = QueryWithFilters(QueryType.SUBAWARDS)
         filter_query = query_with_filters.generate_elasticsearch_query(filters)
-        s = SubawardSearch().filter(filter_query)
+        s = SubawardSearch().filter(filter_query).filter("exists", field="award_id").extra(size=0)
 
         s.aggs.bucket(
             "types",

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -89,7 +89,6 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
                 empty_results = {"subcontracts": 0, "subgrants": 0}
             results = empty_results
         elif subawards:
-            # results = self.handle_subawards(filters)
             results = self.query_elasticsearch_for_subawards(filters)
         else:
             results = self.query_elasticsearch_for_prime_awards(filters)

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -97,7 +97,6 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         }
 
         return Response(raw_response)
-    
 
     def query_elasticsearch_for_prime_awards(self, filters) -> list:
         query_with_filters = QueryWithFilters(QueryType.AWARDS)


### PR DESCRIPTION
**Description:**
Updates `spending_by_award_count` endpoint to use Elasticsearch for subawards. 

**Technical details:**
No particular special details for this ticket.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API Documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
6. [X] Data validation completed
8. [X] Jira Ticket [DEV-12208](https://federal-spending-transparency.atlassian.net/browse/DEV-12208):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
- Matview impact assessment completed
Doesn't impact Matviews

- Frontend impact assessment completed
- Frontend <OPTIONAL>
Doesn't impact frontend

- Appropriate Operations ticket(s) created
No data changes are required for this ticket.


```
