### PR TITLE
[DEV-12529] change awards limit to 100

### DIFF
--- a/requirements/requirements-app.txt
+++ b/requirements/requirements-app.txt
@@ -1,7 +1,7 @@
 asyncpg==0.29.*
 attrs==23.2.*
 boto3==1.34.*
-certifi==2024.2.2
+certifi==2024.7.4
 dataclasses-json==0.6.*
 dj-database-url==2.1.0
 django-cors-headers==4.3.*


### PR DESCRIPTION
**Description:**
When filtering over multiple time periods that have 11+ fiscal years in Spending Over Time, only 10 are returned if the spending_level is awards. I changed the limit from 10 to 100

**Technical details:**
In this case it makes more sense to hard code a limit rather than look for unique hits and use that as the limit because there is only 1 result per year and the data starts at 2007, the results will never get to be unreasonably large. This will work through 2107

**Requirements for PR merge:**

1. N/A Unit & integration tests updated
2. N/A API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - N/A Frontend <OPTIONAL>
    - N/A Operations <OPTIONAL>
    - N/A Domain Expert <OPTIONAL>
4. N/A Matview impact assessment completed
5. N/A Frontend impact assessment completed
6. N/A Data validation completed
7. N/A Appropriate Operations ticket(s) created
8. [X] Jira Ticket [DEV-12529](https://federal-spending-transparency.atlassian.net/browse/DEV-12529):
    - [x] Link to this Pull-Request
    - N/A Performance evaluation of affected (API | Script | Download)
    - N/A Before / After data comparison

**Area for explaining above N/A when needed:**
```
```


[DEV-12529]: https://federal-spending-transparency.atlassian.net/browse/DEV-12529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ