### PR TITLE
[DEV-12478] Update location autocomplete to limit by location_type [hotfix][staging]

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/autocomplete/location.md
+++ b/usaspending_api/api_contracts/contracts/v2/autocomplete/location.md
@@ -19,7 +19,7 @@ This route sends a request to the backend to retrieve locations matching the spe
 
     + Attributes (object)
         + `limit` (optional, number)
-            + Default: 10
+            + Default: 5
         + `search_text` (required, string)
     + Body
 

--- a/usaspending_api/references/v2/views/location_autocomplete.py
+++ b/usaspending_api/references/v2/views/location_autocomplete.py
@@ -1,10 +1,9 @@
 import json
 from collections import OrderedDict
-from typing import List
 
 from elasticsearch_dsl import Q as ES_Q
 from elasticsearch_dsl.response import Response as ES_Response
-from elasticsearch_dsl.response.hit import Hit
+from elasticsearch_dsl.utils import AttrList
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -13,8 +12,21 @@ from usaspending_api.common.elasticsearch.search_wrappers import LocationSearch
 from usaspending_api.common.validator.tinyshield import validate_post_request
 
 models = [
-    {"key": "search_text", "name": "search_text", "type": "text", "text_type": "search", "optional": False},
-    {"key": "limit", "name": "limit", "type": "integer", "max": 500, "optional": True, "default": 10},
+    {
+        "key": "search_text",
+        "name": "search_text",
+        "type": "text",
+        "text_type": "search",
+        "optional": False,
+    },
+    {
+        "key": "limit",
+        "name": "limit",
+        "type": "integer",
+        "max": 20,
+        "optional": True,
+        "default": 5,
+    },
 ]
 
 
@@ -30,25 +42,25 @@ class LocationAutocompleteViewSet(APIView):
     def post(self, request):
         es_results: ES_Response = self._query_elasticsearch(request.data["search_text"], request.data["limit"])
 
-        results = self._format_results(es_results.hits)
+        if len(es_results.aggregations.location_types.buckets) == 0:
+            return Response(OrderedDict([("count", 0), ("results", {}), ("messages", [""])]))
+
+        results = self._format_results(es_results.aggregations.location_types.buckets)
         results = {k: v for k, v in results.items() if v is not None}
 
         # Account for cases where there are multiple results in a single ES document
         results_length = sum(len(x) for x in results.values())
         return Response(OrderedDict([("count", results_length), ("results", results), ("messages", [""])]))
 
-    @staticmethod
-    def _filter_results(results: List[Hit], filter_keys: List[str]) -> List[Hit]:
-        return list(filter(lambda x: any(key in dir(x.meta.highlight) for key in filter_keys), results))
-
     def _query_elasticsearch(self, search_text: str, limit: int = 10) -> ES_Response:
-        """Query Elasticsearch for any locations that match the provided `search_text` up to `limit` number of results.
+        """Query Elasticsearch for any locations that match the provided `search_text` up to `limit` number of results
+            for each `location_type`.
 
         Args:
             search_text:
                 Text to search for in any field in Elasticsearch.
             limit:
-                Maximum number of results to return.
+                Maximum number of results, of each location_type, to return.
                 Defaults to 10.
 
         Returns:
@@ -60,22 +72,35 @@ class LocationAutocompleteViewSet(APIView):
         search_text = search_text.replace("-", "")
 
         should_query = [
-            ES_Q("match_phrase_prefix", **{"location": {"query": search_text, "boost": 5}}),
-            ES_Q("match_phrase_prefix", **{"location.contains": {"query": search_text, "boost": 3}}),
-            ES_Q("match", **{"location": {"query": search_text, "operator": "and", "boost": 1}}),
+            ES_Q(
+                "match_phrase_prefix",
+                **{"location": {"query": search_text, "boost": 5}},
+            ),
+            ES_Q(
+                "match_phrase_prefix",
+                **{"location.contains": {"query": search_text, "boost": 3}},
+            ),
+            ES_Q(
+                "match",
+                **{"location": {"query": search_text, "operator": "and", "boost": 1}},
+            ),
         ]
 
         query = ES_Q("bool", should=should_query, minimum_should_match=1)
-        search: LocationSearch = LocationSearch().extra(size=limit).query(query)
+        search: LocationSearch = LocationSearch().extra(size=0).query(query)
+        # Group by location_type then get the top `limit` results for each bucket
+        search.aggs.bucket("location_types", "terms", field="location_type").metric(
+            "most_relevant", "top_hits", size=limit, _source=["location_json", "location_type"]
+        )
         results: ES_Response = search.execute()
 
         return results
 
-    def _format_results(self, es_results: List[Hit]) -> dict:
+    def _format_results(self, location_types_buckets: AttrList) -> dict:
         """Format Elasticsearch results to match the API contract format
 
         Args:
-            es_results: Elasticsearch result hits
+            es_results: List of buckets created from aggregations
 
         Returns:
             A dictionary containing all locations that matched the `search_text`
@@ -124,12 +149,13 @@ class LocationAutocompleteViewSet(APIView):
         }
         results = {v: [] for v in location_singular_plural_mapping.values()}
 
-        for doc in es_results:
-            location_json = json.loads(doc.location_json)
+        for location_type in location_types_buckets:
+            for doc in location_type.most_relevant.hits:
+                location_json = json.loads(doc.location_json)
 
-            # The 'location_type' key is only used during indexing so we can remove it now
-            del location_json["location_type"]
+                # The 'location_type' key is only used during indexing so we can remove it now
+                del location_json["location_type"]
 
-            results[location_singular_plural_mapping[doc.location_type]].append(location_json)
+                results[location_singular_plural_mapping[doc.location_type]].append(location_json)
 
         return {k: v if v else None for k, v in results.items()}

--- a/usaspending_api/references/v2/views/location_autocomplete.py
+++ b/usaspending_api/references/v2/views/location_autocomplete.py
@@ -87,7 +87,15 @@ class LocationAutocompleteViewSet(APIView):
         ]
 
         query = ES_Q("bool", should=should_query, minimum_should_match=1)
-        search: LocationSearch = LocationSearch().extra(size=0).query(query)
+        search: LocationSearch = (
+            LocationSearch()
+            .extra(size=0)
+            .query(query)
+            .sort(
+                {"_score": {"order": "desc"}},
+                {"location.keyword": {"order": "asc"}},
+            )
+        )
         # Group by location_type then get the top `limit` results for each bucket
         search.aggs.bucket("location_types", "terms", field="location_type").metric(
             "most_relevant", "top_hits", size=limit, _source=["location_json", "location_type"]


### PR DESCRIPTION
**Description:**
The `/api/v2/autocomplete/location` endpoint now applies the `limit` value to each `location_type` instead of to the result as a whole.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
8. [x] Jira Ticket [DEV-12478](https://federal-spending-transparency.atlassian.net/browse/DEV-12478):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison
