### PR TITLE
typo: replace paramater with parameter

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/references/total_budgetary_resources.md
+++ b/usaspending_api/api_contracts/contracts/v2/references/total_budgetary_resources.md
@@ -14,7 +14,7 @@ This endpoint returns federal budgetary resources by fiscal year and fiscal peri
     + `fiscal_year` (optional, number)
         The fiscal year to retrieve, 2017 or later.
     + `fiscal_period` (optional, number)
-        The fiscal period. If this optional parameter is provided then `fiscal_year` is a required parameter. If `fiscal_period` is provided without `fiscal_year`, a 400 error is returned.  Valid values: 2-12 (2 = November ... 12 = September). For retrieving quarterly data, provide the period which equals 'quarter * 3' (e.g. Q2 = P6). If neither paramater is provided, the entire available history will be returned.
+        The fiscal period. If this optional parameter is provided then `fiscal_year` is a required parameter. If `fiscal_period` is provided without `fiscal_year`, a 400 error is returned.  Valid values: 2-12 (2 = November ... 12 = September). For retrieving quarterly data, provide the period which equals 'quarter * 3' (e.g. Q2 = P6). If neither parameter is provided, the entire available history will be returned.
 
 + Response 200 (application/json)
 


### PR DESCRIPTION
Nothin fancy, parameter was misspelled in the v2 total_budgetary_resources contract.
