### PR TITLE
[DEV-13000] Remove full vacuum from DEFC loader

### DIFF
--- a/usaspending_api/references/management/commands/load_disaster_emergency_fund_codes.py
+++ b/usaspending_api/references/management/commands/load_disaster_emergency_fund_codes.py
@@ -192,5 +192,5 @@ class Command(mixins.ETLMixin, BaseCommand):
 
     def _vacuum_tables(self):
         self._execute_dml_sql(
-            "vacuum (full, analyze) disaster_emergency_fund_code", "Vacuum disaster_emergency_fund_code table"
+            "vacuum (analyze) disaster_emergency_fund_code", "Vacuum disaster_emergency_fund_code table"
         )


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

Prevents the Postgres vacuum from holding a blocking lock on the DEFC table.

## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

The DEFC loader is currently using a full vacuum that holds an `ACCESS EXCLUSIVE` lock on the table and can cause the pipeline to run much longer than intended. This removes the "full" component of the vacuum to avoid that lock.

## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. N/A Unit & integration tests updated
2. N/A API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. N/A Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [x] Jira Ticket(s)
    1. [DEV-13000](https://federal-spending-transparency.atlassian.net/browse/DEV-13000)

### Explain N/A in above checklist:


[DEV-13000]: https://federal-spending-transparency.atlassian.net/browse/DEV-13000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ