### PR TITLE
[DEV-12286] Handle null recipient hash and level

### DIFF
--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -640,10 +640,12 @@ class SpendingByAwardVisualizationViewSet(APIView):
                 "zip5": hit.get("sub_pop_zip")[0:5],
             }
 
-        if "sub_award_recipient_id" in self.fields:
-            row["sub_award_recipient_id"] = (
-                hit.get("subaward_recipient_hash") + "-" + hit.get("subaward_recipient_level")
-            )
+        if (
+            "sub_award_recipient_id" in self.fields
+            and hit.get("subaward_recipient_hash") is not None
+            and hit.get("subaward_recipient_level") is not None
+        ):
+            row["sub_award_recipient_id"] = f'{hit["subaward_recipient_hash"]}-{hit["subaward_recipient_level"]}'
 
         row["prime_award_generated_internal_id"] = hit["unique_award_key"]
 


### PR DESCRIPTION
**Description:**
When searching on the subaward recipient ID you have the chance of getting a 500 error.

**Technical details:**
This handles the possible case of the recipient hash and/or level being NULL. 

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-12286](https://federal-spending-transparency.atlassian.net/browse/DEV-12286):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
