### PR TITLE
[DEV-15051] Remove check for File A that duplicates Broker validation

### DIFF
--- a/usaspending_api/etl/submission_loader_helpers/file_b.py
+++ b/usaspending_api/etl/submission_loader_helpers/file_b.py
@@ -1,9 +1,10 @@
 import logging
 import re
-
 from collections import defaultdict
+from typing import OrderedDict
 
-from usaspending_api.accounts.models import AppropriationAccountBalances
+from django.db.backends.utils import CursorWrapper
+
 from usaspending_api.etl.broker_etl_helpers import dictfetchall
 from usaspending_api.etl.management.load_base import load_data_into_model
 from usaspending_api.etl.submission_loader_helpers.bulk_create_manager import BulkCreateManager
@@ -16,12 +17,12 @@ from usaspending_api.etl.submission_loader_helpers.treasury_appropriation_accoun
     get_treasury_appropriation_account_tas_lookup,
 )
 from usaspending_api.financial_activities.models import FinancialAccountsByProgramActivityObjectClass
-
+from usaspending_api.submissions.models import SubmissionAttributes
 
 logger = logging.getLogger("script")
 
 
-def get_file_b(submission_attributes, db_cursor):
+def get_file_b(submission_attributes: SubmissionAttributes, db_cursor: CursorWrapper) -> list[OrderedDict]:
     """
     Get broker File B data for a specific submission.
     This function was added as a workaround for the fact that a few agencies (two, as of April, 2017: DOI and ACHP)
@@ -45,7 +46,7 @@ def get_file_b(submission_attributes, db_cursor):
     submission_id = submission_attributes.submission_id
 
     # does this file B have the dupe object class edge case?
-    check_dupe_oc = f"""
+    check_dupe_oc = """
         select      count(*)
         from        published_object_class_program_activity
         where       submission_id = %s and length(object_class) = 4
@@ -169,7 +170,9 @@ def get_file_b(submission_attributes, db_cursor):
     return data
 
 
-def load_file_b(submission_attributes, prg_act_obj_cls_data, db_cursor):
+def load_file_b(
+    submission_attributes: SubmissionAttributes, prg_act_obj_cls_data: list[OrderedDict], db_cursor: CursorWrapper
+) -> None:
     """Process and load file B broker data (aka TAS balances by program activity and object class)."""
     reverse = re.compile(r"(_(cpe|fyb)$)|^transaction_obligated_amount$")
     skipped_tas = defaultdict(int)  # tracks count of rows skipped due to "missing" TAS
@@ -183,11 +186,6 @@ def load_file_b(submission_attributes, prg_act_obj_cls_data, db_cursor):
             skipped_tas[tas_rendering_label] += 1
             continue
 
-        # get the corresponding account balances row (aka "File A" record)
-        account_balances = AppropriationAccountBalances.objects.get(
-            treasury_account_identifier=treasury_account, submission_id=submission_attributes.submission_id
-        )
-
         financial_by_prg_act_obj_cls = FinancialAccountsByProgramActivityObjectClass()
 
         value_map = {
@@ -195,7 +193,6 @@ def load_file_b(submission_attributes, prg_act_obj_cls_data, db_cursor):
             "reporting_period_start": submission_attributes.reporting_period_start,
             "reporting_period_end": submission_attributes.reporting_period_end,
             "treasury_account": treasury_account,
-            "appropriation_account_balances": account_balances,
             "object_class": get_object_class(row["object_class"], row["by_direct_reimbursable_fun"]),
             "program_activity": get_program_activity(row, submission_attributes),
             "disaster_emergency_fund": get_disaster_emergency_fund(row),

--- a/usaspending_api/etl/tests/integration/test_load_multiple_submissions.py
+++ b/usaspending_api/etl/tests/integration/test_load_multiple_submissions.py
@@ -1,13 +1,13 @@
-import pytest
-
-from datetime import datetime, timezone, date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
+import pytest
 from django.conf import settings
-from django.core.management import call_command, CommandError
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.core.management import CommandError, call_command
+from django.db import DEFAULT_DB_ALIAS, connections
 from django.test import TransactionTestCase
 from model_bakery import baker
+
 from usaspending_api.accounts.models import AppropriationAccountBalances
 from usaspending_api.awards.models import FinancialAccountsByAwards
 from usaspending_api.common.helpers.sql_helpers import ordered_dictionary_fetcher
@@ -57,12 +57,23 @@ class TestWithMultipleDatabases(TransactionTestCase):
             tas_rendering_label="222-X-2222-222",
         )
 
+        baker.make(
+            "accounts.TreasuryAppropriationAccount",
+            treasury_account_identifier=100,
+            agency_id="100",
+            availability_type_code="X",
+            main_account_code="1000",
+            sub_account_code="100",
+            tas_rendering_label="100-X-1000-100",
+        )
+
         baker.make("references.ObjectClass", major_object_class="10", object_class="10.1", direct_reimbursable="D")
         baker.make("references.ObjectClass", major_object_class="01", object_class="01.0", direct_reimbursable="D")
 
         baker.make("references.DisasterEmergencyFundCode", code="B", title="BB")
         baker.make("references.DisasterEmergencyFundCode", code="L", title="LL")
         baker.make("references.DisasterEmergencyFundCode", code="N", title="NN")
+        baker.make("references.DisasterEmergencyFundCode", code="Q", title="QQ")
 
         baker.make(
             "submissions.DABSSubmissionWindowSchedule",
@@ -109,7 +120,6 @@ class TestWithMultipleDatabases(TransactionTestCase):
         baker.make("references.ProgramActivityPark", code="ABCD0000", name="TEST PARK")
         connection = connections[settings.BROKER_DB_ALIAS]
         with connection.cursor() as cursor:
-
             self._nuke_broker_data()
 
             cursor.execute(
@@ -126,7 +136,8 @@ class TestWithMultipleDatabases(TransactionTestCase):
                     display_tas
                 ) (values
                     (1, 1, '111', 'X', '1111', '111', '1900-01-01', '00011100000000X1111111', '000-111-X-1111-111'),
-                    (2, 2, '222', 'X', '2222', '222', '1900-01-01', '00022200000000X2222222', '000-222-X-2222-222')
+                    (2, 2, '222', 'X', '2222', '222', '1900-01-01', '00022200000000X2222222', '000-222-X-2222-222'),
+                    (100, 100, '100', 'X', '1000', '100', '1900-01-01', '00010000000000X1001000', '000-100-X-1000-100')
                 )
                 """
             )
@@ -152,9 +163,11 @@ class TestWithMultipleDatabases(TransactionTestCase):
                     (3, '003', '0003', '2000-02-01', '2000-02-29', 2000, 5, false, false, 2, now()),
                     (4, '004', null, '2000-03-01', '2000-03-31', 2000, 6, false, false, 3, now()),
                     (5, null, '005', '2000-04-01', '2000-06-30', 2000, 9, true, false, 2, now()),
-                    -- submissions that should never return for various reasons
-                    (6, '006', null, '2000-01-01', '2000-03-31', 2000, 4, true, false, 1, now()), -- not publish type 2 or 3
-                    (7, '007', null, '2000-01-01', '2000-03-31', 2000, 4, true, true, 2, now()) -- D2
+                    ----- submissions that should never return for various reasons -----
+                    -- not publish type 2 or 3
+                    (6, '006', null, '2000-01-01', '2000-03-31', 2000, 4, true, false, 1, now()),
+                     -- D2
+                    (7, '007', null, '2000-01-01', '2000-03-31', 2000, 4, true, true, 2, now())
                 )
                 """
             )
@@ -235,16 +248,17 @@ class TestWithMultipleDatabases(TransactionTestCase):
                     (1, 1, 1, '1010', 'D', 1111, null, 'x', 'aBcD0000'),
                     (2, 1, 1, '1010', 'D', 2222, 'b', 'b', 'aBcD0000'),
                     (3, 1, 1, '1010', 'D', 3333, 'L', 'p', 'aBcD0000'),
-                    (4, 2, 1, '1010', 'D', 4444, null, 'X', 'aBcD0000'),
-                    (5, 2, 1, '1010', 'D', 5555, null, 'B', 'aBcD0000'),
-                    (6, 2, 1, '1010', 'D', 6666, null, 'P', 'aBcD0000'),
-                    (7, 3, 2, '1010', 'D', 7777, 'L', 'X', 'aBcD0000'),
-                    (8, 3, 2, '1010', 'D', 8888, 'l', 'X', 'aBcD0000'),
-                    (9, 3, 2, '1010', 'D', 9999, 'L', 'X', 'aBcD0000'),
-                    (10, 4, 2, '1010', 'D', 1010, null, 'X', 'aBcD0000'),
-                    (11, 5, 2, '1010', 'D', 1111, 'B', 'X', 'aBcD0000'),
-                    (12, 6, 2, '1010', 'D', 1212, 'L', 'X', 'aBcD0000'),
-                    (13, 7, 2, '1010', 'D', 1313, 'n', 'X', 'aBcD0000')
+                    (4, 1, 100, '1010', 'D', 0, 'Q', 'p', 'aBcD0000'),
+                    (5, 2, 1, '1010', 'D', 4444, null, 'X', 'aBcD0000'),
+                    (6, 2, 1, '1010', 'D', 5555, null, 'B', 'aBcD0000'),
+                    (7, 2, 1, '1010', 'D', 6666, null, 'P', 'aBcD0000'),
+                    (8, 3, 2, '1010', 'D', 7777, 'L', 'X', 'aBcD0000'),
+                    (9, 3, 2, '1010', 'D', 8888, 'l', 'X', 'aBcD0000'),
+                    (10, 3, 2, '1010', 'D', 9999, 'L', 'X', 'aBcD0000'),
+                    (11, 4, 2, '1010', 'D', 1010, null, 'X', 'aBcD0000'),
+                    (12, 5, 2, '1010', 'D', 1111, 'B', 'X', 'aBcD0000'),
+                    (13, 6, 2, '1010', 'D', 1212, 'L', 'X', 'aBcD0000'),
+                    (14, 7, 2, '1010', 'D', 1313, 'n', 'X', 'aBcD0000')
                 )
                 """
             )
@@ -276,10 +290,12 @@ class TestWithMultipleDatabases(TransactionTestCase):
                     (9, 3, 2, '1010', 'D', 99999, 999990, -99, -999, 'L', 'X', 'aBcD0000'),
                     (10, 4, 2, '1010', 'D', 10101, 101010, -10, -101, null, 'X', 'aBcD0000'),
                     (11, 5, 2, '1010', 'D', 11111, 111110, 0, 0, 'B', 'X', 'aBcD0000'),
-                    (12, 5, 2, '1010', 'D', null, null, 0, 0, 'M', 'X', 'aBcD0000'), -- this should not load because of 0/null values
-                    (13, 5, 2, '1010', 'D', 0, 0, null, 0, 'M', 'X', 'aBcD0000'), -- this should not load because of 0/null values
-                    (14, 5, 2, '1010', 'D', null, 0, null, 0, 'm', 'X', 'aBcD0000'), -- this should not load because of 0/null values
-                    (15, 5, 2, '1010', 'D', 0, null, 0, null, 'M', 'X', 'aBcD0000'), -- this should not load because of 0/null values
+                    ----- records in this section shouldn't load because of 0/null values -----
+                    (12, 5, 2, '1010', 'D', null, null, 0, 0, 'M', 'X', 'aBcD0000'),
+                    (13, 5, 2, '1010', 'D', 0, 0, null, 0, 'M', 'X', 'aBcD0000'),
+                    (14, 5, 2, '1010', 'D', null, 0, null, 0, 'm', 'X', 'aBcD0000'),
+                    (15, 5, 2, '1010', 'D', 0, null, 0, null, 'M', 'X', 'aBcD0000'),
+                    ----- end section -----
                     (16, 6, 2, '1010', 'D', 12121, 121210, -12, -121, 'L', 'X', 'aBcD0000'),
                     (17, 7, 2, '1010', 'D', 13131, 131310, -13, -131, 'n', 'X', 'aBcD0000'),
                     (18, 5, 2, '1010', 'D', 0, 0, 0, -1010, 'N', 'X', 'aBcD0000')
@@ -351,7 +367,7 @@ class TestWithMultipleDatabases(TransactionTestCase):
         call_command("load_multiple_submissions", "--submission-ids", 1, 2, 3)
         assert SubmissionAttributes.objects.count() == 3
         assert AppropriationAccountBalances.objects.count() == 3
-        assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 7
+        assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 8
         assert FinancialAccountsByAwards.objects.count() == 9
 
         # We'll need these later.
@@ -362,7 +378,7 @@ class TestWithMultipleDatabases(TransactionTestCase):
         call_command("load_multiple_submissions", "--incremental")
         assert SubmissionAttributes.objects.count() == 5
         assert AppropriationAccountBalances.objects.count() == 5
-        assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 9
+        assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 10
         assert FinancialAccountsByAwards.objects.count() == 12
 
         # Now that we have everything loaded, let's make sure our data make sense.
@@ -424,9 +440,9 @@ class TestWithMultipleDatabases(TransactionTestCase):
             )
             assert cursor.fetchone() == (
                 Decimal("-52116.00"),
-                "B,B,L,L",
-                "B,B,P,P,X,X,X,X,X",
-                ",".join(["ABCD0000"] * 9),
+                "B,B,L,L,Q",
+                "B,B,P,P,P,X,X,X,X,X",
+                ",".join(["ABCD0000"] * 10),
             )
 
             cursor.execute(
@@ -462,7 +478,7 @@ class TestWithMultipleDatabases(TransactionTestCase):
         call_command("load_multiple_submissions", "--incremental")
         assert SubmissionAttributes.objects.count() == 5
         assert AppropriationAccountBalances.objects.count() == 5
-        assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 9
+        assert FinancialAccountsByProgramActivityObjectClass.objects.count() == 10
         assert FinancialAccountsByAwards.objects.count() == 12
 
         # Make a change to a submission.


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

Updates the USAspending submission loader to allow File B records that contain zeroed out data even if there isn't a matching File A record.

## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

The check that is throwing the error was removed for a couple of reasons:
* It duplicates logic currently in Broker that handles validation of File B against File A
* The created `account_balances` object in the File B loader is not actually used by the File B model in USAspending

## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [x] Unit & integration tests updated
2. [x] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [x] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [x] Jira Ticket(s)
    1. [DEV-15051](https://federal-spending-transparency.atlassian.net/browse/DEV-15051)

### Explain N/A in above checklist:


[DEV-15051]: https://federal-spending-transparency.atlassian.net/browse/DEV-15051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ