### PR TITLE
[DEV-15689] Make def_codes filter an enum

### DIFF
--- a/usaspending_api/common/validator/award_filter.py
+++ b/usaspending_api/common/validator/award_filter.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 from usaspending_api.awards.v2.lookups.lookups import award_type_mapping
 from usaspending_api.common.validator.helpers import TINY_SHIELD_SEPARATOR
+from usaspending_api.references.models.disaster_emergency_fund_code import DisasterEmergencyFundCode
 from usaspending_api.search.filters.elasticsearch.psc import PSCCodes
 from usaspending_api.search.filters.elasticsearch.tas import TasCodes, TreasuryAccounts
 
@@ -198,7 +199,12 @@ AWARD_FILTER = [
             STANDARD_FILTER_TREE_MODEL,
         ],
     },
-    {"name": "def_codes", "type": "array", "array_type": "text", "text_type": "search"},
+    {
+        "name": "def_codes",
+        "type": "array",
+        "array_type": "enum",
+        "enum_values": sorted(DisasterEmergencyFundCode.objects.values_list("code", flat=True)),
+    },
     {"name": "description", "type": "text", "text_type": "search"},
     {"name": "award_unique_id", "type": "text", "text_type": "search"},
 ]

--- a/usaspending_api/common/validator/award_filter.py
+++ b/usaspending_api/common/validator/award_filter.py
@@ -1,5 +1,7 @@
 import copy
+from functools import lru_cache
 from sys import maxsize
+from typing import Iterable
 
 from django.conf import settings
 
@@ -8,6 +10,15 @@ from usaspending_api.common.validator.helpers import TINY_SHIELD_SEPARATOR
 from usaspending_api.references.models.disaster_emergency_fund_code import DisasterEmergencyFundCode
 from usaspending_api.search.filters.elasticsearch.psc import PSCCodes
 from usaspending_api.search.filters.elasticsearch.tas import TasCodes, TreasuryAccounts
+
+
+@lru_cache(maxsize=1)
+def _get_def_codes() -> Iterable:
+    """This function is here to avoid issues where this file gets imported by management commands, but the database
+    is not available yet. For example the check_for_endpoint_documentation management command.
+    """
+    return sorted(DisasterEmergencyFundCode.objects.values_list("code", flat=True))
+
 
 TIME_PERIOD_MIN_MESSAGE = (
     "%s falls before the earliest available search date of {min}.  For data going back to %s, use either the "
@@ -203,7 +214,7 @@ AWARD_FILTER = [
         "name": "def_codes",
         "type": "array",
         "array_type": "enum",
-        "enum_values": sorted(DisasterEmergencyFundCode.objects.values_list("code", flat=True)),
+        "enum_values": _get_def_codes,
     },
     {"name": "description", "type": "text", "text_type": "search"},
     {"name": "award_unique_id", "type": "text", "text_type": "search"},

--- a/usaspending_api/common/validator/helpers.py
+++ b/usaspending_api/common/validator/helpers.py
@@ -135,8 +135,13 @@ def validate_datetime(rule: dict) -> str:
 
 def validate_enum(rule: dict) -> Any:
     value = rule["value"]
-    if value not in rule["enum_values"]:
-        error_message = "Field '{}' is outside valid values {}".format(rule["key"], list(rule["enum_values"]))
+    if callable(rule["enum_values"]):
+        enum_values = rule["enum_values"]()
+    else:
+        enum_values = rule["enum_values"]
+
+    if value not in enum_values:
+        error_message = "Field '{}' is outside valid values {}".format(rule["key"], list(enum_values))
         raise InvalidParameterException(error_message)
     return value
 

--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -1415,16 +1415,16 @@ def spending_by_award_test_data():
     # DEF codes
     baker.make(
         "references.DisasterEmergencyFundCode",
-        code = "J",
-        public_law = "J law"
+        code="J",
+        public_law="J law"
     )
     baker.make(
         "references.DisasterEmergencyFundCode",
-        code = "L",
-        public_law = "L law"
+        code="L",
+        public_law="L law"
     )
     baker.make(
         "references.DisasterEmergencyFundCode",
-        code = "Q",
-        public_law = "Q law"
+        code="Q",
+        public_law="Q law"
     )

--- a/usaspending_api/search/tests/data/spending_by_award_test_data.py
+++ b/usaspending_api/search/tests/data/spending_by_award_test_data.py
@@ -1411,3 +1411,20 @@ def spending_by_award_test_data():
 
     # Ref Country Code
     baker.make("references.RefCountryCode", country_code="USA", country_name="UNITED STATES")
+
+    # DEF codes
+    baker.make(
+        "references.DisasterEmergencyFundCode",
+        code = "J",
+        public_law = "J law"
+    )
+    baker.make(
+        "references.DisasterEmergencyFundCode",
+        code = "L",
+        public_law = "L law"
+    )
+    baker.make(
+        "references.DisasterEmergencyFundCode",
+        code = "Q",
+        public_law = "Q law"
+    )

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -4656,6 +4656,10 @@ def test_transactions_defc_date_filter(client, monkeypatch, elasticsearch_transa
     """Test that the Transactions ES query does NOT return transactions with an
     `action_date` before the applicable `earliest_public_law_enactment_date`"""
 
+    # Clear the LRU cache for `_get_def_codes` before this test case runs
+    from usaspending_api.common.validator.award_filter import _get_def_codes
+    _get_def_codes.cache_clear()
+
     baker.make(
         "references.DisasterEmergencyFundCode",
         code="L",

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -4659,12 +4659,14 @@ def test_transactions_defc_date_filter(client, monkeypatch, elasticsearch_transa
     baker.make(
         "references.DisasterEmergencyFundCode",
         code="L",
+        public_law="L law",
         group_name="covid_19",
         earliest_public_law_enactment_date="2020-03-06",
     )
     baker.make(
         "references.DisasterEmergencyFundCode",
         code="A",
+        public_law="A law",
         group_name=None,
         earliest_public_law_enactment_date=None,
     )

--- a/usaspending_api/search/tests/integration/test_spending_over_time.py
+++ b/usaspending_api/search/tests/integration/test_spending_over_time.py
@@ -4553,7 +4553,7 @@ def test_failure_with_invalid_group(client, monkeypatch, elasticsearch_transacti
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         resp.json().get("detail")
-        == "Field 'group' is outside valid values ['calendar_year', 'cy', 'quarter', 'q', 'fiscal_year', 'fy', 'month', 'm']"
+        == "Field 'group' is outside valid values ['calendar_year', 'cy', 'quarter', 'q', 'fiscal_year', 'fy', 'month', 'm']"  # noqa E501
     ), "Expected to fail with invalid group"
 
     # Fails with no group


### PR DESCRIPTION
## Description:
Sanitized user input could make its way into the download SQL query through the `def_codes` filter. This update limits the possible values for the `def_codes` filter to only the valid codes in the database.



## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->



## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

3. [x] Data validation completed (examples listed below)
5. [x] Jira Ticket(s)
    1. [DEV-15689](https://federal-spending-transparency.atlassian.net/browse/DEV-15689)

### Explain N/A in above checklist:


[DEV-15689]: https://federal-spending-transparency.atlassian.net/browse/DEV-15689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ