### PR TITLE
Use setuptools version that still has pkg_resource

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ server = [
     "django-redis==5.4.*",
     "packaging==22.0",
     "pyparsing==3.2.1",
-    "setuptools>=68.1.2",
+    "setuptools<81",
     "supervisor==4.1.0",
     "uwsgi==2.0.23",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2342,11 +2342,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.31.*" },
     { name = "retrying", specifier = "==1.3.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.14" },
-    { name = "setuptools", marker = "extra == 'server'", specifier = ">=68.1.2" },
+    { name = "setuptools", marker = "extra == 'server'", specifier = "<81" },
     { name = "sqlparse", specifier = "==0.5.*" },
     { name = "supervisor", marker = "extra == 'server'", specifier = "==4.1.0" },
     { name = "urllib3", specifier = "==1.26.*" },


### PR DESCRIPTION
## Description:
Setuptools version 82 removed the `pkg_resources` library which is required for our deployments. This PR pins it to a version less than 82.