### PR TITLE
[DEV-13016] add new endpoint

### DIFF
--- a/usaspending_api/accounts/tests/integration/test_federal_account_program_activities_total.py
+++ b/usaspending_api/accounts/tests/integration/test_federal_account_program_activities_total.py
@@ -5,6 +5,7 @@ from rest_framework import status
 
 url = "/api/v2/federal_accounts/{federal_account_code}/program_activities/total/{query_params}"
 
+
 @pytest.fixture
 def program_activities_total_test_data():
     federal_account_1 = baker.make("accounts.FederalAccount", federal_account_code="000-0001")
@@ -55,8 +56,8 @@ def program_activities_total_test_data():
         program_activity=pac_pan_2,
         submission=sa,
         obligations_incurred_by_program_object_class_cpe=130,
-        reporting_period_start = "2024-05-03",
-        reporting_period_end = "2024-05-04",
+        reporting_period_start="2024-05-03",
+        reporting_period_end="2024-05-04",
         object_class=oc3,
     )
     baker.make(
@@ -91,41 +92,48 @@ def program_activities_total_test_data():
         object_class=oc4,
     )
 
+
 @pytest.mark.django_db
 def test_success(client, program_activities_total_test_data):
     resp = client.post("/api/v2/federal_accounts/000-0001/program_activities/total", content_type="application/json")
 
     expected_results = {
-        'results': [
-            {'obligations': 45612.0, 'code': '00000000003', 'name': 'PARK 3', 'type': 'PARK'},
-            {'obligations': 6000.0, 'code': '00000000001', 'name': 'PARK 1', 'type': 'PARK'},
-            {'obligations': 130.0, 'code': '00000000002', 'name': 'PARK 2', 'type': 'PARK'},
-            {'obligations': 1.0, 'code': '0001', 'name': 'PAC/PAN 1', 'type': 'PAC/PAN'},
-            {'obligations': -1500.0, 'code': '00000000003', 'name': 'PARK 3', 'type': 'PARK'}
+        "results": [
+            {"obligations": 45612.0, "code": "00000000003", "name": "PARK 3", "type": "PARK"},
+            {"obligations": 6000.0, "code": "00000000001", "name": "PARK 1", "type": "PARK"},
+            {"obligations": 130.0, "code": "00000000002", "name": "PARK 2", "type": "PARK"},
+            {"obligations": 1.0, "code": "0001", "name": "PAC/PAN 1", "type": "PAC/PAN"},
+            {"obligations": -1500.0, "code": "00000000003", "name": "PARK 3", "type": "PARK"},
         ],
-        'page_metadata': {
-            'page': 1, 'total': 5, 'limit': 10, 'next': None, 'previous': None, 'hasNext': False, 'hasPrevious': False
-        }
+        "page_metadata": {
+            "page": 1,
+            "total": 5,
+            "limit": 10,
+            "next": None,
+            "previous": None,
+            "hasNext": False,
+            "hasPrevious": False,
+        },
     }
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_results
 
+
 @pytest.mark.django_db
 def test_success_with_filters(client, program_activities_total_test_data):
     request = {
-        "filter": {
-            "time_period": [{"start_date": "2020-01-01", "end_date": "2022-01-01"}],
-            "program_activity": ["PAC"]
-        }
+        "filter": {"time_period": [{"start_date": "2020-01-01", "end_date": "2022-01-01"}], "program_activity": ["PAC"]}
     }
-    resp = client.post("/api/v2/federal_accounts/000-0001/program_activities/total", content_type="application/json", data=json.dumps(request))
+    resp = client.post(
+        "/api/v2/federal_accounts/000-0001/program_activities/total",
+        content_type="application/json",
+        data=json.dumps(request),
+    )
 
     expected_results = {
-        'results': [
-            {'obligations': 1.0, 'code': '0001', 'name': 'PAC/PAN 1', 'type': 'PAC/PAN'}
-        ],
-        'page_metadata': {
+        "results": [{"obligations": 1.0, "code": "0001", "name": "PAC/PAN 1", "type": "PAC/PAN"}],
+        "page_metadata": {
             "page": 1,
             "total": 1,
             "limit": 10,
@@ -133,27 +141,28 @@ def test_success_with_filters(client, program_activities_total_test_data):
             "previous": None,
             "hasNext": False,
             "hasPrevious": False,
-        }
+        },
     }
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_results
 
+
 @pytest.mark.django_db
 def test_object_class_filter(client, program_activities_total_test_data):
-    request = {
-        "filter": {
-            "object_class": ["moc1", "oc3"]
-        }
-    }
-    resp = client.post("/api/v2/federal_accounts/000-0001/program_activities/total", content_type="application/json", data=json.dumps(request))
+    request = {"filter": {"object_class": ["moc1", "oc3"]}}
+    resp = client.post(
+        "/api/v2/federal_accounts/000-0001/program_activities/total",
+        content_type="application/json",
+        data=json.dumps(request),
+    )
 
     expected_results = {
-        'results': [
-            {'obligations': 6000.0, 'code': '00000000001', 'name': 'PARK 1', 'type': 'PARK'},
-            {'obligations': 130.0, 'code': '00000000002', 'name': 'PARK 2', 'type': 'PARK'},
-            {'obligations': 1.0, 'code': '0001', 'name': 'PAC/PAN 1', 'type': 'PAC/PAN'}
+        "results": [
+            {"obligations": 6000.0, "code": "00000000001", "name": "PARK 1", "type": "PARK"},
+            {"obligations": 130.0, "code": "00000000002", "name": "PARK 2", "type": "PARK"},
+            {"obligations": 1.0, "code": "0001", "name": "PAC/PAN 1", "type": "PAC/PAN"},
         ],
-        'page_metadata': {
+        "page_metadata": {
             "page": 1,
             "total": 3,
             "limit": 10,
@@ -161,7 +170,7 @@ def test_object_class_filter(client, program_activities_total_test_data):
             "previous": None,
             "hasNext": False,
             "hasPrevious": False,
-        }
+        },
     }
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_results

--- a/usaspending_api/accounts/tests/integration/test_federal_account_program_activities_total.py
+++ b/usaspending_api/accounts/tests/integration/test_federal_account_program_activities_total.py
@@ -1,0 +1,167 @@
+import json
+import pytest
+from model_bakery import baker
+from rest_framework import status
+
+url = "/api/v2/federal_accounts/{federal_account_code}/program_activities/total/{query_params}"
+
+@pytest.fixture
+def program_activities_total_test_data():
+    federal_account_1 = baker.make("accounts.FederalAccount", federal_account_code="000-0001")
+    federal_account_2 = baker.make("accounts.FederalAccount", federal_account_code="000-0002")
+    treasury_account_1 = baker.make("accounts.TreasuryAppropriationAccount", federal_account=federal_account_1)
+    treasury_account_2 = baker.make("accounts.TreasuryAppropriationAccount", federal_account=federal_account_2)
+    park_1 = baker.make("references.ProgramActivityPark", code="00000000001", name="PARK 1")
+    park_2 = baker.make("references.ProgramActivityPark", code="00000000002", name="PARK 2")
+    park_3 = baker.make("references.ProgramActivityPark", code="00000000003", name="PARK 3")
+    park_4 = baker.make("references.ProgramActivityPark", code="00000000004", name="PARK 4")
+    pac_pan_1 = baker.make(
+        "references.RefProgramActivity", program_activity_code="0001", program_activity_name="PAC/PAN 1"
+    )
+    pac_pan_2 = baker.make(
+        "references.RefProgramActivity", program_activity_code="0002", program_activity_name="PAC/PAN 2"
+    )
+    sa = baker.make("submissions.SubmissionAttributes", is_final_balances_for_fy=True, submission_id=1)
+    oc1 = baker.make("references.ObjectClass", major_object_class_name="moc1", object_class_name="oc1")
+    oc2 = baker.make("references.ObjectClass", major_object_class_name="moc1", object_class_name="oc1")
+    oc3 = baker.make("references.ObjectClass", major_object_class_name="moc2", object_class_name="oc3")
+    oc4 = baker.make("references.ObjectClass", major_object_class_name="moc2", object_class_name="oc4")
+    baker.make(
+        "financial_activities.FinancialAccountsByProgramActivityObjectClass",
+        treasury_account=treasury_account_1,
+        program_activity_reporting_key=park_1,
+        program_activity=None,
+        submission=sa,
+        obligations_incurred_by_program_object_class_cpe=6000,
+        reporting_period_start="2020-05-03",
+        reporting_period_end="2020-05-04",
+        object_class=oc1,
+    )
+    baker.make(
+        "financial_activities.FinancialAccountsByProgramActivityObjectClass",
+        treasury_account=treasury_account_1,
+        program_activity_reporting_key=None,
+        program_activity=pac_pan_1,
+        submission=sa,
+        obligations_incurred_by_program_object_class_cpe=1,
+        reporting_period_start="2021-05-03",
+        reporting_period_end="2021-05-04",
+        object_class=oc2,
+    )
+    baker.make(
+        "financial_activities.FinancialAccountsByProgramActivityObjectClass",
+        treasury_account=treasury_account_1,
+        program_activity_reporting_key=park_2,
+        program_activity=pac_pan_2,
+        submission=sa,
+        obligations_incurred_by_program_object_class_cpe=130,
+        reporting_period_start = "2024-05-03",
+        reporting_period_end = "2024-05-04",
+        object_class=oc3,
+    )
+    baker.make(
+        "financial_activities.FinancialAccountsByProgramActivityObjectClass",
+        treasury_account=treasury_account_1,
+        program_activity_reporting_key=park_3,
+        program_activity=None,
+        submission=sa,
+        obligations_incurred_by_program_object_class_cpe=-1500,
+        reporting_period_start="2020-05-03",
+        reporting_period_end="2020-05-04",
+        object_class=oc4,
+    )
+    baker.make(
+        "financial_activities.FinancialAccountsByProgramActivityObjectClass",
+        treasury_account=treasury_account_1,
+        program_activity_reporting_key=park_3,
+        program_activity=None,
+        submission=sa,
+        obligations_incurred_by_program_object_class_cpe=45612,
+        reporting_period_start="2025-05-03",
+        reporting_period_end="2025-05-04",
+        object_class=oc4,
+    )
+    baker.make(
+        "financial_activities.FinancialAccountsByProgramActivityObjectClass",
+        treasury_account=treasury_account_2,
+        program_activity_reporting_key=park_4,
+        program_activity=None,
+        submission=sa,
+        obligations_incurred_by_program_object_class_cpe=1200,
+        object_class=oc4,
+    )
+
+@pytest.mark.django_db
+def test_success(client, program_activities_total_test_data):
+    resp = client.post("/api/v2/federal_accounts/000-0001/program_activities/total", content_type="application/json")
+
+    expected_results = {
+        'results': [
+            {'obligations': 45612.0, 'code': '00000000003', 'name': 'PARK 3', 'type': 'PARK'},
+            {'obligations': 6000.0, 'code': '00000000001', 'name': 'PARK 1', 'type': 'PARK'},
+            {'obligations': 130.0, 'code': '00000000002', 'name': 'PARK 2', 'type': 'PARK'},
+            {'obligations': 1.0, 'code': '0001', 'name': 'PAC/PAN 1', 'type': 'PAC/PAN'},
+            {'obligations': -1500.0, 'code': '00000000003', 'name': 'PARK 3', 'type': 'PARK'}
+        ],
+        'page_metadata': {
+            'page': 1, 'total': 5, 'limit': 10, 'next': None, 'previous': None, 'hasNext': False, 'hasPrevious': False
+        }
+    }
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_results
+
+@pytest.mark.django_db
+def test_success_with_filters(client, program_activities_total_test_data):
+    request = {
+        "filter": {
+            "time_period": [{"start_date": "2020-01-01", "end_date": "2022-01-01"}],
+            "program_activity": ["PAC"]
+        }
+    }
+    resp = client.post("/api/v2/federal_accounts/000-0001/program_activities/total", content_type="application/json", data=json.dumps(request))
+
+    expected_results = {
+        'results': [
+            {'obligations': 1.0, 'code': '0001', 'name': 'PAC/PAN 1', 'type': 'PAC/PAN'}
+        ],
+        'page_metadata': {
+            "page": 1,
+            "total": 1,
+            "limit": 10,
+            "next": None,
+            "previous": None,
+            "hasNext": False,
+            "hasPrevious": False,
+        }
+    }
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_results
+
+@pytest.mark.django_db
+def test_object_class_filter(client, program_activities_total_test_data):
+    request = {
+        "filter": {
+            "object_class": ["moc1", "oc3"]
+        }
+    }
+    resp = client.post("/api/v2/federal_accounts/000-0001/program_activities/total", content_type="application/json", data=json.dumps(request))
+
+    expected_results = {
+        'results': [
+            {'obligations': 6000.0, 'code': '00000000001', 'name': 'PARK 1', 'type': 'PARK'},
+            {'obligations': 130.0, 'code': '00000000002', 'name': 'PARK 2', 'type': 'PARK'},
+            {'obligations': 1.0, 'code': '0001', 'name': 'PAC/PAN 1', 'type': 'PAC/PAN'}
+        ],
+        'page_metadata': {
+            "page": 1,
+            "total": 3,
+            "limit": 10,
+            "next": None,
+            "previous": None,
+            "hasNext": False,
+            "hasPrevious": False,
+        }
+    }
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_results

--- a/usaspending_api/accounts/urls_federal_accounts_v2.py
+++ b/usaspending_api/accounts/urls_federal_accounts_v2.py
@@ -1,6 +1,7 @@
 from django.urls import re_path
 
 from usaspending_api.accounts.v2.views.federal_account_program_activities import FederalAccountProgramActivities
+from usaspending_api.accounts.v2.views.federal_account_program_activities_total import FederalAccountProgramActivitiesTotal
 from usaspending_api.accounts.views import federal_accounts_v2 as views
 
 # bind ViewSets to URLs
@@ -21,6 +22,9 @@ urlpatterns = [
     re_path(
         r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/program_activities/?$",
         FederalAccountProgramActivities.as_view(),
+    ),
+    re_path(r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/program_activities/total/?$",
+        FederalAccountProgramActivitiesTotal.as_view(),
     ),
     re_path(r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/?$", federal_account),
     re_path(r"$", federal_accounts),

--- a/usaspending_api/accounts/urls_federal_accounts_v2.py
+++ b/usaspending_api/accounts/urls_federal_accounts_v2.py
@@ -1,7 +1,9 @@
 from django.urls import re_path
 
 from usaspending_api.accounts.v2.views.federal_account_program_activities import FederalAccountProgramActivities
-from usaspending_api.accounts.v2.views.federal_account_program_activities_total import FederalAccountProgramActivitiesTotal
+from usaspending_api.accounts.v2.views.federal_account_program_activities_total import (
+    FederalAccountProgramActivitiesTotal,
+)
 from usaspending_api.accounts.views import federal_accounts_v2 as views
 
 # bind ViewSets to URLs
@@ -23,7 +25,8 @@ urlpatterns = [
         r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/program_activities/?$",
         FederalAccountProgramActivities.as_view(),
     ),
-    re_path(r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/program_activities/total/?$",
+    re_path(
+        r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/program_activities/total/?$",
         FederalAccountProgramActivitiesTotal.as_view(),
     ),
     re_path(r"(?P<federal_account_code>[0-9]{3}[\-][0-9]{4})/?$", federal_account),

--- a/usaspending_api/accounts/v2/views/federal_account_program_activities_total.py
+++ b/usaspending_api/accounts/v2/views/federal_account_program_activities_total.py
@@ -1,0 +1,81 @@
+from django.db.models import Case, Q, TextField, When, Value, Sum
+from django.db.models.functions import Coalesce
+from rest_framework.response import Response
+from rest_framework.request import Request
+
+from usaspending_api.accounts.v2.views.federal_account_base import FederalAccountBase, PaginationMixin
+from usaspending_api.common.helpers.generic_helper import get_pagination_metadata
+from usaspending_api.common.query_with_filters import QueryWithFilters
+from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
+
+class FederalAccountProgramActivitiesTotal(PaginationMixin, FederalAccountBase):
+    """
+    Retrieve a list of program activity totals for a federal account.
+    """
+
+    endpoint_doc = (
+        "usaspending_api/api_contracts/contracts/v2/views/federal_account_program_activities_total.md"
+    )
+    filters: dict
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.default_sort_column = "obligations"
+        self.sortable_columns = ["obligations", "code", "name", "type"]
+
+    def post(self, request: Request, *args, **kwargs):
+        self.json_request = request.data
+        self.filters = self.json_request.get("filter", [])
+        query = self.get_filter_query()
+        results = (
+            FinancialAccountsByProgramActivityObjectClass.objects.filter(
+                Q(treasury_account__federal_account__federal_account_code=self.federal_account_code,
+                submission__is_final_balances_for_fy=True,
+
+            )).filter(query)
+            .annotate(
+                obligations=Sum("obligations_incurred_by_program_object_class_cpe"),
+                code=Coalesce(
+                    "program_activity_reporting_key__code",
+                    "program_activity__program_activity_code",
+                    output_field=TextField(),
+                ),
+                name=Coalesce(
+                    "program_activity_reporting_key__name",
+                    "program_activity__program_activity_name",
+                    output_field=TextField(),
+                ),
+                type=Case(
+                    When(program_activity_reporting_key__isnull=False, then=Value("PARK")),
+                    default=Value("PAC/PAN"),
+                    output_field=TextField(),
+                ),
+            )
+            .order_by(*self.pagination.robust_order_by_fields)
+            .values("obligations", "code", "name", "type")
+            .distinct()
+        )
+        page_metadata = get_pagination_metadata(len(results), self.pagination.limit, self.pagination.page)
+        return Response(
+            {
+                "results": results[self.pagination.lower_limit: self.pagination.upper_limit],
+                "page_metadata": page_metadata,
+            }
+        )
+
+    def get_filter_query(self) -> Q:
+        query = Q()
+        if "time_period" in self.filters:
+            start_date = self.filters["time_period"][0]["start_date"]
+            end_date = self.filters["time_period"][0]["end_date"]
+            query &= Q(reporting_period_start__gte=start_date, reporting_period_end__lte=end_date)
+        if "object_class" in self.filters:
+            query &= Q(Q(object_class__object_class_name__in=self.filters["object_class"]) | Q(object_class__major_object_class_name__in=self.filters["object_class"]))
+        if "program_activity" in self.filters:
+            if "PARK" in self.filters["program_activity"]:
+                query &= Q(program_activity_reporting_key__isnull=False)
+            if "PAC" in self.filters["program_activity"]:
+                query &= Q(program_activity__isnull=False)
+        else:
+            query &= Q(Q(program_activity_reporting_key__isnull=False) | Q(program_activity__isnull=False))
+        return query

--- a/usaspending_api/api_contracts/contracts/v2/federal_accounts/federal_account_totals/program_activities.md
+++ b/usaspending_api/api_contracts/contracts/v2/federal_accounts/federal_account_totals/program_activities.md
@@ -1,0 +1,46 @@
+FORMAT: 1A
+HOST: https://api.usaspending.gov
+
+# Program Activities Total [/api/v2/federal_accounts/{FEDERAL_ACCOUNT_CODE}/program_activities/total]
+
+This route returns an array of each program activity's obligation, code, name, and type for the specified federal account 
+
+## GET
++ Parameters
+  + `filters`
+    + `federal_account` (required string)
+    + `time_period` (optional, array[TimePeriod], fixed-type)
+    + `object_class` (optional, array[String])
+    + `program_activity` (optional, array) 
+      Each string should be either "PAC" or "PARK"
+
++ Response 200 (application/json)
+  + Attributes (object)
+    + `page_metadata` (required, PageMetadata, fixed-type)
+        Information used for pagination of results. 
+    + `results` (required, array[ProgramActivitiesTotals], fixed-type)
+  + Body
+    
+        {
+            "results":
+
+# Data Structure
+
+## ProgramActivitiesTotals (object)
++ `obligations` (required, float)
++ `code` (required, string)
++ `name` (required, string)
++ `type` (required, enum[string], fixed-type)
+  Whether the Program Activity values are from the older Program Activity Code / Name (PAC/PAN) or the Program Activity Reporting Key (PARK)
+  + Members
+    + `PAC/PAN`
+    + `PARK`
+
+## PageMetadata (object)
++ `limit` (required, number)
++ `page` (required, number)
++ `next` (required, number, nullable)
++ `previous` (required, number, nullable)
++ `hasNext` (required, boolean)
++ `hasPrevious` (required, boolean)
++ `total` (required, number)

--- a/usaspending_api/api_docs/markdown/endpoints.md
+++ b/usaspending_api/api_docs/markdown/endpoints.md
@@ -118,6 +118,7 @@ The currently available endpoints are listed in the following table.
 |[/api/v2/federal_accounts/<ACCOUNT_CODE\>/fiscal_year_snapshot/<YEAR\>/](/api/v2/federal_accounts/4324/fiscal_year_snapshot/2017/)|GET| Returns budget information for a federal account for the year provided based on account's internal ID |
 |[/api/v2/federal_accounts/<ACCOUNT_CODE\>/fiscal_year_snapshot/](/api/v2/federal_accounts/4324/fiscal_year_snapshot/)|GET| Returns budget information for a federal account for the most recent year based on account's internal ID |
 |[/api/v2/federal_accounts/<ACCOUNT_CODE\>/program_activities/](/api/v2/federal_accounts/020-0550/program_activities/)|GET| Returns a list of program activities under a federal account based on its federal account code |
+|[/api/v2/federal_accounts/<ACCOUNT_CODE\>/pogram_activities/totals](/api/v2/federal_account/020-0550/program_activities/totals/)|GET| Returns a list of program activities including the sum of their obligations under a federal account based on its federal account code in |
 |[/api/v2/federal_accounts/](/api/v2/federal_accounts/)|POST| Returns financial spending data by object class |
 |[/api/v2/federal_obligations/](/api/v2/federal_obligations/?fiscal_year=2019&funding_agency_id=315&limit=10&page=1)|GET| Returns a paginated list of obligations for the provided agency for the provided year |
 |[/api/v2/financial_balances/agencies/](/api/v2/financial_balances/agencies/?fiscal_year=2017&funding_agency_id=4324)|GET| Returns financial balances by agency and the latest quarter for the given fiscal year |


### PR DESCRIPTION
## Description:
This is creating a new endpoint in v2 for returning federal account totals for program activities. It's to replace the v1 endpoint's (`/api/v1/tas/categories/total/`) functionality for this specific purpose (v1 endpoint has additional functionality, so it isn't being replace entirely) and add implementation for using PARK or PAC/PAN. 



## Technical Details:
The will return a list of results that contain the obligation (sum of obligations_incurred_by_program_object_class_cpe for the File B records that belong to the last submission; should use is_final_balance_for_fy), name (PARK or PAN name), code (PARK/PAC), and type (enum of either PARK/PAC) of a program activity. 

A federal account is given as part of the url, and supports `time_period`, `object_class`, and `program_activity` as filters



## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [X] Unit & integration tests updated
2. [X] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. N/A Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [X] Jira Ticket(s)
    1. [DEV-13016](https://federal-spending-transparency.atlassian.net/browse/DEV-13016)

### Explain N/A in above checklist:
