### PR TITLE
Add missing test data to download test

### DIFF
--- a/usaspending_api/download/filestreaming/download_generation.py
+++ b/usaspending_api/download/filestreaming/download_generation.py
@@ -841,36 +841,36 @@ def execute_psql(temp_sql_file_path, source_path, download_job):
         # Trace library parses the SQL, but cannot understand the psql-specific \COPY command. Use standard COPY here.
         download_sql = download_sql[1:]
 
-    # Stack 3 context managers: (1) psql code, (2) Download replica query, (3) (same) Postgres query
-    subprocess_trace = SubprocessTrace(
-        name=f"job.{JOB_TYPE}.download.psql",
-        kind=SpanKind.INTERNAL,
-        service="bulk-download",
-    )
-
-    with subprocess_trace as span:
-        span.set_attributes(
-            {
-                "service": "bulk-download",
-                "resource": str(download_sql),
-                "span_type": "Internal",
-                "source_path": str(source_path),
-                # download job details
-                "download_job_id": str(download_job.download_job_id),
-                "download_job_status": str(download_job.job_status.name),
-                "download_file_name": str(download_job.file_name),
-                "download_file_size": download_job.file_size if download_job.file_size is not None else 0,
-                "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
-                "number_of_columns": (
-                    download_job.number_of_columns if download_job.number_of_columns is not None else 0
-                ),
-                "error_message": download_job.error_message if download_job.error_message else "",
-                "monthly_download": str(download_job.monthly_download),
-                "json_request": str(download_job.json_request) if download_job.json_request else "",
-            }
-        )
-
         try:
+            # Stack 3 context managers: (1) psql code, (2) Download replica query, (3) (same) Postgres query
+            subprocess_trace = SubprocessTrace(
+                name=f"job.{JOB_TYPE}.download.psql",
+                kind=SpanKind.INTERNAL,
+                service="bulk-download",
+            )
+
+            with subprocess_trace as span:
+                span.set_attributes(
+                    {
+                        "service": "bulk-download",
+                        "resource": str(download_sql),
+                        "span_type": "Internal",
+                        "source_path": str(source_path),
+                        # download job details
+                        "download_job_id": str(download_job.download_job_id),
+                        "download_job_status": str(download_job.job_status.name),
+                        "download_file_name": str(download_job.file_name),
+                        "download_file_size": download_job.file_size if download_job.file_size is not None else 0,
+                        "number_of_rows": download_job.number_of_rows if download_job.number_of_rows is not None else 0,
+                        "number_of_columns": (
+                            download_job.number_of_columns if download_job.number_of_columns is not None else 0
+                        ),
+                        "error_message": download_job.error_message if download_job.error_message else "",
+                        "monthly_download": str(download_job.monthly_download),
+                        "json_request": str(download_job.json_request) if download_job.json_request else "",
+                    }
+                )
+
             log_time = time.perf_counter()
             temp_env = os.environ.copy()
             if download_job and not download_job.monthly_download:

--- a/usaspending_api/download/tests/integration/test_download_transactions.py
+++ b/usaspending_api/download/tests/integration/test_download_transactions.py
@@ -80,7 +80,7 @@ def download_test_data():
         modification_number=1,
         awarding_agency_id=aa1.id,
         piid="tc1piid",
-        award_date_signed="2018-01-15",
+        award_date_signed="2017-12-31",
         naics_code="100",
     )
     baker.make(
@@ -94,6 +94,7 @@ def download_test_data():
         awarding_agency_id=aa2.id,
         piid="tc2piid",
         naics_code="200",
+        award_date_signed="2017-12-31",
     )
     baker.make(
         TransactionSearch,
@@ -106,6 +107,7 @@ def download_test_data():
         awarding_agency_id=aa2.id,
         fain="ta1fain",
         naics_code="300",
+        award_date_signed="2017-12-31",
     )
 
     # Set latest_award for each award


### PR DESCRIPTION
**Description:**
Bulk download tests are randomly failing most likely due to missing test data.

**Technical details:**
Model bakery is quite helpful in that it will populate fields in your test data that you don't supply a value for. However, this can also be a pain at times when that auto generated data flips between passing and failing a conditional. In this case, the transaction download is filtering based on the `date_signed` which corresponds to the `award_date_signed` on the TransactionSearch model. Only one of the records currently populates the `award_date_signed` field on the model bakery test data which means the other two transactions are assigned random values.

TODO: Plan to run GitHub actions many times to validate that this fix works as expected. Any failure in the test for bulk download will result in this PR to revert to draft.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. N/A Jira Ticket
**Area for explaining above N/A when needed:**
```
```
