### PR TITLE
[DEV-12503] Fix typo in county_fips SQL

### DIFF
--- a/usaspending_api/database_scripts/etl/location_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/location_delta_view.sql
@@ -84,7 +84,7 @@ CREATE VIEW location_delta_view AS
             pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
             AND pop_state_name IS NOT NULL
             AND pop_state_fips IS NOT NULL
-            AND pop_state_code IS NOT NULL
+            AND pop_county_code IS NOT NULL
             AND pop_county_name IS NOT NULL
         )
             THEN TO_JSONB(
@@ -266,7 +266,7 @@ CREATE VIEW location_delta_view AS
             recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
             AND recipient_location_state_name IS NOT NULL
             AND recipient_location_state_fips IS NOT NULL
-            AND recipient_location_state_code IS NOT NULL
+            AND recipient_location_county_code IS NOT NULL
             AND recipient_location_county_name IS NOT NULL
         )
             THEN TO_JSONB(


### PR DESCRIPTION
**Description:**
The location_delta_view SQL was checking if the state_code fields were NULL when creating the count_fips value, but then using the county_code fields to build the county FIPS. The SQL has been updated to correctly check if the county_code fields are NULL instead of the state_code fields.

**Technical details:**


**Requirements for PR merge:**

3. [x] Necessary PR reviewers:
    - [x] Backend
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-12503](https://federal-spending-transparency.atlassian.net/browse/DEV-12503):
    - [x] Link to this Pull-Request

**Area for explaining above N/A when needed:**
```
```
