### PR TITLE
[DEV-12298] Update File B COVID calculations

### DIFF
--- a/usaspending_api/common/calculations/file_b.py
+++ b/usaspending_api/common/calculations/file_b.py
@@ -1,9 +1,8 @@
 import enum
-
 from functools import cached_property
 from typing import Dict, Union
 
-from django.db.models import DecimalField, F, Q, When, Case, Value
+from django.db.models import Case, DecimalField, F, Q, Value, When
 from django.db.models.functions import Coalesce
 
 from usaspending_api.common.helpers.orm_helpers import sum_column_list
@@ -78,7 +77,6 @@ class FileBCalculations:
 
         # Some PYA values share columns, so we handle that here
         # !!! The order of the statements is important !!!
-        pya_columns["X"].extend(pya_columns["P"])
         pya_columns["P"].extend(pya_columns["B"])
 
         return self._build_columns("obligations_incurred_by_program_object_class_cpe", pya_columns)

--- a/usaspending_api/common/tests/integration/test_calculations_for_file_b.py
+++ b/usaspending_api/common/tests/integration/test_calculations_for_file_b.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.db.models import Sum
 from model_bakery import baker
 
@@ -227,7 +226,7 @@ def test_is_non_zero_total_spending_filter(non_zero_test_data):
     nonzero_count = FinancialAccountsByProgramActivityObjectClass.objects.filter(
         covid_calc.is_non_zero_total_spending()
     ).count()
-    assert nonzero_count == 4
+    assert nonzero_count == 5
 
     single_year_calc = FileBCalculations(is_covid_page=False)
     nonzero_count = FinancialAccountsByProgramActivityObjectClass.objects.filter(
@@ -244,7 +243,7 @@ def test_get_obligations(obligation_and_outlay_data):
         .annotate(total=Sum(covid_calc.get_obligations()))
         .get()
     )
-    assert result["total"] == 125200
+    assert result["total"] == 85200
 
     covid_final_sub_calc = FileBCalculations(include_final_sub_filter=True, is_covid_page=True)
     result = (
@@ -252,7 +251,7 @@ def test_get_obligations(obligation_and_outlay_data):
         .annotate(total=Sum(covid_final_sub_calc.get_obligations()))
         .get()
     )
-    assert result["total"] == 62600
+    assert result["total"] == 42600
 
     single_year_calc = FileBCalculations(include_final_sub_filter=False, is_covid_page=False)
     result = (


### PR DESCRIPTION
**Description:**
Updated the SF133 Covid calculations to only include `ussgl480110_rein_undel_ord_cpe` and `ussgl490110_rein_deliv_ord_cpe` when `PYA == P`.

**Technical details:**


**Requirements for PR merge:**

1. [x] Unit & integration tests updated
3. [x] Necessary PR reviewers:
    - [x] Backend
8. [x] Jira Ticket [DEV-12298](https://federal-spending-transparency.atlassian.net/browse/DEV-12298):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
