### PR TITLE
DEV-11858: Reload Transactions Fix

### DIFF
--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -1145,7 +1145,7 @@ class Command(BaseCommand):
             except AnalysisException as e:
                 if re.match(
                     r"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`transaction_normalized` cannot be found\..*$",
-                    e.desc,
+                    e.message,
                     re.MULTILINE,
                 ):
                     # In this case, we just don't populate transaction_id_lookup
@@ -1173,7 +1173,7 @@ class Command(BaseCommand):
                 except AnalysisException as e:
                     if re.match(
                         r"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`transaction_fabs` cannot be found\..*$",
-                        e.desc,
+                        e.message,
                         re.MULTILINE,
                     ):
                         # In this case, we just skip extending the orphaned transactions with this table
@@ -1201,7 +1201,7 @@ class Command(BaseCommand):
                 except AnalysisException as e:
                     if re.match(
                         r"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`transaction_fpds` cannot be found\..*$",
-                        e.desc,
+                        e.message,
                         re.MULTILINE,
                     ):
                         # In this case, we just skip extending the orphaned transactions with this table
@@ -1513,7 +1513,7 @@ class Command(BaseCommand):
                     except AnalysisException as e:
                         if re.match(
                             rf"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`{destination_table}` cannot be found\..*$",
-                            e.desc,
+                            e.message,
                             re.MULTILINE,
                         ):
                             # In this case, we just don't copy anything over

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -1145,7 +1145,7 @@ class Command(BaseCommand):
             except AnalysisException as e:
                 if re.match(
                     r"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`transaction_normalized` cannot be found\..*$",
-                    e.message,
+                    str(e),
                     re.MULTILINE,
                 ):
                     # In this case, we just don't populate transaction_id_lookup
@@ -1173,7 +1173,7 @@ class Command(BaseCommand):
                 except AnalysisException as e:
                     if re.match(
                         r"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`transaction_fabs` cannot be found\..*$",
-                        e.message,
+                        str(e),
                         re.MULTILINE,
                     ):
                         # In this case, we just skip extending the orphaned transactions with this table
@@ -1201,7 +1201,7 @@ class Command(BaseCommand):
                 except AnalysisException as e:
                     if re.match(
                         r"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`transaction_fpds` cannot be found\..*$",
-                        e.message,
+                        str(e),
                         re.MULTILINE,
                     ):
                         # In this case, we just skip extending the orphaned transactions with this table
@@ -1513,7 +1513,7 @@ class Command(BaseCommand):
                     except AnalysisException as e:
                         if re.match(
                             rf"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`{destination_table}` cannot be found\..*$",
-                            e.message,
+                            str(e),
                             re.MULTILINE,
                         ):
                             # In this case, we just don't copy anything over

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta_lookups.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta_lookups.py
@@ -293,7 +293,7 @@ class TestInitialRun:
                 except pyspark.sql.utils.AnalysisException as e:
                     if re.match(
                         rf"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`{table_name}` cannot be found\..*$",
-                        e.message,
+                        str(e),
                         re.MULTILINE,
                     ):
                         pass

--- a/usaspending_api/etl/tests/integration/test_load_transactions_in_delta_lookups.py
+++ b/usaspending_api/etl/tests/integration/test_load_transactions_in_delta_lookups.py
@@ -293,7 +293,7 @@ class TestInitialRun:
                 except pyspark.sql.utils.AnalysisException as e:
                     if re.match(
                         rf"^\[TABLE_OR_VIEW_NOT_FOUND\] The table or view `raw`\.`{table_name}` cannot be found\..*$",
-                        e.desc,
+                        e.message,
                         re.MULTILINE,
                     ):
                         pass


### PR DESCRIPTION
**Description:**
When reloading transactions with a nonexistent `raw.transaction_normalized`, it uses code that hasn't been updated since the Phase 3 deploy, which includes the assumption of `AnalysisException.desc`. This simply updates it to use `str(e)` which contains the message which the code checks for.

**Technical details:**
N/A

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. Matview impact assessment completed
5. Frontend impact assessment completed
6. Data validation completed
7. Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-11858](https://federal-spending-transparency.atlassian.net/browse/DEV-11858):
    - [ ] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
9. [x] Used for the test run on staging with success

**Area for explaining above N/A when needed:**
```
```
