### PR TITLE
[GH-4285] update USAspending community link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ This project is in the public domain within the United States, and copyright and
 All contributions to this project will be released under the [CC0 dedication](LICENSE). By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
 
 ## Additional Resources
-- [USAspending.gov Community](https://usaspending-help.zendesk.com/hc/en-us/community/topics)
+- [USAspending.gov Community](https://onevoicecrm.my.site.com/usaspending/s/)
 - [USAspending Release Notes](https://github.com/fedspendingtransparency/usaspending-website/wiki)
 - [About Federal Spending Transparency](http://fedspendingtransparency.github.io/)
 - [Our Amazing Frontend Repo](https://github.com/fedspendingtransparency/usaspending-website)


### PR DESCRIPTION
## Description

Updates the Community resource in `CONTRIBUTING.md` to use the current Treasury OneVoice portal. The old Zendesk URL now rejects requests, while the replacement is the same Community URL used by the official USAspending frontend.

Closes #4285

## Technical Details

This replaces one Markdown link. The replacement URL follows redirects successfully and returns HTTP 200.

## Requirements for PR Merge

1. [x] Unit & integration tests updated (N/A)
2. [x] API documentation updated (N/A)
3. [x] Data validation completed (N/A)
4. [x] Appropriate Operations ticket(s) created (N/A)
5. [x] Jira Ticket(s) (N/A)

### Explain N/A in above checklist

1. No application code changed, so automated test coverage is unaffected.
2. No endpoint or API contract changed.
3. No data or frontend behavior changed.
4. The documentation link does not require deployment or operations work.
5. This contribution is tracked by GitHub issue #4285 rather than Jira.

Validation completed with an HTTP 200 check on the replacement URL and `git diff --check`.
