### PR TITLE
Change zips_grouped to cd_zips_grouped in ES Location Index for Spark

### DIFF
--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -38,7 +38,7 @@ class DeltaLakeElasticsearchIndexerController(AbstractElasticsearchIndexerContro
             return
 
         # Ensure reference tables the TEMP VIEW may depend on exist
-        create_ref_temp_views(self.spark)
+        create_ref_temp_views(self.spark, create_broker_views=True)
 
         view_file_path = settings.APP_DIR / "database_scripts" / "etl" / f"{sql_view_name}.sql"
 

--- a/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
+++ b/usaspending_api/etl/elasticsearch_loader_helpers/controller_for_spark.py
@@ -64,7 +64,7 @@ class DeltaLakeElasticsearchIndexerController(AbstractElasticsearchIndexerContro
             identifier_replacements["state_data"] = "global_temp.state_data"
             identifier_replacements["ref_country_code"] = "global_temp.ref_country_code"
             identifier_replacements["ref_city_county_state_code"] = "global_temp.ref_city_county_state_code"
-            identifier_replacements["zips_grouped"] = "global_temp.zips_grouped"
+            identifier_replacements["zips_grouped"] = "global_temp.cd_zips_grouped"
 
         else:
             raise ValueError(


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

Change the table we use to populate the Location Index in Spark.

## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

It was originally thought that we should be using the `zips_grouped` table when in fact it should have been `cd_zips_grouped` The end result of using both of these tables is the same because we handle the case of duplicates via the `UNION` statements, but `cd_zips_grouped` is already used in Spark and `zips_grouped` is already in Postgres.

## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. [ ] Appropriate Operations ticket(s) created
5. [ ] Jira Ticket(s)
    1. [DEV-0](https://federal-spending-transparency.atlassian.net/browse/DEV-0)

### Explain N/A in above checklist:
