### PR TITLE
Updates to local and test suite

### DIFF
--- a/.github/actions/init-test-environment/action.yaml
+++ b/.github/actions/init-test-environment/action.yaml
@@ -83,34 +83,14 @@ runs:
         mkdir $SPARK_HOME/conf
         touch $SPARK_HOME/conf/log4j2.properties
         echo "
-        # This takes the log4j2.properties.template and changes log_level to warning
-        rootLogger.level = warn
-        rootLogger.appenderRef.stdout.ref = console
         appender.console.type = Console
-        appender.console.name = console
-        appender.console.target = SYSTEM_ERR
+        appender.console.name = CONSOLE
         appender.console.layout.type = PatternLayout
-        appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
-        logger.repl.name = org.apache.spark.repl.Main
-        logger.repl.level = warn
-        logger.thriftserver.name = org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver
-        logger.thriftserver.level = warn
-        logger.jetty1.name = org.sparkproject.jetty
-        logger.jetty1.level = warn
-        logger.jetty2.name = org.sparkproject.jetty.util.component.AbstractLifeCycle
-        logger.jetty2.level = error
-        logger.replexprTyper.name = org.apache.spark.repl.SparkIMain$exprTyper
-        logger.replexprTyper.level = warn
-        logger.replSparkILoopInterpreter.name = org.apache.spark.repl.SparkILoop$SparkILoopInterpreter
-        logger.replSparkILoopInterpreter.level = warn
-        logger.parquet1.name = org.apache.parquet
-        logger.parquet1.level = error
-        logger.parquet2.name = parquet
-        logger.parquet2.level = error
-        logger.RetryingHMSHandler.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
-        logger.RetryingHMSHandler.level = fatal
-        logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
-        logger.FunctionRegistry.level = error
+        appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss.SSS}][%p] - %m%n
+
+        rootLogger.level = WARN
+        rootLogger.appenderRef.0.ref = CONSOLE
+        rootLogger.appenderRef.0.level = WARN
         " >> $SPARK_HOME/conf/log4j2.properties
 
     - name: Run initial test to trigger DB creation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - test
       - ci
     image: postgres:13.8-alpine
+    shm_size: 1g
     container_name: usaspending-db
     volumes:
       - type: volume

--- a/usaspending_api/common/logging.py
+++ b/usaspending_api/common/logging.py
@@ -126,7 +126,7 @@ class LoggingMiddleware(MiddlewareMixin):
                 self.log["error_msg"] = str(response.data)
             except AttributeError:
                 # For cases when Django responds with an error template, get the response content (byte string)
-                self.log["error_msg"] = response.getvalue().decode("ASCII")
+                self.log["error_msg"] = response.getvalue().decode("UTF-8")
 
             # Adding separate error message to message field for user to view error on Kibana default view
             error_msg_str = "[" + self.log["error_msg"] + "]"

--- a/usaspending_api/tests/conftest_spark.py
+++ b/usaspending_api/tests/conftest_spark.py
@@ -473,7 +473,7 @@ def _build_usas_data_for_spark():
         action_date="2020-04-01",
         fiscal_year=2020,
         award_amount=0.00,
-        total_obligation=0.00,
+        total_obligation=10.00,  # Temp change to allow testing a failed Spark test
         total_subsidy_cost=0.00,
         total_loan_value=0.00,
         total_obl_bin="<1M",


### PR DESCRIPTION
**Description:**
Few different changes that either fix small bugs with local development or the test suite.

**Technical details:**
List of issues addressed:

* The `log4j2.properties` file was not working as expected, the update should now limit the log level for the Spark test cases when they fail
* Without a value for `shm_size` on the `usaspending-db` container I was running into problems with running downloads locally not in a container
* Sometimes Django will return a template for errors such as 404, which at least on local development is causing misleading errors with a failure to decode with ASCII

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
