### PR TITLE
Remove pyspark import and infer schema

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/delete_data.py
@@ -8,7 +8,6 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.mapping import Mapping
 from psycopg2 import sql as psycopg2_sql
-from pyspark.sql.types import StructType, StructField, StringType
 
 
 from usaspending_api.broker.helpers.last_load_date import (
@@ -650,8 +649,7 @@ def _check_awards_for_deletes(
     if spark:  # then use spark against a Delta Table
         awards_table = "int.awards"
         sql = pre_format_sql.format(awards_table=awards_table)
-        schema = StructType([StructField("generated_unique_award_id", StringType())])
-        df = spark.createDataFrame([[val] for val in id_list], schema=schema)
+        df = spark.createDataFrame([[val] for val in id_list])
         results = [row.asDict() for row in spark.sql(sql, from_sql=df).collect()]
     else:
         sql = pre_format_sql.format(awards_table=awards_table).format(from_sql="(values ({ids}))")


### PR DESCRIPTION
**Description:**
Removing the schema from the dataframe to allow running when Pyspark is not available. 

**Technical details:**
Pyspark is only available in Databricks and local development. This thus runs into an error when the code is used by a job that doesn't install the dev dependencies. The workaround is to allow pyspark to infer the schema.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
