### PR TITLE
[DEV-14329] despark

### DIFF
--- a/usaspending_api/common/data_classes.py
+++ b/usaspending_api/common/data_classes.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
-from pyspark.sql.types import StructType
 from typing_extensions import Literal
 
 
@@ -50,36 +49,3 @@ class TransactionColumn:
     #   to be applied on this input. For example, a valid scalar_transformation string is
     #   "CASE {input} WHEN 'UNITED STATES' THEN 'USA' ELSE {input} END"
     scalar_transformation: str = None
-
-
-@dataclass(slots=True)
-class TableSpec:
-    """
-    Delta table metadata class
-    """
-
-    destination_database: str
-    delta_table_create_sql: str | StructType
-
-    destination_table_name: str | None = None
-    source_table: str | None = None
-    source_database: str | None = None
-    model: str | None = None
-    partition_column: str | None = None
-    partition_column_type: str | None = None
-    is_partition_column_unique: bool = False
-    delta_table_create_options: dict | None = None
-    delta_table_create_partitions: list[str] | None = None
-    source_schema: list | dict | None = None
-    custom_schema: str | None = None
-    column_names: list[str] | None = None
-    is_from_broker: bool = False
-    source_query: str | list[str] | Callable | None = None
-    source_query_incremental: str | Callable | None = None
-    user_defined_functions: list[dict] | None = None
-    archive_data_field: str = "update_date"
-    postgres_seq_name: str | None = None
-    postgres_partition_spec: dict | None = None
-    tsvectors: list[str] | dict | None = None
-    swap_table: str | None = None
-    swap_schema: str | None = None

--- a/usaspending_api/common/spark_data_classes.py
+++ b/usaspending_api/common/spark_data_classes.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from pyspark.sql.types import StructType
+
+
+@dataclass(slots=True)
+class TableSpec:
+    """
+    Delta table metadata class
+    """
+
+    destination_database: str
+    delta_table_create_sql: str | StructType
+
+    destination_table_name: str | None = None
+    source_table: str | None = None
+    source_database: str | None = None
+    model: str | None = None
+    partition_column: str | None = None
+    partition_column_type: str | None = None
+    is_partition_column_unique: bool = False
+    delta_table_create_options: dict | None = None
+    delta_table_create_partitions: list[str] | None = None
+    source_schema: list | dict | None = None
+    custom_schema: str | None = None
+    column_names: list[str] | None = None
+    is_from_broker: bool = False
+    source_query: str | list[str] | Callable | None = None
+    source_query_incremental: str | Callable | None = None
+    user_defined_functions: list[dict] | None = None
+    archive_data_field: str = "update_date"
+    postgres_seq_name: str | None = None
+    postgres_partition_spec: dict | None = None
+    tsvectors: list[str] | dict | None = None
+    swap_table: str | None = None
+    swap_schema: str | None = None

--- a/usaspending_api/etl/management/commands/archive_table_in_delta.py
+++ b/usaspending_api/etl/management/commands/archive_table_in_delta.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import psycopg
 from django.core.management.base import BaseCommand
 
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.etl.spark import load_delta_table
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
@@ -14,6 +13,7 @@ from usaspending_api.common.helpers.spark_helpers import (
     get_usas_jdbc_url,
 )
 from usaspending_api.common.helpers.sql_helpers import get_database_dsn_string
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.download.delta_models.download_job import (
     download_job_create_sql_string,
 )

--- a/usaspending_api/etl/management/commands/create_delta_table.py
+++ b/usaspending_api/etl/management/commands/create_delta_table.py
@@ -4,12 +4,12 @@ from django.core.management.base import BaseCommand, CommandParser
 from pyspark.sql.types import StructType
 
 from usaspending_api.awards.delta_models.award_id_lookup import AWARD_ID_LOOKUP_SCHEMA
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
     get_active_spark_session,
 )
 from usaspending_api.common.spark.configs import DEFAULT_EXTRA_CONF
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.config import CONFIG
 from usaspending_api.etl.management.commands.archive_table_in_delta import TABLE_SPEC as ARCHIVE_TABLE_SPEC
 from usaspending_api.etl.management.commands.load_query_to_delta import TABLE_SPEC as LOAD_QUERY_TABLE_SPEC

--- a/usaspending_api/etl/management/commands/load_query_to_delta.py
+++ b/usaspending_api/etl/management/commands/load_query_to_delta.py
@@ -5,7 +5,6 @@ from typing import Callable
 from django.core.management.base import BaseCommand, CommandParser
 from pyspark.sql import SparkSession
 
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.etl.spark import create_ref_temp_views
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
@@ -13,6 +12,7 @@ from usaspending_api.common.helpers.spark_helpers import (
     get_broker_jdbc_url,
     get_jdbc_connection_properties,
 )
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.config import CONFIG
 from usaspending_api.disaster.delta_models import (
     COVID_FABA_SPENDING_DELTA_COLUMNS,

--- a/usaspending_api/etl/management/commands/load_table_to_delta.py
+++ b/usaspending_api/etl/management/commands/load_table_to_delta.py
@@ -18,7 +18,6 @@ from usaspending_api.awards.models import (
     TransactionNormalized,
 )
 from usaspending_api.broker.delta_models.broker_zips import ZIPS_COLUMNS, zips_sql_string
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.etl.spark import extract_db_data_frame, get_partition_bounds_sql, load_delta_table
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
@@ -27,6 +26,7 @@ from usaspending_api.common.helpers.spark_helpers import (
     get_jdbc_connection_properties,
     get_usas_jdbc_url,
 )
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.config import CONFIG
 from usaspending_api.recipient.delta_models import (
     RECIPIENT_LOOKUP_COLUMNS,

--- a/usaspending_api/references/tests/integration/test_cfda_autocomplete_v2.py
+++ b/usaspending_api/references/tests/integration/test_cfda_autocomplete_v2.py
@@ -27,6 +27,12 @@ def cfda_data(db):
         popular_name="National Accuracy Clearinghouse (NAC) Pilot",
         program_title="SNAP Partnership Grant",
     )
+    baker.make(
+        Cfda,
+        program_number="93.HDN",
+        popular_name="",
+        program_title="Child Health and Human Development Research Training – Institutional Awards",
+    )
 
 
 @pytest.mark.django_db
@@ -39,6 +45,17 @@ def test_cfda_autocomplete_success(client, cfda_data):
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.data["results"]) == 1
     assert resp.data["results"][0]["program_title"] == "Biofuel Infrastructure Partnership"
+
+    # test for program number containing alphabetic characters
+    resp = client.post(
+        "/api/v2/autocomplete/cfda/", content_type="application/json", data=json.dumps({"search_text": "93.HDN"})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    print(resp.data)
+    assert len(resp.data["results"]) == 1
+    assert resp.data["results"][0]["program_title"] == (
+        "Child Health and Human Development Research Training – Institutional Awards"
+    )
 
     # test for program title
     resp = client.post(

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -1,5 +1,6 @@
 from django.db.models import Case, F, IntegerField, Q, When
 from django.db.models.functions import Upper
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -13,7 +14,7 @@ from usaspending_api.search.models import AgencyAutocompleteMatview, AgencyOffic
 
 class BaseAutocompleteViewSet(APIView):
     @staticmethod
-    def get_request_payload(request):
+    def get_request_payload(request: Request) -> Response:
         """
         Retrieves all the request attributes needed for the autocomplete endpoints.
 
@@ -30,7 +31,7 @@ class BaseAutocompleteViewSet(APIView):
         try:
             limit = int(json_request.get("limit", 10))
         except ValueError:
-            raise InvalidParameterException("Limit request parameter is not a valid, positive integer")
+            raise InvalidParameterException("Limit request parameter is not a valid, positive integer")  # noqa: B904
 
         # required query parameters were not provided
         if not search_text:
@@ -39,7 +40,7 @@ class BaseAutocompleteViewSet(APIView):
         return search_text, limit
 
     # Shared autocomplete...
-    def agency_autocomplete(self, request):
+    def agency_autocomplete(self, request: Request) -> Response:
         """Search by subtier agencies, return those with award data, toptiers first"""
 
         search_text, limit = self.get_request_payload(request)
@@ -89,7 +90,7 @@ class BaseAutocompleteViewSet(APIView):
         results["messages"] = messages
         return Response(results)
 
-    def agency_office_autocomplete(self, request):
+    def agency_office_autocomplete(self, request: Request) -> Response:  # noqa: PLR0912, PLR0915
         """Returns a collection of agencies, sub-agencies, and offices that match the request."""
 
         search_text, limit = self.get_request_payload(request)
@@ -111,7 +112,11 @@ class BaseAutocompleteViewSet(APIView):
         for toptier_agency in toptier_agency_search_text_matches:
             # This key is created so that we can treat multiple records with the same
             # toptier values as a single result
-            key = f'{toptier_agency["toptier_abbreviation"]}{toptier_agency["toptier_code"]}{toptier_agency["toptier_name"]}'
+            key = (
+                f'{toptier_agency["toptier_abbreviation"]}'
+                f'{toptier_agency["toptier_code"]}'
+                f'{toptier_agency["toptier_name"]}'
+            )
             if key not in toptier_agency_tracker:
                 toptier_agency_tracker[key] = {}
                 toptier_result = self._agency_office_toptier_agency_response_object(toptier_agency)
@@ -149,7 +154,11 @@ class BaseAutocompleteViewSet(APIView):
         for subtier_agency in subtier_agency_search_text_matches:
             # This key is created so that we can treat multiple records with the same
             # subtier values as a single result
-            key = f'{subtier_agency["subtier_abbreviation"]}{subtier_agency["subtier_code"]}{subtier_agency["subtier_name"]}'
+            key = (
+                f'{subtier_agency["subtier_abbreviation"]}'
+                f'{subtier_agency["subtier_code"]}'
+                f'{subtier_agency["subtier_name"]}'
+            )
             if key not in subtier_agency_tracker:
                 subtier_agency_tracker[key] = {}
                 subtier_result = self._agency_office_subtier_agency_response_object(subtier_agency)
@@ -247,7 +256,7 @@ class AwardingAgencyAutocompleteViewSet(BaseAutocompleteViewSet):
     filter_field = "has_awarding_data"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         return self.agency_autocomplete(request)
 
 
@@ -261,7 +270,7 @@ class AwardingAgencyOfficeAutocompleteViewSet(BaseAutocompleteViewSet):
     filter_field = "has_awarding_data"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         return self.agency_office_autocomplete(request)
 
 
@@ -275,7 +284,7 @@ class FundingAgencyOfficeAutocompleteViewSet(BaseAutocompleteViewSet):
     filter_field = "has_funding_data"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         return self.agency_office_autocomplete(request)
 
 
@@ -288,7 +297,7 @@ class FundingAgencyAutocompleteViewSet(BaseAutocompleteViewSet):
     filter_field = "has_funding_data"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         return self.agency_autocomplete(request)
 
 
@@ -300,19 +309,22 @@ class CFDAAutocompleteViewSet(BaseAutocompleteViewSet):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/cfda.md"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         """Return CFDA matches by number, title, or name"""
         search_text, limit = self.get_request_payload(request)
 
         queryset = Cfda.objects.all()
+        print("4444444444444444444444444")
+        print(search_text)
 
-        # Program numbers are 10.4839, 98.2718, etc...
-        if search_text.replace(".", "").isnumeric():
-            queryset = queryset.filter(program_number__icontains=search_text)
-        else:
-            title_filter = queryset.filter(program_title__icontains=search_text)
-            popular_name_filter = queryset.filter(popular_name__icontains=search_text)
-            queryset = title_filter | popular_name_filter
+        # Program numbers are 10.4839, 98.2718, 93.HDN, etc... Alpha and numeric characters
+        program_number_filter = queryset.filter(program_number__icontains=search_text)
+        title_filter = queryset.filter(program_title__icontains=search_text)
+        popular_name_filter = queryset.filter(popular_name__icontains=search_text)
+        queryset = program_number_filter | title_filter | popular_name_filter
+
+        print("5555555555555555555555555555555")
+        print(queryset)
 
         return Response(
             {
@@ -332,7 +344,7 @@ class NAICSAutocompleteViewSet(BaseAutocompleteViewSet):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/naics.md"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         """Return all NAICS table entries matching the provided search text"""
         search_text, limit = self.get_request_payload(request)
 
@@ -362,7 +374,7 @@ class PSCAutocompleteViewSet(BaseAutocompleteViewSet):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/psc.md"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         """Return all PSC table entries matching the provided search text"""
         search_text, limit = self.get_request_payload(request)
 
@@ -389,7 +401,7 @@ class ProgramActivityAutocompleteViewSet(BaseAutocompleteViewSet):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/program_activity.md"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         search_text, limit = self.get_request_payload(request)
 
         queryset = RefProgramActivity.objects.distinct("program_activity_code", "program_activity_name")
@@ -410,7 +422,7 @@ class GlossaryAutocompleteViewSet(BaseAutocompleteViewSet):
     endpoint_doc = "usaspending_api/api_contracts/contracts/v2/autocomplete/glossary.md"
 
     @cache_response()
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         search_text, limit = self.get_request_payload(request)
 
         queryset = Definition.objects.all()

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -32,8 +32,8 @@ class BaseAutocompleteViewSet(APIView):
 
         try:
             limit = int(json_request.get("limit", 10))
-        except ValueError:
-            raise InvalidParameterException("Limit request parameter is not a valid, positive integer")  # noqa: B904
+        except ValueError as ve:
+            raise InvalidParameterException("Limit request parameter is not a valid, positive integer") from ve
 
         # required query parameters were not provided
         if not search_text:
@@ -317,11 +317,11 @@ class CFDAAutocompleteViewSet(BaseAutocompleteViewSet):
 
         queryset = Cfda.objects.all()
         # allow 2 digits, or 2 digits with a dot followed by 1-3 digits or letters
-        # INCLUDE 25, 25.G, 25.HI, 25.HIJ
-        # EXCLUDE 25.HIJK, 25., 256, 256.J, 256.JK, 2567, 25HIJK
-        pattern = r'^\d{2}(\.[a-zA-Z0-9]{1,3})?$'
+        # INCLUDE 2, 25, 25., 25.G, 25.HI, 25.HIJ
+        # EXCLUDE 25.HIJK, 256, 256.J, 256.JK, 2567, 25HIJK
+        pattern = r'^\d{2}\.?[a-zA-Z0-9]{0,3}$'
         if bool(re.match(pattern, search_text)):
-            # Program numbers are 10.4839, 98.2718, 93.HDN, etc... 1-3 Alpha or numeric characters following dot
+            # Program numbers are 10.483, 98.271, 93.HDN, etc... 1-3 Alpha or numeric characters following dot
             queryset = queryset.filter(program_number__icontains=search_text)
         else:
             title_filter = queryset.filter(program_title__icontains=search_text)

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -1,3 +1,5 @@
+import re
+
 from django.db.models import Case, F, IntegerField, Q, When
 from django.db.models.functions import Upper
 from rest_framework.request import Request
@@ -314,17 +316,15 @@ class CFDAAutocompleteViewSet(BaseAutocompleteViewSet):
         search_text, limit = self.get_request_payload(request)
 
         queryset = Cfda.objects.all()
-        print("4444444444444444444444444")
-        print(search_text)
+        pattern = r'^(\d{2}\.|\d{3}\.)'
 
-        # Program numbers are 10.4839, 98.2718, 93.HDN, etc... Alpha and numeric characters
-        program_number_filter = queryset.filter(program_number__icontains=search_text)
-        title_filter = queryset.filter(program_title__icontains=search_text)
-        popular_name_filter = queryset.filter(popular_name__icontains=search_text)
-        queryset = program_number_filter | title_filter | popular_name_filter
-
-        print("5555555555555555555555555555555")
-        print(queryset)
+        if bool(re.match(pattern, search_text)):
+            # Program numbers are 10.4839, 98.2718, 93.HDN, etc... Alpha and numeric characters
+            queryset = queryset.filter(program_number__icontains=search_text)
+        else:
+            title_filter = queryset.filter(program_title__icontains=search_text)
+            popular_name_filter = queryset.filter(popular_name__icontains=search_text)
+            queryset = title_filter | popular_name_filter
 
         return Response(
             {

--- a/usaspending_api/references/v2/views/autocomplete.py
+++ b/usaspending_api/references/v2/views/autocomplete.py
@@ -316,10 +316,12 @@ class CFDAAutocompleteViewSet(BaseAutocompleteViewSet):
         search_text, limit = self.get_request_payload(request)
 
         queryset = Cfda.objects.all()
-        pattern = r'^(\d{2}\.|\d{3}\.)'
-
+        # allow 2 digits, or 2 digits with a dot followed by 1-3 digits or letters
+        # INCLUDE 25, 25.G, 25.HI, 25.HIJ
+        # EXCLUDE 25.HIJK, 25., 256, 256.J, 256.JK, 2567, 25HIJK
+        pattern = r'^\d{2}(\.[a-zA-Z0-9]{1,3})?$'
         if bool(re.match(pattern, search_text)):
-            # Program numbers are 10.4839, 98.2718, 93.HDN, etc... Alpha and numeric characters
+            # Program numbers are 10.4839, 98.2718, 93.HDN, etc... 1-3 Alpha or numeric characters following dot
             queryset = queryset.filter(program_number__icontains=search_text)
         else:
             title_filter = queryset.filter(program_title__icontains=search_text)


### PR DESCRIPTION
## Description:
This PR is to move StructType, an import from spark, into its own dataclass file to avoid breaking the qat deployment pipeline.

## Technical Details:
moved the table_spec dataclass definition from common/data_classes.py to common/spark_data_classes.py

## Requirements for PR Merge:

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. [ ] Appropriate Operations ticket(s) created
5. [ ] Jira Ticket(s)
    1. [DEV-0](https://federal-spending-transparency.atlassian.net/browse/DEV-0)

### Explain N/A in above checklist:
All items are NA because this changes no functionality, rather allows an automated build of the api into qat which was failing due to inclusion of spark in the build. This new split-out file will never be called in api, and therefore will never throw a runtime error.