### PR TITLE
[DEV-15494] Correctly format Pydantic error messages

### DIFF
--- a/usaspending_api/common/helpers/pydantic_error_formatter.py
+++ b/usaspending_api/common/helpers/pydantic_error_formatter.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from pydantic import ValidationError
 
-
 # Pydantic V2 error types mapped to the type names our API has always used
 API_TYPE_BY_ERROR_TYPE = {
     "bool_parsing": "boolean",
@@ -17,7 +16,7 @@ API_TYPE_BY_ERROR_TYPE = {
     "list_type": "array",
     "model_attributes_type": "object",
     "model_type": "object",
-    "string_type": "text"
+    "string_type": "text",
 }
 
 
@@ -32,7 +31,7 @@ def _key_name(loc: tuple[str | int, ...]) -> str:
     return "|".join(field_names)
 
 
-def pydantic_error_formatter(error: ValidationError) -> str:
+def pydantic_error_formatter(error: ValidationError) -> str:  # noqa: PLR0911
     errors: list[dict[str, Any]] = error.errors()
     key_name = _key_name(errors[0]["loc"])
 

--- a/usaspending_api/common/helpers/pydantic_error_formatter.py
+++ b/usaspending_api/common/helpers/pydantic_error_formatter.py
@@ -1,26 +1,53 @@
+from typing import Any
+
 from pydantic import ValidationError
 
 
+# Pydantic V2 error types mapped to the type names our API has always used
+API_TYPE_BY_ERROR_TYPE = {
+    "bool_parsing": "boolean",
+    "bool_type": "boolean",
+    "date_from_datetime_parsing": "date",
+    "date_parsing": "date",
+    "dict_type": "object",
+    "float_parsing": "float",
+    "float_type": "float",
+    "int_parsing": "integer",
+    "int_type": "integer",
+    "list_type": "array",
+    "model_attributes_type": "object",
+    "model_type": "object",
+    "string_type": "text"
+}
+
+
+def _key_name(loc: tuple[str | int, ...]) -> str:
+    """Convert a Pydantic error location into the pipe delimited key used in our API messages.
+
+    List indexes and union member tags are dropped, so ("filters", "recipient_locations", 0, "state") becomes
+    "filters|recipient_locations|state" and ("filters", "naics_codes", "list[str]") becomes "filters|"naics_codes".
+    """
+
+    field_names = [part for part in loc if isinstance(part, str) and "[" not in part and part.islower()]
+    return "|".join(field_names)
+
+
 def pydantic_error_formatter(error: ValidationError) -> str:
-    errors: list[dict] = error.errors()
+    errors: list[dict[str, Any]] = error.errors()
+    key_name = _key_name(errors[0]["loc"])
 
-    for error in errors:
-        # Missing required fields
-        if error.get('msg') == 'Field required':
-            key_name = error['loc'][0]
+    key_errors = [err for err in errors if _key_name(err["loc"]) == key_name]
+    rule_error = next((err for err in key_errors if err["type"] not in API_TYPE_BY_ERROR_TYPE), None)
 
-            return f"Missing value: '{key_name}' is a required field"
+    if rule_error is None:
+        expected_types = ", ".join(dict.fromkeys(API_TYPE_BY_ERROR_TYPE[err["type"]] for err in key_errors))
+        return f"Invalid value in '{key_name}'. '{errors[0]['input']}' is not a valid type ({expected_types})."
 
-        # Incorrect type for a filter
-        else:
-            key_name = error["loc"][0] + "|" + error["loc"][1] if len(error['loc']) > 1 else error['loc'][0]
-            bad_value = error['input']
+    if rule_error["type"] == "missing":
+        return f"Missing value: '{key_name}' is a required field"
 
-            if error['type'].endswith('_type'):
-                expected_type = error['type'].strip("_type")
-            elif error.get('ctx'):
-                expected_type = error['ctx']['expected_type']
-            else:
-                expected_type = "dictionary"
+    if rule_error["type"] == "literal_error":
+        return f"Field '{key_name}' is outside valid values {rule_error['ctx']['expected']}"
 
-            return f"Invalid value in '{key_name}'. '{bad_value}' is not a valid type ({expected_type})."
+    message: str = rule_error["msg"].removeprefix("Value error, ")
+    return f"Invalid value in '{key_name}': {message}"

--- a/usaspending_api/common/pydantic_base_models/codes.py
+++ b/usaspending_api/common/pydantic_base_models/codes.py
@@ -12,8 +12,7 @@ class NAICSCodeObject(BaseModel):
         if self.require is None and self.exclude is None:
             raise PydanticCustomError(
                 "missing_required_field",
-                'At least one of "require" or "exclude" must be provided',
-                {"expected_type": "array, object"},
+                'At least one of "require" or "exclude" must be provided'
             )
         return self
 
@@ -27,8 +26,7 @@ class PSCCodeObject(BaseModel):
         if self.require is None and self.exclude is None:
             raise PydanticCustomError(
                 "missing_required_field",
-                'At least one of "require" or "exclude" must be provided',
-                {"expected_type": "array, object"},
+                'At least one of "require" or "exclude" must be provided'
             )
         return self
 
@@ -42,8 +40,7 @@ class TASCodeObject(BaseModel):
         if self.require is None and self.exclude is None:
             raise PydanticCustomError(
                 "missing_required_field",
-                'At least one of "require" or "exclude" must be provided',
-                {"expected_type": "array, object"}
+                'At least one of "require" or "exclude" must be provided'
             )
         return self
 


### PR DESCRIPTION
## Description:
Some filters can cause the `/api/v2/search/spending_by_award/` endpoint to return a 500 response code instead of a 422 response code. This is due to a key in the Pydantic response model not existing in some cases.



## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->



## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

3. [x] Data validation completed (examples listed below)
5. [x] Jira Ticket(s)
    1. [DEV-15494](https://federal-spending-transparency.atlassian.net/browse/DEV-15494)

### Explain N/A in above checklist:


[DEV-15494]: https://federal-spending-transparency.atlassian.net/browse/DEV-15494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ