### PR TITLE
Adjust num_processes for test suite and add back signal_handling branches

### DIFF
--- a/.github/actions/init-test-environment/action.yaml
+++ b/.github/actions/init-test-environment/action.yaml
@@ -75,9 +75,9 @@ runs:
       if: ${{ inputs.is-spark-test == 'true' }}
       shell: bash
       run: |
-        PIP_SPARK_HOME=$(python -c "import site;print(f'{site.getsitepackages()[0]}/pyspark')")
-        mkdir $PIP_SPARK_HOME/conf
-        touch $PIP_SPARK_HOME/conf/log4j2.properties
+        echo "SPARK_HOME=$(python -c "import site;print(f'{site.getsitepackages()[0]}/pyspark')")" >> $GITHUB_ENV
+        mkdir $SPARK_HOME/conf
+        touch $SPARK_HOME/conf/log4j2.properties
         echo "
         # This takes the log4j2.properties.template and changes log_level to warning
         rootLogger.level = warn
@@ -107,7 +107,7 @@ runs:
         logger.RetryingHMSHandler.level = fatal
         logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
         logger.FunctionRegistry.level = error
-        " >> $PIP_SPARK_HOME/conf/log4j2.properties
+        " >> $SPARK_HOME/conf/log4j2.properties
 
     - name: Run initial test to trigger DB creation
       if: ${{ inputs.is-integration-test == 'true' }}

--- a/.github/actions/init-test-environment/action.yaml
+++ b/.github/actions/init-test-environment/action.yaml
@@ -71,11 +71,15 @@ runs:
         psql $DATABASE_URL -c "SELECT 'GRANT SELECT ON ALL TABLES IN SCHEMA ' || nspname || ' TO readonly' FROM pg_namespace WHERE nspname IN ('raw','int','rpt','temp','public')"
         psql $DATABASE_URL -c "SELECT 'ALTER DEFAULT PRIVILEGES IN SCHEMA ' || nspname || ' GRANT SELECT ON TABLES TO readonly' FROM pg_namespace WHERE nspname IN ('raw','int','rpt','temp','public')"
 
+    - name: Capture SPARK_HOME environment variable
+      if: ${{ inputs.is-spark-test == 'true' }}
+      shell: bash
+      run: echo "SPARK_HOME=$(python -c "import site;print(f'{site.getsitepackages()[0]}/pyspark')")" >> $GITHUB_ENV
+
     - name: Setting spark log levels to warning
       if: ${{ inputs.is-spark-test == 'true' }}
       shell: bash
       run: |
-        echo "SPARK_HOME=$(python -c "import site;print(f'{site.getsitepackages()[0]}/pyspark')")" >> $GITHUB_ENV
         mkdir $SPARK_HOME/conf
         touch $SPARK_HOME/conf/log4j2.properties
         echo "

--- a/.github/actions/run-pytest/action.yaml
+++ b/.github/actions/run-pytest/action.yaml
@@ -64,11 +64,11 @@ runs:
         ".format(
         db_state=os.environ["DB_STATE"],
         cov_report_name=os.environ["COV_REPORT_NAME"],
-        ignore_glob="--ignore-glob=\"{}\"".format(os.environ["IGNORE_GLOB"]) if os.environ.get("IGNORE_GLOB") else ""
+        ignore_glob="--ignore-glob=\"{}\"".format(os.environ["IGNORE_GLOB"]) if os.environ.get("IGNORE_GLOB") else "",
         include_glob=os.environ["INCLUDE_GLOB"],
         keyword="-k \"{}\"".format(os.environ["KEYWORD"]) if os.environ.get("KEYWORD") else "",
         marker="-m \"{}\"".format(os.environ["MARKER"]) if os.environ.get("MARKER") else "",
-        num_processes=os.environ["NUM_PROCESSES"],
+        num_processes=os.environ["NUM_PROCESSES"]
         ))') >> $GITHUB_OUTPUT
 
     - name: Run tests

--- a/.github/actions/run-pytest/action.yaml
+++ b/.github/actions/run-pytest/action.yaml
@@ -19,6 +19,9 @@ inputs:
   marker:
     description: Marker to decide which tests should be run
     default: ""
+  num-processes:
+    description: The number of processes to use for this test suite
+    default: "logical"
   working-directory:
     description: Directory where the requirements can be found; used when multiple repos are checked out
     default: "."
@@ -35,6 +38,7 @@ runs:
         echo "INCLUDE_GLOB=${{ inputs.include-glob }}" >> $GITHUB_ENV
         echo "KEYWORD=${{ inputs.keyword }}" >> $GITHUB_ENV
         echo "MARKER=${{ inputs.marker }}" >> $GITHUB_ENV
+        echo "NUM_PROCESSES=${{ inputs.num-processes }}" >> $GITHUB_ENV
 
     - name: Build pytest command
       working-directory: ${{ inputs.working-directory }}
@@ -50,7 +54,7 @@ runs:
         --cov-report xml:{cov_report_name}
         --dist worksteal
         --durations 50
-        --numprocesses logical
+        --numprocesses {num_processes}
         --override-ini=python_files=\"{include_glob}\"
         --verbosity=1
         {db_state}
@@ -60,10 +64,11 @@ runs:
         ".format(
         db_state=os.environ["DB_STATE"],
         cov_report_name=os.environ["COV_REPORT_NAME"],
+        ignore_glob="--ignore-glob=\"{}\"".format(os.environ["IGNORE_GLOB"]) if os.environ.get("IGNORE_GLOB") else ""
         include_glob=os.environ["INCLUDE_GLOB"],
         keyword="-k \"{}\"".format(os.environ["KEYWORD"]) if os.environ.get("KEYWORD") else "",
         marker="-m \"{}\"".format(os.environ["MARKER"]) if os.environ.get("MARKER") else "",
-        ignore_glob="--ignore-glob=\"{}\"".format(os.environ["IGNORE_GLOB"]) if os.environ.get("IGNORE_GLOB") else ""
+        num_processes=os.environ["NUM_PROCESSES"],
         ))') >> $GITHUB_OUTPUT
 
     - name: Run tests

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -126,7 +126,9 @@ jobs:
       - Run-Spark-Integration-Load-To-From-Delta-Tests
       - Run-Spark-Integration-Other-Tests
       - Run-Non-Spark-Integration-Tests
+      - Run-Non-Spark-Integration-Tests-With-Signal-Handling
       - Run-Unit-Tests
+      - Run-Unit-Tests-With-Signal-Handling
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/code-climate-report-coverage.yaml
     with:

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -98,11 +98,25 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/test-non-spark-integration.yaml
 
+  Run-Non-Spark-Integration-Tests-With-Signal-Handling:
+    name: Run Non-Spark Integration Tests With Signal Handling
+    needs:
+      - Code-Climate-Before-Build
+      - Build-Broker-Docker-Image
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/test-non-spark-integration-signal-handling.yaml
+
   Run-Unit-Tests:
     name: Run Unit Tests
     needs: Code-Climate-Before-Build
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/test-unit.yaml
+
+  Run-Unit-Tests-With-Signal-Handling:
+    name: Run Unit Tests With Signal Handling
+    needs: Code-Climate-Before-Build
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/test-unit-signal-handling.yaml
 
   Code-Climate-Report-Coverage:
     name: Code Climate Report Coverage

--- a/.github/workflows/test-non-spark-integration-signal-handling.yaml
+++ b/.github/workflows/test-non-spark-integration-signal-handling.yaml
@@ -60,9 +60,3 @@ jobs:
           marker: '(signal_handling and not spark)'
           num-processes: 0
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-non-spark-integration-signal-handling.yaml
+++ b/.github/workflows/test-non-spark-integration-signal-handling.yaml
@@ -1,4 +1,4 @@
-name: Spark Integration Tests - test_load_transactions_in_delta_lookups.py
+name: Non-Spark Integration Tests with Signal Handling
 
 env:
   BROKER_DB_HOST: localhost
@@ -22,7 +22,7 @@ on:
 
 defaults:
   run:
-    working-directory: ./usaspending-api
+    working-directory: usaspending-api
 
 jobs:
   Run:
@@ -49,16 +49,15 @@ jobs:
         uses: ./usaspending-api/.github/actions/init-test-environment
         with:
           is-integration-test: true
-          is-spark-test: true
+          is-spark-test: false
           working-directory: ./usaspending-api
 
       - name: Run Test Cases
         uses: ./usaspending-api/.github/actions/run-pytest
         with:
-          cov-report-name: 'spark-load-transactions-lookup-tests'
-          include-glob: 'test_*.py *_test.py'
-          keyword: 'test_load_transactions_in_delta_lookups.py'
-          marker: 'spark'
+          cov-report-name: 'non-spark-integration-tests'
+          include-glob: '**/tests/integration/*'
+          marker: '(signal_handling and not spark)'
           num-processes: 0
           working-directory: ./usaspending-api
 

--- a/.github/workflows/test-non-spark-integration-signal-handling.yaml
+++ b/.github/workflows/test-non-spark-integration-signal-handling.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run Test Cases
         uses: ./usaspending-api/.github/actions/run-pytest
         with:
-          cov-report-name: 'non-spark-integration-tests'
+          cov-report-name: 'non-spark-integration-signal-handling-tests'
           include-glob: '**/tests/integration/*'
           marker: '(signal_handling and not spark)'
           num-processes: 0

--- a/.github/workflows/test-non-spark-integration.yaml
+++ b/.github/workflows/test-non-spark-integration.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           cov-report-name: 'non-spark-integration-tests'
           include-glob: '**/tests/integration/*'
-          marker: '(not spark)'
+          marker: '(not signal_handling and not spark)'
           working-directory: ./usaspending-api
 
   Cancel-Running-Workflow:

--- a/.github/workflows/test-non-spark-integration.yaml
+++ b/.github/workflows/test-non-spark-integration.yaml
@@ -59,9 +59,3 @@ jobs:
           include-glob: '**/tests/integration/*'
           marker: '(not signal_handling and not spark)'
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-spark-integration-load-to-from-delta.yaml
+++ b/.github/workflows/test-spark-integration-load-to-from-delta.yaml
@@ -61,9 +61,3 @@ jobs:
           marker: 'spark'
           num-processes: 2
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-spark-integration-load-to-from-delta.yaml
+++ b/.github/workflows/test-spark-integration-load-to-from-delta.yaml
@@ -59,6 +59,7 @@ jobs:
           include-glob: 'test_*.py *_test.py'
           keyword: 'test_load_to_from_delta.py'
           marker: 'spark'
+          num-processes: 2
           working-directory: ./usaspending-api
 
   Cancel-Running-Workflow:

--- a/.github/workflows/test-spark-integration-load-transactions-fabs-fpds.yaml
+++ b/.github/workflows/test-spark-integration-load-transactions-fabs-fpds.yaml
@@ -61,9 +61,3 @@ jobs:
           marker: 'spark'
           num-processes: 0
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-spark-integration-load-transactions-fabs-fpds.yaml
+++ b/.github/workflows/test-spark-integration-load-transactions-fabs-fpds.yaml
@@ -59,6 +59,7 @@ jobs:
           include-glob: 'test_*.py *_test.py'
           keyword: 'test_load_transactions_in_delta_fabs_fpds.py'
           marker: 'spark'
+          num-processes: 0
           working-directory: ./usaspending-api
 
   Cancel-Running-Workflow:

--- a/.github/workflows/test-spark-integration-load-transactions-lookup.yaml
+++ b/.github/workflows/test-spark-integration-load-transactions-lookup.yaml
@@ -61,9 +61,3 @@ jobs:
           marker: 'spark'
           num-processes: 0
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-spark-integration-other.yaml
+++ b/.github/workflows/test-spark-integration-other.yaml
@@ -60,9 +60,3 @@ jobs:
           keyword: '(not test_load_to_from_delta.py and not test_load_transactions_in_delta_lookups.py and not test_load_transactions_in_delta_fabs_fpds.py)'
           marker: 'spark'
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-unit-signal-handling.yaml
+++ b/.github/workflows/test-unit-signal-handling.yaml
@@ -46,7 +46,7 @@ jobs:
         id: run-test-cases
         uses: ./usaspending-api/.github/actions/run-pytest
         with:
-          cov-report-name: 'unit-tests'
+          cov-report-name: 'unit-signal-handling-tests'
           ignore-glob: '**/tests/integration/*'
           include-glob: 'test_*.py *_test.py'
           marker: '(signal_handling)'

--- a/.github/workflows/test-unit-signal-handling.yaml
+++ b/.github/workflows/test-unit-signal-handling.yaml
@@ -52,9 +52,3 @@ jobs:
           marker: '(signal_handling)'
           num-processes: 0
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/.github/workflows/test-unit-signal-handling.yaml
+++ b/.github/workflows/test-unit-signal-handling.yaml
@@ -1,4 +1,4 @@
-name: Spark Integration Tests - test_load_transactions_in_delta_lookups.py
+name: Unit Tests with Signal Handling
 
 env:
   BROKER_DB_HOST: localhost
@@ -20,10 +20,6 @@ env:
 on:
   workflow_call:
 
-defaults:
-  run:
-    working-directory: ./usaspending-api
-
 jobs:
   Run:
     name: Run
@@ -34,12 +30,6 @@ jobs:
         with:
           path: usaspending-api
 
-      - name: Checkout Broker Backend Repository
-        uses: actions/checkout@v4
-        with:
-          repository: fedspendingtransparency/data-act-broker-backend
-          path: data-act-broker-backend
-
       - name: Init Python Environment
         uses: ./usaspending-api/.github/actions/init-python-environment
         with:
@@ -48,17 +38,18 @@ jobs:
       - name: Init Test Environment
         uses: ./usaspending-api/.github/actions/init-test-environment
         with:
-          is-integration-test: true
-          is-spark-test: true
+          is-integration-test: false
+          is-spark-test: false
           working-directory: ./usaspending-api
 
       - name: Run Test Cases
+        id: run-test-cases
         uses: ./usaspending-api/.github/actions/run-pytest
         with:
-          cov-report-name: 'spark-load-transactions-lookup-tests'
+          cov-report-name: 'unit-tests'
+          ignore-glob: '**/tests/integration/*'
           include-glob: 'test_*.py *_test.py'
-          keyword: 'test_load_transactions_in_delta_lookups.py'
-          marker: 'spark'
+          marker: '(signal_handling)'
           num-processes: 0
           working-directory: ./usaspending-api
 

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -49,6 +49,7 @@ jobs:
           cov-report-name: 'unit-tests'
           ignore-glob: '**/tests/integration/*'
           include-glob: 'test_*.py *_test.py'
+          marker: '(not signal_handling)'
           working-directory: ./usaspending-api
 
   Cancel-Running-Workflow:

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -51,9 +51,3 @@ jobs:
           include-glob: 'test_*.py *_test.py'
           marker: '(not signal_handling)'
           working-directory: ./usaspending-api
-
-  Cancel-Running-Workflow:
-    name: Cancel Running Workflow
-    needs: Run
-    if: failure()
-    uses: ./.github/workflows/cancel-running-workflow.yaml

--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -295,7 +295,7 @@ def configure_logging(service_name="usaspending-api"):
 
         exporter = ConsoleSpanExporter()
 
-    else:
+    elif not IS_LOCAL:
         exporter = OTLPSpanExporter(
             endpoint=os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
         )


### PR DESCRIPTION
**Description:**
Update the GitHub workflows to add the `signal_handling` checks previous implemented in Travis. Additionally, change the number of processes depending on the test suite.

**Technical details:**
The `signal_handling` tests appear to be breaking randomly when run in multiple processes by pytest. While ideally I wanted to avoid having as many runners as the Travis Build, it appears we may need to break out the `signal_handling` tests in order to be consistent build to build, and also keep our performance gains.

Additionally, the value of `num_processes` has been updated to match more closely to what Travis was previously using.

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. N/A Jira Ticket:


**Area for explaining above N/A when needed:**
```
```
