### PR TITLE
Update ai_models.yaml to increase titan max tokens

### DIFF
--- a/usaspending_api/llm/fixtures/ai_models.yaml
+++ b/usaspending_api/llm/fixtures/ai_models.yaml
@@ -62,5 +62,5 @@
     inference_config:
       temperature: 0.0
       topP: 1.0
-      maxTokens: 5000
+      maxTokens: 8192
       stopSequences: []


### PR DESCRIPTION
## Description:
Amazon titan has a max tokens of 8192.  The embedding generator and the models'  `get_embedding_text` methods were built with this assumption.  5000 may truncate the text and result in worse performance.