### PR TITLE
Ftr/dev 12571 fix subawards 503 error

### DIFF
--- a/usaspending_api/database_scripts/etl/subaward_es_view.sql
+++ b/usaspending_api/database_scripts/etl/subaward_es_view.sql
@@ -95,7 +95,7 @@ SELECT
 	s.sub_place_of_perform_county_name AS sub_pop_county_name,
 	s.subaward_description,
 	-- Keywords have a byte limit in elasticsearch that subaward_description was exceeding when sorting
-	s.subaward_description::VARCHAR(8190) AS subaward_description_sort,
+	s.subaward_description::LEFT(8190) AS subaward_description_sort,
 	s.prime_award_group,
 	s.prime_award_type,
 	s.latest_transaction_id,

--- a/usaspending_api/database_scripts/etl/subaward_es_view.sql
+++ b/usaspending_api/database_scripts/etl/subaward_es_view.sql
@@ -95,7 +95,7 @@ SELECT
 	s.sub_place_of_perform_county_name AS sub_pop_county_name,
 	s.subaward_description,
 	-- Keywords have a byte limit in elasticsearch that subaward_description was exceeding when sorting
-	s.subaward_description::LEFT(8190) AS subaward_description_sort,
+	LEFT(s.subaward_description, 8190) AS subaward_description_sort,
 	s.prime_award_group,
 	s.prime_award_type,
 	s.latest_transaction_id,


### PR DESCRIPTION
**Description:**
Putting the changes into qat is failing due to subaward descriptions too large. The previous attempt didn't work because it was truncating subaward description for sorting using `s.subaward_description::VARCHAR(8190) AS subaward_description_sorted` but it's still selecting the whole value. Postgres doesn't truncate using VARCHAR, for some reason it's not enforced during casting but using `LEFT()` or  `SUBSTRING()`will truncate 

**Technical details:**
N/A

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - N/A Frontend <OPTIONAL>
    - N/A Operations <OPTIONAL>
    - N/A Domain Expert <OPTIONAL>
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-12571](https://federal-spending-transparency.atlassian.net/browse/DEV-12571):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```


[DEV-12571]: https://federal-spending-transparency.atlassian.net/browse/DEV-12571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ