### PR TITLE
[DEV-12578] Increases download db timeout limit from 4 to 6 hours

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -28,7 +28,7 @@ DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN = 15
 
 # Default timeout for SQL statements in Django
 DEFAULT_DB_TIMEOUT_IN_SECONDS = int(os.environ.get("DEFAULT_DB_TIMEOUT_IN_SECONDS", 0))
-DOWNLOAD_DB_TIMEOUT_IN_HOURS = 4
+DOWNLOAD_DB_TIMEOUT_IN_HOURS = 6
 CONNECTION_MAX_SECONDS = 10
 
 # Default type for when a Primary Key is not specified


### PR DESCRIPTION
**Description:**
Increases download db timeout limit from 4 to 6 hours using `DOWNLOAD_DB_TIMEOUT_IN_HOURS` setting.

**Requirements for PR merge:**

1. [x] Unit & integration tests updated
2. [x] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. N/A - Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-12578](https://federal-spending-transparency.atlassian.net/browse/DEV-12578):
    - [x] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
