### PR TITLE
[DEV-12637] update length limit for research and development codes fo…

### DIFF
--- a/usaspending_api/references/tests/integration/filter_tree/psc/psc_data_fixtures.py
+++ b/usaspending_api/references/tests/integration/filter_tree/psc/psc_data_fixtures.py
@@ -61,7 +61,7 @@ def rnd_tier_two():
         "id": "AA",
         "description": "tier two R&D",
         "ancestors": ["Research and Development"],
-        "count": 1,
+        "count": 2,
         "children": None,
     }
 
@@ -108,7 +108,7 @@ def rnd_tier_two_special():
 
 def rnd_tier_four_special():
     return {
-        "id": "AU10",
+        "id": "AU11",
         "description": "R&D-TRANS OF HAZARD MAT",
         "ancestors": ["Research and Development", "AU"],
         "count": 0,

--- a/usaspending_api/references/tests/integration/filter_tree/psc/psc_data_fixtures.py
+++ b/usaspending_api/references/tests/integration/filter_tree/psc/psc_data_fixtures.py
@@ -11,7 +11,7 @@ def no_data(db):
 @pytest.fixture
 def basic_rnd(db):
     _psc(db, rnd_tier_two())
-    _psc(db, rnd_tier_three())
+    _psc(db, rnd_tier_three_setup())
     _psc(db, rnd_tier_four())
 
 
@@ -66,6 +66,16 @@ def rnd_tier_two():
     }
 
 
+def rnd_tier_three_setup():
+    return {
+        "id": "AA90",
+        "description": "tier three R&D",
+        "ancestors": ["Research and Development", "AA"],
+        "count": 1,
+        "children": None,
+    }
+
+
 def rnd_tier_three():
     return {
         "id": "AA9",
@@ -78,7 +88,7 @@ def rnd_tier_three():
 
 def rnd_tier_four():
     return {
-        "id": "AA90",
+        "id": "AA91",
         "description": "tier four R&D",
         "ancestors": ["Research and Development", "AA", "AA9"],
         "count": 0,

--- a/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
+++ b/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
@@ -42,7 +42,6 @@ def test_tier_two_product(client, basic_product):
 
 def test_tier_three_product(client, basic_product):
     resp = _call_and_expect_200(client, base_query + "Product/10/")
-    print(resp.json())
     assert resp.json() == {"results": [product_tier_three()]}
 
 

--- a/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
+++ b/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
@@ -27,7 +27,6 @@ def test_tier_two_rnd(client, basic_rnd):
 
 def test_tier_three_rnd(client, basic_rnd):
     resp = _call_and_expect_200(client, base_query + "Research%20and%20Development/AA/")
-    print("results: ", resp.json())
     assert resp.json() == {"results": [rnd_tier_three()]}
 
 

--- a/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
+++ b/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
@@ -27,6 +27,7 @@ def test_tier_two_rnd(client, basic_rnd):
 
 def test_tier_three_rnd(client, basic_rnd):
     resp = _call_and_expect_200(client, base_query + "Research%20and%20Development/AA/")
+    print("results: ", resp.json())
     assert resp.json() == {"results": [rnd_tier_three()]}
 
 

--- a/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
+++ b/usaspending_api/references/tests/integration/filter_tree/psc/test_psc_basic_cases.py
@@ -42,6 +42,7 @@ def test_tier_two_product(client, basic_product):
 
 def test_tier_three_product(client, basic_product):
     resp = _call_and_expect_200(client, base_query + "Product/10/")
+    print(resp.json())
     assert resp.json() == {"results": [product_tier_three()]}
 
 

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -73,7 +73,16 @@ class PSCFilterTree(FilterTree):
             if len(parent) > 3:
                 filters.append(Q(code__iregex=PSC_GROUPS.get(parent, {}).get("count_pattern") or "(?!)"))
             else:
-                filters.append(Q(Q(code__startswith=parent) & Q(code__iregex=r".*[^0]$")))
+                filters.append(
+                    Q(
+                        Q(code__startswith=parent)
+                        & (
+                            Q(code__iregex=r".*[^0]$")
+                            & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
+                        )
+                        | Q(~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))
+                    )
+                )
         if filter_string:
             filters.append(Q(Q(code__icontains=filter_string) | Q(description__icontains=filter_string)))
         retval = []

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -80,7 +80,7 @@ class PSCFilterTree(FilterTree):
                             Q(code__iregex=r".*[^0]$")
                             & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
                         )
-                        | Q(~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))
+                        | ~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
                     )
                 )
         if filter_string:

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -108,7 +108,7 @@ class PSCFilterTree(FilterTree):
         filters = [
             Q(
                 Q(Q(length=2) & ~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))
-                | Q(Q(length=3) & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))
+                | Q(Q(code__iregex=r"^.{3,}$") & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))
             )
         ]
         query = Q()

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -118,7 +118,7 @@ class PSCFilterTree(FilterTree):
             Q(
                 Q(Q(length=2) & ~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))
                 | Q(
-                    Q(code__iregex=r".*0$")
+                    Q(code__endswith="0")
                     & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
                     & Q(length=4)
                 )

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -77,10 +77,12 @@ class PSCFilterTree(FilterTree):
                     Q(
                         Q(code__startswith=parent)
                         & (
-                            ~Q(code__endswith="0")
-                            & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
+                            (
+                                ~Q(code__endswith="0")
+                                & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
+                            )
+                            | ~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
                         )
-                        | ~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
                     )
                 )
         if filter_string:

--- a/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
+++ b/usaspending_api/references/v2/views/filter_tree/psc_filter_tree.py
@@ -77,7 +77,7 @@ class PSCFilterTree(FilterTree):
                     Q(
                         Q(code__startswith=parent)
                         & (
-                            Q(code__iregex=r".*[^0]$")
+                            ~Q(code__endswith="0")
                             & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])
                         )
                         | ~Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0])


### PR DESCRIPTION
…r filtering to 3 or more

**Description:**
Right now in the filter tree for PSC, Research and Development codes aren't producing all the options when filtering on one step after. For example by opening Research and Development -> AA -> nothing
There should be codes 

**Technical details:**
The filter for the query was limited to only lengths of 3 because of this line `Q(Q(length=3) & Q(code__startswith=PSC_GROUPS["Research and Development"]["terms"][0]))`
This used to work but the PSC codes for Research and Development got changed to have a 0 at the end. So for example AA1 became AA10. To keep consistency the have it so for the third tier in Research and Development it gets all that are length 4 and end in 0.

In the fourth tier it keeps length for but also checks that it doesn't end in 0

**Requirements for PR merge:**

1. [X] Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - N/A Frontend <OPTIONAL>
    - N/A Operations <OPTIONAL>
    - N/A Domain Expert <OPTIONAL>
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-12637](https://federal-spending-transparency.atlassian.net/browse/DEV-12637):
    - [X] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```


[DEV-12637]: https://federal-spending-transparency.atlassian.net/browse/DEV-12637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ