### PR TITLE
[DEV-15661] - Setting limit to 0 bypasses the 500,000 row limit for downloads

### DIFF
--- a/usaspending_api/download/tests/integration/test_download_transactions.py
+++ b/usaspending_api/download/tests/integration/test_download_transactions.py
@@ -169,7 +169,7 @@ def test_download_transactions_bad_limit(client, monkeypatch, elasticsearch_tran
         content_type="application/json",
         data=json.dumps({"limit": "wombats", "filters": {"award_type_codes": ["A"]}, "columns": []}),
     )
-    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.django_db(databases=[settings.DOWNLOAD_DB_ALIAS, settings.DEFAULT_DB_ALIAS], transaction=True)

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -18,7 +18,7 @@ from usaspending_api.awards.v2.lookups.lookups import (
     loan_type_mapping,
     other_type_mapping,
 )
-from usaspending_api.common.exceptions import InvalidParameterException
+from usaspending_api.common.exceptions import InvalidParameterException, UnprocessableEntityException
 from usaspending_api.common.validator.award_filter import AWARD_FILTER_NO_RECIPIENT_ID
 from usaspending_api.common.validator.tinyshield import TinyShield
 from usaspending_api.download.helpers import get_date_range_length
@@ -58,6 +58,8 @@ class DownloadValidatorBase:
         if request_data.get("columns"):
             self._json_request["columns"] = request_data.get("columns")
 
+        self.validate_limit_field(request_data)
+
         self.tinyshield_models = []
 
     def get_validated_request(self) -> dict:
@@ -69,6 +71,21 @@ class DownloadValidatorBase:
     def set_filter_defaults(self, defaults: dict) -> None:
         for key, val in defaults.items():
             self._json_request["filters"].setdefault(key, val)
+
+    def validate_limit_field(self, request_data: dict) -> None:
+        """
+        Validate that the limit field (if present) is an acceptable value.
+
+        A limit value is acceptable when less than or equal to the max (500k),
+        while being greater than or equal to 1.
+        """
+
+        limit = request_data.get("limit")
+
+        if limit is not None:
+            if not isinstance(limit, int) or limit <= 0 or limit > settings.MAX_DOWNLOAD_LIMIT:
+                msg = f"Limit must be a positive integer no larger than {settings.MAX_DOWNLOAD_LIMIT}"
+                raise UnprocessableEntityException(msg)
 
     @property
     def json_request(self) -> dict:

--- a/usaspending_api/download/v2/request_validations.py
+++ b/usaspending_api/download/v2/request_validations.py
@@ -159,11 +159,7 @@ class AwardDownloadValidator(DownloadValidatorBase):
                         "name": {"type": "text", "text_type": "search", "optional": False},
                     },
                 },
-                {
-                    "name": "agency",
-                    "key": "filters|agency",
-                    "type": "integer"
-                 },
+                {"name": "agency", "key": "filters|agency", "type": "integer"},
                 {
                     "name": "date_range",
                     "key": "filters|date_range",
@@ -315,8 +311,9 @@ class AwardDownloadValidator(DownloadValidatorBase):
             ]
 
         if "agency" in custom_award_filters or "agencies" in custom_award_filters:
-            final_award_filters["agencies"] = self._update_custom_award_agencies(custom_award_filters,
-                                                                                filter_all_agencies)
+            final_award_filters["agencies"] = self._update_custom_award_agencies(
+                custom_award_filters, filter_all_agencies
+            )
 
         self._json_request["filters"] = final_award_filters
 
@@ -349,9 +346,7 @@ class AwardDownloadValidator(DownloadValidatorBase):
                 agency_output.append({"type": "awarding", "tier": "toptier", "name": toptier_name})
 
         if "agencies" in custom_award_filters:
-            agency_output = [
-                val for val in custom_award_filters["agencies"] if val.get("name", "").lower() != "all"
-            ]
+            agency_output = [val for val in custom_award_filters["agencies"] if val.get("name", "").lower() != "all"]
 
         return agency_output
 
@@ -644,13 +639,7 @@ class AccountDownloadValidator(DownloadValidatorBase):
                     "array_type": "enum",
                     "enum_values": VALID_ACCOUNT_SUBMISSION_TYPES,
                 },
-                {
-                    "name": "agency",
-                    "key": "filters|agency",
-                    "type": "text",
-                    "text_type": "search",
-                    "default": "all"
-                },
+                {"name": "agency", "key": "filters|agency", "type": "text", "text_type": "search", "default": "all"},
                 {
                     "name": "def_codes",
                     "key": "filters|def_codes",
@@ -691,10 +680,7 @@ class AccountDownloadValidator(DownloadValidatorBase):
 
         agency_filter = self._json_request["filters"].get("agency")
         has_agency_filter = agency_filter and agency_filter.lower() != "all"
-        is_valid_id = (
-            agency_filter.isdigit()
-            and ToptierAgency.objects.filter(toptier_agency_id=agency_filter).exists()
-        )
+        is_valid_id = agency_filter.isdigit() and ToptierAgency.objects.filter(toptier_agency_id=agency_filter).exists()
         is_valid_abbr = ToptierAgency.objects.filter(abbreviation=agency_filter).exists()
         if has_agency_filter and not (is_valid_id or is_valid_abbr):
             raise NotFound(
@@ -800,10 +786,7 @@ class SearchDownloadValidator(DownloadValidatorBase):
                     "key": "spending_level",
                     "type": "array",
                     "array_type": "enum",
-                    "enum_values": [
-                        "awards",
-                        "transactions",
-                        "subawards"],
+                    "enum_values": ["awards", "transactions", "subawards"],
                     "optional": True,
                     "default": ["awards", "transactions", "subawards"],
                 },
@@ -821,11 +804,7 @@ class SearchDownloadValidator(DownloadValidatorBase):
                     "key": "download_types",
                     "type": "array",
                     "array_type": "enum",
-                    "enum_values": [
-                        "elasticsearch_awards",
-                        "elasticsearch_sub_awards",
-                        "elasticsearch_transactions"
-                    ],
+                    "enum_values": ["elasticsearch_awards", "elasticsearch_sub_awards", "elasticsearch_transactions"],
                 },
             ]
         )
@@ -834,9 +813,9 @@ class SearchDownloadValidator(DownloadValidatorBase):
         self._json_request = self.get_validated_request()
 
         # Use original value for processing download_types
-        spending_level_to_process = original_spending_level if original_spending_level is not None else ["awards",
-                                                                                                         "transactions",
-                                                                                                         "subawards"]
+        spending_level_to_process = (
+            original_spending_level if original_spending_level is not None else ["awards", "transactions", "subawards"]
+        )
 
         dltypes = []
         for dltype in spending_level_to_process:


### PR DESCRIPTION
## Description:
<!-- High level description of what the PR addresses should be put here. Should be detailed enough to communicate to a PO what this PR addresses without diving into the technical nuances. -->

Setting ”limit”: 0 in an API request to any of the /api/v2/download/ endpoints has created scenarios where the 500,000 row limit is ignored and all rows are written to the download file.


## Technical Details:
<!-- The technical details for the knowledge of other developers. Any detailed caveats or specific deployment steps should be outlined here. -->

A check was added in the base class for API endpoint Validators where it checks for a limit field and then ensure that that field is within a valid range.  If not, it will fail with a 422 Message explaining what the code must be.


## Requirements for PR Merge:
<!-- Items that aren't relevant should be marked as N/A and explained below as needed. -->

1. [ ] Unit & integration tests updated
2. [ ] Jira Ticket(s)
    1. [DEV-15661](https://federal-spending-transparency.atlassian.net/browse/DEV-15661)

### Explain N/A in above checklist:


[DEV-15661]: https://federal-spending-transparency.atlassian.net/browse/DEV-15661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ