### PR TITLE
[DEV-12600] Use reference data for domestic locations

### DIFF
--- a/usaspending_api/database_scripts/etl/location_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/location_delta_view.sql
@@ -209,6 +209,7 @@ WITH
             recipient_location_congressional_code_current ~ '^[0-9]{2}$'
     )
 SELECT
+    ROW_NUMBER() OVER (ORDER BY location, location_json) AS id,
     location,
     location_json
 FROM

--- a/usaspending_api/database_scripts/etl/location_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/location_delta_view.sql
@@ -1,168 +1,132 @@
-DROP VIEW IF EXISTS location_delta_view;
+DROP VIEW IF EXISTS LOCATION_DELTA_VIEW;
 
-CREATE VIEW location_delta_view AS
-    WITH transaction_locations_cte AS (
-    SELECT
-    -- Country
-    CASE
-        WHEN pop_country_name = 'UNITED STATES OF AMERICA'
-            THEN 'UNITED STATES'
-        ELSE
-            pop_country_name
-    END AS pop_country_string,
-    CASE
-        WHEN pop_country_name = 'UNITED STATES OF AMERICA'
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'country'
-                )
-            )
-        ELSE
+CREATE TEMPORARY VIEW LOCATION_DELTA_VIEW AS
+-- Country
+WITH
+    country_cte AS (
+        SELECT
+            UPPER(country_name) AS location,
             TO_JSONB(
                 JSONB_BUILD_OBJECT(
-                    'country_name', pop_country_name,
+                    'country_name', country_name,
                     'location_type', 'country'
                 )
-            )
-    END AS pop_country_json,
+            ) AS location_json
+        FROM
+            ref_country_code
+    ),
     -- State
-    CASE
-        WHEN pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND pop_state_name IS NOT NULL
-            THEN CONCAT(UPPER(pop_state_name), ', ', 'UNITED STATES')
-    END AS pop_state_string,
-    CASE
-        WHEN pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND pop_state_name IS NOT NULL
-            THEN TO_JSONB(
+    state_cte AS (
+        SELECT
+            CONCAT(UPPER(name), ', ', 'UNITED STATES') AS location,
+            TO_JSONB(
                 JSONB_BUILD_OBJECT(
-                    'state_name', UPPER(pop_state_name),
+                    'state_name', UPPER(name),
                     'country_name', 'UNITED STATES',
                     'location_type', 'state'
                 )
-            )
-    END AS pop_state_json,
-    -- City
-    CASE
-        WHEN pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND pop_state_name IS NOT NULL AND pop_city_name IS NOT NULL
-            THEN CONCAT(UPPER(pop_city_name), ', ',	UPPER(pop_state_name), ', ', 'UNITED STATES')
-        WHEN pop_country_name NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND pop_country_name IS NOT NULL	AND pop_city_name IS NOT NULL
-            THEN concat(UPPER(pop_city_name), ', ',	UPPER(pop_country_name))
-    END AS pop_city_string,
-    CASE
-        WHEN pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND pop_state_name IS NOT NULL AND pop_city_name IS NOT NULL
-            THEN TO_JSONB(
+            ) AS location_json
+        FROM
+            state_data
+    ),
+    -- City (domestic)
+    city_domestic AS (
+        SELECT
+            CONCAT(UPPER(ref_city.feature_name), ', ', UPPER(ref_state.name), ', ', 'UNITED STATES') AS location,
+            TO_JSONB(
                 JSONB_BUILD_OBJECT(
-                    'city_name', UPPER(pop_city_name),
-                    'state_name', UPPER(pop_state_name),
+                    'city_name', UPPER(ref_city.feature_name),
+                    'state_name', UPPER(ref_state.name),
                     'country_name', 'UNITED STATES',
                     'location_type', 'city'
                 )
-            )
-        WHEN pop_country_name NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND pop_country_name IS NOT NULL AND pop_city_name IS NOT NULL
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'city_name', UPPER(pop_city_name),
-                    'state_name', NULL,
-                    'country_name', UPPER(pop_country_name),
-                    'location_type', 'city'
-                )
-            )
-    END AS pop_city_json,
+            ) AS location_json
+        FROM
+            ref_city_county_state_code AS ref_city
+        JOIN
+            state_data AS ref_state ON ref_state.code = ref_city.state_alpha
+    ),
     -- County
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_state_fips IS NOT NULL
-            AND pop_state_code IS NOT NULL
-            AND pop_county_name IS NOT NULL
-        )
-            THEN CONCAT(UPPER(pop_county_name), ' COUNTY, ', UPPER(pop_state_name), ', ', 'UNITED STATES')
-    END AS pop_county_string,
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_state_fips IS NOT NULL
-            AND pop_county_code IS NOT NULL
-            AND pop_county_name IS NOT NULL
-        )
-            THEN TO_JSONB(
+    county_cte AS (
+        SELECT
+            CONCAT(UPPER(ref_county.county_name), ' COUNTY, ', UPPER(ref_state.name), ', ', 'UNITED STATES') AS location,
+            TO_JSONB(
                 JSONB_BUILD_OBJECT(
-                    'county_name', UPPER(pop_county_name),
-                    'county_fips', CONCAT(pop_state_fips, pop_county_code),
-                    'state_name', UPPER(pop_state_name),
+                    'county_name', UPPER(ref_county.county_name),
+                    'state_name', UPPER(ref_state.name),
                     'country_name', 'UNITED STATES',
                     'location_type', 'county'
                 )
-            )
-    END AS pop_county_json,
+            ) AS location_json
+        FROM
+            ref_city_county_state_code AS ref_county
+        JOIN
+            state_data AS ref_state ON ref_state.code = ref_county.state_alpha
+    ),
     -- Zip code
-    CASE
-        WHEN pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-        AND pop_state_name IS NOT NULL
-        AND pop_zip5 IS NOT NULL
-            THEN pop_zip5
-    END AS pop_zip_string,
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_zip5 IS NOT NULL
-        )
-            THEN TO_JSONB(
+    zip_cte AS (
+        SELECT
+            CONCAT(zips.zip5, ', ', UPPER(ref_state.name), ', ', 'UNITED STATES') AS location,
+            TO_JSONB(
                 JSONB_BUILD_OBJECT(
-                    'zip_code', pop_zip5,
-                    'state_name', UPPER(pop_state_name),
+                    'zip_code', zips.zip5,
+                    'state_name', UPPER(ref_state.name),
                     'country_name', 'UNITED STATES',
                     'location_type', 'zip_code'
                 )
-            )
-    END AS pop_zip_json,
+            ) AS location_json
+        FROM
+            zips_grouped AS zips
+        JOIN
+            state_data AS ref_state ON ref_state.code = zips.state_abbreviation
+    ),
     -- Current Congressional district
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_congressional_code_current IS NOT NULL
-            AND pop_state_code IS NOT NULL
-        )
-            THEN CONCAT(UPPER(pop_state_code), pop_congressional_code_current)
-    END AS pop_current_cd_string,
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_congressional_code_current IS NOT NULL
-            AND pop_state_code IS NOT NULL
-        )
-            THEN TO_JSONB(
+    current_cd_pop_cte AS (
+        SELECT
+            CONCAT(UPPER(pop_state_code), '-', pop_congressional_code_current) AS location,
+            TO_JSONB(
                 JSONB_BUILD_OBJECT(
-                    'current_cd', CONCAT(UPPER(pop_state_code),	'-', pop_congressional_code_current),
+                    'current_cd', CONCAT(UPPER(pop_state_code), '-', pop_congressional_code_current),
                     'state_name', UPPER(pop_state_name),
                     'country_name', 'UNITED STATES',
                     'location_type', 'current_cd'
                 )
+            ) AS location_json
+        FROM
+            rpt.transaction_search
+        RIGHT JOIN
+            state_data ON state_data.code = pop_state_code
+        WHERE
+            pop_state_code IS NOT NULL
+            AND
+            pop_congressional_code_current ~ '^[0-9]{2}$'
+    ),
+    current_cd_rl_cte AS (
+        SELECT
+            CONCAT(UPPER(recipient_location_state_code), '-', recipient_location_congressional_code_current) AS location,
+            TO_JSONB(
+                JSONB_BUILD_OBJECT(
+                    'current_cd',
+                    CONCAT(UPPER(recipient_location_state_code), '-', recipient_location_congressional_code_current),
+                    'state_name', UPPER(recipient_location_state_name),
+                    'country_name', 'UNITED STATES',
+                    'location_type', 'current_cd'
+                )
             )
-    END AS pop_current_cd_json,
+        FROM
+            rpt.transaction_search
+        RIGHT JOIN
+            state_data ON state_data.code = recipient_location_state_code
+        WHERE
+            recipient_location_state_code IS NOT NULL
+            AND
+            recipient_location_congressional_code_current ~ '^[0-9]{2}$'
+    ),
     -- Original Congressional district
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_congressional_code IS NOT NULL
-            AND pop_state_code IS NOT NULL
-        )
-            THEN CONCAT(UPPER(pop_state_code), pop_congressional_code)
-    END AS pop_original_cd_string,
-    CASE
-        WHEN (
-            pop_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND pop_state_name IS NOT NULL
-            AND pop_congressional_code IS NOT NULL
-            AND pop_state_code IS NOT NULL
-        )
-            THEN TO_JSONB(
+    original_cd_pop_cte AS (
+        SELECT
+            CONCAT(UPPER(pop_state_code), '-', pop_congressional_code) AS location,
+            TO_JSONB(
                 JSONB_BUILD_OBJECT(
                     'original_cd', CONCAT(UPPER(pop_state_code), '-', pop_congressional_code),
                     'state_name', UPPER(pop_state_name),
@@ -170,183 +134,19 @@ CREATE VIEW location_delta_view AS
                     'location_type', 'original_cd'
                 )
             )
-    END AS pop_original_cd_json,
-    CASE
-        WHEN recipient_location_country_name = 'UNITED STATES OF AMERICA'
-            THEN 'UNITED STATES'
-        ELSE recipient_location_country_name
-    END AS recipient_location_country_string,
-    CASE
-        WHEN recipient_location_country_name = 'UNITED STATES OF AMERICA'
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'country'
-                )
-            )
-        ELSE
+        FROM
+            rpt.transaction_search
+        RIGHT JOIN
+            state_data ON state_data.code = pop_state_code
+        WHERE
+            pop_state_code IS NOT NULL
+            AND
+            pop_congressional_code ~ '^[0-9]{2}$'
+    ),
+    original_cd_rl_cte AS (
+        SELECT
+            CONCAT(UPPER(recipient_location_state_code), '-', recipient_location_congressional_code) AS location,
             TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'country_name', recipient_location_country_name,
-                    'location_type', 'country'
-                )
-            )
-    END AS recipient_location_country_json,
-    -- State
-    CASE
-        WHEN recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND recipient_location_state_name IS NOT NULL
-            THEN CONCAT(UPPER(recipient_location_state_name), ', ',	'UNITED STATES')
-    END AS recipient_location_state_string,
-    CASE
-        WHEN recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES') AND recipient_location_state_name IS NOT NULL
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'state_name', UPPER(recipient_location_state_name),
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'state'
-                )
-            )
-    END AS recipient_location_state_json,
-    -- City
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_city_name IS NOT NULL
-        )
-            THEN CONCAT(UPPER(recipient_location_city_name), ', ', UPPER(recipient_location_state_name), ', ', 'UNITED STATES')
-        WHEN (
-            recipient_location_country_name NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_country_name IS NOT NULL
-            AND recipient_location_city_name IS NOT NULL
-        )
-            THEN concat(UPPER(recipient_location_city_name), ', ', UPPER(recipient_location_country_name))
-    END AS recipient_location_city_string,
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_city_name IS NOT NULL
-        )
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'city_name', UPPER(recipient_location_city_name),
-                    'state_name', UPPER(recipient_location_state_name),
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'city'
-                )
-            )
-        WHEN (
-            recipient_location_country_name NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_country_name IS NOT NULL
-            AND recipient_location_city_name IS NOT NULL
-        )
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'city_name', UPPER(recipient_location_city_name),
-                    'state_name', NULL,
-                    'country_name', UPPER(recipient_location_country_name),
-                    'location_type', 'city'
-                )
-            )
-    END AS recipient_location_city_json,
-    -- County
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_state_fips IS NOT NULL
-            AND recipient_location_state_code IS NOT NULL
-            AND recipient_location_county_name IS NOT NULL
-        )
-            THEN CONCAT(UPPER(recipient_location_county_name), ' COUNTY, ', UPPER(recipient_location_state_name), ', ',	'UNITED STATES')
-    END AS recipient_location_county_string,
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_state_fips IS NOT NULL
-            AND recipient_location_county_code IS NOT NULL
-            AND recipient_location_county_name IS NOT NULL
-        )
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'county_name', UPPER(recipient_location_county_name),
-                    'county_fips', CONCAT(recipient_location_state_fips, recipient_location_county_code),
-                    'state_name', UPPER(recipient_location_state_name),
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'county'
-                )
-            )
-    END AS recipient_location_county_json,
-    -- Zip code
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_zip5 IS NOT NULL
-        )
-            THEN recipient_location_zip5
-    END AS recipient_location_zip_string,
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_zip5 IS NOT NULL
-        )
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'zip_code', recipient_location_zip5,
-                    'state_name', UPPER(recipient_location_state_name),
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'zip_code'
-                )
-            )
-    END AS recipient_location_zip_json,
-    -- Current Congressional district
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_congressional_code_current IS NOT NULL
-            AND recipient_location_state_code IS NOT NULL
-        )
-            THEN CONCAT(UPPER(recipient_location_state_code), recipient_location_congressional_code_current)
-    END AS recipient_location_current_cd_string,
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_congressional_code_current IS NOT NULL
-            AND recipient_location_state_code IS NOT NULL
-        )
-            THEN TO_JSONB(
-                JSONB_BUILD_OBJECT(
-                    'current_cd', CONCAT(UPPER(recipient_location_state_code), '-',	recipient_location_congressional_code_current),
-                    'state_name', UPPER(recipient_location_state_name),
-                    'country_name', 'UNITED STATES',
-                    'location_type', 'current_cd'
-                )
-            )
-    END AS recipient_location_current_cd_json,
-    -- Original Congressional district
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_congressional_code IS NOT NULL
-            AND recipient_location_state_code IS NOT NULL
-        )
-            THEN CONCAT(UPPER(recipient_location_state_code), recipient_location_congressional_code)
-    END AS recipient_location_original_cd_string,
-    CASE
-        WHEN (
-            recipient_location_country_name IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
-            AND recipient_location_state_name IS NOT NULL
-            AND recipient_location_congressional_code IS NOT NULL
-            AND recipient_location_state_code IS NOT NULL
-        )
-            THEN TO_JSONB(
                 JSONB_BUILD_OBJECT(
                     'original_cd', CONCAT(UPPER(recipient_location_state_code), '-', recipient_location_congressional_code),
                     'state_name', UPPER(recipient_location_state_name),
@@ -354,107 +154,38 @@ CREATE VIEW location_delta_view AS
                     'location_type', 'original_cd'
                 )
             )
-    END AS recipient_location_original_cd_json
-FROM
-    rpt.transaction_search
-WHERE
-    pop_country_name IS NOT NULL
-    OR
-    recipient_location_country_name IS NOT NULL
-),
-normalized_column_names_cte AS (
-    SELECT
-        pop_country_string AS location,
-        pop_country_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        pop_state_string AS location,
-        pop_state_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        pop_city_string AS location,
-        pop_city_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        pop_county_string AS location,
-        pop_county_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        pop_zip_string AS location,
-        pop_zip_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        pop_current_cd_string AS location,
-        pop_current_cd_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        pop_original_cd_string AS location,
-        pop_original_cd_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_country_string AS location,
-        recipient_location_country_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_state_string AS location,
-        recipient_location_state_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_city_string AS location,
-        recipient_location_city_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_county_string AS location,
-        recipient_location_county_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_zip_string AS location,
-        recipient_location_zip_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_current_cd_string AS location,
-        recipient_location_current_cd_json AS location_json
-    FROM
-        transaction_locations_cte
-    UNION
-    SELECT
-        recipient_location_original_cd_string AS location,
-        recipient_location_original_cd_json AS location_json
-    FROM
-        transaction_locations_cte
-)
+        FROM
+            rpt.transaction_search
+        RIGHT JOIN
+            state_data ON state_data.code = recipient_location_state_code
+        WHERE
+            recipient_location_state_code IS NOT NULL
+            AND
+            recipient_location_congressional_code_current ~ '^[0-9]{2}$'
+    )
 SELECT
-    ROW_NUMBER() OVER (ORDER BY location, location_json) AS id,
     location,
     location_json
 FROM
-    normalized_column_names_cte
-WHERE
-    -- Only include locations that have at least two characters
-    location ~ '[A-Z0-9].*[A-Z0-9]'
-    and
-    location_json IS NOT NULL
+    (
+        SELECT * FROM country_cte
+        UNION
+        SELECT * FROM state_cte
+        UNION
+        SELECT * FROM city_domestic
+        UNION
+        SELECT * FROM county_cte
+        UNION
+        SELECT * FROM zip_cte
+        UNION
+        SELECT * FROM current_cd_pop_cte
+        UNION
+        SELECT * FROM current_cd_rl_cte
+        UNION
+        SELECT * FROM original_cd_pop_cte
+        UNION
+        SELECT * FROM original_cd_rl_cte
+    ) AS union_all
+GROUP BY
+    location,
+    location_json

--- a/usaspending_api/database_scripts/etl/location_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/location_delta_view.sql
@@ -49,41 +49,45 @@ WITH
     -- City (foreign)
     city_foreign_pop_cte AS (
         SELECT
-            CONCAT(UPPER(pop_city_name), ', ', UPPER(pop_country_name)) AS location,
+            CONCAT(UPPER(pop_city_name), ', ', rcc.country_name) AS location,
             TO_JSONB(
                 JSONB_BUILD_OBJECT(
                     'city_name', UPPER(pop_city_name),
                     'state_name', NULL,
-                    'country_name', UPPER(pop_country_name),
+                    'country_name', rcc.country_name,
                     'location_type', 'city'
                 )
             ) AS location_json
         FROM
             rpt.transaction_search
+        JOIN
+            ref_country_code AS rcc ON pop_country_code = rcc.country_code
         WHERE
-            UPPER(pop_country_name) NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
+            rcc.country_name NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
             AND
-            pop_country_name IS NOT NULL
+            rcc.country_name IS NOT NULL
             AND
             pop_city_name IS NOT NULL
     ),
     city_foreign_rl_cte AS (
         SELECT
-            CONCAT(UPPER(recipient_location_city_name), ', ', UPPER(recipient_location_country_name)) AS location,
+            CONCAT(UPPER(recipient_location_city_name), ', ', rcc.country_name) AS location,
             TO_JSONB(
                 JSONB_BUILD_OBJECT(
                     'city_name', UPPER(recipient_location_city_name),
                     'state_name', NULL,
-                    'country_name', UPPER(recipient_location_country_name),
+                    'country_name', rcc.country_name,
                     'location_type', 'city'
                 )
             ) AS location_json
         FROM
             rpt.transaction_search
+        JOIN ref_country_code AS rcc ON
+            recipient_location_country_code = rcc.country_code
         WHERE
-            UPPER(recipient_location_country_name) NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
+            rcc.country_name NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
             AND
-            recipient_location_country_name IS NOT NULL
+            rcc.country_name IS NOT NULL
             AND
             recipient_location_city_name IS NOT NULL
     ),

--- a/usaspending_api/database_scripts/etl/location_delta_view.sql
+++ b/usaspending_api/database_scripts/etl/location_delta_view.sql
@@ -46,6 +46,47 @@ WITH
         JOIN
             state_data AS ref_state ON ref_state.code = ref_city.state_alpha
     ),
+    -- City (foreign)
+    city_foreign_pop_cte AS (
+        SELECT
+            CONCAT(UPPER(pop_city_name), ', ', UPPER(pop_country_name)) AS location,
+            TO_JSONB(
+                JSONB_BUILD_OBJECT(
+                    'city_name', UPPER(pop_city_name),
+                    'state_name', NULL,
+                    'country_name', UPPER(pop_country_name),
+                    'location_type', 'city'
+                )
+            ) AS location_json
+        FROM
+            rpt.transaction_search
+        WHERE
+            UPPER(pop_country_name) NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
+            AND
+            pop_country_name IS NOT NULL
+            AND
+            pop_city_name IS NOT NULL
+    ),
+    city_foreign_rl_cte AS (
+        SELECT
+            CONCAT(UPPER(recipient_location_city_name), ', ', UPPER(recipient_location_country_name)) AS location,
+            TO_JSONB(
+                JSONB_BUILD_OBJECT(
+                    'city_name', UPPER(recipient_location_city_name),
+                    'state_name', NULL,
+                    'country_name', UPPER(recipient_location_country_name),
+                    'location_type', 'city'
+                )
+            ) AS location_json
+        FROM
+            rpt.transaction_search
+        WHERE
+            UPPER(recipient_location_country_name) NOT IN ('UNITED STATES OF AMERICA', 'UNITED STATES')
+            AND
+            recipient_location_country_name IS NOT NULL
+            AND
+            recipient_location_city_name IS NOT NULL
+    ),
     -- County
     county_cte AS (
         SELECT
@@ -173,6 +214,10 @@ FROM
         SELECT * FROM state_cte
         UNION
         SELECT * FROM city_domestic
+        UNION
+        SELECT * FROM city_foreign_pop_cte
+        UNION
+        SELECT * FROM city_foreign_rl_cte
         UNION
         SELECT * FROM county_cte
         UNION

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -58,12 +58,14 @@ class DeltaLakeElasticsearchIndexerController(AbstractElasticsearchIndexerContro
         elif self.config["load_type"] == "recipient":
             identifier_replacements = None
         elif self.config["load_type"] == "location":
-            identifier_replacements["array_agg"] = "collect_list"
-            identifier_replacements["json_agg"] = "collect_list"
-            # Replace the Postgres regex operator with the Databricks regex operator
             identifier_replacements["~"] = "rlike"
             identifier_replacements["jsonb_build_object"] = "map"
             identifier_replacements["to_jsonb"] = "to_json"
+            identifier_replacements["state_data"] = "global_temp.state_data"
+            identifier_replacements["ref_country_code"] = "global_temp.ref_country_code"
+            identifier_replacements["ref_city_county_state_code"] = "global_temp.ref_city_county_state_code"
+            identifier_replacements["zips_grouped"] = "global_temp.zips_grouped"
+
         else:
             raise ValueError(
                 f"Unrecognized load_type {self.config['load_type']}, or this function does not yet support it"


### PR DESCRIPTION
**Description:**
Use our reference data to populate the location index for domestic locations. Foreign cities are still coming from Transactions.

**Technical details:**
The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here.

**Requirements for PR merge:**

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated
3. [ ] Necessary PR reviewers:
    - [ ] Backend
    - [ ] Frontend <OPTIONAL>
    - [ ] Operations <OPTIONAL>
    - [ ] Domain Expert <OPTIONAL>
4. [ ] Matview impact assessment completed
5. [ ] Frontend impact assessment completed
6. [ ] Data validation completed
7. [ ] Appropriate Operations ticket(s) created
8. [ ] Jira Ticket [DEV-123](https://federal-spending-transparency.atlassian.net/browse/DEV-123):
    - [ ] Link to this Pull-Request
    - [ ] Performance evaluation of affected (API | Script | Download)
    - [ ] Before / After data comparison

**Area for explaining above N/A when needed:**
```
```
