### PR TITLE
[DEV-14618] Update NAICS filter to allow a list of strings

### DIFF
--- a/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
+++ b/usaspending_api/api_contracts/contracts/v2/search/spending_by_award.md
@@ -314,7 +314,7 @@ Non Loan Assistance Awards can be searched for specifically by using the Non Loa
     Award IDs surrounded by double quotes (e.g. `"SPE30018FLJFN"`) will perform exact matches as opposed to the default, fuzzier full text matches.  Useful for Award IDs that contain spaces or other word delimiters.
 + `award_amounts` (optional, array[AwardAmounts], fixed-type)
 + `program_numbers`: [`10.331`] (optional, array[string])
-+ `naics_codes` (optional, NAICSCodeObject)
++ `naics_codes` (optional, enum[NAICSCodeObject, array[string]])
 + `tas_codes` (optional, array[TASCodeObject, TASCodeComponentObject])
 + `psc_codes` (optional, enum[PSCCodeObject, array[string]])
     Supports new PSCCodeObject or legacy array of codes.

--- a/usaspending_api/disaster/tests/integration/test_overview.py
+++ b/usaspending_api/disaster/tests/integration/test_overview.py
@@ -1,19 +1,18 @@
-import pytest
-
 from decimal import Decimal
 
+import pytest
 from model_bakery import baker
 
 from usaspending_api.disaster.tests.fixtures.overview_data import (
-    EARLY_MONTH,
-    LATE_MONTH,
-    EARLY_YEAR,
-    LATE_YEAR,
-    LATE_GTAS_CALCULATIONS,
-    QUARTERLY_GTAS_CALCULATIONS,
     EARLY_GTAS_CALCULATIONS,
-    YEAR_2_GTAS_CALCULATIONS,
+    EARLY_MONTH,
+    EARLY_YEAR,
+    LATE_GTAS_CALCULATIONS,
+    LATE_MONTH,
+    LATE_YEAR,
     OTHER_BUDGET_AUTHORITY_GTAS_CALCULATIONS,
+    QUARTERLY_GTAS_CALCULATIONS,
+    YEAR_2_GTAS_CALCULATIONS,
 )
 
 OVERVIEW_URL = "/api/v2/disaster/overview/"
@@ -162,7 +161,7 @@ def test_ignore_funding_for_unselected_defc(
     assert resp.data["spending"]["total_outlays"] == YEAR_2_GTAS_CALCULATIONS["total_outlays"]
 
     resp = client.get(OVERVIEW_URL + "?def_codes=M,N")
-    assert resp.data["funding"] == [
+    assert sorted(resp.data["funding"], key=lambda x: x["def_code"]) == [
         {"amount": YEAR_2_GTAS_CALCULATIONS["total_budgetary_resources"], "def_code": "M"},
         {"amount": YEAR_2_GTAS_CALCULATIONS["total_budgetary_resources"], "def_code": "N"},
     ]

--- a/usaspending_api/search/tests/integration/test_spending_by_award.py
+++ b/usaspending_api/search/tests/integration/test_spending_by_award.py
@@ -931,6 +931,30 @@ def test_inclusive_naics_code(
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json().get("results")) == 2
 
+    resp = client.post(
+        "/api/v2/search/spending_by_award",
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "filters": {
+                    "award_type_codes": ["A", "B", "C", "D"],
+                    "naics_codes": ["1122"],
+                    "time_period": [
+                        {"start_date": "2007-10-01", "end_date": "2020-09-30"}
+                    ],
+                },
+                "fields": ["Award ID"],
+                "page": 1,
+                "limit": 60,
+                "sort": "Award ID",
+                "order": "desc",
+                "spending_level": "awards",
+            }
+        ),
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json().get("results")) == 2
+
 
 @pytest.mark.django_db
 def test_exclusive_naics_code(

--- a/usaspending_api/search/v2/views/spending_by_award.py
+++ b/usaspending_api/search/v2/views/spending_by_award.py
@@ -164,7 +164,7 @@ class Filters(BaseModel):
     description: str | None = None
     extent_competed_type_codes: list[str] | None = None
     keywords: list[str] | None = None
-    naics_codes: NAICSCodeObject | None = None
+    naics_codes: list[str] | NAICSCodeObject | None = None
     place_of_performance_locations: list[StandardLocationObject] | None = None
     place_of_performance_scope: Literal["domestic", "foreign"] | None = None
     program_activities: list[ProgramActivityObject] | None = None


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

The `naics_codes` filter for spending by award should support both formats available to API users.

## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

Small update to the `naics_codes` filter in spending by award endpoint to allow searching on a list of strings where the strings are NAICS codes.

## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [x] Unit & integration tests updated
2. [x] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [x] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. N/A Appropriate Operations ticket(s) created
5. [x] Jira Ticket(s)
    1. [DEV-14618](https://federal-spending-transparency.atlassian.net/browse/DEV-14618)

### Explain N/A in above checklist:


[DEV-14618]: https://federal-spending-transparency.atlassian.net/browse/DEV-14618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ