### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/usaspending_api/awards/management/commands/generate_unlinked_awards_download.py
+++ b/usaspending_api/awards/management/commands/generate_unlinked_awards_download.py
@@ -159,7 +159,7 @@ class Command(BaseCommand):
             upload_download_file_to_s3(zip_file_path, settings.UNLINKED_AWARDS_DOWNLOAD_REDIRECT_DIR)
             logger.info("Marking zip file for deletion in cleanup")
         else:
-            logger.warn("Not uploading zip file to S3. Leaving file locally")
+            logger.warning("Not uploading zip file to S3. Leaving file locally")
             self.filepaths_to_delete.remove(zip_file_path)
 
     @property

--- a/usaspending_api/common/etl/spark.py
+++ b/usaspending_api/common/etl/spark.py
@@ -444,7 +444,7 @@ def convert_array_cols_to_string(
     is_postgres_array_format=False,
     is_for_csv_export=False,
 ) -> DataFrame:
-    """For each column that is an Array of ANYTHING, transfrom it to a string-ified representation of that Array.
+    """For each column that is an Array of ANYTHING, transform it to a string-ified representation of that Array.
 
     This will:
       1. cast each array element to a STRING representation
@@ -691,7 +691,7 @@ def hadoop_copy_merge(
             logger.debug(f"Including part file: {file_path.getName()}")
             part_files.append(f.getPath())
     if not part_files:
-        logger.warn("Source directory is empty with no part files. Attempting creation of file with CSV header only")
+        logger.warning("Source directory is empty with no part files. Attempting creation of file with CSV header only")
         out_stream = None
         try:
             merged_file_path = f"{parts_dir}.{file_format}"

--- a/usaspending_api/disaster/management/commands/generate_covid19_download.py
+++ b/usaspending_api/disaster/management/commands/generate_covid19_download.py
@@ -162,9 +162,9 @@ class Command(BaseCommand):
             logger.info(f"Created database record {db_id} for future retrieval")
             logger.info("Marking zip file for deletion in cleanup")
         else:
-            logger.warn("Not uploading zip file to S3. Leaving file locally")
+            logger.warning("Not uploading zip file to S3. Leaving file locally")
             self.filepaths_to_delete.remove(self.zip_file_path)
-            logger.warn("Not creating database record")
+            logger.warning("Not creating database record")
 
     @property
     def download_file_list(self):

--- a/usaspending_api/etl/management/commands/load_transactions_in_delta.py
+++ b/usaspending_api/etl/management/commands/load_transactions_in_delta.py
@@ -224,7 +224,7 @@ class Command(BaseCommand):
         """
 
         # TODO: The values returned here are put into a list in an 'IN' clause in award_id_lookup_post_delete.
-        #       However, there is a limit on the number of values one can manually put into an 'IN' cluase (i.e., not
+        #       However, there is a limit on the number of values one can manually put into an 'IN' clause (i.e., not
         #       returned by a SELECT subquery inside the 'IN').  Thus, this code should return a dataframe directly,
         #       create a temporary view from the dataframe in award_id_lookup_post_delete, and use that temporary
         #       view to either do a subquery in the 'IN' clause or to JOIN against.
@@ -1146,7 +1146,7 @@ class Command(BaseCommand):
                     re.MULTILINE,
                 ):
                     # In this case, we just don't populate transaction_id_lookup
-                    logger.warn(
+                    logger.warning(
                         "Skipping population of transaction_id_lookup table; no raw.transaction_normalized table."
                     )
                     raw_transaction_normalized_exists = False
@@ -1174,7 +1174,7 @@ class Command(BaseCommand):
                         re.MULTILINE,
                     ):
                         # In this case, we just skip extending the orphaned transactions with this table
-                        logger.warn(
+                        logger.warning(
                             "Skipping extension of orphaned_transaction_info table using raw.transaction_fabs table."
                         )
 
@@ -1202,7 +1202,7 @@ class Command(BaseCommand):
                         re.MULTILINE,
                     ):
                         # In this case, we just skip extending the orphaned transactions with this table
-                        logger.warn(
+                        logger.warning(
                             "Skipping extension of orphaned_transaction_info table using raw.transaction_fpds table."
                         )
 
@@ -1250,7 +1250,7 @@ class Command(BaseCommand):
                         """
                     )
                 else:
-                    logger.warn(
+                    logger.warning(
                         "No raw.transaction_fabs or raw.transaction_fpds tables, so not finding additional orphaned "
                         "transactions in raw.transaction_normalized"
                     )
@@ -1364,7 +1364,7 @@ class Command(BaseCommand):
 
             if not raw_transaction_normalized_exists:
                 # In this case, we just don't populate award_id_lookup
-                logger.warn("Skipping population of award_id_lookup table; no raw.transaction_normalized table.")
+                logger.warning("Skipping population of award_id_lookup table; no raw.transaction_normalized table.")
 
                 # Without a raw.transaction_normalized table, can't get a maximum award_id from it, either.
                 max_id = None
@@ -1514,7 +1514,7 @@ class Command(BaseCommand):
                             re.MULTILINE,
                         ):
                             # In this case, we just don't copy anything over
-                            logger.warn(
+                            logger.warning(
                                 f"Skipping copy of {destination_table} table from 'raw' to 'int' database; "
                                 f"no raw.{destination_table} table."
                             )

--- a/usaspending_api/transactions/management/commands/delete_procurement_records.py
+++ b/usaspending_api/transactions/management/commands/delete_procurement_records.py
@@ -42,7 +42,7 @@ class Command(AgnosticDeletes, BaseCommand):
                 logger.info(f"Obtained {len(numeric_ids)} IDs for {date_}")
                 ids_to_delete[date_].extend(numeric_ids)
             else:
-                logger.warn(f"No {'valid ' if bool(string_ids) else ''}IDs for {date_}!")
+                logger.warning(f"No {'valid ' if bool(string_ids) else ''}IDs for {date_}!")
 
         total_ids = sum([len(v) for v in ids_to_delete.values()])
         logger.info(f"Total number of delete records to process: {total_ids}")


### PR DESCRIPTION
**Description:**
This small PR resolves the annoying deprecation warnings of the `logger` library, which you can find in the [CI logs](https://github.com/fedspendingtransparency/usaspending-api/actions/runs/15356539156/job/43216863274#step:6:230):
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

**Technical details:**

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```


[DEV-123]: https://federal-spending-transparency.atlassian.net/browse/DEV-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ