### PR TITLE
[DEV-12349] add spending_level filter

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
@@ -39,6 +39,11 @@ This endpoint takes award filters, and returns the number of awards in each awar
 + Response 200 (application/json)
     + Attributes (object)
         + `results` (AwardTypeResult)
+        + `spending_level` (required, enum[string])
+            Spending level value that was provided in the request.
+            + Members
+                + `awards`
+                + `subawards`
         + `messages` (optional, array[string])
             An array of warnings or instructional directives to aid consumers of this endpoint with development and debugging.
 

--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award_count.md
@@ -19,8 +19,15 @@ This endpoint takes award filters, and returns the number of awards in each awar
 
     + Attributes (object)
         + `filters` (required, AdvancedFilterObject)
+        + `spending_level` (optional, enum[string])
+            Group the spending by level. This also determines what data source is used for the totals.
+            + Members
+                + `awards` 
+                + `subawards`
+            + Default
+                + `awards`
         + `subawards`: false (optional, boolean)
-            True when you want to group by Subawards instead of Awards. Defaulted to False.
+            True when you want to group by Subawards instead of Awards. Defaulted to False unless spending_level is set to `subawards`, then the default is True.
     + Body
 
             {

--- a/usaspending_api/search/tests/integration/test_spending_by_award_count.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award_count.py
@@ -238,6 +238,7 @@ def test_spending_by_award_count(client, monkeypatch, elasticsearch_award_index,
 
     expected_response = {
         "results": {"contracts": 2, "idvs": 4, "loans": 1, "direct_payments": 0, "grants": 0, "other": 1},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -263,6 +264,7 @@ def test_spending_by_award_count_idvs(client, monkeypatch, elasticsearch_award_i
 
     expected_response = {
         "results": {"contracts": 0, "idvs": 3, "loans": 0, "direct_payments": 0, "grants": 0, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -290,6 +292,7 @@ def test_spending_by_award_count_new_awards_only(client, monkeypatch, elasticsea
 
     expected_response = {
         "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 1, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -312,6 +315,7 @@ def test_spending_by_award_count_new_awards_only(client, monkeypatch, elasticsea
 
     expected_response = {
         "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 0, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -340,6 +344,7 @@ def test_spending_by_award_count_program_activity_subawards(
 
     expected_response = {
         "results": {"subcontracts": 1, "subgrants": 1},
+        "spending_level": "subawards",
         "messages": [get_time_period_message()],
     }
 
@@ -358,6 +363,7 @@ def test_spending_by_award_count_program_activity_subawards(
 
     expected_response = {
         "results": {"subcontracts": 1, "subgrants": 1},
+        "spending_level": "subawards",
         "messages": [get_time_period_message()],
     }
 
@@ -377,6 +383,7 @@ def test_spending_by_award_count_program_activity_subawards(
 
     expected_response = {
         "results": {"subcontracts": 0, "subgrants": 0},
+        "spending_level": "subawards",
         "messages": [get_time_period_message()],
     }
 
@@ -402,6 +409,7 @@ def test_spending_by_award_count_program_activity(client, monkeypatch, elasticse
 
     expected_response = {
         "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 1, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -421,6 +429,7 @@ def test_spending_by_award_count_program_activity(client, monkeypatch, elasticse
 
     expected_response = {
         "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 0, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -440,6 +449,7 @@ def test_spending_by_award_count_program_activity(client, monkeypatch, elasticse
 
     expected_response = {
         "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 1, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -459,6 +469,7 @@ def test_spending_by_award_count_program_activity(client, monkeypatch, elasticse
 
     expected_response = {
         "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 1, "other": 0},
+        "spending_level": "awards",
         "messages": [get_time_period_message()],
     }
 
@@ -487,16 +498,14 @@ def test_spending_level_filter(client, monkeypatch, elasticsearch_award_index, e
         "/api/v2/search/spending_by_award_count", content_type="application/json", data=json.dumps(request)
     )
 
-    print(resp.data["results"])
-    assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["results"] == {
-        "contracts": 0,
-        "direct_payments": 0,
-        "grants": 0,
-        "idvs": 0,
-        "loans": 0,
-        "other": 0,
+    expected_response = {
+        "results": {"contracts": 0, "direct_payments": 0, "grants": 0, "idvs": 0, "loans": 0, "other": 0},
+        "spending_level": "awards",
+        "messages": [get_time_period_message()],
     }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert expected_response == resp.data
 
     request = {
         "spending_level": "subawards",
@@ -509,8 +518,14 @@ def test_spending_level_filter(client, monkeypatch, elasticsearch_award_index, e
         "/api/v2/search/spending_by_award_count", content_type="application/json", data=json.dumps(request)
     )
 
+    expected_response = {
+        "results": {"subgrants": 0, "subcontracts": 0},
+        "spending_level": "subawards",
+        "messages": [get_time_period_message()],
+    }
+
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["results"] == {"subgrants": 0, "subcontracts": 0}
+    assert expected_response == resp.data
 
     # Checks that subawards = true takes precedent over spending_level = awards
     request = {
@@ -525,5 +540,11 @@ def test_spending_level_filter(client, monkeypatch, elasticsearch_award_index, e
         "/api/v2/search/spending_by_award_count", content_type="application/json", data=json.dumps(request)
     )
 
+    expected_response = {
+        "results": {"subgrants": 0, "subcontracts": 0},
+        "spending_level": "subawards",
+        "messages": [get_time_period_message()],
+    }
+
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.data["results"] == {"subgrants": 0, "subcontracts": 0}
+    assert expected_response == resp.data

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -106,6 +106,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
 
         raw_response = {
             "results": results,
+            "spending_level": "subawards" if subawards else json_request["spending_level"],
             "messages": get_generic_filters_message(self.original_filters.keys(), [elem["name"] for elem in models]),
         }
 

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -21,6 +21,7 @@ from usaspending_api.common.validator.award_filter import AWARD_FILTER_NO_RECIPI
 from usaspending_api.common.validator.pagination import PAGINATION
 from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.search.filters.elasticsearch.filter import QueryType
+from usaspending_api.search.v2.views.enums import SpendingLevel
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,15 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
             },
         }
         models = [
-            {"name": "subawards", "key": "subawards", "type": "boolean", "default": False},
+            {
+                "name": "spending_level",
+                "key": "spending_level",
+                "type": "enum",
+                "enum_values": [SpendingLevel.AWARD.value, SpendingLevel.SUBAWARD.value],
+                "optional": True,
+                "default": SpendingLevel.AWARD.value,
+            },
+            {"name": "subawards", "key": "subawards", "type": "boolean"},
             {
                 "name": "object_class",
                 "key": "filter|object_class",
@@ -75,7 +84,11 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
         json_request = tiny_shield.block(request.data)
         if "filters" in json_request and "program_activities" in json_request["filters"]:
             tiny_shield.enforce_object_keys_min(json_request, program_activities_rule)
-        subawards = json_request["subawards"]
+        subawards = (
+            json_request["subawards"]
+            if "subawards" in json_request
+            else True if json_request["spending_level"] == SpendingLevel.SUBAWARD.value else False
+        )
         filters = json_request.get("filters", None)
         if filters is None:
             raise InvalidParameterException("Missing required request parameters: 'filters'")

--- a/usaspending_api/search/v2/views/spending_by_award_count.py
+++ b/usaspending_api/search/v2/views/spending_by_award_count.py
@@ -51,6 +51,7 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
             },
         }
         models = [
+            {"name": "subawards", "key": "subawards", "type": "boolean"},
             {
                 "name": "spending_level",
                 "key": "spending_level",
@@ -59,7 +60,6 @@ class SpendingByAwardCountVisualizationViewSet(APIView):
                 "optional": True,
                 "default": SpendingLevel.AWARD.value,
             },
-            {"name": "subawards", "key": "subawards", "type": "boolean"},
             {
                 "name": "object_class",
                 "key": "filter|object_class",


### PR DESCRIPTION
**Description:**
This allows `/api/v2/search/spending_by_award_count` to accept the spending_level filter 

**Technical details:**
`spending_level` supports `awards` and `subawards` and is updated similarly to other endpoints that support `spending_level`

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. [X] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-12349](https://federal-spending-transparency.atlassian.net/browse/DEV-12349):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
