### PR TITLE
[DEV-11927] Update recipient_id description on API contracts where present

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/download/count.md
+++ b/usaspending_api/api_contracts/contracts/v2/download/count.md
@@ -93,7 +93,7 @@ Returns the number of transactions that would be included in a download request 
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: `Hampton` (optional, array[string])
 + `recipient_id` (optional, string)
-    A hash of recipient UEI, DUNS, name, and level. A unique identifier for recipients, used for profile page urls.
+    A hash of recipient UEI, DUNS, name, and level. A unique identifier for recipients, used for profile page urls. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_agency.md
@@ -133,7 +133,7 @@ This endpoint returns a list of the top results of Awarding Agencies sorted by t
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_subagency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/awarding_subagency.md
@@ -136,7 +136,7 @@ This endpoint returns a list of the top results of Awarding Subagencies sorted b
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/cfda.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/cfda.md
@@ -130,7 +130,7 @@ This endpoint returns a list of the top results of CFDA sorted by the total amou
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/country.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/country.md
@@ -131,7 +131,7 @@ This endpoint returns a list of the top results of Countries sorted by the total
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/county.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/county.md
@@ -131,7 +131,7 @@ This endpoint returns a list of the top results of Counties sorted by the total 
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/defc.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/defc.md
@@ -132,7 +132,7 @@ This endpoint should return a an aggregate list of DEFC's sorted by the total am
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/district.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/district.md
@@ -131,7 +131,7 @@ This endpoint returns a list of the top results of Congressional Districts sorte
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/federal_account.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/federal_account.md
@@ -133,7 +133,7 @@ This endpoint returns a list of the top results of Federal Accounts sorted by th
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_agency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_agency.md
@@ -130,7 +130,7 @@ This endpoint returns a list of the top results of Funding Agencies sorted by th
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_subagency.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/funding_subagency.md
@@ -136,7 +136,7 @@ This endpoint returns a list of the top results of Funding Subagencies sorted by
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`, `Roads`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/naics.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/naics.md
@@ -130,7 +130,7 @@ This endpoint returns a list of the top results of NAICS sorted by the total amo
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/psc.md
@@ -130,7 +130,7 @@ This endpoint returns a list of the top results of PSC sorted by the total amoun
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient.md
@@ -134,7 +134,7 @@ This endpoint returns a list of the top results of Recipients sorted by the tota
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient_duns.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/recipient_duns.md
@@ -133,7 +133,7 @@ This endpoint returns a list of the top results of Recipient DUNS sorted by the 
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/state_territory.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_category/state_territory.md
@@ -131,7 +131,7 @@ This endpoint returns a list of the top results of State Territories sorted by t
 + `agencies` (optional, array[AgencyObject], fixed-type)
 + `recipient_search_text`: [`Hampton`] (optional, array[string])
 + `recipient_id` (optional, string)
-    A unique identifier for the recipient which includes the recipient hash and level.
+    A unique identifier for the recipient which includes the recipient hash and level. This filter is not supported by subawards.
 + `recipient_scope` (optional, enum[string])
     + Members
         + `domestic`


### PR DESCRIPTION
**Description:**
The `recipient_id` filter is currently called out on multiple API contracts. While this filter is available to Awards and Transactions, it is not available for Subawards. This PR updates the contracts where the `recipient_id` filter currently exists to clarify that it is not available for Subawards.

**Technical details:**
Instead of adding `recipient_id` filter to API contracts where it wasn't currently present, this looks to make sure that the API contracts that currently call it out are correctly specifying that the filter isn't available for Subawards.

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-11927](https://federal-spending-transparency.atlassian.net/browse/DEV-11927):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
