### PR TITLE
[DEV-12385] change default sorting to total_budgetary_resources

### DIFF
--- a/usaspending_api/agency/v2/views/subcomponents.py
+++ b/usaspending_api/agency/v2/views/subcomponents.py
@@ -29,7 +29,7 @@ class SubcomponentList(PaginationMixin, AgencyBase):
     @cache_response()
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         self.sortable_columns = ["name", "total_obligations", "total_outlays", "total_budgetary_resources"]
-        self.default_sort_column = "total_obligations"
+        self.default_sort_column = "total_budgetary_resources"
         results = self.format_results(self.get_file_a_queryset(), self.get_file_b_queryset())
         page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
         return Response(
@@ -64,10 +64,10 @@ class SubcomponentList(PaginationMixin, AgencyBase):
                 {
                     "name": x["bureau_info"].split(";")[0] if x.get("bureau_info") is not None else None,
                     "id": x["bureau_info"].split(";")[1] if x.get("bureau_info") is not None else None,
-                    "total_obligations": x["total_obligations"] if x["total_obligations"] else None,
-                    "total_outlays": x["total_outlays"] if x["total_outlays"] else None,
+                    "total_obligations": x["total_obligations"] if "total_obligations" in x else None,
+                    "total_outlays": x["total_outlays"] if "total_outlays" in x else None,
                     "total_budgetary_resources": (
-                        x["total_budgetary_resources"] if x["total_budgetary_resources"] else None
+                        x["total_budgetary_resources"] if "total_budgetary_resources" in x else None
                     ),
                 }
                 for x in combined_response


### PR DESCRIPTION
**Description:**
Currently the default sorting is based on total_obligations but it should be total_budgetary_resources because that's what in the api contract and will fix the front end sorting

**Technical details:**
When trying to run locally I was getting a keyerror due to x not having total_obligations or total_outlays which is why there's a change there but I can change it back if needed. 

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3.  Necessary PR reviewers:
    - [ ] Backend
    - N/A Frontend <OPTIONAL>
    - N/A Operations <OPTIONAL>
    - N/A Domain Expert <OPTIONAL>
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-12385](https://federal-spending-transparency.atlassian.net/browse/DEV-12385):
    - [ ] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
