### PR TITLE
[OPS-2988] Use SQL parameters instead of f-string

### DIFF
--- a/usaspending_api/search/filters/postgres/defc.py
+++ b/usaspending_api/search/filters/postgres/defc.py
@@ -6,7 +6,7 @@ class DefCodes:
     underscore_name = "def_codes"
 
     @classmethod
-    def build_def_codes_filter(cls, filter_values):
+    def build_def_codes_filter(cls, filter_values: list[str]):
         """Build a SQL filter to only include Subawards that are associated with any
         DEF codes included in the API request.
 
@@ -23,8 +23,7 @@ class DefCodes:
                 disaster code's `earliest_public_law_enactment_date`
 
         Args:
-            filter_values (List[str]): List of DEF codes to use in filtering. These come
-                from the API request.
+            filter_values: List of DEF codes to use in filtering. These come from the API request.
 
         Returns:
             Q(): Subquery filter containing Award IDs that are associated with the
@@ -45,7 +44,7 @@ class DefCodes:
                     join rpt.award_search as aws
                         on ss.award_id = aws.award_id
                     where
-                         array[{def_codes}] && aws.disaster_emergency_fund_codes
+                         %s::text[] && aws.disaster_emergency_fund_codes
                     )
                     select
                         us.broker_subaward_id
@@ -54,14 +53,13 @@ class DefCodes:
                     join disaster_emergency_fund_code as defc
                         on defc.code = us.singular_defc
                     where
-                        us.singular_defc in ({def_codes})
+                        us.singular_defc = any(%s)
                         and (
                             defc.earliest_public_law_enactment_date is null
                             or defc.earliest_public_law_enactment_date <= sub_action_date
                         );
-                """.format(
-                    def_codes=",".join([f"'{code}'" for code in filter_values])
-                )
+                """,
+                [filter_values, filter_values]
             )
 
             results = cursor.fetchall()


### PR DESCRIPTION
## Description:
Use parameters with `cursor.execute()` instead of f-strings for sanitation of user input.



## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->



## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

3. [x] Data validation completed (examples listed below)
5. [x] Jira Ticket(s)
    1. [OPS-2988](https://federal-spending-transparency.atlassian.net/browse/OPS-2988)

### Explain N/A in above checklist:


[OPS-2988]: https://federal-spending-transparency.atlassian.net/browse/OPS-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ