### PR TITLE
[DEV-14329] despark II

### DIFF
--- a/usaspending_api/common/data_classes.py
+++ b/usaspending_api/common/data_classes.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
-from pyspark.sql.types import StructType
 from typing_extensions import Literal
 
 
@@ -50,36 +49,3 @@ class TransactionColumn:
     #   to be applied on this input. For example, a valid scalar_transformation string is
     #   "CASE {input} WHEN 'UNITED STATES' THEN 'USA' ELSE {input} END"
     scalar_transformation: str = None
-
-
-@dataclass(slots=True)
-class TableSpec:
-    """
-    Delta table metadata class
-    """
-
-    destination_database: str
-    delta_table_create_sql: str | StructType
-
-    destination_table_name: str | None = None
-    source_table: str | None = None
-    source_database: str | None = None
-    model: str | None = None
-    partition_column: str | None = None
-    partition_column_type: str | None = None
-    is_partition_column_unique: bool = False
-    delta_table_create_options: dict | None = None
-    delta_table_create_partitions: list[str] | None = None
-    source_schema: list | dict | None = None
-    custom_schema: str | None = None
-    column_names: list[str] | None = None
-    is_from_broker: bool = False
-    source_query: str | list[str] | Callable | None = None
-    source_query_incremental: str | Callable | None = None
-    user_defined_functions: list[dict] | None = None
-    archive_data_field: str = "update_date"
-    postgres_seq_name: str | None = None
-    postgres_partition_spec: dict | None = None
-    tsvectors: list[str] | dict | None = None
-    swap_table: str | None = None
-    swap_schema: str | None = None

--- a/usaspending_api/common/spark_data_classes.py
+++ b/usaspending_api/common/spark_data_classes.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from pyspark.sql.types import StructType
+
+
+@dataclass(slots=True)
+class TableSpec:
+    """
+    Delta table metadata class
+    """
+
+    destination_database: str
+    delta_table_create_sql: str | StructType
+
+    destination_table_name: str | None = None
+    source_table: str | None = None
+    source_database: str | None = None
+    model: str | None = None
+    partition_column: str | None = None
+    partition_column_type: str | None = None
+    is_partition_column_unique: bool = False
+    delta_table_create_options: dict | None = None
+    delta_table_create_partitions: list[str] | None = None
+    source_schema: list | dict | None = None
+    custom_schema: str | None = None
+    column_names: list[str] | None = None
+    is_from_broker: bool = False
+    source_query: str | list[str] | Callable | None = None
+    source_query_incremental: str | Callable | None = None
+    user_defined_functions: list[dict] | None = None
+    archive_data_field: str = "update_date"
+    postgres_seq_name: str | None = None
+    postgres_partition_spec: dict | None = None
+    tsvectors: list[str] | dict | None = None
+    swap_table: str | None = None
+    swap_schema: str | None = None

--- a/usaspending_api/etl/management/commands/archive_table_in_delta.py
+++ b/usaspending_api/etl/management/commands/archive_table_in_delta.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import psycopg
 from django.core.management.base import BaseCommand
 
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.etl.spark import load_delta_table
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
@@ -14,6 +13,7 @@ from usaspending_api.common.helpers.spark_helpers import (
     get_usas_jdbc_url,
 )
 from usaspending_api.common.helpers.sql_helpers import get_database_dsn_string
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.download.delta_models.download_job import (
     download_job_create_sql_string,
 )

--- a/usaspending_api/etl/management/commands/create_delta_table.py
+++ b/usaspending_api/etl/management/commands/create_delta_table.py
@@ -4,12 +4,12 @@ from django.core.management.base import BaseCommand, CommandParser
 from pyspark.sql.types import StructType
 
 from usaspending_api.awards.delta_models.award_id_lookup import AWARD_ID_LOOKUP_SCHEMA
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
     get_active_spark_session,
 )
 from usaspending_api.common.spark.configs import DEFAULT_EXTRA_CONF
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.config import CONFIG
 from usaspending_api.etl.management.commands.archive_table_in_delta import TABLE_SPEC as ARCHIVE_TABLE_SPEC
 from usaspending_api.etl.management.commands.load_query_to_delta import TABLE_SPEC as LOAD_QUERY_TABLE_SPEC

--- a/usaspending_api/etl/management/commands/load_query_to_delta.py
+++ b/usaspending_api/etl/management/commands/load_query_to_delta.py
@@ -5,7 +5,6 @@ from typing import Callable
 from django.core.management.base import BaseCommand, CommandParser
 from pyspark.sql import SparkSession
 
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.etl.spark import create_ref_temp_views
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
@@ -13,6 +12,7 @@ from usaspending_api.common.helpers.spark_helpers import (
     get_broker_jdbc_url,
     get_jdbc_connection_properties,
 )
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.config import CONFIG
 from usaspending_api.disaster.delta_models import (
     COVID_FABA_SPENDING_DELTA_COLUMNS,

--- a/usaspending_api/etl/management/commands/load_table_to_delta.py
+++ b/usaspending_api/etl/management/commands/load_table_to_delta.py
@@ -18,7 +18,6 @@ from usaspending_api.awards.models import (
     TransactionNormalized,
 )
 from usaspending_api.broker.delta_models.broker_zips import ZIPS_COLUMNS, zips_sql_string
-from usaspending_api.common.data_classes import TableSpec
 from usaspending_api.common.etl.spark import extract_db_data_frame, get_partition_bounds_sql, load_delta_table
 from usaspending_api.common.helpers.spark_helpers import (
     configure_spark_session,
@@ -27,6 +26,7 @@ from usaspending_api.common.helpers.spark_helpers import (
     get_jdbc_connection_properties,
     get_usas_jdbc_url,
 )
+from usaspending_api.common.spark_data_classes import TableSpec
 from usaspending_api.config import CONFIG
 from usaspending_api.recipient.delta_models import (
     RECIPIENT_LOOKUP_COLUMNS,

--- a/usaspending_api/etl/tests/data/delta_model_for_test.py
+++ b/usaspending_api/etl/tests/data/delta_model_for_test.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 
-from usaspending_api.common.data_classes import TableSpec
+from usaspending_api.common.spark_data_classes import TableSpec
 
 
 class TestModel(models.Model):


### PR DESCRIPTION
## Description:
This PR is to move StructType, an import from spark, into its own dataclass file to avoid breaking the qat deployment pipeline.


## Technical Details:
moved the table_spec dataclass definition from common/data_classes.py to common/spark_data_classes.py


## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. [ ] Appropriate Operations ticket(s) created
5. [ ] Jira Ticket(s)
    1. [DEV-0](https://federal-spending-transparency.atlassian.net/browse/DEV-0)

### Explain N/A in above checklist:
All items are NA because this changes no functionality, rather allows an automated build of the api into qat which was failing due to inclusion of spark in the build. This new split-out file will never be called in api, and therefore will never throw a runtime error.