### PR TITLE
[DEV-13689] update filtering when only a filter is provided, show chi…

### DIFF
--- a/usaspending_api/references/tests/integration/test_assistance_listing.py
+++ b/usaspending_api/references/tests/integration/test_assistance_listing.py
@@ -91,8 +91,18 @@ def test_filter_without_code(client, assistance_listings_test_data):
     resp = client.get("/api/v2/references/assistance_listing/?filter=Title 1", content_type="application/json")
 
     expected_results = [
-        {"code": "10", "description": None, "count": 1},
-        {"code": "11", "description": None, "count": 1},
+        {
+            "code": "10",
+            "description": None,
+            "count": 1,
+            "children": [{"code": "10.001", "description": "CFDA Title 1"}],
+        },
+        {
+            "code": "11",
+            "description": None,
+            "count": 1,
+            "children": [{"code": "11.004", "description": "CFDA Title 1"}],
+        },
     ]
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_results

--- a/usaspending_api/references/v2/views/filter_tree/assistance_listing.py
+++ b/usaspending_api/references/v2/views/filter_tree/assistance_listing.py
@@ -44,6 +44,8 @@ class AssistanceListingViewSet(APIView):
 
         if cfda_code:
             qs = qs.filter(program_number__startswith=cfda_code)
+
+        if cfda_code or cfda_filter:
             annotations["children"] = ArrayAgg(
                 Func(
                     Cast(Value("code"), TextField()),


### PR DESCRIPTION
## Description:

Currently when a filter is provided, it doesn't show the children that belong within that filter. The only change is that when a filter alone is provided it will show the children under each code.
<img width="1406" height="947" alt="image" src="https://github.com/user-attachments/assets/26f60344-23cb-4aae-9ad8-aa77ea8c14e0" />



## Technical Details:
N/A



## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [X] Unit & integration tests updated
2. N/A API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. N/A Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [X] Jira Ticket(s)
    1. [DEV-13689](https://federal-spending-transparency.atlassian.net/browse/DEV-13689)

### Explain N/A in above checklist:


[DEV-13689]: https://federal-spending-transparency.atlassian.net/browse/DEV-13689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ