### PR TITLE
[DEV-13988] Limit the S3 objects we check during download zip process

### DIFF
--- a/usaspending_api/common/etl/spark.py
+++ b/usaspending_api/common/etl/spark.py
@@ -687,22 +687,20 @@ def rename_part_files(
     list_of_part_files = sorted(
         [
             file.key
-            for file in retrieve_s3_bucket_object_list(bucket_name)
-            if (
-                file.key.startswith(f"{temp_download_dir_name}/{destination_file_name}/part-")
-                and file.key.endswith(file_format)
+            for file in retrieve_s3_bucket_object_list(
+                bucket_name, key_prefix=f"{temp_download_dir_name}/{destination_file_name}/part-"
             )
+            if file.key.endswith(file_format)
         ]
     )
 
     full_file_paths = []
 
     for index, part_file in enumerate(list_of_part_files):
-        old_key = f"{bucket_name}/{part_file}"
         new_key = f"{temp_download_dir_name}/{destination_file_name}_{str(index + 1).zfill(2)}.{file_format}"
-        logger.info(f"Renaming {old_key} to {bucket_name}/{new_key}")
+        logger.info(f"Renaming {bucket_name}/{part_file} to {bucket_name}/{new_key}")
 
-        rename_s3_object(bucket_name=bucket_name, old_key=old_key, new_key=new_key)
+        rename_s3_object(bucket_name=bucket_name, old_key=part_file, new_key=new_key)
         full_file_paths.append(f"s3a://{bucket_name}/{new_key}")
 
     return full_file_paths

--- a/usaspending_api/common/tests/integration/test_s3_helpers.py
+++ b/usaspending_api/common/tests/integration/test_s3_helpers.py
@@ -1,0 +1,31 @@
+import pytest
+
+from usaspending_api.common.helpers.s3_helpers import _get_boto3, rename_s3_object, retrieve_s3_bucket_object_list
+
+
+@pytest.fixture
+def create_empty_files(s3_unittest_data_bucket):
+    s3_client = _get_boto3("client", "s3")
+    test_file_names = ["SAMPLE_FILE_A.txt", "SAMPLE_FILE_B.txt", "SAMPLE_FILE_C.txt", "ANOTHER_FILE.txt"]
+    for file_name in test_file_names:
+        s3_client.put_object(Bucket=s3_unittest_data_bucket, Key=file_name)
+
+
+def test_retrieve_s3_bucket_object_list(create_empty_files, s3_unittest_data_bucket):
+    object_keys = sorted(s3_object.key for s3_object in retrieve_s3_bucket_object_list(s3_unittest_data_bucket))
+    assert object_keys == ["ANOTHER_FILE.txt", "SAMPLE_FILE_A.txt", "SAMPLE_FILE_B.txt", "SAMPLE_FILE_C.txt"]
+
+    object_keys = sorted(
+        s3_object.key for s3_object in retrieve_s3_bucket_object_list(s3_unittest_data_bucket, key_prefix="SAMPLE_FILE")
+    )
+    assert object_keys == ["SAMPLE_FILE_A.txt", "SAMPLE_FILE_B.txt", "SAMPLE_FILE_C.txt"]
+
+
+def test_rename_s3_object(create_empty_files, s3_unittest_data_bucket):
+    object_keys = sorted(s3_object.key for s3_object in retrieve_s3_bucket_object_list(s3_unittest_data_bucket))
+    assert object_keys == ["ANOTHER_FILE.txt", "SAMPLE_FILE_A.txt", "SAMPLE_FILE_B.txt", "SAMPLE_FILE_C.txt"]
+
+    rename_s3_object(s3_unittest_data_bucket, "ANOTHER_FILE.txt", "CHANGED_NAME.txt")
+
+    object_keys = sorted(s3_object.key for s3_object in retrieve_s3_bucket_object_list(s3_unittest_data_bucket))
+    assert object_keys == ["CHANGED_NAME.txt", "SAMPLE_FILE_A.txt", "SAMPLE_FILE_B.txt", "SAMPLE_FILE_C.txt"]

--- a/usaspending_api/common/tests/integration/test_spark_helpers.py
+++ b/usaspending_api/common/tests/integration/test_spark_helpers.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from usaspending_api.common.etl.spark import rename_part_files
+from usaspending_api.common.helpers.s3_helpers import _get_boto3, retrieve_s3_bucket_object_list
+
+
+@pytest.fixture
+def create_empty_files(s3_unittest_data_bucket):
+    s3_client = _get_boto3("client", "s3")
+    test_file_names = [
+        "temp_download/new_file_name/another-csv-file.csv",
+        "temp_download/new_file_name/another-txt-file.txt",
+        "temp_download/new_file_name/part-sample-a.csv",
+        "temp_download/new_file_name/part-sample-b.csv",
+        "temp_download/new_file_name/part-sample-c.csv",
+    ]
+    for file_name in test_file_names:
+        s3_client.put_object(Bucket=s3_unittest_data_bucket, Key=file_name)
+
+
+def test_rename_part_files(create_empty_files, s3_unittest_data_bucket):
+    object_keys = sorted(s3_object.key for s3_object in retrieve_s3_bucket_object_list(s3_unittest_data_bucket))
+    assert object_keys == [
+        "temp_download/new_file_name/another-csv-file.csv",
+        "temp_download/new_file_name/another-txt-file.txt",
+        "temp_download/new_file_name/part-sample-a.csv",
+        "temp_download/new_file_name/part-sample-b.csv",
+        "temp_download/new_file_name/part-sample-c.csv",
+    ]
+
+    logger = MagicMock()
+    file_paths = rename_part_files(s3_unittest_data_bucket, "new_file_name", logger)
+
+    expected_renamed_keys = [
+        "temp_download/new_file_name_01.csv",
+        "temp_download/new_file_name_02.csv",
+        "temp_download/new_file_name_03.csv",
+    ]
+
+    expected_object_keys = [
+        "temp_download/new_file_name/another-csv-file.csv",
+        "temp_download/new_file_name/another-txt-file.txt",
+        *expected_renamed_keys,
+    ]
+    assert sorted(file_paths) == [
+        f"s3a://{s3_unittest_data_bucket}/{object_key}" for object_key in expected_renamed_keys
+    ]
+
+    object_keys = sorted(s3_object.key for s3_object in retrieve_s3_bucket_object_list(s3_unittest_data_bucket))
+    assert object_keys == expected_object_keys


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

This will be merged into `staging` and then merged into `master` as a hotfix.

The change limits the S3 objects that we scan when looking for the part files to rename and zip.

## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

Added some test cases and the ability to specify a prefix when pulling objects from S3.

## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [x] Unit & integration tests updated
2. [x] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [x] Jira Ticket(s)
    1. [DEV-13988](https://federal-spending-transparency.atlassian.net/browse/DEV-13988)

### Explain N/A in above checklist:


[DEV-13988]: https://federal-spending-transparency.atlassian.net/browse/DEV-13988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ