### PR TITLE
[DEV-13183] Enable Spark Download for File C by default

### DIFF
--- a/usaspending_api/download/tests/integration/test_download_accounts.py
+++ b/usaspending_api/download/tests/integration/test_download_accounts.py
@@ -512,6 +512,11 @@ def test_file_c_spark_download(client, download_test_data, spark, s3_unittest_da
     call_command(
         "create_delta_table",
         f"--spark-s3-bucket={s3_unittest_data_bucket}",
+        f"--destination-table=object_class_program_activity_download",
+    )
+    call_command(
+        "create_delta_table",
+        f"--spark-s3-bucket={s3_unittest_data_bucket}",
         f"--destination-table=account_balances_download",
     )
 
@@ -524,14 +529,13 @@ def test_file_c_spark_download(client, download_test_data, spark, s3_unittest_da
                 "filters": {
                     "budget_function": "all",
                     "agency": "all",
-                    "submission_types": ["award_financial"],
+                    "submission_types": ["account_balances", "object_class_program_activity", "award_financial"],
                     "fy": "2021",
                     "period": 12,
                 },
                 "file_format": "csv",
             }
         ),
-        headers={"X-Experimental-API": "download"},
     )
 
     assert resp.status_code == status.HTTP_200_OK

--- a/usaspending_api/download/tests/integration/test_download_accounts.py
+++ b/usaspending_api/download/tests/integration/test_download_accounts.py
@@ -14,7 +14,7 @@ from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.awards.v2.lookups.lookups import award_type_mapping
 from usaspending_api.common.helpers.sql_helpers import get_database_dsn_string
 from usaspending_api.download.filestreaming import download_generation
-from usaspending_api.download.lookups import JOB_STATUS, VALID_ACCOUNT_SUBMISSION_TYPES
+from usaspending_api.download.lookups import JOB_STATUS
 from usaspending_api.etl.award_helpers import update_awards
 from usaspending_api.search.models import TransactionSearch
 
@@ -364,8 +364,8 @@ def test_duplicate_submission_types_success(client, download_test_data):
     download_types = resp.json()["download_request"]["download_types"]
 
     assert resp.status_code == status.HTTP_200_OK
-    assert len(download_types) == len(VALID_ACCOUNT_SUBMISSION_TYPES), "De-duplication failed"
-    assert set(download_types) == set(VALID_ACCOUNT_SUBMISSION_TYPES), "Wrong values in response"
+    assert len(download_types) == 2, "De-duplication failed"
+    assert sorted(download_types) == ["account_balances", "object_class_program_activity"], "Wrong values in response"
 
 
 @pytest.mark.django_db(databases=[settings.DOWNLOAD_DB_ALIAS, settings.DEFAULT_DB_ALIAS])

--- a/usaspending_api/download/v2/base_download_viewset.py
+++ b/usaspending_api/download/v2/base_download_viewset.py
@@ -11,7 +11,6 @@ from rest_framework.views import APIView
 from usaspending_api.broker.lookups import EXTERNAL_DATA_TYPE_DICT
 from usaspending_api.broker.models import ExternalDataLoadDate
 from usaspending_api.common.api_versioning import API_TRANSFORM_FUNCTIONS, api_transformations
-from usaspending_api.common.experimental_api_flags import is_experimental_download_api
 from usaspending_api.common.helpers.dict_helpers import order_nested_object
 from usaspending_api.common.spark.jobs import DatabricksStrategy, LocalStrategy, SparkJobs
 from usaspending_api.common.sqs.sqs_handler import get_sqs_queue
@@ -70,11 +69,7 @@ class BaseDownloadViewSet(APIView):
         return self.build_download_response(download_job)
 
     def process_request(self, download_job: DownloadJob, request: Request, json_request: dict):
-        if (
-            is_experimental_download_api(request)
-            and json_request["request_type"] == "account"
-            and "award_financial" in json_request["download_types"]
-        ):
+        if json_request["request_type"] == "account" and "award_financial" in json_request["download_types"]:
             # goes to spark for File C account download
             self.process_account_download_in_spark(download_job=download_job)
         elif settings.IS_LOCAL and settings.RUN_LOCAL_DOWNLOAD_IN_PROCESS:


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

Removes the experimental header logic that hid Spark downloads for File C.


## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [x] Unit & integration tests updated
2. [x] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. [ ] Appropriate Operations ticket(s) created
5. [x] Jira Ticket(s)
    1. [DEV-13183](https://federal-spending-transparency.atlassian.net/browse/DEV-13183)

### Explain N/A in above checklist:


[DEV-13183]: https://federal-spending-transparency.atlassian.net/browse/DEV-13183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ