### PR TITLE
[DEV-12578] [Staging] Increases download db timeout limit from 4 to 6 hours

### DIFF
--- a/usaspending_api/settings.py
+++ b/usaspending_api/settings.py
@@ -28,7 +28,7 @@ DATA_DICTIONARY_DOWNLOAD_RETRY_COOLDOWN = 15
 
 # Default timeout for SQL statements in Django
 DEFAULT_DB_TIMEOUT_IN_SECONDS = int(os.environ.get("DEFAULT_DB_TIMEOUT_IN_SECONDS", 0))
-DOWNLOAD_DB_TIMEOUT_IN_HOURS = 4
+DOWNLOAD_DB_TIMEOUT_IN_HOURS = 6
 CONNECTION_MAX_SECONDS = 10
 
 # Default type for when a Primary Key is not specified


### PR DESCRIPTION
Staging PR for https://github.com/fedspendingtransparency/usaspending-api/pull/4385 
