### PR TITLE
[DEV-12075] Narrow keyword and award description results

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -577,6 +577,9 @@ def generate_export_query(
         generate_raw_quoted_query(source_query), selected_columns, annotated_group_by_columns
     )
     options = FILE_FORMATS[file_format]["options"]
+
+    print(query_annotated)
+
     return rf"\COPY ({query_annotated}) TO STDOUT {options}"
 
 

--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -65,7 +65,8 @@ def spending_by_award_test_data():
         latest_transaction_id=2,
         generated_unique_award_id="CONT_AWD_TESTING_1",
         date_signed="2008-01-01",
-        description="test test test",
+        description="the test test test",
+        naics_description="the test test test",
         awarding_agency_id=1,
         awarding_toptier_agency_code="ABC",
         awarding_toptier_agency_name="TOPTIER AGENCY 1",
@@ -121,6 +122,8 @@ def spending_by_award_test_data():
         recipient_location_country_code="USA",
         recipient_location_county_code="012",
         naics_code="112244",
+        description="the description for a test",
+        naics_description="the description for a test",
     )
     award_3 = baker.make(
         "search.AwardSearch",
@@ -419,6 +422,8 @@ def spending_by_award_test_data():
         product_or_service_code="PSC2",
         sub_awardee_or_recipient_uei="UEI_10010001",
         unique_award_key="CONT_AWD_TESTING_1",
+        subaward_description="the test test test",
+        product_or_service_description="the test test test",
     )
     baker.make(
         "search.SubawardSearch",
@@ -440,6 +445,8 @@ def spending_by_award_test_data():
         product_or_service_code="PSC0",
         action_date="2020-04-02",
         unique_award_key="CONT_AWD_TESTING_1",
+        subaward_description="the description for a test",
+        product_or_service_description="the description for a test",
     )
     baker.make(
         "search.SubawardSearch",

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -870,9 +870,12 @@ def _test_correct_response_for_keywords(client):
             }
         ),
     )
-    expected_result = [{"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1"}]
+    expected_result = [
+        {"internal_id": 2, "Award ID": "abc222", "generated_internal_id": "CONT_AWD_TESTING_2"},
+        {"internal_id": 1, "Award ID": "abc111", "generated_internal_id": "CONT_AWD_TESTING_1"},
+    ]
     assert resp.status_code == status.HTTP_200_OK
-    assert len(resp.json().get("results")) == 1
+    assert len(resp.json().get("results")) == 2
     assert resp.json().get("results") == expected_result, "Keyword filter does not match expected result"
 
 
@@ -2317,6 +2320,103 @@ def test_spending_by_award_unique_id_subaward(
         },
     }
     expected_response = []
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+
+def test_spending_by_award_description_specificity(
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, spending_by_award_test_data
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
+    # get award with description "the test test test" and not "the description for test"
+    test_payload = {
+        "subawards": False,
+        "fields": ["Award ID"],
+        "filters": {"award_type_codes": ["A", "B", "C", "D"], "description": "the test"},
+    }
+    expected_response = [
+        {
+            "internal_id": 1,
+            "Award ID": "abc111",
+            "generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+    ]
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+    # get subaward with description "the test test test" and not "the description for test"
+    test_payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {"award_type_codes": ["A", "B", "C", "D"], "description": "the test"},
+    }
+    expected_response = [
+        {
+            "internal_id": "11111",
+            "prime_award_internal_id": 1,
+            "Sub-Award ID": "11111",
+            "prime_award_generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+    ]
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+
+def test_spending_by_award_keyword_specificity(
+    client, monkeypatch, elasticsearch_award_index, elasticsearch_subaward_index, spending_by_award_test_data
+):
+    setup_elasticsearch_test(monkeypatch, elasticsearch_award_index)
+    setup_elasticsearch_test(monkeypatch, elasticsearch_subaward_index)
+
+    # get award with naics_description "the test test test" and not "the description for test"
+    test_payload = {
+        "subawards": False,
+        "fields": ["Award ID"],
+        "filters": {"award_type_codes": ["A", "B", "C", "D"], "keyword": "the test"},
+    }
+    expected_response = [
+        {
+            "internal_id": 1,
+            "Award ID": "abc111",
+            "generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+    ]
+    resp = client.post(
+        "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.json().get("results"), "Unexpected or missing content!"
+
+    # get subaward with product_or_service_description "the test test test" and not
+    # "the description for test"
+    test_payload = {
+        "subawards": True,
+        "fields": ["Sub-Award ID"],
+        "filters": {"award_type_codes": ["A", "B", "C", "D"], "keyword": "the test"},
+    }
+    expected_response = [
+        {
+            "internal_id": "11111",
+            "prime_award_internal_id": 1,
+            "Sub-Award ID": "11111",
+            "prime_award_generated_internal_id": "CONT_AWD_TESTING_1",
+        },
+    ]
     resp = client.post(
         "/api/v2/search/spending_by_award/", content_type="application/json", data=json.dumps(test_payload)
     )

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -326,6 +326,8 @@ class SpendingByAwardVisualizationViewSet(APIView):
         else:
             search = base_search.filter(filter_query).sort(*sorts)[record_num : record_num + self.pagination["limit"]]
 
+        print(search.to_dict())
+
         response = search.handle_execute()
 
         return response


### PR DESCRIPTION
**Description:**
Improves the keywords and description filters such that when searching `booz allen` it only returns results that include the exact search criteria, in its exact order. Additionally, it continues to support partial matches.

**Technical details:**
Accomplishes this by using `multi_match` queries with the `phrase_phrefix` type in a similar manner to #4262. Additionally, I added integration tests to ensure that this functionality stays consistent.

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
6. [X] Data validation completed
8. [X] Jira Ticket [DEV-12075](https://federal-spending-transparency.atlassian.net/browse/DEV-12075):
    - [X] Link to this Pull-Request
    - [X] Performance evaluation of affected (API | Script | Download)
    - [X] Before / After data comparison

**Area for explaining above N/A when needed:**
```
2. API documentation updated
5. Frontend impact assessment completed
6.  Frontend <OPTIONAL>
Doesn't impact endpoint interface

4. [ ] Matview impact assessment completed
Doesn't impact matviews

7. [ ] Appropriate Operations ticket(s) created
No changes necessary to data
```
