### PR TITLE
[DEV-12725] Update latest_duns_sam_parent CTE to be deterministic

### DIFF
--- a/usaspending_api/recipient/delta_models/recipient_lookup.py
+++ b/usaspending_api/recipient/delta_models/recipient_lookup.py
@@ -308,7 +308,10 @@ recipient_lookup_load_sql_string_list = [
                             ORDER BY
                                 sr.ultimate_parent_unique_ide ASC NULLS LAST,
                                 sr.ultimate_parent_uei ASC NULLS LAST,
-                                sr.update_date DESC NULLS LAST
+                                sr.update_date DESC NULLS LAST,
+                                -- Order by the legal_business_name as a last resort for cases where all other columns
+                                -- are the same within the same partition.
+                                UPPER(sr.ultimate_parent_legal_enti)
                         ) AS row_num
                     FROM int.sam_recipient sr
 


### PR DESCRIPTION
**Description:**
Update the `ORDER BY` logic of the `latest_duns_sam_parent` CTE to order by the parent recipient name as a last resort.

**Technical details:**
The `latest_duns_sam_parent` CTE could return the same DUNS, UEI, and update date for a parent recipient, but with two different name values. In this case, the previous `ORDER BY` logic could **not** guarantee a consistent ordering. The new logic will order the parent recipients alphabetically as a last resort and we will always take the first result.

**Requirements for PR merge:**

3. [x] Necessary PR reviewers:
    - [x] Backend
4. [x] Matview impact assessment completed
5. [x] Frontend impact assessment completed
6. [x] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [x] Jira Ticket [DEV-12725](https://federal-spending-transparency.atlassian.net/browse/DEV-12725):
    - [x] Link to this Pull-Request
    - [x] Performance evaluation of affected (API | Script | Download)
    - [x] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
