### PR TITLE
[DEV-15434] Added check for Recipient Count View

### DIFF
--- a/usaspending_api/common/cache.py
+++ b/usaspending_api/common/cache.py
@@ -8,7 +8,6 @@ from rest_framework_extensions.key_constructor import bits
 from rest_framework_extensions.key_constructor.constructors import DefaultKeyConstructor
 
 from usaspending_api.common.helpers.dict_helpers import order_nested_object
-from usaspending_api.recipient.v2.views.list_recipients import RecipientCount
 
 
 class PathKeyBit(bits.QueryParamsKeyBit):
@@ -36,9 +35,9 @@ class GetPostQueryParamsKeyBit(bits.QueryParamsKeyBit):
             whitelist = view_instance.cache_key_whitelist
             params = {}
             for param in whitelist:
-                if param in request.query_params and not isinstance(view_instance, RecipientCount):
-                    # RecipientCount Views only care about request body, and ignore query params for proper caching
-                    params[param] = request.query_params[param]
+                # Currently, the only view with a whitelist attr is RecipientCount
+                # RecipientCount only reads the request body, not query params.
+                # Take this into consideration when implementing whitelist attr
                 if param in request.data:
                     params[param] = request.data[param]
         else:

--- a/usaspending_api/common/cache.py
+++ b/usaspending_api/common/cache.py
@@ -1,10 +1,14 @@
 import hashlib
 import json
+from typing import Any, Callable
 
+from rest_framework.request import Request
+from rest_framework.views import APIView
 from rest_framework_extensions.key_constructor import bits
 from rest_framework_extensions.key_constructor.constructors import DefaultKeyConstructor
 
 from usaspending_api.common.helpers.dict_helpers import order_nested_object
+from usaspending_api.recipient.v2.views.list_recipients import RecipientCount
 
 
 class PathKeyBit(bits.QueryParamsKeyBit):
@@ -12,7 +16,9 @@ class PathKeyBit(bits.QueryParamsKeyBit):
     Adds query path as a key bit
     """
 
-    def get_source_dict(self, params, view_instance, view_method, request, args, kwargs):
+    def get_source_dict(
+        self, params: dict, view_instance: APIView, view_method: Callable, request: Request, args: Any, kwargs: Any
+    ) -> dict[str, str]:
         return {"path": request.path}
 
 
@@ -22,13 +28,16 @@ class GetPostQueryParamsKeyBit(bits.QueryParamsKeyBit):
     directives in a POST request (i.e., request.data) as well as GET parameters
     """
 
-    def get_source_dict(self, params, view_instance, view_method, request, args, kwargs):
+    def get_source_dict(
+        self, params: dict, view_instance: APIView, view_method: Callable, request: Request, args: Any, kwargs: Any
+    ) -> dict[str, str]:
 
         if hasattr(view_instance, "cache_key_whitelist"):
             whitelist = view_instance.cache_key_whitelist
             params = {}
             for param in whitelist:
-                if param in request.query_params:
+                if param in request.query_params and not isinstance(view_instance, RecipientCount):
+                    # RecipientCount Views only care about request body, and ignore query params for proper caching
                     params[param] = request.query_params[param]
                 if param in request.data:
                     params[param] = request.data[param]
@@ -43,14 +52,14 @@ class GetPostQueryParamsKeyBit(bits.QueryParamsKeyBit):
 
 class USAspendingKeyConstructor(DefaultKeyConstructor):
     """
-    Handle cache key construction for API requests. If we never need to create more nuanced keys, see the
+    Handle cache key construction for API requests. If we ever need to create more nuanced keys, see the
     drf-extensions documentation: http://chibisov.github.io/drf-extensions/docs/#default-key-constructor
     """
 
     path_bit = PathKeyBit()
     request_params = GetPostQueryParamsKeyBit()
 
-    def prepare_key(self, key_dict):
+    def prepare_key(self, key_dict: dict) -> str:
         # Order the key_dict using the order_nested_object function to make sure cache keys are always exactly the same
         ordered_key_dict = json.dumps(order_nested_object(key_dict))
         key_hex = hashlib.md5(ordered_key_dict.encode("utf-8"), usedforsecurity=False).hexdigest()


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->


The RecipientCount view from list_recipients.py only reads data from the API request’s body before caching, however the cache.py helper accepts parameters from the request body and the query parameters. This means that someone can send an API request to the RecipientCount endpoint with a query parameter, but no request body, causing an unfiltered search to be done and cached. The problem is that even though the result was completely unfiltered, it would be cached with the query parameter causing future requests (with the same filter in the body instead of query parameters) to be returned incorrectly.


## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

The Recipient Count View only reads the request body.  The cache function has been updated as to not take into account the query parameters for that view.


## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [ ] Unit & integration tests updated
2. [ ] API documentation updated (examples listed below)
    1. API Contracts
    2. API UI
    3. Comments
3. [ ] Data validation completed (examples listed below)
    1. Does this work well with the current frontend? Or is the frontend aware of a needed change?
    2. Is performance impacted in the changes (e.g., API, pipeline, downloads, etc.)?
    3. Is the expected data returned with the expected format?
4. [ ] Appropriate Operations ticket(s) created
5. [ ] Jira Ticket(s)
    1. [DEV-15434](https://federal-spending-transparency.atlassian.net/browse/DEV-15434)

### Explain N/A in above checklist:


[DEV-15434]: https://federal-spending-transparency.atlassian.net/browse/DEV-15434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ