### PR TITLE
[DEV-12587] - File A (Account Balances) spark downloads

### DIFF
--- a/usaspending_api/common/etl/spark.py
+++ b/usaspending_api/common/etl/spark.py
@@ -16,7 +16,7 @@ from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col, concat, concat_ws, expr, lit, regexp_replace, to_date, transform, when
 from pyspark.sql.types import ArrayType, DecimalType, StringType, StructType
 
-from usaspending_api.accounts.models import FederalAccount, TreasuryAppropriationAccount
+from usaspending_api.accounts.models import AppropriationAccountBalances, FederalAccount, TreasuryAppropriationAccount
 from usaspending_api.common.helpers.spark_helpers import (
     get_broker_jdbc_url,
     get_jdbc_connection_properties,
@@ -51,6 +51,7 @@ from usaspending_api.submissions.models import DABSSubmissionWindowSchedule, Sub
 MAX_PARTITIONS = CONFIG.SPARK_MAX_PARTITIONS
 _USAS_RDS_REF_TABLES = [
     Agency,
+    AppropriationAccountBalances,
     Cfda,
     CGAC,
     CityCountyStateCode,

--- a/usaspending_api/download/tests/integration/test_account_download_dataframe_builder.py
+++ b/usaspending_api/download/tests/integration/test_account_download_dataframe_builder.py
@@ -5,8 +5,7 @@ import pytest
 from django.core.management import call_command
 from model_bakery import baker
 
-from usaspending_api.accounts.models import AppropriationAccountBalances
-from usaspending_api.common.etl.spark import _USAS_RDS_REF_TABLES, create_ref_temp_views
+from usaspending_api.common.etl.spark import create_ref_temp_views
 from usaspending_api.download.management.commands.delta_downloads.builders import (
     FederalAccountDownloadDataFrameBuilder,
     TreasuryAccountDownloadDataFrameBuilder,
@@ -186,8 +185,12 @@ def test_filter_treasury_by_agency(spark, account_download_table, agency_models)
 def test_account_balances(mock_get_submission_ids_for_periods, spark, account_download_table):
     baker.make("references.CGAC", cgac_code="1").save()
     baker.make("references.CGAC", cgac_code="2").save()
+    baker.make("references.CGAC", cgac_code="3").save()
+    baker.make("references.CGAC", cgac_code="4").save()
     baker.make("references.ToptierAgency", toptier_agency_id=1).save()
+    baker.make("references.ToptierAgency", toptier_agency_id=2).save()
     baker.make("accounts.FederalAccount", id=1, parent_toptier_agency_id=1).save()
+    baker.make("accounts.FederalAccount", id=2, parent_toptier_agency_id=2).save()
     baker.make(
         "submissions.SubmissionAttributes",
         submission_id=1,
@@ -216,9 +219,16 @@ def test_account_balances(mock_get_submission_ids_for_periods, spark, account_do
         allocation_transfer_agency_id="2",
         federal_account_id=1,
     ).save()
+    baker.make(
+        "accounts.TreasuryAppropriationAccount",
+        treasury_account_identifier=2,
+        agency_id="3",
+        allocation_transfer_agency_id="4",
+        federal_account_id=2,
+    ).save()
     baker.make("accounts.AppropriationAccountBalances", submission_id=1, treasury_account_identifier_id=1).save()
-    baker.make("accounts.AppropriationAccountBalances", submission_id=2, treasury_account_identifier_id=1).save()
-    baker.make("accounts.AppropriationAccountBalances", submission_id=3, treasury_account_identifier_id=1).save()
+    baker.make("accounts.AppropriationAccountBalances", submission_id=2, treasury_account_identifier_id=2).save()
+    baker.make("accounts.AppropriationAccountBalances", submission_id=3, treasury_account_identifier_id=2).save()
 
     mock_get_submission_ids_for_periods.return_value = [1, 2, 3]
     # make the temp views


### PR DESCRIPTION
## Description:
This PR add the `appropriation_account_balances` table to the `global_temp` spark database.  It enables download of the account balances (File A) for both Treasury Accounts and Federal Accounts.

## Technical Details:
The `appropriation_account_balances` table is just over 500,000 rows, so it seems reasonable to load it into the global_temp instead of using the `create_delta_table` and `load_query_to_delta` commands to create a delta table.  The joins to submission attributes and other tables are includes in the pyspark dataframe api format.

## Requirements for PR Merge:

1. [x] Unit & integration tests updated
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
5. [x] Jira Ticket(s)
    1. [DEV-12587](https://federal-spending-transparency.atlassian.net/browse/DEV-12587)
