### PR TITLE
[DEV-13442] Fix OpenSearch unique count too many loops

### DIFF
--- a/usaspending_api/common/elasticsearch/aggregation_helpers.py
+++ b/usaspending_api/common/elasticsearch/aggregation_helpers.py
@@ -12,5 +12,14 @@ def create_count_aggregation(field_name):
         init_script="state.list = []",
         map_script="if(doc[params.fieldName].size() > 0) state.list.add(doc[params.fieldName].value);",
         combine_script="return state.list;",
-        reduce_script="Map uniqueValueMap = new HashMap(); int count = 0;for(shardList in states) {if(shardList != null) { for(key in shardList) {if(!uniqueValueMap.containsKey(key)) {count +=1;uniqueValueMap.put(key, key); }}}}  return count;",
+        reduce_script="""
+            Set uniqueValues = new HashSet();
+            for (shardList in states) {
+                if (shardList != null) {
+                    Set tempValues = new HashSet(shardList);
+                    uniqueValues.addAll(tempValues);
+                }
+            }
+            return uniqueValues.size();
+        """,
     )


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

Fixes a bug that impacts unique counts with a large number of unique items.

## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

The bug is causing the following error message: `The maximum number of statements that can be executed in a loop has been reached`.

To get around this, the change is to leverage the uniqueness of a Set and only loop over each Shard.

## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. N/A Unit & integration tests updated
2. [x] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [x] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [x] Jira Ticket(s)
    1. [DEV-13442](https://federal-spending-transparency.atlassian.net/browse/DEV-13442)

### Explain N/A in above checklist:

No tests were updated as they should continue to function as expected given the limited amount of test data. This is a bug that only shows in deployed environments with specific criteria that create a large number of unique items that are counted.


[DEV-13442]: https://federal-spending-transparency.atlassian.net/browse/DEV-13442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ